### PR TITLE
fix(ui): set EUR as default for platform fee and lock requires_ticket field

### DIFF
--- a/src/lib/components/events/admin/EssentialsStep.svelte
+++ b/src/lib/components/events/admin/EssentialsStep.svelte
@@ -316,13 +316,16 @@
 	<!-- Requires Ticket -->
 	<div class="space-y-2">
 		<label
-			class="flex cursor-pointer items-center gap-3 rounded-md border border-input p-3 transition-colors hover:bg-accent"
+			class="flex items-center gap-3 rounded-md border border-input p-3 transition-colors {isEditMode
+				? 'cursor-not-allowed opacity-60'
+				: 'cursor-pointer hover:bg-accent'}"
 		>
 			<input
 				type="checkbox"
 				checked={formData.requires_ticket || false}
 				onchange={(e) => onUpdate({ requires_ticket: e.currentTarget.checked })}
-				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+				disabled={isEditMode}
+				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
 			/>
 			<div class="flex-1">
 				<div class="flex items-center gap-2 font-medium">
@@ -334,6 +337,20 @@
 				</div>
 			</div>
 		</label>
+
+		{#if isEditMode}
+			<div
+				class="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-100"
+			>
+				⚠️ This setting cannot be changed after the event is created
+			</div>
+		{:else if formData.requires_ticket}
+			<div
+				class="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100"
+			>
+				ℹ️ Note: This setting cannot be changed once the event is created. Choose carefully!
+			</div>
+		{/if}
 	</div>
 
 	<!-- Navigation Buttons -->

--- a/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
@@ -337,7 +337,7 @@
 			<div>
 				<div class="block text-sm font-medium text-muted-foreground">Platform Fee (Fixed)</div>
 				<div class="mt-1 rounded-md border border-border bg-muted px-3 py-2 text-sm">
-					${data.organization.platform_fee_fixed}
+					€{data.organization.platform_fee_fixed}
 				</div>
 				<p class="mt-1 text-xs text-muted-foreground">Fixed fee per ticket sold</p>
 			</div>


### PR DESCRIPTION
## Summary

This PR implements two minor UI fixes:
1. Sets EUR (€) as the default currency for platform fee display
2. Locks the `requires_ticket` field after event creation with appropriate warnings

## Changes

### 1. Platform Fee Currency Display
**File:** `src/routes/(auth)/org/[slug]/admin/settings/+page.svelte`

- Changed platform fee fixed display from `$` to `€`
- The platform fee is always in EUR, so the display now reflects the correct currency

**Before:**
```
Platform Fee (Fixed): $0.50
```

**After:**
```
Platform Fee (Fixed): €0.50
```

### 2. Requires Ticket Field Protection
**File:** `src/lib/components/events/admin/EssentialsStep.svelte`

The `requires_ticket` setting is now properly locked after event creation to prevent data inconsistencies.

**In Edit Mode:**
- Checkbox is disabled
- Visual indicators: grayed out, opacity reduced, cursor shows not-allowed
- Yellow warning displayed: "⚠️ This setting cannot be changed after the event is created"

**In Creation Mode (when checked):**
- Blue info message: "ℹ️ Note: This setting cannot be changed once the event is created. Choose carefully!"
- Warns users before they commit to using tickets vs RSVPs

## Why These Changes?

### Platform Fee Currency
- The backend always uses EUR for platform fees
- Displaying `$` was misleading for European organizations
- Now shows correct currency symbol

### Requires Ticket Lock
- Changing `requires_ticket` after creation would cause data integrity issues:
  - Existing RSVPs would become invalid if switching to tickets
  - Existing tickets would become invalid if switching to RSVPs
- Backend doesn't support changing this field post-creation
- Frontend now prevents this action and clearly communicates the constraint

## UI/UX Improvements

- **Clear visual feedback:** Disabled state is obvious with opacity and cursor changes
- **Proactive warnings:** Users are warned before making irreversible decisions
- **Consistent messaging:** Uses standard warning/info colors (yellow/blue)
- **Accessible:** Proper disabled state for screen readers

## Testing

- [x] Platform fee displays with € symbol in org settings
- [x] Requires ticket checkbox disabled in event edit mode
- [x] Warning message appears in edit mode
- [x] Info message appears in creation mode when checkbox is checked
- [x] Visual disabled state (opacity, cursor) works correctly
- [x] Checkbox functionality still works in creation mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)