### PR TITLE
Fix event image removal and improve editor UX

### DIFF
--- a/src/lib/components/events/EventCard.svelte
+++ b/src/lib/components/events/EventCard.svelte
@@ -46,8 +46,10 @@
 	let fallbackGradient = $derived(getEventFallbackGradient(event.id));
 	let isPast = $derived(isEventPast(event.end));
 
-	// Image URLs with backend URL prepended
-	let imageUrl = $derived(event.cover_art && !imageError ? event.cover_art : null);
+	// Image URLs with backend URL prepended and fallback to organization
+	let eventCoverArtUrl = $derived(getImageUrl(event.cover_art));
+	let orgCoverArtUrl = $derived(getImageUrl(event.organization.cover_art));
+	let imageUrl = $derived(!imageError ? eventCoverArtUrl || orgCoverArtUrl : null);
 	let orgLogoUrl = $derived(getImageUrl(event.organization.logo));
 
 	// Accessible card label for screen readers

--- a/src/lib/components/events/EventHeader.svelte
+++ b/src/lib/components/events/EventHeader.svelte
@@ -26,7 +26,10 @@
 		return `${BACKEND_URL}${path}`;
 	}
 
-	// Compute organization logo URL
+	// Compute image URLs with backend URL prepended
+	const eventCoverArtUrl = $derived(getImageUrl(event.cover_art));
+	const orgCoverArtUrl = $derived(getImageUrl(event.organization.cover_art));
+	const coverImageUrl = $derived(eventCoverArtUrl || orgCoverArtUrl);
 	const orgLogoUrl = $derived(getImageUrl(event.organization.logo));
 
 	// Compute location display
@@ -58,9 +61,9 @@
 <header class={cn('relative w-full overflow-hidden', className)}>
 	<!-- Cover Image or Gradient -->
 	<div class="relative h-64 w-full md:h-96">
-		{#if event.cover_art}
+		{#if coverImageUrl}
 			<img
-				src={event.cover_art}
+				src={coverImageUrl}
 				alt="{event.name} cover image"
 				class="h-full w-full object-cover"
 				loading="eager"


### PR DESCRIPTION
## Summary
Fixes the issue where users couldn't remove old event images in the event editor, and adds several UX improvements to the event creation/editing flow.

## Changes Made

### 🐛 Image Removal Fix (Primary Issue)
- **Fixed ImageUploader component** to properly handle removal of existing images
- Added `previewRemoved` state flag to track when user explicitly removes an image
- Refactored preview logic to use `$derived` for cleaner reactivity
- Split preview state into `selectedFilePreview` (new uploads) and `preview` (existing server images)
- Now correctly shows upload area after removing existing images
- Properly sends delete flags to backend when images are removed

### ✨ Event Wizard UX Improvements
- **Smooth scroll to top** when advancing from Step 1 to Step 2
  - Prevents users from being stuck at bottom of page after clicking "Save & Continue"
- **WYSIWYG Markdown Editor** for event description
  - Replaced plain textarea with MarkdownEditor component
  - Live preview toggle
  - Formatting toolbar (Bold, Italic, Link, List)
  - Same editor used in organization settings for consistency

### 🎨 Event Display Improvements
- **Proper backend URL resolution** for all event images
- **Fallback to organization images** when event images not available
  - EventCard: Shows org cover art if event cover art missing
  - EventHeader: Shows org cover art if event cover art missing
- **Fixed image URL handling** across EventCard, EventHeader, and admin components

### 🔧 Technical Implementation
**ImageUploader.svelte:**
- Added `previewRemoved` state to track explicit removal
- Added `selectedFilePreview` state for new file uploads
- Changed `previewUrl` to `$derived` computed value
- Updated `removeImage()` to set removal flag instead of reverting to preview

**EventWizard.svelte:**
- Added `window.scrollTo({ top: 0, behavior: 'smooth' })` on step transition
- Imported `eventadminDeleteLogo` and `eventadminDeleteCoverArt` endpoints
- Added delete mutations for both logo and cover art
- Updated form save flow to delete images when flags are set

**DetailsStep.svelte:**
- Imported and integrated `MarkdownEditor` component
- Added local state for description with proper syncing
- Added `handleDescriptionChange` callback

**EventCard.svelte & EventHeader.svelte:**
- Added proper image URL resolution with `getImageUrl()` helper
- Implemented fallback logic: event image → org image → gradient/icon

## Testing
- ✅ Can now remove existing event images and see upload area
- ✅ Can upload new images after removing old ones
- ✅ Smooth scroll works when advancing to step 2
- ✅ Markdown editor provides live preview and formatting
- ✅ Event cards and headers show proper images with fallbacks
- ✅ All images properly resolve backend URLs

## Screenshots/Demo
The image removal now works as expected:
1. Edit event with existing logo/cover art
2. Click X button on image
3. Image disappears and upload area appears
4. Can upload new image or save without image (triggers backend delete)

## Related Issues
Fixes issue reported by user: "in the event's edit page, I can't remove the old pictures to add new ones"

🤖 Generated with [Claude Code](https://claude.com/claude-code)