### PR TITLE
fix: resolve merge conflict and add skeleton loading components

### DIFF
--- a/src/lib/api/generated/sdk.gen.ts
+++ b/src/lib/api/generated/sdk.gen.ts
@@ -9,364 +9,364 @@ import {
 } from './client';
 import { client } from './client.gen';
 import type {
-	AccountDeleteAccountConfirm51Aca775Data,
-	AccountDeleteAccountConfirm51Aca775Responses,
-	AccountDeleteAccountRequest8786843dData,
-	AccountDeleteAccountRequest8786843dResponses,
-	AccountExportData68C7E4DbData,
-	AccountExportData68C7E4DbResponses,
-	AccountMe6420Cff8Data,
-	AccountMe6420Cff8Responses,
-	AccountRegister0E682147Data,
-	AccountRegister0E682147Responses,
-	AccountResendVerificationEmailDca4C406Data,
-	AccountResendVerificationEmailDca4C406Errors,
-	AccountResendVerificationEmailDca4C406Responses,
-	AccountResetPassword03A7Fc3dData,
-	AccountResetPassword03A7Fc3dResponses,
-	AccountResetPasswordRequest159B2A43Data,
-	AccountResetPasswordRequest159B2A43Responses,
-	AccountUpdateProfile5D6D1Db7Data,
-	AccountUpdateProfile5D6D1Db7Responses,
-	AccountVerifyEmailC5B88297Data,
-	AccountVerifyEmailC5B88297Responses,
+	AccountDeleteAccountConfirm77E53A9bData,
+	AccountDeleteAccountConfirm77E53A9bResponses,
+	AccountDeleteAccountRequest36F5A4F2Data,
+	AccountDeleteAccountRequest36F5A4F2Responses,
+	AccountExportDataBa4Eefa4Data,
+	AccountExportDataBa4Eefa4Responses,
+	AccountMe250Fac7cData,
+	AccountMe250Fac7cResponses,
+	AccountRegister60A39A8dData,
+	AccountRegister60A39A8dResponses,
+	AccountResendVerificationEmail58F3B280Data,
+	AccountResendVerificationEmail58F3B280Errors,
+	AccountResendVerificationEmail58F3B280Responses,
+	AccountResetPassword1Fb3F0E6Data,
+	AccountResetPassword1Fb3F0E6Responses,
+	AccountResetPasswordRequest6Ca44671Data,
+	AccountResetPasswordRequest6Ca44671Responses,
+	AccountUpdateProfileC460A981Data,
+	AccountUpdateProfileC460A981Responses,
+	AccountVerifyEmailC1Db4Da9Data,
+	AccountVerifyEmailC1Db4Da9Responses,
 	ApiApiHealthcheckData,
 	ApiApiHealthcheckResponses,
 	ApiApiVersionData,
 	ApiApiVersionResponses,
-	AuthDemoObtainTokenF9683D25Data,
-	AuthDemoObtainTokenF9683D25Responses,
-	AuthGoogleLogin778Da160Data,
-	AuthGoogleLogin778Da160Responses,
-	AuthObtainTokenF0Ed10A6Data,
-	AuthObtainTokenF0Ed10A6Responses,
-	AuthObtainTokenWithOtpCad64Ee2Data,
-	AuthObtainTokenWithOtpCad64Ee2Responses,
-	CityGetCity7711686bData,
-	CityGetCity7711686bResponses,
-	CityListCities6B5493E8Data,
-	CityListCities6B5493E8Responses,
-	CityListCountries5Dac3B77Data,
-	CityListCountries5Dac3B77Responses,
-	DashboardDashboardEvents6Cb96588Data,
-	DashboardDashboardEvents6Cb96588Responses,
-	DashboardDashboardEventSeriesC961639bData,
-	DashboardDashboardEventSeriesC961639bResponses,
-	DashboardDashboardInvitations2F2132B0Data,
-	DashboardDashboardInvitations2F2132B0Responses,
-	DashboardDashboardOrganizations03Daa3C4Data,
-	DashboardDashboardOrganizations03Daa3C4Responses,
-	EventadminAddTagsF8D9D0CaData,
-	EventadminAddTagsF8D9D0CaResponses,
-	EventadminApproveInvitationRequestBc0774C6Data,
-	EventadminApproveInvitationRequestBc0774C6Responses,
-	EventadminCancelTicket1082Aa5bData,
-	EventadminCancelTicket1082Aa5bResponses,
-	EventadminCheckInTicket957Dc27bData,
-	EventadminCheckInTicket957Dc27bErrors,
-	EventadminCheckInTicket957Dc27bResponses,
-	EventadminClearTags9A9B25CdData,
-	EventadminClearTags9A9B25CdResponses,
-	EventadminConfirmTicketPaymentD8E41153Data,
-	EventadminConfirmTicketPaymentD8E41153Responses,
-	EventadminCreateEventTokenB430C9A3Data,
-	EventadminCreateEventTokenB430C9A3Responses,
-	EventadminCreateInvitations626265E4Data,
-	EventadminCreateInvitations626265E4Errors,
-	EventadminCreateInvitations626265E4Responses,
-	EventadminCreateRsvpA0Abb388Data,
-	EventadminCreateRsvpA0Abb388Responses,
-	EventadminCreateTicketTier03150584Data,
-	EventadminCreateTicketTier03150584Responses,
-	EventadminDeleteCoverArt3F30469fData,
-	EventadminDeleteCoverArt3F30469fResponses,
-	EventadminDeleteEventToken1104AffcData,
-	EventadminDeleteEventToken1104AffcResponses,
-	EventadminDeleteInvitationEndpoint7A5Baf74Data,
-	EventadminDeleteInvitationEndpoint7A5Baf74Errors,
-	EventadminDeleteInvitationEndpoint7A5Baf74Responses,
-	EventadminDeleteLogo3967075cData,
-	EventadminDeleteLogo3967075cResponses,
-	EventadminDeleteRsvp111B4Ef4Data,
-	EventadminDeleteRsvp111B4Ef4Responses,
-	EventadminDeleteTicketTierA7C3519aData,
-	EventadminDeleteTicketTierA7C3519aResponses,
-	EventadminGetRsvpB753B6DfData,
-	EventadminGetRsvpB753B6DfResponses,
-	EventadminGetTicket19Afa38dData,
-	EventadminGetTicket19Afa38dResponses,
-	EventadminListEventTokensC77C30C8Data,
-	EventadminListEventTokensC77C30C8Responses,
-	EventadminListInvitationRequests3453A7F0Data,
-	EventadminListInvitationRequests3453A7F0Responses,
-	EventadminListInvitations8672F3C5Data,
-	EventadminListInvitations8672F3C5Responses,
-	EventadminListPendingInvitations2074D91cData,
-	EventadminListPendingInvitations2074D91cResponses,
-	EventadminListRsvps7Ad29E6cData,
-	EventadminListRsvps7Ad29E6cResponses,
-	EventadminListTickets720A6A89Data,
-	EventadminListTickets720A6A89Responses,
-	EventadminListTicketTiersF0C8F341Data,
-	EventadminListTicketTiersF0C8F341Responses,
-	EventadminMarkTicketRefundedBd44B3D6Data,
-	EventadminMarkTicketRefundedBd44B3D6Responses,
-	EventadminRejectInvitationRequest4D2C7F01Data,
-	EventadminRejectInvitationRequest4D2C7F01Responses,
-	EventadminRemoveTags1Eb533CdData,
-	EventadminRemoveTags1Eb533CdResponses,
-	EventadminUpdateEvent669A5A17Data,
-	EventadminUpdateEvent669A5A17Errors,
-	EventadminUpdateEvent669A5A17Responses,
-	EventadminUpdateEventStatus9B733B32Data,
-	EventadminUpdateEventStatus9B733B32Responses,
-	EventadminUpdateEventToken98D07979Data,
-	EventadminUpdateEventToken98D07979Responses,
-	EventadminUpdateRsvp4F4B015cData,
-	EventadminUpdateRsvp4F4B015cResponses,
-	EventadminUpdateTicketTierAded0749Data,
-	EventadminUpdateTicketTierAded0749Responses,
-	EventadminUploadCoverArt3F027833Data,
-	EventadminUploadCoverArt3F027833Responses,
-	EventadminUploadLogo97D3C2AeData,
-	EventadminUploadLogo97D3C2AeResponses,
-	EventClaimInvitationA333Ba68Data,
-	EventClaimInvitationA333Ba68Errors,
-	EventClaimInvitationA333Ba68Responses,
-	EventCreateInvitationRequest9B1Cdcf3Data,
-	EventCreateInvitationRequest9B1Cdcf3Responses,
-	EventDeleteInvitationRequestE2Bc00BbData,
-	EventDeleteInvitationRequestE2Bc00BbResponses,
-	EventGetEventAttendeesDf088923Data,
-	EventGetEventAttendeesDf088923Responses,
-	EventGetEventBySlugs1867901aData,
-	EventGetEventBySlugs1867901aResponses,
-	EventGetEventF33D9Fe5Data,
-	EventGetEventF33D9Fe5Responses,
-	EventGetMyEventStatusA5537Ae4Data,
-	EventGetMyEventStatusA5537Ae4Responses,
-	EventGetQuestionnaire21149006Data,
-	EventGetQuestionnaire21149006Responses,
-	EventListEvents7Fc6E819Data,
-	EventListEvents7Fc6E819Responses,
-	EventListResources0640A3A6Data,
-	EventListResources0640A3A6Responses,
-	EventListTiersD39F67BdData,
-	EventListTiersD39F67BdResponses,
-	EventListUserInvitationRequests11F4Dbf2Data,
-	EventListUserInvitationRequests11F4Dbf2Responses,
-	EventRsvpEvent2Fc4F913Data,
-	EventRsvpEvent2Fc4F913Errors,
-	EventRsvpEvent2Fc4F913Responses,
-	EventseriesadminAddTags90D97164Data,
-	EventseriesadminAddTags90D97164Responses,
-	EventseriesadminClearTags39B860D9Data,
-	EventseriesadminClearTags39B860D9Responses,
-	EventseriesadminDeleteCoverArtAdacffceData,
-	EventseriesadminDeleteCoverArtAdacffceResponses,
-	EventseriesadminDeleteEventSeries4342CeaeData,
-	EventseriesadminDeleteEventSeries4342CeaeResponses,
-	EventseriesadminDeleteLogo60503B96Data,
-	EventseriesadminDeleteLogo60503B96Responses,
-	EventseriesadminRemoveTagsDace0E92Data,
-	EventseriesadminRemoveTagsDace0E92Responses,
-	EventseriesadminUpdateEventSeries787B5A6bData,
-	EventseriesadminUpdateEventSeries787B5A6bErrors,
-	EventseriesadminUpdateEventSeries787B5A6bResponses,
-	EventseriesadminUploadCoverArtCef38D76Data,
-	EventseriesadminUploadCoverArtCef38D76Responses,
-	EventseriesadminUploadLogoD5A34979Data,
-	EventseriesadminUploadLogoD5A34979Responses,
-	EventseriesGetEventSeries0879D813Data,
-	EventseriesGetEventSeries0879D813Responses,
-	EventseriesGetEventSeriesBySlugs2Bc4198fData,
-	EventseriesGetEventSeriesBySlugs2Bc4198fResponses,
-	EventseriesListEventSeries5C5D600cData,
-	EventseriesListEventSeries5C5D600cResponses,
-	EventseriesListResourcesFc094B71Data,
-	EventseriesListResourcesFc094B71Responses,
-	EventSubmitQuestionnaireB02E3452Data,
-	EventSubmitQuestionnaireB02E3452Errors,
-	EventSubmitQuestionnaireB02E3452Responses,
-	EventTicketCheckout58D472B4Data,
-	EventTicketCheckout58D472B4Errors,
-	EventTicketCheckout58D472B4Responses,
-	EventTicketPwycCheckout9D58C7F3Data,
-	EventTicketPwycCheckout9D58C7F3Errors,
-	EventTicketPwycCheckout9D58C7F3Responses,
-	OrganizationadminAddStaff3E15765eData,
-	OrganizationadminAddStaff3E15765eResponses,
-	OrganizationadminAddTags1F41252aData,
-	OrganizationadminAddTags1F41252aResponses,
-	OrganizationadminApproveMembershipRequestE1Bd2D4fData,
-	OrganizationadminApproveMembershipRequestE1Bd2D4fResponses,
-	OrganizationadminClearTags943F2C71Data,
-	OrganizationadminClearTags943F2C71Responses,
-	OrganizationadminCreateEvent051E2C16Data,
-	OrganizationadminCreateEvent051E2C16Errors,
-	OrganizationadminCreateEvent051E2C16Responses,
-	OrganizationadminCreateEventSeries909F81BdData,
-	OrganizationadminCreateEventSeries909F81BdErrors,
-	OrganizationadminCreateEventSeries909F81BdResponses,
-	OrganizationadminCreateOrganizationTokenB11748D5Data,
-	OrganizationadminCreateOrganizationTokenB11748D5Responses,
-	OrganizationadminCreateResource42869D36Data,
-	OrganizationadminCreateResource42869D36Responses,
-	OrganizationadminDeleteCoverArt0F663C07Data,
-	OrganizationadminDeleteCoverArt0F663C07Responses,
-	OrganizationadminDeleteLogo2B684AbaData,
-	OrganizationadminDeleteLogo2B684AbaResponses,
-	OrganizationadminDeleteOrganizationToken920E477cData,
-	OrganizationadminDeleteOrganizationToken920E477cResponses,
-	OrganizationadminDeleteResource6D0C6Bf8Data,
-	OrganizationadminDeleteResource6D0C6Bf8Responses,
-	OrganizationadminGetOrganization52A02A44Data,
-	OrganizationadminGetOrganization52A02A44Responses,
-	OrganizationadminGetResource3F8F93C9Data,
-	OrganizationadminGetResource3F8F93C9Responses,
-	OrganizationadminListMembers3986D3D0Data,
-	OrganizationadminListMembers3986D3D0Responses,
-	OrganizationadminListMembershipRequests2Bae90A0Data,
-	OrganizationadminListMembershipRequests2Bae90A0Responses,
-	OrganizationadminListOrganizationTokensAd2141C7Data,
-	OrganizationadminListOrganizationTokensAd2141C7Responses,
-	OrganizationadminListResources90241F4dData,
-	OrganizationadminListResources90241F4dResponses,
-	OrganizationadminListStaff636E217aData,
-	OrganizationadminListStaff636E217aResponses,
-	OrganizationadminRejectMembershipRequest48075D3fData,
-	OrganizationadminRejectMembershipRequest48075D3fResponses,
-	OrganizationadminRemoveMember6Ec7227fData,
-	OrganizationadminRemoveMember6Ec7227fResponses,
-	OrganizationadminRemoveStaffEab475EfData,
-	OrganizationadminRemoveStaffEab475EfResponses,
-	OrganizationadminRemoveTags17210274Data,
-	OrganizationadminRemoveTags17210274Responses,
-	OrganizationadminStripeAccountVerify3F404331Data,
-	OrganizationadminStripeAccountVerify3F404331Responses,
-	OrganizationadminStripeConnect5702Ef2eData,
-	OrganizationadminStripeConnect5702Ef2eResponses,
-	OrganizationadminUpdateOrganization6E5B1F9bData,
-	OrganizationadminUpdateOrganization6E5B1F9bResponses,
-	OrganizationadminUpdateOrganizationToken5284Deb3Data,
-	OrganizationadminUpdateOrganizationToken5284Deb3Responses,
-	OrganizationadminUpdateResource93D02613Data,
-	OrganizationadminUpdateResource93D02613Responses,
-	OrganizationadminUpdateStaffPermissionsE7D1DdfdData,
-	OrganizationadminUpdateStaffPermissionsE7D1DdfdResponses,
-	OrganizationadminUploadCoverArtF9C552CbData,
-	OrganizationadminUploadCoverArtF9C552CbResponses,
-	OrganizationadminUploadLogoB141E351Data,
-	OrganizationadminUploadLogoB141E351Responses,
-	OrganizationClaimInvitation5C32FadfData,
-	OrganizationClaimInvitation5C32FadfErrors,
-	OrganizationClaimInvitation5C32FadfResponses,
-	OrganizationCreateMembershipRequestC7302D18Data,
-	OrganizationCreateMembershipRequestC7302D18Responses,
-	OrganizationGetOrganization45F68219Data,
-	OrganizationGetOrganization45F68219Responses,
-	OrganizationListOrganizations3C31A7EaData,
-	OrganizationListOrganizations3C31A7EaResponses,
-	OrganizationListResources902770CcData,
-	OrganizationListResources902770CcResponses,
-	OtpDisableOtp44832EbfData,
-	OtpDisableOtp44832EbfResponses,
-	OtpEnableOtpBd1478D0Data,
-	OtpEnableOtpBd1478D0Responses,
-	OtpSetupOtpB2211117Data,
-	OtpSetupOtpB2211117Responses,
-	PermissionMyPermissions26660239Data,
-	PermissionMyPermissions26660239Responses,
-	PotluckClaimPotluckItemDecef2E5Data,
-	PotluckClaimPotluckItemDecef2E5Responses,
-	PotluckCreatePotluckItem74Eaf78eData,
-	PotluckCreatePotluckItem74Eaf78eResponses,
-	PotluckDeletePotluckItem71B5E436Data,
-	PotluckDeletePotluckItem71B5E436Responses,
-	PotluckListPotluckItemsF3A8D13fData,
-	PotluckListPotluckItemsF3A8D13fResponses,
-	PotluckUnclaimPotluckItem7D8B3F84Data,
-	PotluckUnclaimPotluckItem7D8B3F84Responses,
-	PotluckUpdatePotluckItem2Cab8494Data,
-	PotluckUpdatePotluckItem2Cab8494Responses,
-	QuestionnaireAssignEventD8Feb5F1Data,
-	QuestionnaireAssignEventD8Feb5F1Responses,
-	QuestionnaireAssignEventSeriesB66Af321Data,
-	QuestionnaireAssignEventSeriesB66Af321Responses,
-	QuestionnaireCreateFtQuestionB4E4BeecData,
-	QuestionnaireCreateFtQuestionB4E4BeecResponses,
-	QuestionnaireCreateMcOption7714C9DeData,
-	QuestionnaireCreateMcOption7714C9DeResponses,
-	QuestionnaireCreateMcQuestion06701522Data,
-	QuestionnaireCreateMcQuestion06701522Responses,
-	QuestionnaireCreateOrgQuestionnaire3C5D9045Data,
-	QuestionnaireCreateOrgQuestionnaire3C5D9045Errors,
-	QuestionnaireCreateOrgQuestionnaire3C5D9045Responses,
-	QuestionnaireCreateSectionDbdfdf9dData,
-	QuestionnaireCreateSectionDbdfdf9dResponses,
-	QuestionnaireDeleteFtQuestion49C2E429Data,
-	QuestionnaireDeleteFtQuestion49C2E429Responses,
-	QuestionnaireDeleteMcOption775Fa06dData,
-	QuestionnaireDeleteMcOption775Fa06dResponses,
-	QuestionnaireDeleteMcQuestionA6713B01Data,
-	QuestionnaireDeleteMcQuestionA6713B01Responses,
-	QuestionnaireDeleteOrgQuestionnaire80Cd631aData,
-	QuestionnaireDeleteOrgQuestionnaire80Cd631aResponses,
-	QuestionnaireDeleteSection6935C91eData,
-	QuestionnaireDeleteSection6935C91eResponses,
-	QuestionnaireEvaluateSubmission95B64A41Data,
-	QuestionnaireEvaluateSubmission95B64A41Errors,
-	QuestionnaireEvaluateSubmission95B64A41Responses,
-	QuestionnaireGetOrgQuestionnaire6A6547A7Data,
-	QuestionnaireGetOrgQuestionnaire6A6547A7Responses,
-	QuestionnaireGetSubmissionDetailD93F30A9Data,
-	QuestionnaireGetSubmissionDetailD93F30A9Responses,
-	QuestionnaireListOrgQuestionnaires42A9D3CbData,
-	QuestionnaireListOrgQuestionnaires42A9D3CbResponses,
-	QuestionnaireListSubmissions4C7B40BcData,
-	QuestionnaireListSubmissions4C7B40BcResponses,
-	QuestionnaireReplaceEvents73E6B122Data,
-	QuestionnaireReplaceEvents73E6B122Responses,
-	QuestionnaireReplaceEventSeriesA98A2508Data,
-	QuestionnaireReplaceEventSeriesA98A2508Responses,
-	QuestionnaireUnassignEvent7E85350dData,
-	QuestionnaireUnassignEvent7E85350dResponses,
-	QuestionnaireUnassignEventSeriesA3Cf8D10Data,
-	QuestionnaireUnassignEventSeriesA3Cf8D10Responses,
-	QuestionnaireUpdateFtQuestion11774009Data,
-	QuestionnaireUpdateFtQuestion11774009Responses,
-	QuestionnaireUpdateMcOption5Fc0E101Data,
-	QuestionnaireUpdateMcOption5Fc0E101Responses,
-	QuestionnaireUpdateMcQuestionAad6A276Data,
-	QuestionnaireUpdateMcQuestionAad6A276Responses,
-	QuestionnaireUpdateOrgQuestionnaire13E422A0Data,
-	QuestionnaireUpdateOrgQuestionnaire13E422A0Responses,
-	QuestionnaireUpdateQuestionnaireStatusA762B758Data,
-	QuestionnaireUpdateQuestionnaireStatusA762B758Responses,
-	QuestionnaireUpdateSection0B4561B1Data,
-	QuestionnaireUpdateSection0B4561B1Responses,
-	StripewebhookHandleWebhookAb33E84dData,
-	StripewebhookHandleWebhookAb33E84dResponses,
-	TagListTagsCa3Ddb22Data,
-	TagListTagsCa3Ddb22Responses,
+	AuthDemoObtainTokenC30F0580Data,
+	AuthDemoObtainTokenC30F0580Responses,
+	AuthGoogleLogin03Be8978Data,
+	AuthGoogleLogin03Be8978Responses,
+	AuthObtainToken1Ada7A04Data,
+	AuthObtainToken1Ada7A04Responses,
+	AuthObtainTokenWithOtp6Dee1057Data,
+	AuthObtainTokenWithOtp6Dee1057Responses,
+	CityGetCityB0410Ba7Data,
+	CityGetCityB0410Ba7Responses,
+	CityListCitiesEd3A17BdData,
+	CityListCitiesEd3A17BdResponses,
+	CityListCountries2Bb24454Data,
+	CityListCountries2Bb24454Responses,
+	DashboardDashboardEventsAae8306bData,
+	DashboardDashboardEventsAae8306bResponses,
+	DashboardDashboardEventSeries5D1Acbc6Data,
+	DashboardDashboardEventSeries5D1Acbc6Responses,
+	DashboardDashboardInvitations7Ee7C5BaData,
+	DashboardDashboardInvitations7Ee7C5BaResponses,
+	DashboardDashboardOrganizationsF23703B2Data,
+	DashboardDashboardOrganizationsF23703B2Responses,
+	EventadminAddTags9523D639Data,
+	EventadminAddTags9523D639Responses,
+	EventadminApproveInvitationRequestDb4637FdData,
+	EventadminApproveInvitationRequestDb4637FdResponses,
+	EventadminCancelTicket14582C4eData,
+	EventadminCancelTicket14582C4eResponses,
+	EventadminCheckInTicket15Ab77B0Data,
+	EventadminCheckInTicket15Ab77B0Errors,
+	EventadminCheckInTicket15Ab77B0Responses,
+	EventadminClearTags0650Bd81Data,
+	EventadminClearTags0650Bd81Responses,
+	EventadminConfirmTicketPayment73914A92Data,
+	EventadminConfirmTicketPayment73914A92Responses,
+	EventadminCreateEventToken2705Ac10Data,
+	EventadminCreateEventToken2705Ac10Responses,
+	EventadminCreateInvitationsF317F105Data,
+	EventadminCreateInvitationsF317F105Errors,
+	EventadminCreateInvitationsF317F105Responses,
+	EventadminCreateRsvp6074Fdf2Data,
+	EventadminCreateRsvp6074Fdf2Responses,
+	EventadminCreateTicketTier84Db5110Data,
+	EventadminCreateTicketTier84Db5110Responses,
+	EventadminDeleteCoverArt509922C1Data,
+	EventadminDeleteCoverArt509922C1Responses,
+	EventadminDeleteEventTokenC3Fc3A27Data,
+	EventadminDeleteEventTokenC3Fc3A27Responses,
+	EventadminDeleteInvitationEndpoint38F40Fb9Data,
+	EventadminDeleteInvitationEndpoint38F40Fb9Errors,
+	EventadminDeleteInvitationEndpoint38F40Fb9Responses,
+	EventadminDeleteLogoE4111774Data,
+	EventadminDeleteLogoE4111774Responses,
+	EventadminDeleteRsvpBe54BbcfData,
+	EventadminDeleteRsvpBe54BbcfResponses,
+	EventadminDeleteTicketTier1D0E7C44Data,
+	EventadminDeleteTicketTier1D0E7C44Responses,
+	EventadminGetRsvpFfff5A62Data,
+	EventadminGetRsvpFfff5A62Responses,
+	EventadminGetTicketCe124C38Data,
+	EventadminGetTicketCe124C38Responses,
+	EventadminListEventTokensA00318C2Data,
+	EventadminListEventTokensA00318C2Responses,
+	EventadminListInvitationRequestsCd34C64bData,
+	EventadminListInvitationRequestsCd34C64bResponses,
+	EventadminListInvitationsF2Bb3Cb9Data,
+	EventadminListInvitationsF2Bb3Cb9Responses,
+	EventadminListPendingInvitations5F282536Data,
+	EventadminListPendingInvitations5F282536Responses,
+	EventadminListRsvps8Ad05025Data,
+	EventadminListRsvps8Ad05025Responses,
+	EventadminListTickets458061F5Data,
+	EventadminListTickets458061F5Responses,
+	EventadminListTicketTiers59879806Data,
+	EventadminListTicketTiers59879806Responses,
+	EventadminMarkTicketRefunded0Cf0F029Data,
+	EventadminMarkTicketRefunded0Cf0F029Responses,
+	EventadminRejectInvitationRequestD9389077Data,
+	EventadminRejectInvitationRequestD9389077Responses,
+	EventadminRemoveTags62E32901Data,
+	EventadminRemoveTags62E32901Responses,
+	EventadminUpdateEvent3Ad899D2Data,
+	EventadminUpdateEvent3Ad899D2Errors,
+	EventadminUpdateEvent3Ad899D2Responses,
+	EventadminUpdateEventStatus68Fc4E39Data,
+	EventadminUpdateEventStatus68Fc4E39Responses,
+	EventadminUpdateEventTokenE2D9030bData,
+	EventadminUpdateEventTokenE2D9030bResponses,
+	EventadminUpdateRsvpF8E082B7Data,
+	EventadminUpdateRsvpF8E082B7Responses,
+	EventadminUpdateTicketTierAe1D4E8aData,
+	EventadminUpdateTicketTierAe1D4E8aResponses,
+	EventadminUploadCoverArt83630BfcData,
+	EventadminUploadCoverArt83630BfcResponses,
+	EventadminUploadLogo0A9764F8Data,
+	EventadminUploadLogo0A9764F8Responses,
+	EventClaimInvitation5E9C84C8Data,
+	EventClaimInvitation5E9C84C8Errors,
+	EventClaimInvitation5E9C84C8Responses,
+	EventCreateInvitationRequestBdfc94B7Data,
+	EventCreateInvitationRequestBdfc94B7Responses,
+	EventDeleteInvitationRequest0B935E61Data,
+	EventDeleteInvitationRequest0B935E61Responses,
+	EventGetEventAttendees798A730cData,
+	EventGetEventAttendees798A730cResponses,
+	EventGetEventBySlugs311D61BbData,
+	EventGetEventBySlugs311D61BbResponses,
+	EventGetEventD6F13929Data,
+	EventGetEventD6F13929Responses,
+	EventGetMyEventStatus229B6062Data,
+	EventGetMyEventStatus229B6062Responses,
+	EventGetQuestionnaireCc423C0cData,
+	EventGetQuestionnaireCc423C0cResponses,
+	EventListEvents23D151A0Data,
+	EventListEvents23D151A0Responses,
+	EventListResources8512C98eData,
+	EventListResources8512C98eResponses,
+	EventListTiers8D0D74DfData,
+	EventListTiers8D0D74DfResponses,
+	EventListUserInvitationRequests497500D2Data,
+	EventListUserInvitationRequests497500D2Responses,
+	EventRsvpEvent417D6F93Data,
+	EventRsvpEvent417D6F93Errors,
+	EventRsvpEvent417D6F93Responses,
+	EventseriesadminAddTagsEdecd586Data,
+	EventseriesadminAddTagsEdecd586Responses,
+	EventseriesadminClearTags3Be88830Data,
+	EventseriesadminClearTags3Be88830Responses,
+	EventseriesadminDeleteCoverArtD482Bb1dData,
+	EventseriesadminDeleteCoverArtD482Bb1dResponses,
+	EventseriesadminDeleteEventSeriesE0020657Data,
+	EventseriesadminDeleteEventSeriesE0020657Responses,
+	EventseriesadminDeleteLogo8801A010Data,
+	EventseriesadminDeleteLogo8801A010Responses,
+	EventseriesadminRemoveTags748118B9Data,
+	EventseriesadminRemoveTags748118B9Responses,
+	EventseriesadminUpdateEventSeries3912324eData,
+	EventseriesadminUpdateEventSeries3912324eErrors,
+	EventseriesadminUpdateEventSeries3912324eResponses,
+	EventseriesadminUploadCoverArt5Eb583C2Data,
+	EventseriesadminUploadCoverArt5Eb583C2Responses,
+	EventseriesadminUploadLogo454Bc4C2Data,
+	EventseriesadminUploadLogo454Bc4C2Responses,
+	EventseriesGetEventSeriesBySlugs305F958fData,
+	EventseriesGetEventSeriesBySlugs305F958fResponses,
+	EventseriesGetEventSeriesF286001eData,
+	EventseriesGetEventSeriesF286001eResponses,
+	EventseriesListEventSeries695C7F05Data,
+	EventseriesListEventSeries695C7F05Responses,
+	EventseriesListResources9E3B380eData,
+	EventseriesListResources9E3B380eResponses,
+	EventSubmitQuestionnaireA3213FddData,
+	EventSubmitQuestionnaireA3213FddErrors,
+	EventSubmitQuestionnaireA3213FddResponses,
+	EventTicketCheckoutEf1Cc44dData,
+	EventTicketCheckoutEf1Cc44dErrors,
+	EventTicketCheckoutEf1Cc44dResponses,
+	EventTicketPwycCheckoutD2F9D317Data,
+	EventTicketPwycCheckoutD2F9D317Errors,
+	EventTicketPwycCheckoutD2F9D317Responses,
+	OrganizationadminAddStaff24421D52Data,
+	OrganizationadminAddStaff24421D52Responses,
+	OrganizationadminAddTagsD8D73E41Data,
+	OrganizationadminAddTagsD8D73E41Responses,
+	OrganizationadminApproveMembershipRequest742E6595Data,
+	OrganizationadminApproveMembershipRequest742E6595Responses,
+	OrganizationadminClearTagsFce87Df0Data,
+	OrganizationadminClearTagsFce87Df0Responses,
+	OrganizationadminCreateEvent5D6D9536Data,
+	OrganizationadminCreateEvent5D6D9536Errors,
+	OrganizationadminCreateEvent5D6D9536Responses,
+	OrganizationadminCreateEventSeries0E8E48F6Data,
+	OrganizationadminCreateEventSeries0E8E48F6Errors,
+	OrganizationadminCreateEventSeries0E8E48F6Responses,
+	OrganizationadminCreateOrganizationToken60E5F681Data,
+	OrganizationadminCreateOrganizationToken60E5F681Responses,
+	OrganizationadminCreateResource626F66F9Data,
+	OrganizationadminCreateResource626F66F9Responses,
+	OrganizationadminDeleteCoverArtB1Ab5A10Data,
+	OrganizationadminDeleteCoverArtB1Ab5A10Responses,
+	OrganizationadminDeleteLogo01Cb7A33Data,
+	OrganizationadminDeleteLogo01Cb7A33Responses,
+	OrganizationadminDeleteOrganizationTokenB1187879Data,
+	OrganizationadminDeleteOrganizationTokenB1187879Responses,
+	OrganizationadminDeleteResource07D5A13bData,
+	OrganizationadminDeleteResource07D5A13bResponses,
+	OrganizationadminGetOrganizationE58408BeData,
+	OrganizationadminGetOrganizationE58408BeResponses,
+	OrganizationadminGetResource188Bd9CeData,
+	OrganizationadminGetResource188Bd9CeResponses,
+	OrganizationadminListMembers8439C293Data,
+	OrganizationadminListMembers8439C293Responses,
+	OrganizationadminListMembershipRequests1Fe08280Data,
+	OrganizationadminListMembershipRequests1Fe08280Responses,
+	OrganizationadminListOrganizationTokensCa448BedData,
+	OrganizationadminListOrganizationTokensCa448BedResponses,
+	OrganizationadminListResourcesE64E26E7Data,
+	OrganizationadminListResourcesE64E26E7Responses,
+	OrganizationadminListStaff43C6669aData,
+	OrganizationadminListStaff43C6669aResponses,
+	OrganizationadminRejectMembershipRequest2B977B40Data,
+	OrganizationadminRejectMembershipRequest2B977B40Responses,
+	OrganizationadminRemoveMemberD2C3B638Data,
+	OrganizationadminRemoveMemberD2C3B638Responses,
+	OrganizationadminRemoveStaff1Cc5B08bData,
+	OrganizationadminRemoveStaff1Cc5B08bResponses,
+	OrganizationadminRemoveTags6A00Ef16Data,
+	OrganizationadminRemoveTags6A00Ef16Responses,
+	OrganizationadminStripeAccountVerify5337F3F2Data,
+	OrganizationadminStripeAccountVerify5337F3F2Responses,
+	OrganizationadminStripeConnect9Aef347dData,
+	OrganizationadminStripeConnect9Aef347dResponses,
+	OrganizationadminUpdateOrganizationEe5B024aData,
+	OrganizationadminUpdateOrganizationEe5B024aResponses,
+	OrganizationadminUpdateOrganizationToken0270752dData,
+	OrganizationadminUpdateOrganizationToken0270752dResponses,
+	OrganizationadminUpdateResource852Ec77bData,
+	OrganizationadminUpdateResource852Ec77bResponses,
+	OrganizationadminUpdateStaffPermissions77Dae2EbData,
+	OrganizationadminUpdateStaffPermissions77Dae2EbResponses,
+	OrganizationadminUploadCoverArt3F00Bfd7Data,
+	OrganizationadminUploadCoverArt3F00Bfd7Responses,
+	OrganizationadminUploadLogoFe609D30Data,
+	OrganizationadminUploadLogoFe609D30Responses,
+	OrganizationClaimInvitation54B9F34bData,
+	OrganizationClaimInvitation54B9F34bErrors,
+	OrganizationClaimInvitation54B9F34bResponses,
+	OrganizationCreateMembershipRequest5Cf8052cData,
+	OrganizationCreateMembershipRequest5Cf8052cResponses,
+	OrganizationGetOrganization1E83Fee3Data,
+	OrganizationGetOrganization1E83Fee3Responses,
+	OrganizationListOrganizations677967C6Data,
+	OrganizationListOrganizations677967C6Responses,
+	OrganizationListResourcesDfae4Ce0Data,
+	OrganizationListResourcesDfae4Ce0Responses,
+	OtpDisableOtp0Db1Dc6aData,
+	OtpDisableOtp0Db1Dc6aResponses,
+	OtpEnableOtpD67A68A0Data,
+	OtpEnableOtpD67A68A0Responses,
+	OtpSetupOtpD344D864Data,
+	OtpSetupOtpD344D864Responses,
+	PermissionMyPermissions0B7734E0Data,
+	PermissionMyPermissions0B7734E0Responses,
+	PotluckClaimPotluckItem0Ed17079Data,
+	PotluckClaimPotluckItem0Ed17079Responses,
+	PotluckCreatePotluckItemC97Ec366Data,
+	PotluckCreatePotluckItemC97Ec366Responses,
+	PotluckDeletePotluckItem743Da4DbData,
+	PotluckDeletePotluckItem743Da4DbResponses,
+	PotluckListPotluckItems7962228cData,
+	PotluckListPotluckItems7962228cResponses,
+	PotluckUnclaimPotluckItem75438D08Data,
+	PotluckUnclaimPotluckItem75438D08Responses,
+	PotluckUpdatePotluckItem95775212Data,
+	PotluckUpdatePotluckItem95775212Responses,
+	QuestionnaireAssignEvent6C0D8657Data,
+	QuestionnaireAssignEvent6C0D8657Responses,
+	QuestionnaireAssignEventSeriesE8D3A08fData,
+	QuestionnaireAssignEventSeriesE8D3A08fResponses,
+	QuestionnaireCreateFtQuestion093Ed38dData,
+	QuestionnaireCreateFtQuestion093Ed38dResponses,
+	QuestionnaireCreateMcOption8006A4E9Data,
+	QuestionnaireCreateMcOption8006A4E9Responses,
+	QuestionnaireCreateMcQuestion20D1Da93Data,
+	QuestionnaireCreateMcQuestion20D1Da93Responses,
+	QuestionnaireCreateOrgQuestionnaireF91E8483Data,
+	QuestionnaireCreateOrgQuestionnaireF91E8483Errors,
+	QuestionnaireCreateOrgQuestionnaireF91E8483Responses,
+	QuestionnaireCreateSection6946F67bData,
+	QuestionnaireCreateSection6946F67bResponses,
+	QuestionnaireDeleteFtQuestion996D4F7cData,
+	QuestionnaireDeleteFtQuestion996D4F7cResponses,
+	QuestionnaireDeleteMcOption61152CdaData,
+	QuestionnaireDeleteMcOption61152CdaResponses,
+	QuestionnaireDeleteMcQuestion33E11B28Data,
+	QuestionnaireDeleteMcQuestion33E11B28Responses,
+	QuestionnaireDeleteOrgQuestionnaireBec1C8C9Data,
+	QuestionnaireDeleteOrgQuestionnaireBec1C8C9Responses,
+	QuestionnaireDeleteSection01B1Bce7Data,
+	QuestionnaireDeleteSection01B1Bce7Responses,
+	QuestionnaireEvaluateSubmissionD114F4AdData,
+	QuestionnaireEvaluateSubmissionD114F4AdErrors,
+	QuestionnaireEvaluateSubmissionD114F4AdResponses,
+	QuestionnaireGetOrgQuestionnaireFd2Ed8F8Data,
+	QuestionnaireGetOrgQuestionnaireFd2Ed8F8Responses,
+	QuestionnaireGetSubmissionDetail334A11E6Data,
+	QuestionnaireGetSubmissionDetail334A11E6Responses,
+	QuestionnaireListOrgQuestionnaires49D842F3Data,
+	QuestionnaireListOrgQuestionnaires49D842F3Responses,
+	QuestionnaireListSubmissions0C906E39Data,
+	QuestionnaireListSubmissions0C906E39Responses,
+	QuestionnaireReplaceEvents753A3A83Data,
+	QuestionnaireReplaceEvents753A3A83Responses,
+	QuestionnaireReplaceEventSeries6F47FafeData,
+	QuestionnaireReplaceEventSeries6F47FafeResponses,
+	QuestionnaireUnassignEvent65E181A3Data,
+	QuestionnaireUnassignEvent65E181A3Responses,
+	QuestionnaireUnassignEventSeriesC4B9708aData,
+	QuestionnaireUnassignEventSeriesC4B9708aResponses,
+	QuestionnaireUpdateFtQuestionE5F3Ee15Data,
+	QuestionnaireUpdateFtQuestionE5F3Ee15Responses,
+	QuestionnaireUpdateMcOptionE6Fac541Data,
+	QuestionnaireUpdateMcOptionE6Fac541Responses,
+	QuestionnaireUpdateMcQuestion3D37Cc5fData,
+	QuestionnaireUpdateMcQuestion3D37Cc5fResponses,
+	QuestionnaireUpdateOrgQuestionnaire1812Acc4Data,
+	QuestionnaireUpdateOrgQuestionnaire1812Acc4Responses,
+	QuestionnaireUpdateQuestionnaireStatus4340C259Data,
+	QuestionnaireUpdateQuestionnaireStatus4340C259Responses,
+	QuestionnaireUpdateSection2Ae3Ace9Data,
+	QuestionnaireUpdateSection2Ae3Ace9Responses,
+	StripewebhookHandleWebhook7Ce75AaaData,
+	StripewebhookHandleWebhook7Ce75AaaResponses,
+	TagListTags4B7C76E5Data,
+	TagListTags4B7C76E5Responses,
 	TokenRefreshData,
 	TokenRefreshResponses,
-	UserpreferencesGetEventPreferences3D6F9189Data,
-	UserpreferencesGetEventPreferences3D6F9189Responses,
-	UserpreferencesGetEventSeriesPreferencesAa9Fac27Data,
-	UserpreferencesGetEventSeriesPreferencesAa9Fac27Responses,
-	UserpreferencesGetGeneralPreferencesA2Ac890eData,
-	UserpreferencesGetGeneralPreferencesA2Ac890eResponses,
-	UserpreferencesGetOrganizationPreferences949D37A6Data,
-	UserpreferencesGetOrganizationPreferences949D37A6Responses,
-	UserpreferencesUpdateEventPreferences3Ca1F5D4Data,
-	UserpreferencesUpdateEventPreferences3Ca1F5D4Responses,
-	UserpreferencesUpdateEventSeriesPreferences1645B0AaData,
-	UserpreferencesUpdateEventSeriesPreferences1645B0AaResponses,
-	UserpreferencesUpdateGlobalPreferencesCa70F70eData,
-	UserpreferencesUpdateGlobalPreferencesCa70F70eResponses,
-	UserpreferencesUpdateOrganizationPreferencesC6Ac6679Data,
-	UserpreferencesUpdateOrganizationPreferencesC6Ac6679Responses
+	UserpreferencesGetEventPreferencesFcb49Eb8Data,
+	UserpreferencesGetEventPreferencesFcb49Eb8Responses,
+	UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Data,
+	UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Responses,
+	UserpreferencesGetGeneralPreferences9Aea63E9Data,
+	UserpreferencesGetGeneralPreferences9Aea63E9Responses,
+	UserpreferencesGetOrganizationPreferences88F57589Data,
+	UserpreferencesGetOrganizationPreferences88F57589Responses,
+	UserpreferencesUpdateEventPreferences501B0Ad6Data,
+	UserpreferencesUpdateEventPreferences501B0Ad6Responses,
+	UserpreferencesUpdateEventSeriesPreferences193210FbData,
+	UserpreferencesUpdateEventSeriesPreferences193210FbResponses,
+	UserpreferencesUpdateGlobalPreferencesD739D116Data,
+	UserpreferencesUpdateGlobalPreferencesD739D116Responses,
+	UserpreferencesUpdateOrganizationPreferences195D88D0Data,
+	UserpreferencesUpdateOrganizationPreferences195D88D0Responses
 } from './types.gen';
 
 export type Options<
@@ -437,9 +437,9 @@ export const apiApiHealthcheck = <ThrowOnError extends boolean = false>(
  * Users registered via Google SSO must use POST /auth/google/login instead.
  */
 export const authObtainToken = <ThrowOnError extends boolean = false>(
-	options: Options<AuthObtainTokenF0Ed10A6Data, ThrowOnError>
+	options: Options<AuthObtainToken1Ada7A04Data, ThrowOnError>
 ) => {
-	return (options.client ?? client).post<AuthObtainTokenF0Ed10A6Responses, unknown, ThrowOnError>({
+	return (options.client ?? client).post<AuthObtainToken1Ada7A04Responses, unknown, ThrowOnError>({
 		url: '/api/auth/token/pair',
 		...options,
 		headers: {
@@ -475,10 +475,10 @@ export const tokenRefresh = <ThrowOnError extends boolean = false>(
  * Email must end with @example.com.
  */
 export const authDemoObtainToken = <ThrowOnError extends boolean = false>(
-	options: Options<AuthDemoObtainTokenF9683D25Data, ThrowOnError>
+	options: Options<AuthDemoObtainTokenC30F0580Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		AuthDemoObtainTokenF9683D25Responses,
+		AuthDemoObtainTokenC30F0580Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -501,10 +501,10 @@ export const authDemoObtainToken = <ThrowOnError extends boolean = false>(
  * pair on success. Returns 401 if the TOTP code is invalid.
  */
 export const authObtainTokenWithOtp = <ThrowOnError extends boolean = false>(
-	options: Options<AuthObtainTokenWithOtpCad64Ee2Data, ThrowOnError>
+	options: Options<AuthObtainTokenWithOtp6Dee1057Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		AuthObtainTokenWithOtpCad64Ee2Responses,
+		AuthObtainTokenWithOtp6Dee1057Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -527,9 +527,9 @@ export const authObtainTokenWithOtp = <ThrowOnError extends boolean = false>(
  * use password-based authentication.
  */
 export const authGoogleLogin = <ThrowOnError extends boolean = false>(
-	options: Options<AuthGoogleLogin778Da160Data, ThrowOnError>
+	options: Options<AuthGoogleLogin03Be8978Data, ThrowOnError>
 ) => {
-	return (options.client ?? client).post<AuthGoogleLogin778Da160Responses, unknown, ThrowOnError>({
+	return (options.client ?? client).post<AuthGoogleLogin03Be8978Responses, unknown, ThrowOnError>({
 		url: '/api/auth/google/login',
 		...options,
 		headers: {
@@ -549,9 +549,9 @@ export const authGoogleLogin = <ThrowOnError extends boolean = false>(
  * POST /otp/verify to activate 2FA.
  */
 export const otpSetupOtp = <ThrowOnError extends boolean = false>(
-	options?: Options<OtpSetupOtpB2211117Data, ThrowOnError>
+	options?: Options<OtpSetupOtpD344D864Data, ThrowOnError>
 ) => {
-	return (options?.client ?? client).get<OtpSetupOtpB2211117Responses, unknown, ThrowOnError>({
+	return (options?.client ?? client).get<OtpSetupOtpD344D864Responses, unknown, ThrowOnError>({
 		security: [
 			{
 				scheme: 'bearer',
@@ -573,9 +573,9 @@ export const otpSetupOtp = <ThrowOnError extends boolean = false>(
  * will require the TOTP code via POST /auth/token/pair/otp. Returns 403 if code is invalid.
  */
 export const otpEnableOtp = <ThrowOnError extends boolean = false>(
-	options: Options<OtpEnableOtpBd1478D0Data, ThrowOnError>
+	options: Options<OtpEnableOtpD67A68A0Data, ThrowOnError>
 ) => {
-	return (options.client ?? client).post<OtpEnableOtpBd1478D0Responses, unknown, ThrowOnError>({
+	return (options.client ?? client).post<OtpEnableOtpD67A68A0Responses, unknown, ThrowOnError>({
 		security: [
 			{
 				scheme: 'bearer',
@@ -601,9 +601,9 @@ export const otpEnableOtp = <ThrowOnError extends boolean = false>(
  * if the TOTP code is invalid.
  */
 export const otpDisableOtp = <ThrowOnError extends boolean = false>(
-	options: Options<OtpDisableOtp44832EbfData, ThrowOnError>
+	options: Options<OtpDisableOtp0Db1Dc6aData, ThrowOnError>
 ) => {
-	return (options.client ?? client).post<OtpDisableOtp44832EbfResponses, unknown, ThrowOnError>({
+	return (options.client ?? client).post<OtpDisableOtp0Db1Dc6aResponses, unknown, ThrowOnError>({
 		security: [
 			{
 				scheme: 'bearer',
@@ -629,10 +629,10 @@ export const otpDisableOtp = <ThrowOnError extends boolean = false>(
  * prevent abuse.
  */
 export const accountExportData = <ThrowOnError extends boolean = false>(
-	options?: Options<AccountExportData68C7E4DbData, ThrowOnError>
+	options?: Options<AccountExportDataBa4Eefa4Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).post<
-		AccountExportData68C7E4DbResponses,
+		AccountExportDataBa4Eefa4Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -656,9 +656,9 @@ export const accountExportData = <ThrowOnError extends boolean = false>(
  * Use this to display user info in the UI or verify authentication status.
  */
 export const accountMe = <ThrowOnError extends boolean = false>(
-	options?: Options<AccountMe6420Cff8Data, ThrowOnError>
+	options?: Options<AccountMe250Fac7cData, ThrowOnError>
 ) => {
-	return (options?.client ?? client).get<AccountMe6420Cff8Responses, unknown, ThrowOnError>({
+	return (options?.client ?? client).get<AccountMe250Fac7cResponses, unknown, ThrowOnError>({
 		security: [
 			{
 				scheme: 'bearer',
@@ -679,10 +679,10 @@ export const accountMe = <ThrowOnError extends boolean = false>(
  * fields are updated. Returns the updated user profile.
  */
 export const accountUpdateProfile = <ThrowOnError extends boolean = false>(
-	options: Options<AccountUpdateProfile5D6D1Db7Data, ThrowOnError>
+	options: Options<AccountUpdateProfileC460A981Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		AccountUpdateProfile5D6D1Db7Responses,
+		AccountUpdateProfileC460A981Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -712,9 +712,9 @@ export const accountUpdateProfile = <ThrowOnError extends boolean = false>(
  * account already exists.
  */
 export const accountRegister = <ThrowOnError extends boolean = false>(
-	options: Options<AccountRegister0E682147Data, ThrowOnError>
+	options: Options<AccountRegister60A39A8dData, ThrowOnError>
 ) => {
-	return (options.client ?? client).post<AccountRegister0E682147Responses, unknown, ThrowOnError>({
+	return (options.client ?? client).post<AccountRegister60A39A8dResponses, unknown, ThrowOnError>({
 		url: '/api/account/register',
 		...options,
 		headers: {
@@ -734,10 +734,10 @@ export const accountRegister = <ThrowOnError extends boolean = false>(
  * The verification token is single-use and expires after a set period.
  */
 export const accountVerifyEmail = <ThrowOnError extends boolean = false>(
-	options: Options<AccountVerifyEmailC5B88297Data, ThrowOnError>
+	options: Options<AccountVerifyEmailC1Db4Da9Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		AccountVerifyEmailC5B88297Responses,
+		AccountVerifyEmailC1Db4Da9Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -759,11 +759,11 @@ export const accountVerifyEmail = <ThrowOnError extends boolean = false>(
  * email is already verified. Requires authentication with the unverified account's JWT.
  */
 export const accountResendVerificationEmail = <ThrowOnError extends boolean = false>(
-	options?: Options<AccountResendVerificationEmailDca4C406Data, ThrowOnError>
+	options?: Options<AccountResendVerificationEmail58F3B280Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).post<
-		AccountResendVerificationEmailDca4C406Responses,
-		AccountResendVerificationEmailDca4C406Errors,
+		AccountResendVerificationEmail58F3B280Responses,
+		AccountResendVerificationEmail58F3B280Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -787,10 +787,10 @@ export const accountResendVerificationEmail = <ThrowOnError extends boolean = fa
  * This two-step process prevents accidental deletions.
  */
 export const accountDeleteAccountRequest = <ThrowOnError extends boolean = false>(
-	options?: Options<AccountDeleteAccountRequest8786843dData, ThrowOnError>
+	options?: Options<AccountDeleteAccountRequest36F5A4F2Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).post<
-		AccountDeleteAccountRequest8786843dResponses,
+		AccountDeleteAccountRequest36F5A4F2Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -811,14 +811,15 @@ export const accountDeleteAccountRequest = <ThrowOnError extends boolean = false
  * Permanently delete the account using the confirmation token from email.
  *
  * Call this with the token received via email after POST /account/delete-request.
- * This action is irreversible and deletes all user data. The deletion token is
- * single-use and expires after a set period.
+ * This action is irreversible and deletes all user data. The deletion is processed
+ * asynchronously in the background. The deletion token is single-use and expires
+ * after a set period.
  */
 export const accountDeleteAccountConfirm = <ThrowOnError extends boolean = false>(
-	options: Options<AccountDeleteAccountConfirm51Aca775Data, ThrowOnError>
+	options: Options<AccountDeleteAccountConfirm77E53A9bData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		AccountDeleteAccountConfirm51Aca775Responses,
+		AccountDeleteAccountConfirm77E53A9bResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -841,10 +842,10 @@ export const accountDeleteAccountConfirm = <ThrowOnError extends boolean = false
  * endpoint. After receiving the email, use POST /account/password/reset with the token.
  */
 export const accountResetPasswordRequest = <ThrowOnError extends boolean = false>(
-	options: Options<AccountResetPasswordRequest159B2A43Data, ThrowOnError>
+	options: Options<AccountResetPasswordRequest6Ca44671Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		AccountResetPasswordRequest159B2A43Responses,
+		AccountResetPasswordRequest6Ca44671Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -867,10 +868,10 @@ export const accountResetPasswordRequest = <ThrowOnError extends boolean = false
  * expires after a set period. After reset, the user must login again with the new password.
  */
 export const accountResetPassword = <ThrowOnError extends boolean = false>(
-	options: Options<AccountResetPassword03A7Fc3dData, ThrowOnError>
+	options: Options<AccountResetPassword1Fb3F0E6Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		AccountResetPassword03A7Fc3dResponses,
+		AccountResetPassword1Fb3F0E6Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -893,10 +894,10 @@ export const accountResetPassword = <ThrowOnError extends boolean = false>(
  * sections in the UI.
  */
 export const dashboardDashboardOrganizations = <ThrowOnError extends boolean = false>(
-	options?: Options<DashboardDashboardOrganizations03Daa3C4Data, ThrowOnError>
+	options?: Options<DashboardDashboardOrganizationsF23703B2Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		DashboardDashboardOrganizations03Daa3C4Responses,
+		DashboardDashboardOrganizationsF23703B2Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -921,10 +922,10 @@ export const dashboardDashboardOrganizations = <ThrowOnError extends boolean = f
  * display "My Events" sections in the UI.
  */
 export const dashboardDashboardEvents = <ThrowOnError extends boolean = false>(
-	options?: Options<DashboardDashboardEvents6Cb96588Data, ThrowOnError>
+	options?: Options<DashboardDashboardEventsAae8306bData, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		DashboardDashboardEvents6Cb96588Responses,
+		DashboardDashboardEventsAae8306bResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -948,10 +949,10 @@ export const dashboardDashboardEvents = <ThrowOnError extends boolean = false>(
  * series you have permission to view. Use this to display "My Series" sections in the UI.
  */
 export const dashboardDashboardEventSeries = <ThrowOnError extends boolean = false>(
-	options?: Options<DashboardDashboardEventSeriesC961639bData, ThrowOnError>
+	options?: Options<DashboardDashboardEventSeries5D1Acbc6Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		DashboardDashboardEventSeriesC961639bResponses,
+		DashboardDashboardEventSeries5D1Acbc6Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -975,10 +976,10 @@ export const dashboardDashboardEventSeries = <ThrowOnError extends boolean = fal
  * Use this to display a "Pending Invitations" section prompting users to RSVP or purchase tickets.
  */
 export const dashboardDashboardInvitations = <ThrowOnError extends boolean = false>(
-	options?: Options<DashboardDashboardInvitations2F2132B0Data, ThrowOnError>
+	options?: Options<DashboardDashboardInvitations7Ee7C5BaData, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		DashboardDashboardInvitations2F2132B0Responses,
+		DashboardDashboardInvitations7Ee7C5BaResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1003,10 +1004,10 @@ export const dashboardDashboardInvitations = <ThrowOnError extends boolean = fal
  * or reverse with '-name'. Supports text search and filtering.
  */
 export const organizationListOrganizations = <ThrowOnError extends boolean = false>(
-	options?: Options<OrganizationListOrganizations3C31A7EaData, ThrowOnError>
+	options?: Options<OrganizationListOrganizations677967C6Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		OrganizationListOrganizations3C31A7EaResponses,
+		OrganizationListOrganizations677967C6Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1030,10 +1031,10 @@ export const organizationListOrganizations = <ThrowOnError extends boolean = fal
  * settings. Use this to display the organization profile page.
  */
 export const organizationGetOrganization = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationGetOrganization45F68219Data, ThrowOnError>
+	options: Options<OrganizationGetOrganization1E83Fee3Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationGetOrganization45F68219Responses,
+		OrganizationGetOrganization1E83Fee3Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1057,10 +1058,10 @@ export const organizationGetOrganization = <ThrowOnError extends boolean = false
  * be public or restricted to members only. Supports filtering by type and text search.
  */
 export const organizationListResources = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationListResources902770CcData, ThrowOnError>
+	options: Options<OrganizationListResourcesDfae4Ce0Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationListResources902770CcResponses,
+		OrganizationListResourcesDfae4Ce0Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1085,10 +1086,10 @@ export const organizationListResources = <ThrowOnError extends boolean = false>(
  * request for tracking status.
  */
 export const organizationCreateMembershipRequest = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationCreateMembershipRequestC7302D18Data, ThrowOnError>
+	options: Options<OrganizationCreateMembershipRequest5Cf8052cData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationCreateMembershipRequestC7302D18Responses,
+		OrganizationCreateMembershipRequest5Cf8052cResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1117,11 +1118,11 @@ export const organizationCreateMembershipRequest = <ThrowOnError extends boolean
  * or 400 if the token is invalid/expired.
  */
 export const organizationClaimInvitation = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationClaimInvitation5C32FadfData, ThrowOnError>
+	options: Options<OrganizationClaimInvitation54B9F34bData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationClaimInvitation5C32FadfResponses,
-		OrganizationClaimInvitation5C32FadfErrors,
+		OrganizationClaimInvitation54B9F34bResponses,
+		OrganizationClaimInvitation54B9F34bErrors,
 		ThrowOnError
 	>({
 		security: [
@@ -1141,10 +1142,10 @@ export const organizationClaimInvitation = <ThrowOnError extends boolean = false
  * Get comprehensive organization details including all platform fee and Stripe fields.
  */
 export const organizationadminGetOrganization = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminGetOrganization52A02A44Data, ThrowOnError>
+	options: Options<OrganizationadminGetOrganizationE58408BeData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationadminGetOrganization52A02A44Responses,
+		OrganizationadminGetOrganizationE58408BeResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1165,10 +1166,10 @@ export const organizationadminGetOrganization = <ThrowOnError extends boolean = 
  * Update organization by slug.
  */
 export const organizationadminUpdateOrganization = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminUpdateOrganization6E5B1F9bData, ThrowOnError>
+	options: Options<OrganizationadminUpdateOrganizationEe5B024aData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		OrganizationadminUpdateOrganization6E5B1F9bResponses,
+		OrganizationadminUpdateOrganizationEe5B024aResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1193,10 +1194,10 @@ export const organizationadminUpdateOrganization = <ThrowOnError extends boolean
  * Get a link to onboard the organization to Stripe.
  */
 export const organizationadminStripeConnect = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminStripeConnect5702Ef2eData, ThrowOnError>
+	options: Options<OrganizationadminStripeConnect9Aef347dData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminStripeConnect5702Ef2eResponses,
+		OrganizationadminStripeConnect9Aef347dResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1217,10 +1218,10 @@ export const organizationadminStripeConnect = <ThrowOnError extends boolean = fa
  * Get the organization's Stripe account status.
  */
 export const organizationadminStripeAccountVerify = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminStripeAccountVerify3F404331Data, ThrowOnError>
+	options: Options<OrganizationadminStripeAccountVerify5337F3F2Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminStripeAccountVerify3F404331Responses,
+		OrganizationadminStripeAccountVerify5337F3F2Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1241,10 +1242,10 @@ export const organizationadminStripeAccountVerify = <ThrowOnError extends boolea
  * Upload logo to organization.
  */
 export const organizationadminUploadLogo = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminUploadLogoB141E351Data, ThrowOnError>
+	options: Options<OrganizationadminUploadLogoFe609D30Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminUploadLogoB141E351Responses,
+		OrganizationadminUploadLogoFe609D30Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1270,10 +1271,10 @@ export const organizationadminUploadLogo = <ThrowOnError extends boolean = false
  * Upload cover art to organization.
  */
 export const organizationadminUploadCoverArt = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminUploadCoverArtF9C552CbData, ThrowOnError>
+	options: Options<OrganizationadminUploadCoverArt3F00Bfd7Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminUploadCoverArtF9C552CbResponses,
+		OrganizationadminUploadCoverArt3F00Bfd7Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1299,10 +1300,10 @@ export const organizationadminUploadCoverArt = <ThrowOnError extends boolean = f
  * Delete logo from organization.
  */
 export const organizationadminDeleteLogo = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminDeleteLogo2B684AbaData, ThrowOnError>
+	options: Options<OrganizationadminDeleteLogo01Cb7A33Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		OrganizationadminDeleteLogo2B684AbaResponses,
+		OrganizationadminDeleteLogo01Cb7A33Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1323,10 +1324,10 @@ export const organizationadminDeleteLogo = <ThrowOnError extends boolean = false
  * Delete cover art from organization.
  */
 export const organizationadminDeleteCoverArt = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminDeleteCoverArt0F663C07Data, ThrowOnError>
+	options: Options<OrganizationadminDeleteCoverArtB1Ab5A10Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		OrganizationadminDeleteCoverArt0F663C07Responses,
+		OrganizationadminDeleteCoverArtB1Ab5A10Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1347,11 +1348,11 @@ export const organizationadminDeleteCoverArt = <ThrowOnError extends boolean = f
  * Create a new event series.
  */
 export const organizationadminCreateEventSeries = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminCreateEventSeries909F81BdData, ThrowOnError>
+	options: Options<OrganizationadminCreateEventSeries0E8E48F6Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminCreateEventSeries909F81BdResponses,
-		OrganizationadminCreateEventSeries909F81BdErrors,
+		OrganizationadminCreateEventSeries0E8E48F6Responses,
+		OrganizationadminCreateEventSeries0E8E48F6Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -1375,11 +1376,11 @@ export const organizationadminCreateEventSeries = <ThrowOnError extends boolean 
  * Create a new event.
  */
 export const organizationadminCreateEvent = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminCreateEvent051E2C16Data, ThrowOnError>
+	options: Options<OrganizationadminCreateEvent5D6D9536Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminCreateEvent051E2C16Responses,
-		OrganizationadminCreateEvent051E2C16Errors,
+		OrganizationadminCreateEvent5D6D9536Responses,
+		OrganizationadminCreateEvent5D6D9536Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -1402,11 +1403,13 @@ export const organizationadminCreateEvent = <ThrowOnError extends boolean = fals
  *
  * List all tokens for an organization that the user has admin rights for.
  */
-export const organizationadminListOrganizationTokens = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminListOrganizationTokensAd2141C7Data, ThrowOnError>
+export const organizationadminListOrganizationTokens = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<OrganizationadminListOrganizationTokensCa448BedData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationadminListOrganizationTokensAd2141C7Responses,
+		OrganizationadminListOrganizationTokensCa448BedResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1426,11 +1429,13 @@ export const organizationadminListOrganizationTokens = <ThrowOnError extends boo
  *
  * Create a new token for an organization.
  */
-export const organizationadminCreateOrganizationToken = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminCreateOrganizationTokenB11748D5Data, ThrowOnError>
+export const organizationadminCreateOrganizationToken = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<OrganizationadminCreateOrganizationToken60E5F681Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminCreateOrganizationTokenB11748D5Responses,
+		OrganizationadminCreateOrganizationToken60E5F681Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1454,11 +1459,13 @@ export const organizationadminCreateOrganizationToken = <ThrowOnError extends bo
  *
  * Delete an organization token.
  */
-export const organizationadminDeleteOrganizationToken = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminDeleteOrganizationToken920E477cData, ThrowOnError>
+export const organizationadminDeleteOrganizationToken = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<OrganizationadminDeleteOrganizationTokenB1187879Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		OrganizationadminDeleteOrganizationToken920E477cResponses,
+		OrganizationadminDeleteOrganizationTokenB1187879Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1478,11 +1485,13 @@ export const organizationadminDeleteOrganizationToken = <ThrowOnError extends bo
  *
  * Update an organization token.
  */
-export const organizationadminUpdateOrganizationToken = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminUpdateOrganizationToken5284Deb3Data, ThrowOnError>
+export const organizationadminUpdateOrganizationToken = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<OrganizationadminUpdateOrganizationToken0270752dData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		OrganizationadminUpdateOrganizationToken5284Deb3Responses,
+		OrganizationadminUpdateOrganizationToken0270752dResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1508,11 +1517,13 @@ export const organizationadminUpdateOrganizationToken = <ThrowOnError extends bo
  *
  * By default shows all requests. Use ?status=pending to filter by status.
  */
-export const organizationadminListMembershipRequests = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminListMembershipRequests2Bae90A0Data, ThrowOnError>
+export const organizationadminListMembershipRequests = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<OrganizationadminListMembershipRequests1Fe08280Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationadminListMembershipRequests2Bae90A0Responses,
+		OrganizationadminListMembershipRequests1Fe08280Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1532,11 +1543,13 @@ export const organizationadminListMembershipRequests = <ThrowOnError extends boo
  *
  * Approve a membership request.
  */
-export const organizationadminApproveMembershipRequest = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminApproveMembershipRequestE1Bd2D4fData, ThrowOnError>
+export const organizationadminApproveMembershipRequest = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<OrganizationadminApproveMembershipRequest742E6595Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminApproveMembershipRequestE1Bd2D4fResponses,
+		OrganizationadminApproveMembershipRequest742E6595Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1556,11 +1569,13 @@ export const organizationadminApproveMembershipRequest = <ThrowOnError extends b
  *
  * Reject a membership request.
  */
-export const organizationadminRejectMembershipRequest = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminRejectMembershipRequest48075D3fData, ThrowOnError>
+export const organizationadminRejectMembershipRequest = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<OrganizationadminRejectMembershipRequest2B977B40Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminRejectMembershipRequest48075D3fResponses,
+		OrganizationadminRejectMembershipRequest2B977B40Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1581,10 +1596,10 @@ export const organizationadminRejectMembershipRequest = <ThrowOnError extends bo
  * List all resources for a specific organization.
  */
 export const organizationadminListResources = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminListResources90241F4dData, ThrowOnError>
+	options: Options<OrganizationadminListResourcesE64E26E7Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationadminListResources90241F4dResponses,
+		OrganizationadminListResourcesE64E26E7Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1608,10 +1623,10 @@ export const organizationadminListResources = <ThrowOnError extends boolean = fa
  * For FILE type resources, include the file parameter.
  */
 export const organizationadminCreateResource = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminCreateResource42869D36Data, ThrowOnError>
+	options: Options<OrganizationadminCreateResource626F66F9Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminCreateResource42869D36Responses,
+		OrganizationadminCreateResource626F66F9Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1637,10 +1652,10 @@ export const organizationadminCreateResource = <ThrowOnError extends boolean = f
  * Delete a resource from the organization.
  */
 export const organizationadminDeleteResource = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminDeleteResource6D0C6Bf8Data, ThrowOnError>
+	options: Options<OrganizationadminDeleteResource07D5A13bData, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		OrganizationadminDeleteResource6D0C6Bf8Responses,
+		OrganizationadminDeleteResource07D5A13bResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1661,10 +1676,10 @@ export const organizationadminDeleteResource = <ThrowOnError extends boolean = f
  * Retrieve a specific resource for the organization.
  */
 export const organizationadminGetResource = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminGetResource3F8F93C9Data, ThrowOnError>
+	options: Options<OrganizationadminGetResource188Bd9CeData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationadminGetResource3F8F93C9Responses,
+		OrganizationadminGetResource188Bd9CeResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1685,10 +1700,10 @@ export const organizationadminGetResource = <ThrowOnError extends boolean = fals
  * Update a resource for the organization.
  */
 export const organizationadminUpdateResource = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminUpdateResource93D02613Data, ThrowOnError>
+	options: Options<OrganizationadminUpdateResource852Ec77bData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		OrganizationadminUpdateResource93D02613Responses,
+		OrganizationadminUpdateResource852Ec77bResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1713,10 +1728,10 @@ export const organizationadminUpdateResource = <ThrowOnError extends boolean = f
  * List all members of an organization.
  */
 export const organizationadminListMembers = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminListMembers3986D3D0Data, ThrowOnError>
+	options: Options<OrganizationadminListMembers8439C293Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationadminListMembers3986D3D0Responses,
+		OrganizationadminListMembers8439C293Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1737,10 +1752,10 @@ export const organizationadminListMembers = <ThrowOnError extends boolean = fals
  * Remove a member from an organization.
  */
 export const organizationadminRemoveMember = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminRemoveMember6Ec7227fData, ThrowOnError>
+	options: Options<OrganizationadminRemoveMemberD2C3B638Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		OrganizationadminRemoveMember6Ec7227fResponses,
+		OrganizationadminRemoveMemberD2C3B638Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1761,10 +1776,10 @@ export const organizationadminRemoveMember = <ThrowOnError extends boolean = fal
  * List all staff of an organization.
  */
 export const organizationadminListStaff = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminListStaff636E217aData, ThrowOnError>
+	options: Options<OrganizationadminListStaff43C6669aData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		OrganizationadminListStaff636E217aResponses,
+		OrganizationadminListStaff43C6669aResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1785,10 +1800,10 @@ export const organizationadminListStaff = <ThrowOnError extends boolean = false>
  * Remove a staff member from an organization.
  */
 export const organizationadminRemoveStaff = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminRemoveStaffEab475EfData, ThrowOnError>
+	options: Options<OrganizationadminRemoveStaff1Cc5B08bData, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		OrganizationadminRemoveStaffEab475EfResponses,
+		OrganizationadminRemoveStaff1Cc5B08bResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1809,10 +1824,10 @@ export const organizationadminRemoveStaff = <ThrowOnError extends boolean = fals
  * Add a staff member to an organization.
  */
 export const organizationadminAddStaff = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminAddStaff3E15765eData, ThrowOnError>
+	options: Options<OrganizationadminAddStaff24421D52Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminAddStaff3E15765eResponses,
+		OrganizationadminAddStaff24421D52Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1836,11 +1851,13 @@ export const organizationadminAddStaff = <ThrowOnError extends boolean = false>(
  *
  * Update a staff member's permissions.
  */
-export const organizationadminUpdateStaffPermissions = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminUpdateStaffPermissionsE7D1DdfdData, ThrowOnError>
+export const organizationadminUpdateStaffPermissions = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<OrganizationadminUpdateStaffPermissions77Dae2EbData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		OrganizationadminUpdateStaffPermissionsE7D1DdfdResponses,
+		OrganizationadminUpdateStaffPermissions77Dae2EbResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1865,10 +1882,10 @@ export const organizationadminUpdateStaffPermissions = <ThrowOnError extends boo
  * Clear akk tags from the organization.
  */
 export const organizationadminClearTags = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminClearTags943F2C71Data, ThrowOnError>
+	options: Options<OrganizationadminClearTagsFce87Df0Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		OrganizationadminClearTags943F2C71Responses,
+		OrganizationadminClearTagsFce87Df0Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1889,10 +1906,10 @@ export const organizationadminClearTags = <ThrowOnError extends boolean = false>
  * Add one or more tags to the organization.
  */
 export const organizationadminAddTags = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminAddTags1F41252aData, ThrowOnError>
+	options: Options<OrganizationadminAddTagsD8D73E41Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminAddTags1F41252aResponses,
+		OrganizationadminAddTagsD8D73E41Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1917,10 +1934,10 @@ export const organizationadminAddTags = <ThrowOnError extends boolean = false>(
  * Remove one or more tags from the organization.
  */
 export const organizationadminRemoveTags = <ThrowOnError extends boolean = false>(
-	options: Options<OrganizationadminRemoveTags17210274Data, ThrowOnError>
+	options: Options<OrganizationadminRemoveTags6A00Ef16Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		OrganizationadminRemoveTags17210274Responses,
+		OrganizationadminRemoveTags6A00Ef16Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -1951,9 +1968,9 @@ export const organizationadminRemoveTags = <ThrowOnError extends boolean = false
  * tags, and text search.
  */
 export const eventListEvents = <ThrowOnError extends boolean = false>(
-	options?: Options<EventListEvents7Fc6E819Data, ThrowOnError>
+	options?: Options<EventListEvents23D151A0Data, ThrowOnError>
 ) => {
-	return (options?.client ?? client).get<EventListEvents7Fc6E819Responses, unknown, ThrowOnError>({
+	return (options?.client ?? client).get<EventListEvents23D151A0Responses, unknown, ThrowOnError>({
 		security: [
 			{
 				scheme: 'bearer',
@@ -1975,11 +1992,11 @@ export const eventListEvents = <ThrowOnError extends boolean = false>(
  * and RSVP deadlines. Returns the event on success, or 400 if the token is invalid/expired.
  */
 export const eventClaimInvitation = <ThrowOnError extends boolean = false>(
-	options: Options<EventClaimInvitationA333Ba68Data, ThrowOnError>
+	options: Options<EventClaimInvitation5E9C84C8Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventClaimInvitationA333Ba68Responses,
-		EventClaimInvitationA333Ba68Errors,
+		EventClaimInvitation5E9C84C8Responses,
+		EventClaimInvitation5E9C84C8Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -2003,10 +2020,10 @@ export const eventClaimInvitation = <ThrowOnError extends boolean = false>(
  * and event creators always have access.
  */
 export const eventGetEventAttendees = <ThrowOnError extends boolean = false>(
-	options: Options<EventGetEventAttendeesDf088923Data, ThrowOnError>
+	options: Options<EventGetEventAttendees798A730cData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventGetEventAttendeesDf088923Responses,
+		EventGetEventAttendees798A730cResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2033,10 +2050,10 @@ export const eventGetEventAttendees = <ThrowOnError extends boolean = false>(
  * (RSVP button, buy ticket, fill questionnaire, etc.).
  */
 export const eventGetMyEventStatus = <ThrowOnError extends boolean = false>(
-	options: Options<EventGetMyEventStatusA5537Ae4Data, ThrowOnError>
+	options: Options<EventGetMyEventStatus229B6062Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventGetMyEventStatusA5537Ae4Responses,
+		EventGetMyEventStatus229B6062Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2062,10 +2079,10 @@ export const eventGetMyEventStatus = <ThrowOnError extends boolean = false>(
  * need an invitation.
  */
 export const eventCreateInvitationRequest = <ThrowOnError extends boolean = false>(
-	options: Options<EventCreateInvitationRequest9B1Cdcf3Data, ThrowOnError>
+	options: Options<EventCreateInvitationRequestBdfc94B7Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventCreateInvitationRequest9B1Cdcf3Responses,
+		EventCreateInvitationRequestBdfc94B7Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2094,9 +2111,9 @@ export const eventCreateInvitationRequest = <ThrowOnError extends boolean = fals
  * (file, link, etc.) and text search.
  */
 export const eventListResources = <ThrowOnError extends boolean = false>(
-	options: Options<EventListResources0640A3A6Data, ThrowOnError>
+	options: Options<EventListResources8512C98eData, ThrowOnError>
 ) => {
-	return (options.client ?? client).get<EventListResources0640A3A6Responses, unknown, ThrowOnError>(
+	return (options.client ?? client).get<EventListResources8512C98eResponses, unknown, ThrowOnError>(
 		{
 			security: [
 				{
@@ -2120,10 +2137,10 @@ export const eventListResources = <ThrowOnError extends boolean = false>(
  * belong to you.
  */
 export const eventDeleteInvitationRequest = <ThrowOnError extends boolean = false>(
-	options: Options<EventDeleteInvitationRequestE2Bc00BbData, ThrowOnError>
+	options: Options<EventDeleteInvitationRequest0B935E61Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventDeleteInvitationRequestE2Bc00BbResponses,
+		EventDeleteInvitationRequest0B935E61Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2148,10 +2165,10 @@ export const eventDeleteInvitationRequest = <ThrowOnError extends boolean = fals
  * rejected requests. Use this to track which events you've requested access to.
  */
 export const eventListUserInvitationRequests = <ThrowOnError extends boolean = false>(
-	options?: Options<EventListUserInvitationRequests11F4Dbf2Data, ThrowOnError>
+	options?: Options<EventListUserInvitationRequests497500D2Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		EventListUserInvitationRequests11F4Dbf2Responses,
+		EventListUserInvitationRequests497500D2Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2175,10 +2192,10 @@ export const eventListUserInvitationRequests = <ThrowOnError extends boolean = f
  * the event doesn't exist or you don't have permission to view it.
  */
 export const eventGetEventBySlugs = <ThrowOnError extends boolean = false>(
-	options: Options<EventGetEventBySlugs1867901aData, ThrowOnError>
+	options: Options<EventGetEventBySlugs311D61BbData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventGetEventBySlugs1867901aResponses,
+		EventGetEventBySlugs311D61BbResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2202,9 +2219,9 @@ export const eventGetEventBySlugs = <ThrowOnError extends boolean = false>(
  * ticket tiers, and visibility settings. Use this to display the event detail page.
  */
 export const eventGetEvent = <ThrowOnError extends boolean = false>(
-	options: Options<EventGetEventF33D9Fe5Data, ThrowOnError>
+	options: Options<EventGetEventD6F13929Data, ThrowOnError>
 ) => {
-	return (options.client ?? client).get<EventGetEventF33D9Fe5Responses, unknown, ThrowOnError>({
+	return (options.client ?? client).get<EventGetEventD6F13929Responses, unknown, ThrowOnError>({
 		security: [
 			{
 				scheme: 'bearer',
@@ -2228,11 +2245,11 @@ export const eventGetEvent = <ThrowOnError extends boolean = false>(
  * request invitation).
  */
 export const eventRsvpEvent = <ThrowOnError extends boolean = false>(
-	options: Options<EventRsvpEvent2Fc4F913Data, ThrowOnError>
+	options: Options<EventRsvpEvent417D6F93Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventRsvpEvent2Fc4F913Responses,
-		EventRsvpEvent2Fc4F913Errors,
+		EventRsvpEvent417D6F93Responses,
+		EventRsvpEvent417D6F93Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -2256,9 +2273,9 @@ export const eventRsvpEvent = <ThrowOnError extends boolean = false>(
  * settings and sales_start_at/sales_end_at to determine which are currently on sale.
  */
 export const eventListTiers = <ThrowOnError extends boolean = false>(
-	options: Options<EventListTiersD39F67BdData, ThrowOnError>
+	options: Options<EventListTiers8D0D74DfData, ThrowOnError>
 ) => {
-	return (options.client ?? client).get<EventListTiersD39F67BdResponses, unknown, ThrowOnError>({
+	return (options.client ?? client).get<EventListTiers8D0D74DfResponses, unknown, ThrowOnError>({
 		security: [
 			{
 				scheme: 'bearer',
@@ -2283,11 +2300,11 @@ export const eventListTiers = <ThrowOnError extends boolean = false>(
  * to take (e.g., complete questionnaire, request invitation, wait for tickets to go on sale).
  */
 export const eventTicketCheckout = <ThrowOnError extends boolean = false>(
-	options: Options<EventTicketCheckout58D472B4Data, ThrowOnError>
+	options: Options<EventTicketCheckoutEf1Cc44dData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventTicketCheckout58D472B4Responses,
-		EventTicketCheckout58D472B4Errors,
+		EventTicketCheckoutEf1Cc44dResponses,
+		EventTicketCheckoutEf1Cc44dErrors,
 		ThrowOnError
 	>({
 		security: [
@@ -2313,11 +2330,11 @@ export const eventTicketCheckout = <ThrowOnError extends boolean = false>(
  * blocking you and what next_step to take).
  */
 export const eventTicketPwycCheckout = <ThrowOnError extends boolean = false>(
-	options: Options<EventTicketPwycCheckout9D58C7F3Data, ThrowOnError>
+	options: Options<EventTicketPwycCheckoutD2F9D317Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventTicketPwycCheckout9D58C7F3Responses,
-		EventTicketPwycCheckout9D58C7F3Errors,
+		EventTicketPwycCheckoutD2F9D317Responses,
+		EventTicketPwycCheckoutD2F9D317Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -2345,10 +2362,10 @@ export const eventTicketPwycCheckout = <ThrowOnError extends boolean = false>(
  * complete before accessing the event.
  */
 export const eventGetQuestionnaire = <ThrowOnError extends boolean = false>(
-	options: Options<EventGetQuestionnaire21149006Data, ThrowOnError>
+	options: Options<EventGetQuestionnaireCc423C0cData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventGetQuestionnaire21149006Responses,
+		EventGetQuestionnaireCc423C0cResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2374,11 +2391,11 @@ export const eventGetQuestionnaire = <ThrowOnError extends boolean = false>(
  * Passing the questionnaire may be required before you can RSVP or purchase tickets.
  */
 export const eventSubmitQuestionnaire = <ThrowOnError extends boolean = false>(
-	options: Options<EventSubmitQuestionnaireB02E3452Data, ThrowOnError>
+	options: Options<EventSubmitQuestionnaireA3213FddData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventSubmitQuestionnaireB02E3452Responses,
-		EventSubmitQuestionnaireB02E3452Errors,
+		EventSubmitQuestionnaireA3213FddResponses,
+		EventSubmitQuestionnaireA3213FddErrors,
 		ThrowOnError
 	>({
 		security: [
@@ -2402,10 +2419,10 @@ export const eventSubmitQuestionnaire = <ThrowOnError extends boolean = false>(
  * Delete an event token.
  */
 export const eventadminDeleteEventToken = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminDeleteEventToken1104AffcData, ThrowOnError>
+	options: Options<EventadminDeleteEventTokenC3Fc3A27Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventadminDeleteEventToken1104AffcResponses,
+		EventadminDeleteEventTokenC3Fc3A27Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2426,10 +2443,10 @@ export const eventadminDeleteEventToken = <ThrowOnError extends boolean = false>
  * Update an event token.
  */
 export const eventadminUpdateEventToken = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminUpdateEventToken98D07979Data, ThrowOnError>
+	options: Options<EventadminUpdateEventTokenE2D9030bData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		EventadminUpdateEventToken98D07979Responses,
+		EventadminUpdateEventTokenE2D9030bResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2454,10 +2471,10 @@ export const eventadminUpdateEventToken = <ThrowOnError extends boolean = false>
  * List all event tokens.
  */
 export const eventadminListEventTokens = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminListEventTokensC77C30C8Data, ThrowOnError>
+	options: Options<EventadminListEventTokensA00318C2Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventadminListEventTokensC77C30C8Responses,
+		EventadminListEventTokensA00318C2Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2478,10 +2495,10 @@ export const eventadminListEventTokens = <ThrowOnError extends boolean = false>(
  * Create a new event token.
  */
 export const eventadminCreateEventToken = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminCreateEventTokenB430C9A3Data, ThrowOnError>
+	options: Options<EventadminCreateEventToken2705Ac10Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminCreateEventTokenB430C9A3Responses,
+		EventadminCreateEventToken2705Ac10Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2508,10 +2525,10 @@ export const eventadminCreateEventToken = <ThrowOnError extends boolean = false>
  * By default shows all requests. Use ?status=pending to filter by status.
  */
 export const eventadminListInvitationRequests = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminListInvitationRequests3453A7F0Data, ThrowOnError>
+	options: Options<EventadminListInvitationRequestsCd34C64bData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventadminListInvitationRequests3453A7F0Responses,
+		EventadminListInvitationRequestsCd34C64bResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2532,10 +2549,10 @@ export const eventadminListInvitationRequests = <ThrowOnError extends boolean = 
  * Approve an invitation request.
  */
 export const eventadminApproveInvitationRequest = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminApproveInvitationRequestBc0774C6Data, ThrowOnError>
+	options: Options<EventadminApproveInvitationRequestDb4637FdData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminApproveInvitationRequestBc0774C6Responses,
+		EventadminApproveInvitationRequestDb4637FdResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2556,10 +2573,10 @@ export const eventadminApproveInvitationRequest = <ThrowOnError extends boolean 
  * Reject an invitation request.
  */
 export const eventadminRejectInvitationRequest = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminRejectInvitationRequest4D2C7F01Data, ThrowOnError>
+	options: Options<EventadminRejectInvitationRequestD9389077Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminRejectInvitationRequest4D2C7F01Responses,
+		EventadminRejectInvitationRequestD9389077Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2580,11 +2597,11 @@ export const eventadminRejectInvitationRequest = <ThrowOnError extends boolean =
  * Update event by ID.
  */
 export const eventadminUpdateEvent = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminUpdateEvent669A5A17Data, ThrowOnError>
+	options: Options<EventadminUpdateEvent3Ad899D2Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		EventadminUpdateEvent669A5A17Responses,
-		EventadminUpdateEvent669A5A17Errors,
+		EventadminUpdateEvent3Ad899D2Responses,
+		EventadminUpdateEvent3Ad899D2Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -2608,10 +2625,10 @@ export const eventadminUpdateEvent = <ThrowOnError extends boolean = false>(
  * Update event status to the specified value.
  */
 export const eventadminUpdateEventStatus = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminUpdateEventStatus9B733B32Data, ThrowOnError>
+	options: Options<EventadminUpdateEventStatus68Fc4E39Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminUpdateEventStatus9B733B32Responses,
+		EventadminUpdateEventStatus68Fc4E39Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2632,10 +2649,10 @@ export const eventadminUpdateEventStatus = <ThrowOnError extends boolean = false
  * Upload logo to event.
  */
 export const eventadminUploadLogo = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminUploadLogo97D3C2AeData, ThrowOnError>
+	options: Options<EventadminUploadLogo0A9764F8Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminUploadLogo97D3C2AeResponses,
+		EventadminUploadLogo0A9764F8Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2661,10 +2678,10 @@ export const eventadminUploadLogo = <ThrowOnError extends boolean = false>(
  * Upload cover art to event.
  */
 export const eventadminUploadCoverArt = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminUploadCoverArt3F027833Data, ThrowOnError>
+	options: Options<EventadminUploadCoverArt83630BfcData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminUploadCoverArt3F027833Responses,
+		EventadminUploadCoverArt83630BfcResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2690,10 +2707,10 @@ export const eventadminUploadCoverArt = <ThrowOnError extends boolean = false>(
  * Delete logo from event.
  */
 export const eventadminDeleteLogo = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminDeleteLogo3967075cData, ThrowOnError>
+	options: Options<EventadminDeleteLogoE4111774Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventadminDeleteLogo3967075cResponses,
+		EventadminDeleteLogoE4111774Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2714,10 +2731,10 @@ export const eventadminDeleteLogo = <ThrowOnError extends boolean = false>(
  * Delete cover art from event.
  */
 export const eventadminDeleteCoverArt = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminDeleteCoverArt3F30469fData, ThrowOnError>
+	options: Options<EventadminDeleteCoverArt509922C1Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventadminDeleteCoverArt3F30469fResponses,
+		EventadminDeleteCoverArt509922C1Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2738,10 +2755,10 @@ export const eventadminDeleteCoverArt = <ThrowOnError extends boolean = false>(
  * Remove one or more tags from the organization.
  */
 export const eventadminClearTags = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminClearTags9A9B25CdData, ThrowOnError>
+	options: Options<EventadminClearTags0650Bd81Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventadminClearTags9A9B25CdResponses,
+		EventadminClearTags0650Bd81Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2762,9 +2779,9 @@ export const eventadminClearTags = <ThrowOnError extends boolean = false>(
  * Add one or more tags to the organization.
  */
 export const eventadminAddTags = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminAddTagsF8D9D0CaData, ThrowOnError>
+	options: Options<EventadminAddTags9523D639Data, ThrowOnError>
 ) => {
-	return (options.client ?? client).post<EventadminAddTagsF8D9D0CaResponses, unknown, ThrowOnError>(
+	return (options.client ?? client).post<EventadminAddTags9523D639Responses, unknown, ThrowOnError>(
 		{
 			security: [
 				{
@@ -2788,10 +2805,10 @@ export const eventadminAddTags = <ThrowOnError extends boolean = false>(
  * Remove one or more tags from the organization.
  */
 export const eventadminRemoveTags = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminRemoveTags1Eb533CdData, ThrowOnError>
+	options: Options<EventadminRemoveTags62E32901Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminRemoveTags1Eb533CdResponses,
+		EventadminRemoveTags62E32901Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2816,10 +2833,10 @@ export const eventadminRemoveTags = <ThrowOnError extends boolean = false>(
  * List all ticket tiers for an event.
  */
 export const eventadminListTicketTiers = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminListTicketTiersF0C8F341Data, ThrowOnError>
+	options: Options<EventadminListTicketTiers59879806Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventadminListTicketTiersF0C8F341Responses,
+		EventadminListTicketTiers59879806Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2840,10 +2857,10 @@ export const eventadminListTicketTiers = <ThrowOnError extends boolean = false>(
  * Create a new ticket tier for an event.
  */
 export const eventadminCreateTicketTier = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminCreateTicketTier03150584Data, ThrowOnError>
+	options: Options<EventadminCreateTicketTier84Db5110Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminCreateTicketTier03150584Responses,
+		EventadminCreateTicketTier84Db5110Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2870,10 +2887,10 @@ export const eventadminCreateTicketTier = <ThrowOnError extends boolean = false>
  * Note this might raise a 400 if ticket with this tier where already bought.
  */
 export const eventadminDeleteTicketTier = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminDeleteTicketTierA7C3519aData, ThrowOnError>
+	options: Options<EventadminDeleteTicketTier1D0E7C44Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventadminDeleteTicketTierA7C3519aResponses,
+		EventadminDeleteTicketTier1D0E7C44Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2894,10 +2911,10 @@ export const eventadminDeleteTicketTier = <ThrowOnError extends boolean = false>
  * Update a ticket tier.
  */
 export const eventadminUpdateTicketTier = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminUpdateTicketTierAded0749Data, ThrowOnError>
+	options: Options<EventadminUpdateTicketTierAe1D4E8aData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		EventadminUpdateTicketTierAded0749Responses,
+		EventadminUpdateTicketTierAe1D4E8aResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2926,10 +2943,10 @@ export const eventadminUpdateTicketTier = <ThrowOnError extends boolean = false>
  * - tier__payment_method: Filter by payment method (ONLINE, OFFLINE, AT_THE_DOOR, FREE)
  */
 export const eventadminListTickets = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminListTickets720A6A89Data, ThrowOnError>
+	options: Options<EventadminListTickets458061F5Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventadminListTickets720A6A89Responses,
+		EventadminListTickets458061F5Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2950,10 +2967,10 @@ export const eventadminListTickets = <ThrowOnError extends boolean = false>(
  * Get a ticket by its ID.
  */
 export const eventadminGetTicket = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminGetTicket19Afa38dData, ThrowOnError>
+	options: Options<EventadminGetTicketCe124C38Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventadminGetTicket19Afa38dResponses,
+		EventadminGetTicketCe124C38Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -2974,10 +2991,10 @@ export const eventadminGetTicket = <ThrowOnError extends boolean = false>(
  * Confirm payment for a pending offline ticket and activate it.
  */
 export const eventadminConfirmTicketPayment = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminConfirmTicketPaymentD8E41153Data, ThrowOnError>
+	options: Options<EventadminConfirmTicketPayment73914A92Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminConfirmTicketPaymentD8E41153Responses,
+		EventadminConfirmTicketPayment73914A92Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3001,10 +3018,10 @@ export const eventadminConfirmTicketPayment = <ThrowOnError extends boolean = fa
  * Online tickets (Stripe) are automatically managed via webhooks.
  */
 export const eventadminMarkTicketRefunded = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminMarkTicketRefundedBd44B3D6Data, ThrowOnError>
+	options: Options<EventadminMarkTicketRefunded0Cf0F029Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminMarkTicketRefundedBd44B3D6Responses,
+		EventadminMarkTicketRefunded0Cf0F029Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3028,10 +3045,10 @@ export const eventadminMarkTicketRefunded = <ThrowOnError extends boolean = fals
  * Online tickets (Stripe) should be refunded via Stripe Dashboard.
  */
 export const eventadminCancelTicket = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminCancelTicket1082Aa5bData, ThrowOnError>
+	options: Options<EventadminCancelTicket14582C4eData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminCancelTicket1082Aa5bResponses,
+		EventadminCancelTicket14582C4eResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3052,11 +3069,11 @@ export const eventadminCancelTicket = <ThrowOnError extends boolean = false>(
  * Check in an attendee by scanning their ticket.
  */
 export const eventadminCheckInTicket = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminCheckInTicket957Dc27bData, ThrowOnError>
+	options: Options<EventadminCheckInTicket15Ab77B0Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminCheckInTicket957Dc27bResponses,
-		EventadminCheckInTicket957Dc27bErrors,
+		EventadminCheckInTicket15Ab77B0Responses,
+		EventadminCheckInTicket15Ab77B0Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -3076,10 +3093,10 @@ export const eventadminCheckInTicket = <ThrowOnError extends boolean = false>(
  * List all invitations for registered users.
  */
 export const eventadminListInvitations = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminListInvitations8672F3C5Data, ThrowOnError>
+	options: Options<EventadminListInvitationsF2Bb3Cb9Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventadminListInvitations8672F3C5Responses,
+		EventadminListInvitationsF2Bb3Cb9Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3100,11 +3117,11 @@ export const eventadminListInvitations = <ThrowOnError extends boolean = false>(
  * Create direct invitations for users by email addresses.
  */
 export const eventadminCreateInvitations = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminCreateInvitations626265E4Data, ThrowOnError>
+	options: Options<EventadminCreateInvitationsF317F105Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminCreateInvitations626265E4Responses,
-		EventadminCreateInvitations626265E4Errors,
+		EventadminCreateInvitationsF317F105Responses,
+		EventadminCreateInvitationsF317F105Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -3128,10 +3145,10 @@ export const eventadminCreateInvitations = <ThrowOnError extends boolean = false
  * List all pending invitations for unregistered users.
  */
 export const eventadminListPendingInvitations = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminListPendingInvitations2074D91cData, ThrowOnError>
+	options: Options<EventadminListPendingInvitations5F282536Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventadminListPendingInvitations2074D91cResponses,
+		EventadminListPendingInvitations5F282536Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3152,11 +3169,11 @@ export const eventadminListPendingInvitations = <ThrowOnError extends boolean = 
  * Delete an invitation (registered or pending).
  */
 export const eventadminDeleteInvitationEndpoint = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminDeleteInvitationEndpoint7A5Baf74Data, ThrowOnError>
+	options: Options<EventadminDeleteInvitationEndpoint38F40Fb9Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventadminDeleteInvitationEndpoint7A5Baf74Responses,
-		EventadminDeleteInvitationEndpoint7A5Baf74Errors,
+		EventadminDeleteInvitationEndpoint38F40Fb9Responses,
+		EventadminDeleteInvitationEndpoint38F40Fb9Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -3180,10 +3197,10 @@ export const eventadminDeleteInvitationEndpoint = <ThrowOnError extends boolean 
  * Supports filtering by status and user_id.
  */
 export const eventadminListRsvps = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminListRsvps7Ad29E6cData, ThrowOnError>
+	options: Options<EventadminListRsvps8Ad05025Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventadminListRsvps7Ad29E6cResponses,
+		EventadminListRsvps8Ad05025Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3207,10 +3224,10 @@ export const eventadminListRsvps = <ThrowOnError extends boolean = false>(
  * (e.g., via text, email, or in person).
  */
 export const eventadminCreateRsvp = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminCreateRsvpA0Abb388Data, ThrowOnError>
+	options: Options<EventadminCreateRsvp6074Fdf2Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventadminCreateRsvpA0Abb388Responses,
+		EventadminCreateRsvp6074Fdf2Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3238,10 +3255,10 @@ export const eventadminCreateRsvp = <ThrowOnError extends boolean = false>(
  * Note: This is different from setting status to "no" - it completely removes the RSVP record.
  */
 export const eventadminDeleteRsvp = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminDeleteRsvp111B4Ef4Data, ThrowOnError>
+	options: Options<EventadminDeleteRsvpBe54BbcfData, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventadminDeleteRsvp111B4Ef4Responses,
+		EventadminDeleteRsvpBe54BbcfResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3262,9 +3279,9 @@ export const eventadminDeleteRsvp = <ThrowOnError extends boolean = false>(
  * Get details of a specific RSVP.
  */
 export const eventadminGetRsvp = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminGetRsvpB753B6DfData, ThrowOnError>
+	options: Options<EventadminGetRsvpFfff5A62Data, ThrowOnError>
 ) => {
-	return (options.client ?? client).get<EventadminGetRsvpB753B6DfResponses, unknown, ThrowOnError>({
+	return (options.client ?? client).get<EventadminGetRsvpFfff5A62Responses, unknown, ThrowOnError>({
 		security: [
 			{
 				scheme: 'bearer',
@@ -3284,10 +3301,10 @@ export const eventadminGetRsvp = <ThrowOnError extends boolean = false>(
  * Use this to change a user's RSVP status when they contact you to update their response.
  */
 export const eventadminUpdateRsvp = <ThrowOnError extends boolean = false>(
-	options: Options<EventadminUpdateRsvp4F4B015cData, ThrowOnError>
+	options: Options<EventadminUpdateRsvpF8E082B7Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		EventadminUpdateRsvp4F4B015cResponses,
+		EventadminUpdateRsvpF8E082B7Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3312,10 +3329,10 @@ export const eventadminUpdateRsvp = <ThrowOnError extends boolean = false>(
  * Get a user's permission map, per organization.
  */
 export const permissionMyPermissions = <ThrowOnError extends boolean = false>(
-	options?: Options<PermissionMyPermissions26660239Data, ThrowOnError>
+	options?: Options<PermissionMyPermissions0B7734E0Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		PermissionMyPermissions26660239Responses,
+		PermissionMyPermissions0B7734E0Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3339,10 +3356,10 @@ export const permissionMyPermissions = <ThrowOnError extends boolean = false>(
  * filtered by visibility and permissions. Supports filtering by organization and text search.
  */
 export const eventseriesListEventSeries = <ThrowOnError extends boolean = false>(
-	options?: Options<EventseriesListEventSeries5C5D600cData, ThrowOnError>
+	options?: Options<EventseriesListEventSeries695C7F05Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		EventseriesListEventSeries5C5D600cResponses,
+		EventseriesListEventSeries695C7F05Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3366,10 +3383,10 @@ export const eventseriesListEventSeries = <ThrowOnError extends boolean = false>
  * if the series doesn't exist or you don't have permission to view it.
  */
 export const eventseriesGetEventSeriesBySlugs = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesGetEventSeriesBySlugs2Bc4198fData, ThrowOnError>
+	options: Options<EventseriesGetEventSeriesBySlugs305F958fData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventseriesGetEventSeriesBySlugs2Bc4198fResponses,
+		EventseriesGetEventSeriesBySlugs305F958fResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3393,10 +3410,10 @@ export const eventseriesGetEventSeriesBySlugs = <ThrowOnError extends boolean = 
  * to display the series profile page and list related events.
  */
 export const eventseriesGetEventSeries = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesGetEventSeries0879D813Data, ThrowOnError>
+	options: Options<EventseriesGetEventSeriesF286001eData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventseriesGetEventSeries0879D813Responses,
+		EventseriesGetEventSeriesF286001eResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3421,10 +3438,10 @@ export const eventseriesGetEventSeries = <ThrowOnError extends boolean = false>(
  * by type and text search.
  */
 export const eventseriesListResources = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesListResourcesFc094B71Data, ThrowOnError>
+	options: Options<EventseriesListResources9E3B380eData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		EventseriesListResourcesFc094B71Responses,
+		EventseriesListResources9E3B380eResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3448,10 +3465,10 @@ export const eventseriesListResources = <ThrowOnError extends boolean = false>(
  * Requires 'delete_event_series' permission (typically organization owners only).
  */
 export const eventseriesadminDeleteEventSeries = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminDeleteEventSeries4342CeaeData, ThrowOnError>
+	options: Options<EventseriesadminDeleteEventSeriesE0020657Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventseriesadminDeleteEventSeries4342CeaeResponses,
+		EventseriesadminDeleteEventSeriesE0020657Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3475,11 +3492,11 @@ export const eventseriesadminDeleteEventSeries = <ThrowOnError extends boolean =
  * (organization staff/owners). Changes apply to the series but not individual events.
  */
 export const eventseriesadminUpdateEventSeries = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminUpdateEventSeries787B5A6bData, ThrowOnError>
+	options: Options<EventseriesadminUpdateEventSeries3912324eData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		EventseriesadminUpdateEventSeries787B5A6bResponses,
-		EventseriesadminUpdateEventSeries787B5A6bErrors,
+		EventseriesadminUpdateEventSeries3912324eResponses,
+		EventseriesadminUpdateEventSeries3912324eErrors,
 		ThrowOnError
 	>({
 		security: [
@@ -3506,10 +3523,10 @@ export const eventseriesadminUpdateEventSeries = <ThrowOnError extends boolean =
  * 'edit_event_series' permission.
  */
 export const eventseriesadminUploadLogo = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminUploadLogoD5A34979Data, ThrowOnError>
+	options: Options<EventseriesadminUploadLogo454Bc4C2Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventseriesadminUploadLogoD5A34979Responses,
+		EventseriesadminUploadLogo454Bc4C2Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3538,10 +3555,10 @@ export const eventseriesadminUploadLogo = <ThrowOnError extends boolean = false>
  * 'edit_event_series' permission.
  */
 export const eventseriesadminUploadCoverArt = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminUploadCoverArtCef38D76Data, ThrowOnError>
+	options: Options<EventseriesadminUploadCoverArt5Eb583C2Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventseriesadminUploadCoverArtCef38D76Responses,
+		EventseriesadminUploadCoverArt5Eb583C2Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3569,10 +3586,10 @@ export const eventseriesadminUploadCoverArt = <ThrowOnError extends boolean = fa
  * Removes the logo image. Requires 'edit_event_series' permission.
  */
 export const eventseriesadminDeleteLogo = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminDeleteLogo60503B96Data, ThrowOnError>
+	options: Options<EventseriesadminDeleteLogo8801A010Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventseriesadminDeleteLogo60503B96Responses,
+		EventseriesadminDeleteLogo8801A010Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3595,10 +3612,10 @@ export const eventseriesadminDeleteLogo = <ThrowOnError extends boolean = false>
  * Removes the cover art image. Requires 'edit_event_series' permission.
  */
 export const eventseriesadminDeleteCoverArt = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminDeleteCoverArtAdacffceData, ThrowOnError>
+	options: Options<EventseriesadminDeleteCoverArtD482Bb1dData, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventseriesadminDeleteCoverArtAdacffceResponses,
+		EventseriesadminDeleteCoverArtD482Bb1dResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3621,10 +3638,10 @@ export const eventseriesadminDeleteCoverArt = <ThrowOnError extends boolean = fa
  * Clears all categorization tags. Requires 'edit_event_series' permission.
  */
 export const eventseriesadminClearTags = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminClearTags39B860D9Data, ThrowOnError>
+	options: Options<EventseriesadminClearTags3Be88830Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		EventseriesadminClearTags39B860D9Responses,
+		EventseriesadminClearTags3Be88830Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3648,10 +3665,10 @@ export const eventseriesadminClearTags = <ThrowOnError extends boolean = false>(
  * Requires 'edit_event_series' permission.
  */
 export const eventseriesadminAddTags = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminAddTags90D97164Data, ThrowOnError>
+	options: Options<EventseriesadminAddTagsEdecd586Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventseriesadminAddTags90D97164Responses,
+		EventseriesadminAddTagsEdecd586Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3679,10 +3696,10 @@ export const eventseriesadminAddTags = <ThrowOnError extends boolean = false>(
  * 'edit_event_series' permission.
  */
 export const eventseriesadminRemoveTags = <ThrowOnError extends boolean = false>(
-	options: Options<EventseriesadminRemoveTagsDace0E92Data, ThrowOnError>
+	options: Options<EventseriesadminRemoveTags748118B9Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		EventseriesadminRemoveTagsDace0E92Responses,
+		EventseriesadminRemoveTags748118B9Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3711,10 +3728,10 @@ export const eventseriesadminRemoveTags = <ThrowOnError extends boolean = false>
  * what you've claimed.
  */
 export const potluckListPotluckItems = <ThrowOnError extends boolean = false>(
-	options: Options<PotluckListPotluckItemsF3A8D13fData, ThrowOnError>
+	options: Options<PotluckListPotluckItems7962228cData, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		PotluckListPotluckItemsF3A8D13fResponses,
+		PotluckListPotluckItems7962228cResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3738,10 +3755,10 @@ export const potluckListPotluckItems = <ThrowOnError extends boolean = false>(
  * POST /{event_id}/potluck/{item_id}/claim. Requires permission to create potluck items.
  */
 export const potluckCreatePotluckItem = <ThrowOnError extends boolean = false>(
-	options: Options<PotluckCreatePotluckItem74Eaf78eData, ThrowOnError>
+	options: Options<PotluckCreatePotluckItemC97Ec366Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		PotluckCreatePotluckItem74Eaf78eResponses,
+		PotluckCreatePotluckItemC97Ec366Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3768,10 +3785,10 @@ export const potluckCreatePotluckItem = <ThrowOnError extends boolean = false>(
  * Deletes the item even if it's been claimed. Requires permission to manage potluck items.
  */
 export const potluckDeletePotluckItem = <ThrowOnError extends boolean = false>(
-	options: Options<PotluckDeletePotluckItem71B5E436Data, ThrowOnError>
+	options: Options<PotluckDeletePotluckItem743Da4DbData, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		PotluckDeletePotluckItem71B5E436Responses,
+		PotluckDeletePotluckItem743Da4DbResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3795,10 +3812,10 @@ export const potluckDeletePotluckItem = <ThrowOnError extends boolean = false>(
  * (typically event organizers).
  */
 export const potluckUpdatePotluckItem = <ThrowOnError extends boolean = false>(
-	options: Options<PotluckUpdatePotluckItem2Cab8494Data, ThrowOnError>
+	options: Options<PotluckUpdatePotluckItem95775212Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		PotluckUpdatePotluckItem2Cab8494Responses,
+		PotluckUpdatePotluckItem95775212Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3826,10 +3843,10 @@ export const potluckUpdatePotluckItem = <ThrowOnError extends boolean = false>(
  * you want to commit to bringing a specific item.
  */
 export const potluckClaimPotluckItem = <ThrowOnError extends boolean = false>(
-	options: Options<PotluckClaimPotluckItemDecef2E5Data, ThrowOnError>
+	options: Options<PotluckClaimPotluckItem0Ed17079Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		PotluckClaimPotluckItemDecef2E5Responses,
+		PotluckClaimPotluckItem0Ed17079Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3853,10 +3870,10 @@ export const potluckClaimPotluckItem = <ThrowOnError extends boolean = false>(
  * by you.
  */
 export const potluckUnclaimPotluckItem = <ThrowOnError extends boolean = false>(
-	options: Options<PotluckUnclaimPotluckItem7D8B3F84Data, ThrowOnError>
+	options: Options<PotluckUnclaimPotluckItem75438D08Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		PotluckUnclaimPotluckItem7D8B3F84Responses,
+		PotluckUnclaimPotluckItem75438D08Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3884,10 +3901,10 @@ export const potluckUnclaimPotluckItem = <ThrowOnError extends boolean = false>(
  * or evaluations with "pending review" status).
  */
 export const questionnaireListOrgQuestionnaires = <ThrowOnError extends boolean = false>(
-	options?: Options<QuestionnaireListOrgQuestionnaires42A9D3CbData, ThrowOnError>
+	options?: Options<QuestionnaireListOrgQuestionnaires49D842F3Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		QuestionnaireListOrgQuestionnaires42A9D3CbResponses,
+		QuestionnaireListOrgQuestionnaires49D842F3Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3913,11 +3930,11 @@ export const questionnaireListOrgQuestionnaires = <ThrowOnError extends boolean 
  * 'create_questionnaire' permission (organization staff/owners).
  */
 export const questionnaireCreateOrgQuestionnaire = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireCreateOrgQuestionnaire3C5D9045Data, ThrowOnError>
+	options: Options<QuestionnaireCreateOrgQuestionnaireF91E8483Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireCreateOrgQuestionnaire3C5D9045Responses,
-		QuestionnaireCreateOrgQuestionnaire3C5D9045Errors,
+		QuestionnaireCreateOrgQuestionnaireF91E8483Responses,
+		QuestionnaireCreateOrgQuestionnaireF91E8483Errors,
 		ThrowOnError
 	>({
 		security: [
@@ -3943,10 +3960,10 @@ export const questionnaireCreateOrgQuestionnaire = <ThrowOnError extends boolean
  * Permanently removes the questionnaire. Requires 'delete_questionnaire' permission.
  */
 export const questionnaireDeleteOrgQuestionnaire = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireDeleteOrgQuestionnaire80Cd631aData, ThrowOnError>
+	options: Options<QuestionnaireDeleteOrgQuestionnaireBec1C8C9Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		QuestionnaireDeleteOrgQuestionnaire80Cd631aResponses,
+		QuestionnaireDeleteOrgQuestionnaireBec1C8C9Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3970,10 +3987,10 @@ export const questionnaireDeleteOrgQuestionnaire = <ThrowOnError extends boolean
  * edit an existing questionnaire. Requires permission to manage the organization's questionnaires.
  */
 export const questionnaireGetOrgQuestionnaire = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireGetOrgQuestionnaire6A6547A7Data, ThrowOnError>
+	options: Options<QuestionnaireGetOrgQuestionnaireFd2Ed8F8Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		QuestionnaireGetOrgQuestionnaire6A6547A7Responses,
+		QuestionnaireGetOrgQuestionnaireFd2Ed8F8Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -3999,10 +4016,10 @@ export const questionnaireGetOrgQuestionnaire = <ThrowOnError extends boolean = 
  * Requires 'edit_questionnaire' permission.
  */
 export const questionnaireUpdateOrgQuestionnaire = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireUpdateOrgQuestionnaire13E422A0Data, ThrowOnError>
+	options: Options<QuestionnaireUpdateOrgQuestionnaire1812Acc4Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		QuestionnaireUpdateOrgQuestionnaire13E422A0Responses,
+		QuestionnaireUpdateOrgQuestionnaire1812Acc4Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4030,10 +4047,10 @@ export const questionnaireUpdateOrgQuestionnaire = <ThrowOnError extends boolean
  * 'edit_questionnaire' permission.
  */
 export const questionnaireCreateSection = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireCreateSectionDbdfdf9dData, ThrowOnError>
+	options: Options<QuestionnaireCreateSection6946F67bData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireCreateSectionDbdfdf9dResponses,
+		QuestionnaireCreateSection6946F67bResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4060,10 +4077,10 @@ export const questionnaireCreateSection = <ThrowOnError extends boolean = false>
  * Removes the section and all questions within it. Requires 'edit_questionnaire' permission.
  */
 export const questionnaireDeleteSection = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireDeleteSection6935C91eData, ThrowOnError>
+	options: Options<QuestionnaireDeleteSection01B1Bce7Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		QuestionnaireDeleteSection6935C91eResponses,
+		QuestionnaireDeleteSection01B1Bce7Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4086,10 +4103,10 @@ export const questionnaireDeleteSection = <ThrowOnError extends boolean = false>
  * Modify section name or display order. Requires 'edit_questionnaire' permission.
  */
 export const questionnaireUpdateSection = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireUpdateSection0B4561B1Data, ThrowOnError>
+	options: Options<QuestionnaireUpdateSection2Ae3Ace9Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		QuestionnaireUpdateSection0B4561B1Responses,
+		QuestionnaireUpdateSection2Ae3Ace9Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4118,10 +4135,10 @@ export const questionnaireUpdateSection = <ThrowOnError extends boolean = false>
  * 'edit_questionnaire' permission.
  */
 export const questionnaireCreateMcQuestion = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireCreateMcQuestion06701522Data, ThrowOnError>
+	options: Options<QuestionnaireCreateMcQuestion20D1Da93Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireCreateMcQuestion06701522Responses,
+		QuestionnaireCreateMcQuestion20D1Da93Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4148,10 +4165,10 @@ export const questionnaireCreateMcQuestion = <ThrowOnError extends boolean = fal
  * Removes the question and all its options. Requires 'edit_questionnaire' permission.
  */
 export const questionnaireDeleteMcQuestion = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireDeleteMcQuestionA6713B01Data, ThrowOnError>
+	options: Options<QuestionnaireDeleteMcQuestion33E11B28Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		QuestionnaireDeleteMcQuestionA6713B01Responses,
+		QuestionnaireDeleteMcQuestion33E11B28Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4172,10 +4189,10 @@ export const questionnaireDeleteMcQuestion = <ThrowOnError extends boolean = fal
  * Create a multiple choice question.
  */
 export const questionnaireUpdateMcQuestion = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireUpdateMcQuestionAad6A276Data, ThrowOnError>
+	options: Options<QuestionnaireUpdateMcQuestion3D37Cc5fData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		QuestionnaireUpdateMcQuestionAad6A276Responses,
+		QuestionnaireUpdateMcQuestion3D37Cc5fResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4200,10 +4217,10 @@ export const questionnaireUpdateMcQuestion = <ThrowOnError extends boolean = fal
  * Create a multiple choice question.
  */
 export const questionnaireCreateMcOption = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireCreateMcOption7714C9DeData, ThrowOnError>
+	options: Options<QuestionnaireCreateMcOption8006A4E9Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireCreateMcOption7714C9DeResponses,
+		QuestionnaireCreateMcOption8006A4E9Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4230,10 +4247,10 @@ export const questionnaireCreateMcOption = <ThrowOnError extends boolean = false
  * Removes the option from a question. Requires 'edit_questionnaire' permission.
  */
 export const questionnaireDeleteMcOption = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireDeleteMcOption775Fa06dData, ThrowOnError>
+	options: Options<QuestionnaireDeleteMcOption61152CdaData, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		QuestionnaireDeleteMcOption775Fa06dResponses,
+		QuestionnaireDeleteMcOption61152CdaResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4254,10 +4271,10 @@ export const questionnaireDeleteMcOption = <ThrowOnError extends boolean = false
  * Create a multiple choice question.
  */
 export const questionnaireUpdateMcOption = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireUpdateMcOption5Fc0E101Data, ThrowOnError>
+	options: Options<QuestionnaireUpdateMcOptionE6Fac541Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		QuestionnaireUpdateMcOption5Fc0E101Responses,
+		QuestionnaireUpdateMcOptionE6Fac541Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4285,10 +4302,10 @@ export const questionnaireUpdateMcOption = <ThrowOnError extends boolean = false
  * scoring criteria. Requires 'edit_questionnaire' permission.
  */
 export const questionnaireCreateFtQuestion = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireCreateFtQuestionB4E4BeecData, ThrowOnError>
+	options: Options<QuestionnaireCreateFtQuestion093Ed38dData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireCreateFtQuestionB4E4BeecResponses,
+		QuestionnaireCreateFtQuestion093Ed38dResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4315,10 +4332,10 @@ export const questionnaireCreateFtQuestion = <ThrowOnError extends boolean = fal
  * Removes the question. Requires 'edit_questionnaire' permission.
  */
 export const questionnaireDeleteFtQuestion = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireDeleteFtQuestion49C2E429Data, ThrowOnError>
+	options: Options<QuestionnaireDeleteFtQuestion996D4F7cData, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		QuestionnaireDeleteFtQuestion49C2E429Responses,
+		QuestionnaireDeleteFtQuestion996D4F7cResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4339,10 +4356,10 @@ export const questionnaireDeleteFtQuestion = <ThrowOnError extends boolean = fal
  * Create a multiple choice question.
  */
 export const questionnaireUpdateFtQuestion = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireUpdateFtQuestion11774009Data, ThrowOnError>
+	options: Options<QuestionnaireUpdateFtQuestionE5F3Ee15Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		QuestionnaireUpdateFtQuestion11774009Responses,
+		QuestionnaireUpdateFtQuestionE5F3Ee15Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4377,10 +4394,10 @@ export const questionnaireUpdateFtQuestion = <ThrowOnError extends boolean = fal
  * - -submitted_at: Newest submissions first (default)
  */
 export const questionnaireListSubmissions = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireListSubmissions4C7B40BcData, ThrowOnError>
+	options: Options<QuestionnaireListSubmissions0C906E39Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		QuestionnaireListSubmissions4C7B40BcResponses,
+		QuestionnaireListSubmissions0C906E39Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4405,10 +4422,10 @@ export const questionnaireListSubmissions = <ThrowOnError extends boolean = fals
  * 'evaluate_questionnaire' permission.
  */
 export const questionnaireGetSubmissionDetail = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireGetSubmissionDetailD93F30A9Data, ThrowOnError>
+	options: Options<QuestionnaireGetSubmissionDetail334A11E6Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		QuestionnaireGetSubmissionDetailD93F30A9Responses,
+		QuestionnaireGetSubmissionDetail334A11E6Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4433,11 +4450,11 @@ export const questionnaireGetSubmissionDetail = <ThrowOnError extends boolean = 
  * 'evaluate_questionnaire' permission.
  */
 export const questionnaireEvaluateSubmission = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireEvaluateSubmission95B64A41Data, ThrowOnError>
+	options: Options<QuestionnaireEvaluateSubmissionD114F4AdData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireEvaluateSubmission95B64A41Responses,
-		QuestionnaireEvaluateSubmission95B64A41Errors,
+		QuestionnaireEvaluateSubmissionD114F4AdResponses,
+		QuestionnaireEvaluateSubmissionD114F4AdErrors,
 		ThrowOnError
 	>({
 		security: [
@@ -4467,11 +4484,13 @@ export const questionnaireEvaluateSubmission = <ThrowOnError extends boolean = f
  *
  * Requires 'edit_questionnaire' permission.
  */
-export const questionnaireUpdateQuestionnaireStatus = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireUpdateQuestionnaireStatusA762B758Data, ThrowOnError>
+export const questionnaireUpdateQuestionnaireStatus = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<QuestionnaireUpdateQuestionnaireStatus4340C259Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireUpdateQuestionnaireStatusA762B758Responses,
+		QuestionnaireUpdateQuestionnaireStatus4340C259Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4495,10 +4514,10 @@ export const questionnaireUpdateQuestionnaireStatus = <ThrowOnError extends bool
  * events belong to the same organization. Requires 'edit_questionnaire' permission.
  */
 export const questionnaireReplaceEvents = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireReplaceEvents73E6B122Data, ThrowOnError>
+	options: Options<QuestionnaireReplaceEvents753A3A83Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		QuestionnaireReplaceEvents73E6B122Responses,
+		QuestionnaireReplaceEvents753A3A83Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4526,10 +4545,10 @@ export const questionnaireReplaceEvents = <ThrowOnError extends boolean = false>
  * permission.
  */
 export const questionnaireUnassignEvent = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireUnassignEvent7E85350dData, ThrowOnError>
+	options: Options<QuestionnaireUnassignEvent65E181A3Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		QuestionnaireUnassignEvent7E85350dResponses,
+		QuestionnaireUnassignEvent65E181A3Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4553,10 +4572,10 @@ export const questionnaireUnassignEvent = <ThrowOnError extends boolean = false>
  * 'edit_questionnaire' permission.
  */
 export const questionnaireAssignEvent = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireAssignEventD8Feb5F1Data, ThrowOnError>
+	options: Options<QuestionnaireAssignEvent6C0D8657Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireAssignEventD8Feb5F1Responses,
+		QuestionnaireAssignEvent6C0D8657Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4580,10 +4599,10 @@ export const questionnaireAssignEvent = <ThrowOnError extends boolean = false>(
  * series belong to the same organization. Requires 'edit_questionnaire' permission.
  */
 export const questionnaireReplaceEventSeries = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireReplaceEventSeriesA98A2508Data, ThrowOnError>
+	options: Options<QuestionnaireReplaceEventSeries6F47FafeData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		QuestionnaireReplaceEventSeriesA98A2508Responses,
+		QuestionnaireReplaceEventSeries6F47FafeResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4611,10 +4630,10 @@ export const questionnaireReplaceEventSeries = <ThrowOnError extends boolean = f
  * permission.
  */
 export const questionnaireUnassignEventSeries = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireUnassignEventSeriesA3Cf8D10Data, ThrowOnError>
+	options: Options<QuestionnaireUnassignEventSeriesC4B9708aData, ThrowOnError>
 ) => {
 	return (options.client ?? client).delete<
-		QuestionnaireUnassignEventSeriesA3Cf8D10Responses,
+		QuestionnaireUnassignEventSeriesC4B9708aResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4638,10 +4657,10 @@ export const questionnaireUnassignEventSeries = <ThrowOnError extends boolean = 
  * 'edit_questionnaire' permission.
  */
 export const questionnaireAssignEventSeries = <ThrowOnError extends boolean = false>(
-	options: Options<QuestionnaireAssignEventSeriesB66Af321Data, ThrowOnError>
+	options: Options<QuestionnaireAssignEventSeriesE8D3A08fData, ThrowOnError>
 ) => {
 	return (options.client ?? client).post<
-		QuestionnaireAssignEventSeriesB66Af321Responses,
+		QuestionnaireAssignEventSeriesE8D3A08fResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4665,10 +4684,10 @@ export const questionnaireAssignEventSeries = <ThrowOnError extends boolean = fa
  * overridden at organization, series, or event level.
  */
 export const userpreferencesGetGeneralPreferences = <ThrowOnError extends boolean = false>(
-	options?: Options<UserpreferencesGetGeneralPreferencesA2Ac890eData, ThrowOnError>
+	options?: Options<UserpreferencesGetGeneralPreferences9Aea63E9Data, ThrowOnError>
 ) => {
 	return (options?.client ?? client).get<
-		UserpreferencesGetGeneralPreferencesA2Ac890eResponses,
+		UserpreferencesGetGeneralPreferences9Aea63E9Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4691,11 +4710,13 @@ export const userpreferencesGetGeneralPreferences = <ThrowOnError extends boolea
  * Modify notification and privacy settings. Set overwrite_children=true to cascade changes
  * to all organization/series/event-level preferences, overriding custom settings.
  */
-export const userpreferencesUpdateGlobalPreferences = <ThrowOnError extends boolean = false>(
-	options: Options<UserpreferencesUpdateGlobalPreferencesCa70F70eData, ThrowOnError>
+export const userpreferencesUpdateGlobalPreferences = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<UserpreferencesUpdateGlobalPreferencesD739D116Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		UserpreferencesUpdateGlobalPreferencesCa70F70eResponses,
+		UserpreferencesUpdateGlobalPreferencesD739D116Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4722,11 +4743,13 @@ export const userpreferencesUpdateGlobalPreferences = <ThrowOnError extends bool
  * Returns organization-level overrides for notifications and privacy. Falls back to global
  * preferences if not customized.
  */
-export const userpreferencesGetOrganizationPreferences = <ThrowOnError extends boolean = false>(
-	options: Options<UserpreferencesGetOrganizationPreferences949D37A6Data, ThrowOnError>
+export const userpreferencesGetOrganizationPreferences = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<UserpreferencesGetOrganizationPreferences88F57589Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		UserpreferencesGetOrganizationPreferences949D37A6Responses,
+		UserpreferencesGetOrganizationPreferences88F57589Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4749,11 +4772,13 @@ export const userpreferencesGetOrganizationPreferences = <ThrowOnError extends b
  * Overrides global defaults for this organization. Set overwrite_children=true to cascade
  * changes to all series/event-level preferences within this organization.
  */
-export const userpreferencesUpdateOrganizationPreferences = <ThrowOnError extends boolean = false>(
-	options: Options<UserpreferencesUpdateOrganizationPreferencesC6Ac6679Data, ThrowOnError>
+export const userpreferencesUpdateOrganizationPreferences = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<UserpreferencesUpdateOrganizationPreferences195D88D0Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		UserpreferencesUpdateOrganizationPreferencesC6Ac6679Responses,
+		UserpreferencesUpdateOrganizationPreferences195D88D0Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4780,11 +4805,13 @@ export const userpreferencesUpdateOrganizationPreferences = <ThrowOnError extend
  * Returns series-level overrides for notifications. Falls back to organization or global
  * preferences if not customized.
  */
-export const userpreferencesGetEventSeriesPreferences = <ThrowOnError extends boolean = false>(
-	options: Options<UserpreferencesGetEventSeriesPreferencesAa9Fac27Data, ThrowOnError>
+export const userpreferencesGetEventSeriesPreferences = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		UserpreferencesGetEventSeriesPreferencesAa9Fac27Responses,
+		UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4807,11 +4834,13 @@ export const userpreferencesGetEventSeriesPreferences = <ThrowOnError extends bo
  * Overrides organization/global defaults for this series. Set overwrite_children=true to
  * cascade changes to all individual event preferences within this series.
  */
-export const userpreferencesUpdateEventSeriesPreferences = <ThrowOnError extends boolean = false>(
-	options: Options<UserpreferencesUpdateEventSeriesPreferences1645B0AaData, ThrowOnError>
+export const userpreferencesUpdateEventSeriesPreferences = <
+	ThrowOnError extends boolean = false
+>(
+	options: Options<UserpreferencesUpdateEventSeriesPreferences193210FbData, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		UserpreferencesUpdateEventSeriesPreferences1645B0AaResponses,
+		UserpreferencesUpdateEventSeriesPreferences193210FbResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4839,10 +4868,10 @@ export const userpreferencesUpdateEventSeriesPreferences = <ThrowOnError extends
  * global preferences if not customized.
  */
 export const userpreferencesGetEventPreferences = <ThrowOnError extends boolean = false>(
-	options: Options<UserpreferencesGetEventPreferences3D6F9189Data, ThrowOnError>
+	options: Options<UserpreferencesGetEventPreferencesFcb49Eb8Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).get<
-		UserpreferencesGetEventPreferences3D6F9189Responses,
+		UserpreferencesGetEventPreferencesFcb49Eb8Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4866,10 +4895,10 @@ export const userpreferencesGetEventPreferences = <ThrowOnError extends boolean 
  * level always takes precedence.
  */
 export const userpreferencesUpdateEventPreferences = <ThrowOnError extends boolean = false>(
-	options: Options<UserpreferencesUpdateEventPreferences3Ca1F5D4Data, ThrowOnError>
+	options: Options<UserpreferencesUpdateEventPreferences501B0Ad6Data, ThrowOnError>
 ) => {
 	return (options.client ?? client).put<
-		UserpreferencesUpdateEventPreferences3Ca1F5D4Responses,
+		UserpreferencesUpdateEventPreferences501B0Ad6Responses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4897,10 +4926,10 @@ export const userpreferencesUpdateEventPreferences = <ThrowOnError extends boole
  * security. This endpoint is called by Stripe, not by clients directly.
  */
 export const stripewebhookHandleWebhook = <ThrowOnError extends boolean = false>(
-	options?: Options<StripewebhookHandleWebhookAb33E84dData, ThrowOnError>
+	options?: Options<StripewebhookHandleWebhook7Ce75AaaData, ThrowOnError>
 ) => {
 	return (options?.client ?? client).post<
-		StripewebhookHandleWebhookAb33E84dResponses,
+		StripewebhookHandleWebhook7Ce75AaaResponses,
 		unknown,
 		ThrowOnError
 	>({
@@ -4916,12 +4945,12 @@ export const stripewebhookHandleWebhook = <ThrowOnError extends boolean = false>
  *
  * Tags are used to categorize organizations, events, and series. Supports autocomplete via
  * the 'search' query parameter (e.g., /api/tags/?search=tech). Use this to populate tag
- * selection dropdowns or filters.
+ * selection dropdowns or filters. Results are ordered by popularity (most used first).
  */
 export const tagListTags = <ThrowOnError extends boolean = false>(
-	options?: Options<TagListTagsCa3Ddb22Data, ThrowOnError>
+	options?: Options<TagListTags4B7C76E5Data, ThrowOnError>
 ) => {
-	return (options?.client ?? client).get<TagListTagsCa3Ddb22Responses, unknown, ThrowOnError>({
+	return (options?.client ?? client).get<TagListTags4B7C76E5Responses, unknown, ThrowOnError>({
 		url: '/api/tags/',
 		...options
 	});
@@ -4937,9 +4966,9 @@ export const tagListTags = <ThrowOnError extends boolean = false>(
  * filtering events by location.
  */
 export const cityListCities = <ThrowOnError extends boolean = false>(
-	options?: Options<CityListCities6B5493E8Data, ThrowOnError>
+	options?: Options<CityListCitiesEd3A17BdData, ThrowOnError>
 ) => {
-	return (options?.client ?? client).get<CityListCities6B5493E8Responses, unknown, ThrowOnError>({
+	return (options?.client ?? client).get<CityListCitiesEd3A17BdResponses, unknown, ThrowOnError>({
 		url: '/api/cities/',
 		...options
 	});
@@ -4954,9 +4983,9 @@ export const cityListCities = <ThrowOnError extends boolean = false>(
  * selection dropdowns in location pickers.
  */
 export const cityListCountries = <ThrowOnError extends boolean = false>(
-	options?: Options<CityListCountries5Dac3B77Data, ThrowOnError>
+	options?: Options<CityListCountries2Bb24454Data, ThrowOnError>
 ) => {
-	return (options?.client ?? client).get<CityListCountries5Dac3B77Responses, unknown, ThrowOnError>(
+	return (options?.client ?? client).get<CityListCountries2Bb24454Responses, unknown, ThrowOnError>(
 		{
 			url: '/api/cities/countries',
 			...options
@@ -4973,9 +5002,9 @@ export const cityListCountries = <ThrowOnError extends boolean = false>(
  * get full city information after selecting from a search result.
  */
 export const cityGetCity = <ThrowOnError extends boolean = false>(
-	options: Options<CityGetCity7711686bData, ThrowOnError>
+	options: Options<CityGetCityB0410Ba7Data, ThrowOnError>
 ) => {
-	return (options.client ?? client).get<CityGetCity7711686bResponses, unknown, ThrowOnError>({
+	return (options.client ?? client).get<CityGetCityB0410Ba7Responses, unknown, ThrowOnError>({
 		url: '/api/cities/{city_id}',
 		...options
 	});

--- a/src/lib/api/generated/types.gen.ts
+++ b/src/lib/api/generated/types.gen.ts
@@ -4562,14 +4562,14 @@ export type ApiApiHealthcheckResponses = {
 export type ApiApiHealthcheckResponse =
 	ApiApiHealthcheckResponses[keyof ApiApiHealthcheckResponses];
 
-export type AuthObtainTokenF0Ed10A6Data = {
+export type AuthObtainToken1Ada7A04Data = {
 	body: TokenObtainPairInputSchema;
 	path?: never;
 	query?: never;
 	url: '/api/auth/token/pair';
 };
 
-export type AuthObtainTokenF0Ed10A6Responses = {
+export type AuthObtainToken1Ada7A04Responses = {
 	/**
 	 * Response
 	 *
@@ -4578,8 +4578,8 @@ export type AuthObtainTokenF0Ed10A6Responses = {
 	200: TokenObtainPairOutputSchema | TempToken;
 };
 
-export type AuthObtainTokenF0Ed10A6Response =
-	AuthObtainTokenF0Ed10A6Responses[keyof AuthObtainTokenF0Ed10A6Responses];
+export type AuthObtainToken1Ada7A04Response =
+	AuthObtainToken1Ada7A04Responses[keyof AuthObtainToken1Ada7A04Responses];
 
 export type TokenRefreshData = {
 	body: TokenRefreshInputSchema;
@@ -4597,289 +4597,289 @@ export type TokenRefreshResponses = {
 
 export type TokenRefreshResponse = TokenRefreshResponses[keyof TokenRefreshResponses];
 
-export type AuthDemoObtainTokenF9683D25Data = {
+export type AuthDemoObtainTokenC30F0580Data = {
 	body: DemoLoginSchema;
 	path?: never;
 	query?: never;
 	url: '/api/auth/demo/token/pair';
 };
 
-export type AuthDemoObtainTokenF9683D25Responses = {
+export type AuthDemoObtainTokenC30F0580Responses = {
 	/**
 	 * OK
 	 */
 	200: TokenObtainPairOutputSchema;
 };
 
-export type AuthDemoObtainTokenF9683D25Response =
-	AuthDemoObtainTokenF9683D25Responses[keyof AuthDemoObtainTokenF9683D25Responses];
+export type AuthDemoObtainTokenC30F0580Response =
+	AuthDemoObtainTokenC30F0580Responses[keyof AuthDemoObtainTokenC30F0580Responses];
 
-export type AuthObtainTokenWithOtpCad64Ee2Data = {
+export type AuthObtainTokenWithOtp6Dee1057Data = {
 	body: TempTokenWithTotp;
 	path?: never;
 	query?: never;
 	url: '/api/auth/token/pair/otp';
 };
 
-export type AuthObtainTokenWithOtpCad64Ee2Responses = {
+export type AuthObtainTokenWithOtp6Dee1057Responses = {
 	/**
 	 * OK
 	 */
 	200: TokenObtainPairOutputSchema;
 };
 
-export type AuthObtainTokenWithOtpCad64Ee2Response =
-	AuthObtainTokenWithOtpCad64Ee2Responses[keyof AuthObtainTokenWithOtpCad64Ee2Responses];
+export type AuthObtainTokenWithOtp6Dee1057Response =
+	AuthObtainTokenWithOtp6Dee1057Responses[keyof AuthObtainTokenWithOtp6Dee1057Responses];
 
-export type AuthGoogleLogin778Da160Data = {
+export type AuthGoogleLogin03Be8978Data = {
 	body: GoogleIdTokenSchema;
 	path?: never;
 	query?: never;
 	url: '/api/auth/google/login';
 };
 
-export type AuthGoogleLogin778Da160Responses = {
+export type AuthGoogleLogin03Be8978Responses = {
 	/**
 	 * OK
 	 */
 	200: TokenObtainPairOutputSchema;
 };
 
-export type AuthGoogleLogin778Da160Response =
-	AuthGoogleLogin778Da160Responses[keyof AuthGoogleLogin778Da160Responses];
+export type AuthGoogleLogin03Be8978Response =
+	AuthGoogleLogin03Be8978Responses[keyof AuthGoogleLogin03Be8978Responses];
 
-export type OtpSetupOtpB2211117Data = {
+export type OtpSetupOtpD344D864Data = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/otp/setup';
 };
 
-export type OtpSetupOtpB2211117Responses = {
+export type OtpSetupOtpD344D864Responses = {
 	/**
 	 * OK
 	 */
 	200: TotpProvisioningUriSchema;
 };
 
-export type OtpSetupOtpB2211117Response =
-	OtpSetupOtpB2211117Responses[keyof OtpSetupOtpB2211117Responses];
+export type OtpSetupOtpD344D864Response =
+	OtpSetupOtpD344D864Responses[keyof OtpSetupOtpD344D864Responses];
 
-export type OtpEnableOtpBd1478D0Data = {
+export type OtpEnableOtpD67A68A0Data = {
 	body: OtpVerifySchema;
 	path?: never;
 	query?: never;
 	url: '/api/otp/verify';
 };
 
-export type OtpEnableOtpBd1478D0Responses = {
+export type OtpEnableOtpD67A68A0Responses = {
 	/**
 	 * OK
 	 */
 	200: RevelUserSchema;
 };
 
-export type OtpEnableOtpBd1478D0Response =
-	OtpEnableOtpBd1478D0Responses[keyof OtpEnableOtpBd1478D0Responses];
+export type OtpEnableOtpD67A68A0Response =
+	OtpEnableOtpD67A68A0Responses[keyof OtpEnableOtpD67A68A0Responses];
 
-export type OtpDisableOtp44832EbfData = {
+export type OtpDisableOtp0Db1Dc6aData = {
 	body: OtpVerifySchema;
 	path?: never;
 	query?: never;
 	url: '/api/otp/disable';
 };
 
-export type OtpDisableOtp44832EbfResponses = {
+export type OtpDisableOtp0Db1Dc6aResponses = {
 	/**
 	 * OK
 	 */
 	200: RevelUserSchema;
 };
 
-export type OtpDisableOtp44832EbfResponse =
-	OtpDisableOtp44832EbfResponses[keyof OtpDisableOtp44832EbfResponses];
+export type OtpDisableOtp0Db1Dc6aResponse =
+	OtpDisableOtp0Db1Dc6aResponses[keyof OtpDisableOtp0Db1Dc6aResponses];
 
-export type AccountExportData68C7E4DbData = {
+export type AccountExportDataBa4Eefa4Data = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/account/export-data';
 };
 
-export type AccountExportData68C7E4DbResponses = {
+export type AccountExportDataBa4Eefa4Responses = {
 	/**
 	 * OK
 	 */
 	200: ResponseMessage;
 };
 
-export type AccountExportData68C7E4DbResponse =
-	AccountExportData68C7E4DbResponses[keyof AccountExportData68C7E4DbResponses];
+export type AccountExportDataBa4Eefa4Response =
+	AccountExportDataBa4Eefa4Responses[keyof AccountExportDataBa4Eefa4Responses];
 
-export type AccountMe6420Cff8Data = {
+export type AccountMe250Fac7cData = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/account/me';
 };
 
-export type AccountMe6420Cff8Responses = {
+export type AccountMe250Fac7cResponses = {
 	/**
 	 * OK
 	 */
 	200: RevelUserSchema;
 };
 
-export type AccountMe6420Cff8Response =
-	AccountMe6420Cff8Responses[keyof AccountMe6420Cff8Responses];
+export type AccountMe250Fac7cResponse =
+	AccountMe250Fac7cResponses[keyof AccountMe250Fac7cResponses];
 
-export type AccountUpdateProfile5D6D1Db7Data = {
+export type AccountUpdateProfileC460A981Data = {
 	body: ProfileUpdateSchema;
 	path?: never;
 	query?: never;
 	url: '/api/account/me';
 };
 
-export type AccountUpdateProfile5D6D1Db7Responses = {
+export type AccountUpdateProfileC460A981Responses = {
 	/**
 	 * OK
 	 */
 	200: RevelUserSchema;
 };
 
-export type AccountUpdateProfile5D6D1Db7Response =
-	AccountUpdateProfile5D6D1Db7Responses[keyof AccountUpdateProfile5D6D1Db7Responses];
+export type AccountUpdateProfileC460A981Response =
+	AccountUpdateProfileC460A981Responses[keyof AccountUpdateProfileC460A981Responses];
 
-export type AccountRegister0E682147Data = {
+export type AccountRegister60A39A8dData = {
 	body: RegisterUserSchema;
 	path?: never;
 	query?: never;
 	url: '/api/account/register';
 };
 
-export type AccountRegister0E682147Responses = {
+export type AccountRegister60A39A8dResponses = {
 	/**
 	 * Created
 	 */
 	201: RevelUserSchema;
 };
 
-export type AccountRegister0E682147Response =
-	AccountRegister0E682147Responses[keyof AccountRegister0E682147Responses];
+export type AccountRegister60A39A8dResponse =
+	AccountRegister60A39A8dResponses[keyof AccountRegister60A39A8dResponses];
 
-export type AccountVerifyEmailC5B88297Data = {
+export type AccountVerifyEmailC1Db4Da9Data = {
 	body: VerifyEmailSchema;
 	path?: never;
 	query?: never;
 	url: '/api/account/verify';
 };
 
-export type AccountVerifyEmailC5B88297Responses = {
+export type AccountVerifyEmailC1Db4Da9Responses = {
 	/**
 	 * OK
 	 */
 	200: VerifyEmailResponseSchema;
 };
 
-export type AccountVerifyEmailC5B88297Response =
-	AccountVerifyEmailC5B88297Responses[keyof AccountVerifyEmailC5B88297Responses];
+export type AccountVerifyEmailC1Db4Da9Response =
+	AccountVerifyEmailC1Db4Da9Responses[keyof AccountVerifyEmailC1Db4Da9Responses];
 
-export type AccountResendVerificationEmailDca4C406Data = {
+export type AccountResendVerificationEmail58F3B280Data = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/account/verify-resend';
 };
 
-export type AccountResendVerificationEmailDca4C406Errors = {
+export type AccountResendVerificationEmail58F3B280Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: ResponseMessage;
 };
 
-export type AccountResendVerificationEmailDca4C406Error =
-	AccountResendVerificationEmailDca4C406Errors[keyof AccountResendVerificationEmailDca4C406Errors];
+export type AccountResendVerificationEmail58F3B280Error =
+	AccountResendVerificationEmail58F3B280Errors[keyof AccountResendVerificationEmail58F3B280Errors];
 
-export type AccountResendVerificationEmailDca4C406Responses = {
+export type AccountResendVerificationEmail58F3B280Responses = {
 	/**
 	 * OK
 	 */
 	200: ResponseMessage;
 };
 
-export type AccountResendVerificationEmailDca4C406Response =
-	AccountResendVerificationEmailDca4C406Responses[keyof AccountResendVerificationEmailDca4C406Responses];
+export type AccountResendVerificationEmail58F3B280Response =
+	AccountResendVerificationEmail58F3B280Responses[keyof AccountResendVerificationEmail58F3B280Responses];
 
-export type AccountDeleteAccountRequest8786843dData = {
+export type AccountDeleteAccountRequest36F5A4F2Data = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/account/delete-request';
 };
 
-export type AccountDeleteAccountRequest8786843dResponses = {
+export type AccountDeleteAccountRequest36F5A4F2Responses = {
 	/**
 	 * OK
 	 */
 	200: ResponseMessage;
 };
 
-export type AccountDeleteAccountRequest8786843dResponse =
-	AccountDeleteAccountRequest8786843dResponses[keyof AccountDeleteAccountRequest8786843dResponses];
+export type AccountDeleteAccountRequest36F5A4F2Response =
+	AccountDeleteAccountRequest36F5A4F2Responses[keyof AccountDeleteAccountRequest36F5A4F2Responses];
 
-export type AccountDeleteAccountConfirm51Aca775Data = {
+export type AccountDeleteAccountConfirm77E53A9bData = {
 	body: DeleteAccountConfirmSchema;
 	path?: never;
 	query?: never;
 	url: '/api/account/delete-confirm';
 };
 
-export type AccountDeleteAccountConfirm51Aca775Responses = {
+export type AccountDeleteAccountConfirm77E53A9bResponses = {
 	/**
 	 * OK
 	 */
 	200: ResponseMessage;
 };
 
-export type AccountDeleteAccountConfirm51Aca775Response =
-	AccountDeleteAccountConfirm51Aca775Responses[keyof AccountDeleteAccountConfirm51Aca775Responses];
+export type AccountDeleteAccountConfirm77E53A9bResponse =
+	AccountDeleteAccountConfirm77E53A9bResponses[keyof AccountDeleteAccountConfirm77E53A9bResponses];
 
-export type AccountResetPasswordRequest159B2A43Data = {
+export type AccountResetPasswordRequest6Ca44671Data = {
 	body: PasswordResetRequestSchema;
 	path?: never;
 	query?: never;
 	url: '/api/account/password/reset-request';
 };
 
-export type AccountResetPasswordRequest159B2A43Responses = {
+export type AccountResetPasswordRequest6Ca44671Responses = {
 	/**
 	 * OK
 	 */
 	200: ResponseMessage;
 };
 
-export type AccountResetPasswordRequest159B2A43Response =
-	AccountResetPasswordRequest159B2A43Responses[keyof AccountResetPasswordRequest159B2A43Responses];
+export type AccountResetPasswordRequest6Ca44671Response =
+	AccountResetPasswordRequest6Ca44671Responses[keyof AccountResetPasswordRequest6Ca44671Responses];
 
-export type AccountResetPassword03A7Fc3dData = {
+export type AccountResetPassword1Fb3F0E6Data = {
 	body: PasswordResetSchema;
 	path?: never;
 	query?: never;
 	url: '/api/account/password/reset';
 };
 
-export type AccountResetPassword03A7Fc3dResponses = {
+export type AccountResetPassword1Fb3F0E6Responses = {
 	/**
 	 * OK
 	 */
 	200: ResponseMessage;
 };
 
-export type AccountResetPassword03A7Fc3dResponse =
-	AccountResetPassword03A7Fc3dResponses[keyof AccountResetPassword03A7Fc3dResponses];
+export type AccountResetPassword1Fb3F0E6Response =
+	AccountResetPassword1Fb3F0E6Responses[keyof AccountResetPassword1Fb3F0E6Responses];
 
-export type DashboardDashboardOrganizations03Daa3C4Data = {
+export type DashboardDashboardOrganizationsF23703B2Data = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -4915,17 +4915,17 @@ export type DashboardDashboardOrganizations03Daa3C4Data = {
 	url: '/api/dashboard/organizations';
 };
 
-export type DashboardDashboardOrganizations03Daa3C4Responses = {
+export type DashboardDashboardOrganizationsF23703B2Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaOrganizationRetrieveSchema;
 };
 
-export type DashboardDashboardOrganizations03Daa3C4Response =
-	DashboardDashboardOrganizations03Daa3C4Responses[keyof DashboardDashboardOrganizations03Daa3C4Responses];
+export type DashboardDashboardOrganizationsF23703B2Response =
+	DashboardDashboardOrganizationsF23703B2Responses[keyof DashboardDashboardOrganizationsF23703B2Responses];
 
-export type DashboardDashboardEvents6Cb96588Data = {
+export type DashboardDashboardEventsAae8306bData = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -4985,17 +4985,17 @@ export type DashboardDashboardEvents6Cb96588Data = {
 	url: '/api/dashboard/events';
 };
 
-export type DashboardDashboardEvents6Cb96588Responses = {
+export type DashboardDashboardEventsAae8306bResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaEventInListSchema;
 };
 
-export type DashboardDashboardEvents6Cb96588Response =
-	DashboardDashboardEvents6Cb96588Responses[keyof DashboardDashboardEvents6Cb96588Responses];
+export type DashboardDashboardEventsAae8306bResponse =
+	DashboardDashboardEventsAae8306bResponses[keyof DashboardDashboardEventsAae8306bResponses];
 
-export type DashboardDashboardEventSeriesC961639bData = {
+export type DashboardDashboardEventSeries5D1Acbc6Data = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -5031,17 +5031,17 @@ export type DashboardDashboardEventSeriesC961639bData = {
 	url: '/api/dashboard/event_series';
 };
 
-export type DashboardDashboardEventSeriesC961639bResponses = {
+export type DashboardDashboardEventSeries5D1Acbc6Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaEventSeriesRetrieveSchema;
 };
 
-export type DashboardDashboardEventSeriesC961639bResponse =
-	DashboardDashboardEventSeriesC961639bResponses[keyof DashboardDashboardEventSeriesC961639bResponses];
+export type DashboardDashboardEventSeries5D1Acbc6Response =
+	DashboardDashboardEventSeries5D1Acbc6Responses[keyof DashboardDashboardEventSeries5D1Acbc6Responses];
 
-export type DashboardDashboardInvitations2F2132B0Data = {
+export type DashboardDashboardInvitations7Ee7C5BaData = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -5061,17 +5061,17 @@ export type DashboardDashboardInvitations2F2132B0Data = {
 	url: '/api/dashboard/invitations';
 };
 
-export type DashboardDashboardInvitations2F2132B0Responses = {
+export type DashboardDashboardInvitations7Ee7C5BaResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaInvitationSchema;
 };
 
-export type DashboardDashboardInvitations2F2132B0Response =
-	DashboardDashboardInvitations2F2132B0Responses[keyof DashboardDashboardInvitations2F2132B0Responses];
+export type DashboardDashboardInvitations7Ee7C5BaResponse =
+	DashboardDashboardInvitations7Ee7C5BaResponses[keyof DashboardDashboardInvitations7Ee7C5BaResponses];
 
-export type OrganizationListOrganizations3C31A7EaData = {
+export type OrganizationListOrganizations677967C6Data = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -5107,17 +5107,17 @@ export type OrganizationListOrganizations3C31A7EaData = {
 	url: '/api/organizations/';
 };
 
-export type OrganizationListOrganizations3C31A7EaResponses = {
+export type OrganizationListOrganizations677967C6Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaOrganizationRetrieveSchema;
 };
 
-export type OrganizationListOrganizations3C31A7EaResponse =
-	OrganizationListOrganizations3C31A7EaResponses[keyof OrganizationListOrganizations3C31A7EaResponses];
+export type OrganizationListOrganizations677967C6Response =
+	OrganizationListOrganizations677967C6Responses[keyof OrganizationListOrganizations677967C6Responses];
 
-export type OrganizationGetOrganization45F68219Data = {
+export type OrganizationGetOrganization1E83Fee3Data = {
 	body?: never;
 	path: {
 		/**
@@ -5129,17 +5129,17 @@ export type OrganizationGetOrganization45F68219Data = {
 	url: '/api/organizations/{slug}';
 };
 
-export type OrganizationGetOrganization45F68219Responses = {
+export type OrganizationGetOrganization1E83Fee3Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationRetrieveSchema;
 };
 
-export type OrganizationGetOrganization45F68219Response =
-	OrganizationGetOrganization45F68219Responses[keyof OrganizationGetOrganization45F68219Responses];
+export type OrganizationGetOrganization1E83Fee3Response =
+	OrganizationGetOrganization1E83Fee3Responses[keyof OrganizationGetOrganization1E83Fee3Responses];
 
-export type OrganizationListResources902770CcData = {
+export type OrganizationListResourcesDfae4Ce0Data = {
 	body?: never;
 	path: {
 		/**
@@ -5165,17 +5165,17 @@ export type OrganizationListResources902770CcData = {
 	url: '/api/organizations/{slug}/resources';
 };
 
-export type OrganizationListResources902770CcResponses = {
+export type OrganizationListResourcesDfae4Ce0Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaAdditionalResourceSchema;
 };
 
-export type OrganizationListResources902770CcResponse =
-	OrganizationListResources902770CcResponses[keyof OrganizationListResources902770CcResponses];
+export type OrganizationListResourcesDfae4Ce0Response =
+	OrganizationListResourcesDfae4Ce0Responses[keyof OrganizationListResourcesDfae4Ce0Responses];
 
-export type OrganizationCreateMembershipRequestC7302D18Data = {
+export type OrganizationCreateMembershipRequest5Cf8052cData = {
 	body: OrganizationMembershipRequestCreateSchema;
 	path: {
 		/**
@@ -5187,17 +5187,17 @@ export type OrganizationCreateMembershipRequestC7302D18Data = {
 	url: '/api/organizations/{slug}/membership-requests';
 };
 
-export type OrganizationCreateMembershipRequestC7302D18Responses = {
+export type OrganizationCreateMembershipRequest5Cf8052cResponses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationMembershipRequestRetrieve;
 };
 
-export type OrganizationCreateMembershipRequestC7302D18Response =
-	OrganizationCreateMembershipRequestC7302D18Responses[keyof OrganizationCreateMembershipRequestC7302D18Responses];
+export type OrganizationCreateMembershipRequest5Cf8052cResponse =
+	OrganizationCreateMembershipRequest5Cf8052cResponses[keyof OrganizationCreateMembershipRequest5Cf8052cResponses];
 
-export type OrganizationClaimInvitation5C32FadfData = {
+export type OrganizationClaimInvitation54B9F34bData = {
 	body?: never;
 	path: {
 		/**
@@ -5209,27 +5209,27 @@ export type OrganizationClaimInvitation5C32FadfData = {
 	url: '/api/organizations/claim-invitation/{token}';
 };
 
-export type OrganizationClaimInvitation5C32FadfErrors = {
+export type OrganizationClaimInvitation54B9F34bErrors = {
 	/**
 	 * Bad Request
 	 */
 	400: ResponseMessage;
 };
 
-export type OrganizationClaimInvitation5C32FadfError =
-	OrganizationClaimInvitation5C32FadfErrors[keyof OrganizationClaimInvitation5C32FadfErrors];
+export type OrganizationClaimInvitation54B9F34bError =
+	OrganizationClaimInvitation54B9F34bErrors[keyof OrganizationClaimInvitation54B9F34bErrors];
 
-export type OrganizationClaimInvitation5C32FadfResponses = {
+export type OrganizationClaimInvitation54B9F34bResponses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationRetrieveSchema;
 };
 
-export type OrganizationClaimInvitation5C32FadfResponse =
-	OrganizationClaimInvitation5C32FadfResponses[keyof OrganizationClaimInvitation5C32FadfResponses];
+export type OrganizationClaimInvitation54B9F34bResponse =
+	OrganizationClaimInvitation54B9F34bResponses[keyof OrganizationClaimInvitation54B9F34bResponses];
 
-export type OrganizationadminGetOrganization52A02A44Data = {
+export type OrganizationadminGetOrganizationE58408BeData = {
 	body?: never;
 	path: {
 		/**
@@ -5241,17 +5241,17 @@ export type OrganizationadminGetOrganization52A02A44Data = {
 	url: '/api/organization-admin/{slug}';
 };
 
-export type OrganizationadminGetOrganization52A02A44Responses = {
+export type OrganizationadminGetOrganizationE58408BeResponses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationAdminDetailSchema;
 };
 
-export type OrganizationadminGetOrganization52A02A44Response =
-	OrganizationadminGetOrganization52A02A44Responses[keyof OrganizationadminGetOrganization52A02A44Responses];
+export type OrganizationadminGetOrganizationE58408BeResponse =
+	OrganizationadminGetOrganizationE58408BeResponses[keyof OrganizationadminGetOrganizationE58408BeResponses];
 
-export type OrganizationadminUpdateOrganization6E5B1F9bData = {
+export type OrganizationadminUpdateOrganizationEe5B024aData = {
 	body: OrganizationEditSchema;
 	path: {
 		/**
@@ -5263,17 +5263,17 @@ export type OrganizationadminUpdateOrganization6E5B1F9bData = {
 	url: '/api/organization-admin/{slug}';
 };
 
-export type OrganizationadminUpdateOrganization6E5B1F9bResponses = {
+export type OrganizationadminUpdateOrganizationEe5B024aResponses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationRetrieveSchema;
 };
 
-export type OrganizationadminUpdateOrganization6E5B1F9bResponse =
-	OrganizationadminUpdateOrganization6E5B1F9bResponses[keyof OrganizationadminUpdateOrganization6E5B1F9bResponses];
+export type OrganizationadminUpdateOrganizationEe5B024aResponse =
+	OrganizationadminUpdateOrganizationEe5B024aResponses[keyof OrganizationadminUpdateOrganizationEe5B024aResponses];
 
-export type OrganizationadminStripeConnect5702Ef2eData = {
+export type OrganizationadminStripeConnect9Aef347dData = {
 	body?: never;
 	path: {
 		/**
@@ -5285,17 +5285,17 @@ export type OrganizationadminStripeConnect5702Ef2eData = {
 	url: '/api/organization-admin/{slug}/stripe/connect';
 };
 
-export type OrganizationadminStripeConnect5702Ef2eResponses = {
+export type OrganizationadminStripeConnect9Aef347dResponses = {
 	/**
 	 * OK
 	 */
 	200: StripeOnboardingLinkSchema;
 };
 
-export type OrganizationadminStripeConnect5702Ef2eResponse =
-	OrganizationadminStripeConnect5702Ef2eResponses[keyof OrganizationadminStripeConnect5702Ef2eResponses];
+export type OrganizationadminStripeConnect9Aef347dResponse =
+	OrganizationadminStripeConnect9Aef347dResponses[keyof OrganizationadminStripeConnect9Aef347dResponses];
 
-export type OrganizationadminStripeAccountVerify3F404331Data = {
+export type OrganizationadminStripeAccountVerify5337F3F2Data = {
 	body?: never;
 	path: {
 		/**
@@ -5307,17 +5307,17 @@ export type OrganizationadminStripeAccountVerify3F404331Data = {
 	url: '/api/organization-admin/{slug}/stripe/account/verify';
 };
 
-export type OrganizationadminStripeAccountVerify3F404331Responses = {
+export type OrganizationadminStripeAccountVerify5337F3F2Responses = {
 	/**
 	 * OK
 	 */
 	200: StripeAccountStatusSchema;
 };
 
-export type OrganizationadminStripeAccountVerify3F404331Response =
-	OrganizationadminStripeAccountVerify3F404331Responses[keyof OrganizationadminStripeAccountVerify3F404331Responses];
+export type OrganizationadminStripeAccountVerify5337F3F2Response =
+	OrganizationadminStripeAccountVerify5337F3F2Responses[keyof OrganizationadminStripeAccountVerify5337F3F2Responses];
 
-export type OrganizationadminUploadLogoB141E351Data = {
+export type OrganizationadminUploadLogoFe609D30Data = {
 	/**
 	 * FileParams
 	 */
@@ -5337,17 +5337,17 @@ export type OrganizationadminUploadLogoB141E351Data = {
 	url: '/api/organization-admin/{slug}/upload-logo';
 };
 
-export type OrganizationadminUploadLogoB141E351Responses = {
+export type OrganizationadminUploadLogoFe609D30Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationRetrieveSchema;
 };
 
-export type OrganizationadminUploadLogoB141E351Response =
-	OrganizationadminUploadLogoB141E351Responses[keyof OrganizationadminUploadLogoB141E351Responses];
+export type OrganizationadminUploadLogoFe609D30Response =
+	OrganizationadminUploadLogoFe609D30Responses[keyof OrganizationadminUploadLogoFe609D30Responses];
 
-export type OrganizationadminUploadCoverArtF9C552CbData = {
+export type OrganizationadminUploadCoverArt3F00Bfd7Data = {
 	/**
 	 * FileParams
 	 */
@@ -5367,17 +5367,17 @@ export type OrganizationadminUploadCoverArtF9C552CbData = {
 	url: '/api/organization-admin/{slug}/upload-cover-art';
 };
 
-export type OrganizationadminUploadCoverArtF9C552CbResponses = {
+export type OrganizationadminUploadCoverArt3F00Bfd7Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationRetrieveSchema;
 };
 
-export type OrganizationadminUploadCoverArtF9C552CbResponse =
-	OrganizationadminUploadCoverArtF9C552CbResponses[keyof OrganizationadminUploadCoverArtF9C552CbResponses];
+export type OrganizationadminUploadCoverArt3F00Bfd7Response =
+	OrganizationadminUploadCoverArt3F00Bfd7Responses[keyof OrganizationadminUploadCoverArt3F00Bfd7Responses];
 
-export type OrganizationadminDeleteLogo2B684AbaData = {
+export type OrganizationadminDeleteLogo01Cb7A33Data = {
 	body?: never;
 	path: {
 		/**
@@ -5389,17 +5389,17 @@ export type OrganizationadminDeleteLogo2B684AbaData = {
 	url: '/api/organization-admin/{slug}/delete-logo';
 };
 
-export type OrganizationadminDeleteLogo2B684AbaResponses = {
+export type OrganizationadminDeleteLogo01Cb7A33Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminDeleteLogo2B684AbaResponse =
-	OrganizationadminDeleteLogo2B684AbaResponses[keyof OrganizationadminDeleteLogo2B684AbaResponses];
+export type OrganizationadminDeleteLogo01Cb7A33Response =
+	OrganizationadminDeleteLogo01Cb7A33Responses[keyof OrganizationadminDeleteLogo01Cb7A33Responses];
 
-export type OrganizationadminDeleteCoverArt0F663C07Data = {
+export type OrganizationadminDeleteCoverArtB1Ab5A10Data = {
 	body?: never;
 	path: {
 		/**
@@ -5411,17 +5411,17 @@ export type OrganizationadminDeleteCoverArt0F663C07Data = {
 	url: '/api/organization-admin/{slug}/delete-cover-art';
 };
 
-export type OrganizationadminDeleteCoverArt0F663C07Responses = {
+export type OrganizationadminDeleteCoverArtB1Ab5A10Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminDeleteCoverArt0F663C07Response =
-	OrganizationadminDeleteCoverArt0F663C07Responses[keyof OrganizationadminDeleteCoverArt0F663C07Responses];
+export type OrganizationadminDeleteCoverArtB1Ab5A10Response =
+	OrganizationadminDeleteCoverArtB1Ab5A10Responses[keyof OrganizationadminDeleteCoverArtB1Ab5A10Responses];
 
-export type OrganizationadminCreateEventSeries909F81BdData = {
+export type OrganizationadminCreateEventSeries0E8E48F6Data = {
 	body: EventSeriesEditSchema;
 	path: {
 		/**
@@ -5433,27 +5433,27 @@ export type OrganizationadminCreateEventSeries909F81BdData = {
 	url: '/api/organization-admin/{slug}/create-event-series';
 };
 
-export type OrganizationadminCreateEventSeries909F81BdErrors = {
+export type OrganizationadminCreateEventSeries0E8E48F6Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: ValidationErrorResponse;
 };
 
-export type OrganizationadminCreateEventSeries909F81BdError =
-	OrganizationadminCreateEventSeries909F81BdErrors[keyof OrganizationadminCreateEventSeries909F81BdErrors];
+export type OrganizationadminCreateEventSeries0E8E48F6Error =
+	OrganizationadminCreateEventSeries0E8E48F6Errors[keyof OrganizationadminCreateEventSeries0E8E48F6Errors];
 
-export type OrganizationadminCreateEventSeries909F81BdResponses = {
+export type OrganizationadminCreateEventSeries0E8E48F6Responses = {
 	/**
 	 * OK
 	 */
 	200: EventSeriesRetrieveSchema;
 };
 
-export type OrganizationadminCreateEventSeries909F81BdResponse =
-	OrganizationadminCreateEventSeries909F81BdResponses[keyof OrganizationadminCreateEventSeries909F81BdResponses];
+export type OrganizationadminCreateEventSeries0E8E48F6Response =
+	OrganizationadminCreateEventSeries0E8E48F6Responses[keyof OrganizationadminCreateEventSeries0E8E48F6Responses];
 
-export type OrganizationadminCreateEvent051E2C16Data = {
+export type OrganizationadminCreateEvent5D6D9536Data = {
 	body: EventCreateSchema;
 	path: {
 		/**
@@ -5465,27 +5465,27 @@ export type OrganizationadminCreateEvent051E2C16Data = {
 	url: '/api/organization-admin/{slug}/create-event';
 };
 
-export type OrganizationadminCreateEvent051E2C16Errors = {
+export type OrganizationadminCreateEvent5D6D9536Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: ValidationErrorResponse;
 };
 
-export type OrganizationadminCreateEvent051E2C16Error =
-	OrganizationadminCreateEvent051E2C16Errors[keyof OrganizationadminCreateEvent051E2C16Errors];
+export type OrganizationadminCreateEvent5D6D9536Error =
+	OrganizationadminCreateEvent5D6D9536Errors[keyof OrganizationadminCreateEvent5D6D9536Errors];
 
-export type OrganizationadminCreateEvent051E2C16Responses = {
+export type OrganizationadminCreateEvent5D6D9536Responses = {
 	/**
 	 * OK
 	 */
 	200: EventDetailSchema;
 };
 
-export type OrganizationadminCreateEvent051E2C16Response =
-	OrganizationadminCreateEvent051E2C16Responses[keyof OrganizationadminCreateEvent051E2C16Responses];
+export type OrganizationadminCreateEvent5D6D9536Response =
+	OrganizationadminCreateEvent5D6D9536Responses[keyof OrganizationadminCreateEvent5D6D9536Responses];
 
-export type OrganizationadminListOrganizationTokensAd2141C7Data = {
+export type OrganizationadminListOrganizationTokensCa448BedData = {
 	body?: never;
 	path: {
 		/**
@@ -5522,17 +5522,17 @@ export type OrganizationadminListOrganizationTokensAd2141C7Data = {
 	url: '/api/organization-admin/{slug}/tokens';
 };
 
-export type OrganizationadminListOrganizationTokensAd2141C7Responses = {
+export type OrganizationadminListOrganizationTokensCa448BedResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaOrganizationTokenSchema;
 };
 
-export type OrganizationadminListOrganizationTokensAd2141C7Response =
-	OrganizationadminListOrganizationTokensAd2141C7Responses[keyof OrganizationadminListOrganizationTokensAd2141C7Responses];
+export type OrganizationadminListOrganizationTokensCa448BedResponse =
+	OrganizationadminListOrganizationTokensCa448BedResponses[keyof OrganizationadminListOrganizationTokensCa448BedResponses];
 
-export type OrganizationadminCreateOrganizationTokenB11748D5Data = {
+export type OrganizationadminCreateOrganizationToken60E5F681Data = {
 	body: OrganizationTokenCreateSchema;
 	path: {
 		/**
@@ -5544,17 +5544,17 @@ export type OrganizationadminCreateOrganizationTokenB11748D5Data = {
 	url: '/api/organization-admin/{slug}/token';
 };
 
-export type OrganizationadminCreateOrganizationTokenB11748D5Responses = {
+export type OrganizationadminCreateOrganizationToken60E5F681Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationTokenSchema;
 };
 
-export type OrganizationadminCreateOrganizationTokenB11748D5Response =
-	OrganizationadminCreateOrganizationTokenB11748D5Responses[keyof OrganizationadminCreateOrganizationTokenB11748D5Responses];
+export type OrganizationadminCreateOrganizationToken60E5F681Response =
+	OrganizationadminCreateOrganizationToken60E5F681Responses[keyof OrganizationadminCreateOrganizationToken60E5F681Responses];
 
-export type OrganizationadminDeleteOrganizationToken920E477cData = {
+export type OrganizationadminDeleteOrganizationTokenB1187879Data = {
 	body?: never;
 	path: {
 		/**
@@ -5570,17 +5570,17 @@ export type OrganizationadminDeleteOrganizationToken920E477cData = {
 	url: '/api/organization-admin/{slug}/token/{token_id}';
 };
 
-export type OrganizationadminDeleteOrganizationToken920E477cResponses = {
+export type OrganizationadminDeleteOrganizationTokenB1187879Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminDeleteOrganizationToken920E477cResponse =
-	OrganizationadminDeleteOrganizationToken920E477cResponses[keyof OrganizationadminDeleteOrganizationToken920E477cResponses];
+export type OrganizationadminDeleteOrganizationTokenB1187879Response =
+	OrganizationadminDeleteOrganizationTokenB1187879Responses[keyof OrganizationadminDeleteOrganizationTokenB1187879Responses];
 
-export type OrganizationadminUpdateOrganizationToken5284Deb3Data = {
+export type OrganizationadminUpdateOrganizationToken0270752dData = {
 	body: OrganizationTokenUpdateSchema;
 	path: {
 		/**
@@ -5596,17 +5596,17 @@ export type OrganizationadminUpdateOrganizationToken5284Deb3Data = {
 	url: '/api/organization-admin/{slug}/token/{token_id}';
 };
 
-export type OrganizationadminUpdateOrganizationToken5284Deb3Responses = {
+export type OrganizationadminUpdateOrganizationToken0270752dResponses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationTokenSchema;
 };
 
-export type OrganizationadminUpdateOrganizationToken5284Deb3Response =
-	OrganizationadminUpdateOrganizationToken5284Deb3Responses[keyof OrganizationadminUpdateOrganizationToken5284Deb3Responses];
+export type OrganizationadminUpdateOrganizationToken0270752dResponse =
+	OrganizationadminUpdateOrganizationToken0270752dResponses[keyof OrganizationadminUpdateOrganizationToken0270752dResponses];
 
-export type OrganizationadminListMembershipRequests2Bae90A0Data = {
+export type OrganizationadminListMembershipRequests1Fe08280Data = {
 	body?: never;
 	path: {
 		/**
@@ -5628,17 +5628,17 @@ export type OrganizationadminListMembershipRequests2Bae90A0Data = {
 	url: '/api/organization-admin/{slug}/membership-requests';
 };
 
-export type OrganizationadminListMembershipRequests2Bae90A0Responses = {
+export type OrganizationadminListMembershipRequests1Fe08280Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaOrganizationMembershipRequestRetrieve;
 };
 
-export type OrganizationadminListMembershipRequests2Bae90A0Response =
-	OrganizationadminListMembershipRequests2Bae90A0Responses[keyof OrganizationadminListMembershipRequests2Bae90A0Responses];
+export type OrganizationadminListMembershipRequests1Fe08280Response =
+	OrganizationadminListMembershipRequests1Fe08280Responses[keyof OrganizationadminListMembershipRequests1Fe08280Responses];
 
-export type OrganizationadminApproveMembershipRequestE1Bd2D4fData = {
+export type OrganizationadminApproveMembershipRequest742E6595Data = {
 	body?: never;
 	path: {
 		/**
@@ -5654,17 +5654,17 @@ export type OrganizationadminApproveMembershipRequestE1Bd2D4fData = {
 	url: '/api/organization-admin/{slug}/membership-requests/{request_id}/approve';
 };
 
-export type OrganizationadminApproveMembershipRequestE1Bd2D4fResponses = {
+export type OrganizationadminApproveMembershipRequest742E6595Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminApproveMembershipRequestE1Bd2D4fResponse =
-	OrganizationadminApproveMembershipRequestE1Bd2D4fResponses[keyof OrganizationadminApproveMembershipRequestE1Bd2D4fResponses];
+export type OrganizationadminApproveMembershipRequest742E6595Response =
+	OrganizationadminApproveMembershipRequest742E6595Responses[keyof OrganizationadminApproveMembershipRequest742E6595Responses];
 
-export type OrganizationadminRejectMembershipRequest48075D3fData = {
+export type OrganizationadminRejectMembershipRequest2B977B40Data = {
 	body?: never;
 	path: {
 		/**
@@ -5680,17 +5680,17 @@ export type OrganizationadminRejectMembershipRequest48075D3fData = {
 	url: '/api/organization-admin/{slug}/membership-requests/{request_id}/reject';
 };
 
-export type OrganizationadminRejectMembershipRequest48075D3fResponses = {
+export type OrganizationadminRejectMembershipRequest2B977B40Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminRejectMembershipRequest48075D3fResponse =
-	OrganizationadminRejectMembershipRequest48075D3fResponses[keyof OrganizationadminRejectMembershipRequest48075D3fResponses];
+export type OrganizationadminRejectMembershipRequest2B977B40Response =
+	OrganizationadminRejectMembershipRequest2B977B40Responses[keyof OrganizationadminRejectMembershipRequest2B977B40Responses];
 
-export type OrganizationadminListResources90241F4dData = {
+export type OrganizationadminListResourcesE64E26E7Data = {
 	body?: never;
 	path: {
 		/**
@@ -5716,17 +5716,17 @@ export type OrganizationadminListResources90241F4dData = {
 	url: '/api/organization-admin/{slug}/resources';
 };
 
-export type OrganizationadminListResources90241F4dResponses = {
+export type OrganizationadminListResourcesE64E26E7Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaAdditionalResourceSchema;
 };
 
-export type OrganizationadminListResources90241F4dResponse =
-	OrganizationadminListResources90241F4dResponses[keyof OrganizationadminListResources90241F4dResponses];
+export type OrganizationadminListResourcesE64E26E7Response =
+	OrganizationadminListResourcesE64E26E7Responses[keyof OrganizationadminListResourcesE64E26E7Responses];
 
-export type OrganizationadminCreateResource42869D36Data = {
+export type OrganizationadminCreateResource626F66F9Data = {
 	/**
 	 * FormParams
 	 */
@@ -5778,17 +5778,17 @@ export type OrganizationadminCreateResource42869D36Data = {
 	url: '/api/organization-admin/{slug}/resources';
 };
 
-export type OrganizationadminCreateResource42869D36Responses = {
+export type OrganizationadminCreateResource626F66F9Responses = {
 	/**
 	 * OK
 	 */
 	200: AdditionalResourceSchema;
 };
 
-export type OrganizationadminCreateResource42869D36Response =
-	OrganizationadminCreateResource42869D36Responses[keyof OrganizationadminCreateResource42869D36Responses];
+export type OrganizationadminCreateResource626F66F9Response =
+	OrganizationadminCreateResource626F66F9Responses[keyof OrganizationadminCreateResource626F66F9Responses];
 
-export type OrganizationadminDeleteResource6D0C6Bf8Data = {
+export type OrganizationadminDeleteResource07D5A13bData = {
 	body?: never;
 	path: {
 		/**
@@ -5804,17 +5804,17 @@ export type OrganizationadminDeleteResource6D0C6Bf8Data = {
 	url: '/api/organization-admin/{slug}/resources/{resource_id}';
 };
 
-export type OrganizationadminDeleteResource6D0C6Bf8Responses = {
+export type OrganizationadminDeleteResource07D5A13bResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminDeleteResource6D0C6Bf8Response =
-	OrganizationadminDeleteResource6D0C6Bf8Responses[keyof OrganizationadminDeleteResource6D0C6Bf8Responses];
+export type OrganizationadminDeleteResource07D5A13bResponse =
+	OrganizationadminDeleteResource07D5A13bResponses[keyof OrganizationadminDeleteResource07D5A13bResponses];
 
-export type OrganizationadminGetResource3F8F93C9Data = {
+export type OrganizationadminGetResource188Bd9CeData = {
 	body?: never;
 	path: {
 		/**
@@ -5830,17 +5830,17 @@ export type OrganizationadminGetResource3F8F93C9Data = {
 	url: '/api/organization-admin/{slug}/resources/{resource_id}';
 };
 
-export type OrganizationadminGetResource3F8F93C9Responses = {
+export type OrganizationadminGetResource188Bd9CeResponses = {
 	/**
 	 * OK
 	 */
 	200: AdditionalResourceSchema;
 };
 
-export type OrganizationadminGetResource3F8F93C9Response =
-	OrganizationadminGetResource3F8F93C9Responses[keyof OrganizationadminGetResource3F8F93C9Responses];
+export type OrganizationadminGetResource188Bd9CeResponse =
+	OrganizationadminGetResource188Bd9CeResponses[keyof OrganizationadminGetResource188Bd9CeResponses];
 
-export type OrganizationadminUpdateResource93D02613Data = {
+export type OrganizationadminUpdateResource852Ec77bData = {
 	body: AdditionalResourceUpdateSchema;
 	path: {
 		/**
@@ -5856,17 +5856,17 @@ export type OrganizationadminUpdateResource93D02613Data = {
 	url: '/api/organization-admin/{slug}/resources/{resource_id}';
 };
 
-export type OrganizationadminUpdateResource93D02613Responses = {
+export type OrganizationadminUpdateResource852Ec77bResponses = {
 	/**
 	 * OK
 	 */
 	200: AdditionalResourceSchema;
 };
 
-export type OrganizationadminUpdateResource93D02613Response =
-	OrganizationadminUpdateResource93D02613Responses[keyof OrganizationadminUpdateResource93D02613Responses];
+export type OrganizationadminUpdateResource852Ec77bResponse =
+	OrganizationadminUpdateResource852Ec77bResponses[keyof OrganizationadminUpdateResource852Ec77bResponses];
 
-export type OrganizationadminListMembers3986D3D0Data = {
+export type OrganizationadminListMembers8439C293Data = {
 	body?: never;
 	path: {
 		/**
@@ -5891,17 +5891,17 @@ export type OrganizationadminListMembers3986D3D0Data = {
 	url: '/api/organization-admin/{slug}/members';
 };
 
-export type OrganizationadminListMembers3986D3D0Responses = {
+export type OrganizationadminListMembers8439C293Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaOrganizationMemberSchema;
 };
 
-export type OrganizationadminListMembers3986D3D0Response =
-	OrganizationadminListMembers3986D3D0Responses[keyof OrganizationadminListMembers3986D3D0Responses];
+export type OrganizationadminListMembers8439C293Response =
+	OrganizationadminListMembers8439C293Responses[keyof OrganizationadminListMembers8439C293Responses];
 
-export type OrganizationadminRemoveMember6Ec7227fData = {
+export type OrganizationadminRemoveMemberD2C3B638Data = {
 	body?: never;
 	path: {
 		/**
@@ -5917,17 +5917,17 @@ export type OrganizationadminRemoveMember6Ec7227fData = {
 	url: '/api/organization-admin/{slug}/members/{user_id}';
 };
 
-export type OrganizationadminRemoveMember6Ec7227fResponses = {
+export type OrganizationadminRemoveMemberD2C3B638Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminRemoveMember6Ec7227fResponse =
-	OrganizationadminRemoveMember6Ec7227fResponses[keyof OrganizationadminRemoveMember6Ec7227fResponses];
+export type OrganizationadminRemoveMemberD2C3B638Response =
+	OrganizationadminRemoveMemberD2C3B638Responses[keyof OrganizationadminRemoveMemberD2C3B638Responses];
 
-export type OrganizationadminListStaff636E217aData = {
+export type OrganizationadminListStaff43C6669aData = {
 	body?: never;
 	path: {
 		/**
@@ -5952,17 +5952,17 @@ export type OrganizationadminListStaff636E217aData = {
 	url: '/api/organization-admin/{slug}/staff';
 };
 
-export type OrganizationadminListStaff636E217aResponses = {
+export type OrganizationadminListStaff43C6669aResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaOrganizationStaffSchema;
 };
 
-export type OrganizationadminListStaff636E217aResponse =
-	OrganizationadminListStaff636E217aResponses[keyof OrganizationadminListStaff636E217aResponses];
+export type OrganizationadminListStaff43C6669aResponse =
+	OrganizationadminListStaff43C6669aResponses[keyof OrganizationadminListStaff43C6669aResponses];
 
-export type OrganizationadminRemoveStaffEab475EfData = {
+export type OrganizationadminRemoveStaff1Cc5B08bData = {
 	body?: never;
 	path: {
 		/**
@@ -5978,17 +5978,17 @@ export type OrganizationadminRemoveStaffEab475EfData = {
 	url: '/api/organization-admin/{slug}/staff/{user_id}';
 };
 
-export type OrganizationadminRemoveStaffEab475EfResponses = {
+export type OrganizationadminRemoveStaff1Cc5B08bResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminRemoveStaffEab475EfResponse =
-	OrganizationadminRemoveStaffEab475EfResponses[keyof OrganizationadminRemoveStaffEab475EfResponses];
+export type OrganizationadminRemoveStaff1Cc5B08bResponse =
+	OrganizationadminRemoveStaff1Cc5B08bResponses[keyof OrganizationadminRemoveStaff1Cc5B08bResponses];
 
-export type OrganizationadminAddStaff3E15765eData = {
+export type OrganizationadminAddStaff24421D52Data = {
 	body?: PermissionsSchema | null;
 	path: {
 		/**
@@ -6004,17 +6004,17 @@ export type OrganizationadminAddStaff3E15765eData = {
 	url: '/api/organization-admin/{slug}/staff/{user_id}';
 };
 
-export type OrganizationadminAddStaff3E15765eResponses = {
+export type OrganizationadminAddStaff24421D52Responses = {
 	/**
 	 * Created
 	 */
 	201: OrganizationStaffSchema;
 };
 
-export type OrganizationadminAddStaff3E15765eResponse =
-	OrganizationadminAddStaff3E15765eResponses[keyof OrganizationadminAddStaff3E15765eResponses];
+export type OrganizationadminAddStaff24421D52Response =
+	OrganizationadminAddStaff24421D52Responses[keyof OrganizationadminAddStaff24421D52Responses];
 
-export type OrganizationadminUpdateStaffPermissionsE7D1DdfdData = {
+export type OrganizationadminUpdateStaffPermissions77Dae2EbData = {
 	body: PermissionsSchema;
 	path: {
 		/**
@@ -6030,17 +6030,17 @@ export type OrganizationadminUpdateStaffPermissionsE7D1DdfdData = {
 	url: '/api/organization-admin/{slug}/staff/{user_id}/permissions';
 };
 
-export type OrganizationadminUpdateStaffPermissionsE7D1DdfdResponses = {
+export type OrganizationadminUpdateStaffPermissions77Dae2EbResponses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationStaffSchema;
 };
 
-export type OrganizationadminUpdateStaffPermissionsE7D1DdfdResponse =
-	OrganizationadminUpdateStaffPermissionsE7D1DdfdResponses[keyof OrganizationadminUpdateStaffPermissionsE7D1DdfdResponses];
+export type OrganizationadminUpdateStaffPermissions77Dae2EbResponse =
+	OrganizationadminUpdateStaffPermissions77Dae2EbResponses[keyof OrganizationadminUpdateStaffPermissions77Dae2EbResponses];
 
-export type OrganizationadminClearTags943F2C71Data = {
+export type OrganizationadminClearTagsFce87Df0Data = {
 	body?: never;
 	path: {
 		/**
@@ -6052,17 +6052,17 @@ export type OrganizationadminClearTags943F2C71Data = {
 	url: '/api/organization-admin/{slug}/tags';
 };
 
-export type OrganizationadminClearTags943F2C71Responses = {
+export type OrganizationadminClearTagsFce87Df0Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type OrganizationadminClearTags943F2C71Response =
-	OrganizationadminClearTags943F2C71Responses[keyof OrganizationadminClearTags943F2C71Responses];
+export type OrganizationadminClearTagsFce87Df0Response =
+	OrganizationadminClearTagsFce87Df0Responses[keyof OrganizationadminClearTagsFce87Df0Responses];
 
-export type OrganizationadminAddTags1F41252aData = {
+export type OrganizationadminAddTagsD8D73E41Data = {
 	body: TagUpdateSchema;
 	path: {
 		/**
@@ -6074,7 +6074,7 @@ export type OrganizationadminAddTags1F41252aData = {
 	url: '/api/organization-admin/{slug}/tags';
 };
 
-export type OrganizationadminAddTags1F41252aResponses = {
+export type OrganizationadminAddTagsD8D73E41Responses = {
 	/**
 	 * Response
 	 *
@@ -6083,10 +6083,10 @@ export type OrganizationadminAddTags1F41252aResponses = {
 	200: Array<TagSchema>;
 };
 
-export type OrganizationadminAddTags1F41252aResponse =
-	OrganizationadminAddTags1F41252aResponses[keyof OrganizationadminAddTags1F41252aResponses];
+export type OrganizationadminAddTagsD8D73E41Response =
+	OrganizationadminAddTagsD8D73E41Responses[keyof OrganizationadminAddTagsD8D73E41Responses];
 
-export type OrganizationadminRemoveTags17210274Data = {
+export type OrganizationadminRemoveTags6A00Ef16Data = {
 	body: TagUpdateSchema;
 	path: {
 		/**
@@ -6098,7 +6098,7 @@ export type OrganizationadminRemoveTags17210274Data = {
 	url: '/api/organization-admin/{slug}/tags/remove';
 };
 
-export type OrganizationadminRemoveTags17210274Responses = {
+export type OrganizationadminRemoveTags6A00Ef16Responses = {
 	/**
 	 * Response
 	 *
@@ -6107,10 +6107,10 @@ export type OrganizationadminRemoveTags17210274Responses = {
 	200: Array<TagSchema>;
 };
 
-export type OrganizationadminRemoveTags17210274Response =
-	OrganizationadminRemoveTags17210274Responses[keyof OrganizationadminRemoveTags17210274Responses];
+export type OrganizationadminRemoveTags6A00Ef16Response =
+	OrganizationadminRemoveTags6A00Ef16Responses[keyof OrganizationadminRemoveTags6A00Ef16Responses];
 
-export type EventListEvents7Fc6E819Data = {
+export type EventListEvents23D151A0Data = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -6169,17 +6169,17 @@ export type EventListEvents7Fc6E819Data = {
 	url: '/api/events/';
 };
 
-export type EventListEvents7Fc6E819Responses = {
+export type EventListEvents23D151A0Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaEventInListSchema;
 };
 
-export type EventListEvents7Fc6E819Response =
-	EventListEvents7Fc6E819Responses[keyof EventListEvents7Fc6E819Responses];
+export type EventListEvents23D151A0Response =
+	EventListEvents23D151A0Responses[keyof EventListEvents23D151A0Responses];
 
-export type EventClaimInvitationA333Ba68Data = {
+export type EventClaimInvitation5E9C84C8Data = {
 	body?: never;
 	path: {
 		/**
@@ -6191,27 +6191,27 @@ export type EventClaimInvitationA333Ba68Data = {
 	url: '/api/events/claim-invitation/{token}';
 };
 
-export type EventClaimInvitationA333Ba68Errors = {
+export type EventClaimInvitation5E9C84C8Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: ResponseMessage;
 };
 
-export type EventClaimInvitationA333Ba68Error =
-	EventClaimInvitationA333Ba68Errors[keyof EventClaimInvitationA333Ba68Errors];
+export type EventClaimInvitation5E9C84C8Error =
+	EventClaimInvitation5E9C84C8Errors[keyof EventClaimInvitation5E9C84C8Errors];
 
-export type EventClaimInvitationA333Ba68Responses = {
+export type EventClaimInvitation5E9C84C8Responses = {
 	/**
 	 * OK
 	 */
 	200: MinimalEventSchema;
 };
 
-export type EventClaimInvitationA333Ba68Response =
-	EventClaimInvitationA333Ba68Responses[keyof EventClaimInvitationA333Ba68Responses];
+export type EventClaimInvitation5E9C84C8Response =
+	EventClaimInvitation5E9C84C8Responses[keyof EventClaimInvitation5E9C84C8Responses];
 
-export type EventGetEventAttendeesDf088923Data = {
+export type EventGetEventAttendees798A730cData = {
 	body?: never;
 	path: {
 		/**
@@ -6232,17 +6232,17 @@ export type EventGetEventAttendeesDf088923Data = {
 	url: '/api/events/{event_id}/attendee-list';
 };
 
-export type EventGetEventAttendeesDf088923Responses = {
+export type EventGetEventAttendees798A730cResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaMinimalRevelUserSchema;
 };
 
-export type EventGetEventAttendeesDf088923Response =
-	EventGetEventAttendeesDf088923Responses[keyof EventGetEventAttendeesDf088923Responses];
+export type EventGetEventAttendees798A730cResponse =
+	EventGetEventAttendees798A730cResponses[keyof EventGetEventAttendees798A730cResponses];
 
-export type EventGetMyEventStatusA5537Ae4Data = {
+export type EventGetMyEventStatus229B6062Data = {
 	body?: never;
 	path: {
 		/**
@@ -6254,7 +6254,7 @@ export type EventGetMyEventStatusA5537Ae4Data = {
 	url: '/api/events/{event_id}/my-status';
 };
 
-export type EventGetMyEventStatusA5537Ae4Responses = {
+export type EventGetMyEventStatus229B6062Responses = {
 	/**
 	 * Response
 	 *
@@ -6263,10 +6263,10 @@ export type EventGetMyEventStatusA5537Ae4Responses = {
 	200: EventRsvpSchema | EventTicketSchema | EventUserEligibility;
 };
 
-export type EventGetMyEventStatusA5537Ae4Response =
-	EventGetMyEventStatusA5537Ae4Responses[keyof EventGetMyEventStatusA5537Ae4Responses];
+export type EventGetMyEventStatus229B6062Response =
+	EventGetMyEventStatus229B6062Responses[keyof EventGetMyEventStatus229B6062Responses];
 
-export type EventCreateInvitationRequest9B1Cdcf3Data = {
+export type EventCreateInvitationRequestBdfc94B7Data = {
 	body: EventInvitationRequestCreateSchema;
 	path: {
 		/**
@@ -6278,17 +6278,17 @@ export type EventCreateInvitationRequest9B1Cdcf3Data = {
 	url: '/api/events/{event_id}/invitation-requests';
 };
 
-export type EventCreateInvitationRequest9B1Cdcf3Responses = {
+export type EventCreateInvitationRequestBdfc94B7Responses = {
 	/**
 	 * Created
 	 */
 	201: EventInvitationRequestSchema;
 };
 
-export type EventCreateInvitationRequest9B1Cdcf3Response =
-	EventCreateInvitationRequest9B1Cdcf3Responses[keyof EventCreateInvitationRequest9B1Cdcf3Responses];
+export type EventCreateInvitationRequestBdfc94B7Response =
+	EventCreateInvitationRequestBdfc94B7Responses[keyof EventCreateInvitationRequestBdfc94B7Responses];
 
-export type EventListResources0640A3A6Data = {
+export type EventListResources8512C98eData = {
 	body?: never;
 	path: {
 		/**
@@ -6314,17 +6314,17 @@ export type EventListResources0640A3A6Data = {
 	url: '/api/events/{event_id}/resources';
 };
 
-export type EventListResources0640A3A6Responses = {
+export type EventListResources8512C98eResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaAdditionalResourceSchema;
 };
 
-export type EventListResources0640A3A6Response =
-	EventListResources0640A3A6Responses[keyof EventListResources0640A3A6Responses];
+export type EventListResources8512C98eResponse =
+	EventListResources8512C98eResponses[keyof EventListResources8512C98eResponses];
 
-export type EventDeleteInvitationRequestE2Bc00BbData = {
+export type EventDeleteInvitationRequest0B935E61Data = {
 	body?: never;
 	path: {
 		/**
@@ -6336,17 +6336,17 @@ export type EventDeleteInvitationRequestE2Bc00BbData = {
 	url: '/api/events/invitation-requests/{request_id}';
 };
 
-export type EventDeleteInvitationRequestE2Bc00BbResponses = {
+export type EventDeleteInvitationRequest0B935E61Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventDeleteInvitationRequestE2Bc00BbResponse =
-	EventDeleteInvitationRequestE2Bc00BbResponses[keyof EventDeleteInvitationRequestE2Bc00BbResponses];
+export type EventDeleteInvitationRequest0B935E61Response =
+	EventDeleteInvitationRequest0B935E61Responses[keyof EventDeleteInvitationRequest0B935E61Responses];
 
-export type EventListUserInvitationRequests11F4Dbf2Data = {
+export type EventListUserInvitationRequests497500D2Data = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -6374,17 +6374,17 @@ export type EventListUserInvitationRequests11F4Dbf2Data = {
 	url: '/api/events/me/pending-invitation-requests';
 };
 
-export type EventListUserInvitationRequests11F4Dbf2Responses = {
+export type EventListUserInvitationRequests497500D2Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaEventInvitationRequestSchema;
 };
 
-export type EventListUserInvitationRequests11F4Dbf2Response =
-	EventListUserInvitationRequests11F4Dbf2Responses[keyof EventListUserInvitationRequests11F4Dbf2Responses];
+export type EventListUserInvitationRequests497500D2Response =
+	EventListUserInvitationRequests497500D2Responses[keyof EventListUserInvitationRequests497500D2Responses];
 
-export type EventGetEventBySlugs1867901aData = {
+export type EventGetEventBySlugs311D61BbData = {
 	body?: never;
 	path: {
 		/**
@@ -6400,17 +6400,17 @@ export type EventGetEventBySlugs1867901aData = {
 	url: '/api/events/{org_slug}/{event_slug}';
 };
 
-export type EventGetEventBySlugs1867901aResponses = {
+export type EventGetEventBySlugs311D61BbResponses = {
 	/**
 	 * OK
 	 */
 	200: EventDetailSchema;
 };
 
-export type EventGetEventBySlugs1867901aResponse =
-	EventGetEventBySlugs1867901aResponses[keyof EventGetEventBySlugs1867901aResponses];
+export type EventGetEventBySlugs311D61BbResponse =
+	EventGetEventBySlugs311D61BbResponses[keyof EventGetEventBySlugs311D61BbResponses];
 
-export type EventGetEventF33D9Fe5Data = {
+export type EventGetEventD6F13929Data = {
 	body?: never;
 	path: {
 		/**
@@ -6422,17 +6422,17 @@ export type EventGetEventF33D9Fe5Data = {
 	url: '/api/events/{event_id}';
 };
 
-export type EventGetEventF33D9Fe5Responses = {
+export type EventGetEventD6F13929Responses = {
 	/**
 	 * OK
 	 */
 	200: EventDetailSchema;
 };
 
-export type EventGetEventF33D9Fe5Response =
-	EventGetEventF33D9Fe5Responses[keyof EventGetEventF33D9Fe5Responses];
+export type EventGetEventD6F13929Response =
+	EventGetEventD6F13929Responses[keyof EventGetEventD6F13929Responses];
 
-export type EventRsvpEvent2Fc4F913Data = {
+export type EventRsvpEvent417D6F93Data = {
 	body?: never;
 	path: {
 		/**
@@ -6448,27 +6448,27 @@ export type EventRsvpEvent2Fc4F913Data = {
 	url: '/api/events/{event_id}/rsvp/{answer}';
 };
 
-export type EventRsvpEvent2Fc4F913Errors = {
+export type EventRsvpEvent417D6F93Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: EventUserEligibility;
 };
 
-export type EventRsvpEvent2Fc4F913Error =
-	EventRsvpEvent2Fc4F913Errors[keyof EventRsvpEvent2Fc4F913Errors];
+export type EventRsvpEvent417D6F93Error =
+	EventRsvpEvent417D6F93Errors[keyof EventRsvpEvent417D6F93Errors];
 
-export type EventRsvpEvent2Fc4F913Responses = {
+export type EventRsvpEvent417D6F93Responses = {
 	/**
 	 * OK
 	 */
 	200: EventRsvpSchema;
 };
 
-export type EventRsvpEvent2Fc4F913Response =
-	EventRsvpEvent2Fc4F913Responses[keyof EventRsvpEvent2Fc4F913Responses];
+export type EventRsvpEvent417D6F93Response =
+	EventRsvpEvent417D6F93Responses[keyof EventRsvpEvent417D6F93Responses];
 
-export type EventListTiersD39F67BdData = {
+export type EventListTiers8D0D74DfData = {
 	body?: never;
 	path: {
 		/**
@@ -6480,7 +6480,7 @@ export type EventListTiersD39F67BdData = {
 	url: '/api/events/{event_id}/tickets/tiers';
 };
 
-export type EventListTiersD39F67BdResponses = {
+export type EventListTiers8D0D74DfResponses = {
 	/**
 	 * Response
 	 *
@@ -6489,10 +6489,10 @@ export type EventListTiersD39F67BdResponses = {
 	200: Array<TierSchema>;
 };
 
-export type EventListTiersD39F67BdResponse =
-	EventListTiersD39F67BdResponses[keyof EventListTiersD39F67BdResponses];
+export type EventListTiers8D0D74DfResponse =
+	EventListTiers8D0D74DfResponses[keyof EventListTiers8D0D74DfResponses];
 
-export type EventTicketCheckout58D472B4Data = {
+export type EventTicketCheckoutEf1Cc44dData = {
 	body?: never;
 	path: {
 		/**
@@ -6508,17 +6508,17 @@ export type EventTicketCheckout58D472B4Data = {
 	url: '/api/events/{event_id}/tickets/{tier_id}/checkout';
 };
 
-export type EventTicketCheckout58D472B4Errors = {
+export type EventTicketCheckoutEf1Cc44dErrors = {
 	/**
 	 * Bad Request
 	 */
 	400: EventUserEligibility;
 };
 
-export type EventTicketCheckout58D472B4Error =
-	EventTicketCheckout58D472B4Errors[keyof EventTicketCheckout58D472B4Errors];
+export type EventTicketCheckoutEf1Cc44dError =
+	EventTicketCheckoutEf1Cc44dErrors[keyof EventTicketCheckoutEf1Cc44dErrors];
 
-export type EventTicketCheckout58D472B4Responses = {
+export type EventTicketCheckoutEf1Cc44dResponses = {
 	/**
 	 * Response
 	 *
@@ -6527,10 +6527,10 @@ export type EventTicketCheckout58D472B4Responses = {
 	200: StripeCheckoutSessionSchema | EventTicketSchema;
 };
 
-export type EventTicketCheckout58D472B4Response =
-	EventTicketCheckout58D472B4Responses[keyof EventTicketCheckout58D472B4Responses];
+export type EventTicketCheckoutEf1Cc44dResponse =
+	EventTicketCheckoutEf1Cc44dResponses[keyof EventTicketCheckoutEf1Cc44dResponses];
 
-export type EventTicketPwycCheckout9D58C7F3Data = {
+export type EventTicketPwycCheckoutD2F9D317Data = {
 	body: PwycCheckoutPayloadSchema;
 	path: {
 		/**
@@ -6546,17 +6546,17 @@ export type EventTicketPwycCheckout9D58C7F3Data = {
 	url: '/api/events/{event_id}/tickets/{tier_id}/checkout/pwyc';
 };
 
-export type EventTicketPwycCheckout9D58C7F3Errors = {
+export type EventTicketPwycCheckoutD2F9D317Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: EventUserEligibility;
 };
 
-export type EventTicketPwycCheckout9D58C7F3Error =
-	EventTicketPwycCheckout9D58C7F3Errors[keyof EventTicketPwycCheckout9D58C7F3Errors];
+export type EventTicketPwycCheckoutD2F9D317Error =
+	EventTicketPwycCheckoutD2F9D317Errors[keyof EventTicketPwycCheckoutD2F9D317Errors];
 
-export type EventTicketPwycCheckout9D58C7F3Responses = {
+export type EventTicketPwycCheckoutD2F9D317Responses = {
 	/**
 	 * Response
 	 *
@@ -6565,10 +6565,10 @@ export type EventTicketPwycCheckout9D58C7F3Responses = {
 	200: StripeCheckoutSessionSchema | EventTicketSchema;
 };
 
-export type EventTicketPwycCheckout9D58C7F3Response =
-	EventTicketPwycCheckout9D58C7F3Responses[keyof EventTicketPwycCheckout9D58C7F3Responses];
+export type EventTicketPwycCheckoutD2F9D317Response =
+	EventTicketPwycCheckoutD2F9D317Responses[keyof EventTicketPwycCheckoutD2F9D317Responses];
 
-export type EventGetQuestionnaire21149006Data = {
+export type EventGetQuestionnaireCc423C0cData = {
 	body?: never;
 	path: {
 		/**
@@ -6584,17 +6584,17 @@ export type EventGetQuestionnaire21149006Data = {
 	url: '/api/events/{event_id}/questionnaire/{questionnaire_id}';
 };
 
-export type EventGetQuestionnaire21149006Responses = {
+export type EventGetQuestionnaireCc423C0cResponses = {
 	/**
 	 * OK
 	 */
 	200: QuestionnaireSchema;
 };
 
-export type EventGetQuestionnaire21149006Response =
-	EventGetQuestionnaire21149006Responses[keyof EventGetQuestionnaire21149006Responses];
+export type EventGetQuestionnaireCc423C0cResponse =
+	EventGetQuestionnaireCc423C0cResponses[keyof EventGetQuestionnaireCc423C0cResponses];
 
-export type EventSubmitQuestionnaireB02E3452Data = {
+export type EventSubmitQuestionnaireA3213FddData = {
 	body: QuestionnaireSubmissionSchema;
 	path: {
 		/**
@@ -6610,17 +6610,17 @@ export type EventSubmitQuestionnaireB02E3452Data = {
 	url: '/api/events/{event_id}/questionnaire/{questionnaire_id}/submit';
 };
 
-export type EventSubmitQuestionnaireB02E3452Errors = {
+export type EventSubmitQuestionnaireA3213FddErrors = {
 	/**
 	 * Bad Request
 	 */
 	400: ResponseMessage;
 };
 
-export type EventSubmitQuestionnaireB02E3452Error =
-	EventSubmitQuestionnaireB02E3452Errors[keyof EventSubmitQuestionnaireB02E3452Errors];
+export type EventSubmitQuestionnaireA3213FddError =
+	EventSubmitQuestionnaireA3213FddErrors[keyof EventSubmitQuestionnaireA3213FddErrors];
 
-export type EventSubmitQuestionnaireB02E3452Responses = {
+export type EventSubmitQuestionnaireA3213FddResponses = {
 	/**
 	 * Response
 	 *
@@ -6629,10 +6629,10 @@ export type EventSubmitQuestionnaireB02E3452Responses = {
 	200: QuestionnaireSubmissionResponseSchema | QuestionnaireEvaluationForUserSchema;
 };
 
-export type EventSubmitQuestionnaireB02E3452Response =
-	EventSubmitQuestionnaireB02E3452Responses[keyof EventSubmitQuestionnaireB02E3452Responses];
+export type EventSubmitQuestionnaireA3213FddResponse =
+	EventSubmitQuestionnaireA3213FddResponses[keyof EventSubmitQuestionnaireA3213FddResponses];
 
-export type EventadminDeleteEventToken1104AffcData = {
+export type EventadminDeleteEventTokenC3Fc3A27Data = {
 	body?: never;
 	path: {
 		/**
@@ -6648,17 +6648,17 @@ export type EventadminDeleteEventToken1104AffcData = {
 	url: '/api/event-admin/{event_id}/tokens/{token_id}';
 };
 
-export type EventadminDeleteEventToken1104AffcResponses = {
+export type EventadminDeleteEventTokenC3Fc3A27Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminDeleteEventToken1104AffcResponse =
-	EventadminDeleteEventToken1104AffcResponses[keyof EventadminDeleteEventToken1104AffcResponses];
+export type EventadminDeleteEventTokenC3Fc3A27Response =
+	EventadminDeleteEventTokenC3Fc3A27Responses[keyof EventadminDeleteEventTokenC3Fc3A27Responses];
 
-export type EventadminUpdateEventToken98D07979Data = {
+export type EventadminUpdateEventTokenE2D9030bData = {
 	body: EventTokenUpdateSchema;
 	path: {
 		/**
@@ -6674,17 +6674,17 @@ export type EventadminUpdateEventToken98D07979Data = {
 	url: '/api/event-admin/{event_id}/tokens/{token_id}';
 };
 
-export type EventadminUpdateEventToken98D07979Responses = {
+export type EventadminUpdateEventTokenE2D9030bResponses = {
 	/**
 	 * OK
 	 */
 	200: EventTokenSchema;
 };
 
-export type EventadminUpdateEventToken98D07979Response =
-	EventadminUpdateEventToken98D07979Responses[keyof EventadminUpdateEventToken98D07979Responses];
+export type EventadminUpdateEventTokenE2D9030bResponse =
+	EventadminUpdateEventTokenE2D9030bResponses[keyof EventadminUpdateEventTokenE2D9030bResponses];
 
-export type EventadminListEventTokensC77C30C8Data = {
+export type EventadminListEventTokensA00318C2Data = {
 	body?: never;
 	path: {
 		/**
@@ -6721,17 +6721,17 @@ export type EventadminListEventTokensC77C30C8Data = {
 	url: '/api/event-admin/{event_id}/tokens';
 };
 
-export type EventadminListEventTokensC77C30C8Responses = {
+export type EventadminListEventTokensA00318C2Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaEventTokenSchema;
 };
 
-export type EventadminListEventTokensC77C30C8Response =
-	EventadminListEventTokensC77C30C8Responses[keyof EventadminListEventTokensC77C30C8Responses];
+export type EventadminListEventTokensA00318C2Response =
+	EventadminListEventTokensA00318C2Responses[keyof EventadminListEventTokensA00318C2Responses];
 
-export type EventadminCreateEventTokenB430C9A3Data = {
+export type EventadminCreateEventToken2705Ac10Data = {
 	body: EventTokenCreateSchema;
 	path: {
 		/**
@@ -6743,17 +6743,17 @@ export type EventadminCreateEventTokenB430C9A3Data = {
 	url: '/api/event-admin/{event_id}/tokens';
 };
 
-export type EventadminCreateEventTokenB430C9A3Responses = {
+export type EventadminCreateEventToken2705Ac10Responses = {
 	/**
 	 * OK
 	 */
 	200: EventTokenSchema;
 };
 
-export type EventadminCreateEventTokenB430C9A3Response =
-	EventadminCreateEventTokenB430C9A3Responses[keyof EventadminCreateEventTokenB430C9A3Responses];
+export type EventadminCreateEventToken2705Ac10Response =
+	EventadminCreateEventToken2705Ac10Responses[keyof EventadminCreateEventToken2705Ac10Responses];
 
-export type EventadminListInvitationRequests3453A7F0Data = {
+export type EventadminListInvitationRequestsCd34C64bData = {
 	body?: never;
 	path: {
 		/**
@@ -6779,17 +6779,17 @@ export type EventadminListInvitationRequests3453A7F0Data = {
 	url: '/api/event-admin/{event_id}/invitation-requests';
 };
 
-export type EventadminListInvitationRequests3453A7F0Responses = {
+export type EventadminListInvitationRequestsCd34C64bResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaEventInvitationRequestInternalSchema;
 };
 
-export type EventadminListInvitationRequests3453A7F0Response =
-	EventadminListInvitationRequests3453A7F0Responses[keyof EventadminListInvitationRequests3453A7F0Responses];
+export type EventadminListInvitationRequestsCd34C64bResponse =
+	EventadminListInvitationRequestsCd34C64bResponses[keyof EventadminListInvitationRequestsCd34C64bResponses];
 
-export type EventadminApproveInvitationRequestBc0774C6Data = {
+export type EventadminApproveInvitationRequestDb4637FdData = {
 	body?: never;
 	path: {
 		/**
@@ -6805,17 +6805,17 @@ export type EventadminApproveInvitationRequestBc0774C6Data = {
 	url: '/api/event-admin/{event_id}/invitation-requests/{request_id}/approve';
 };
 
-export type EventadminApproveInvitationRequestBc0774C6Responses = {
+export type EventadminApproveInvitationRequestDb4637FdResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminApproveInvitationRequestBc0774C6Response =
-	EventadminApproveInvitationRequestBc0774C6Responses[keyof EventadminApproveInvitationRequestBc0774C6Responses];
+export type EventadminApproveInvitationRequestDb4637FdResponse =
+	EventadminApproveInvitationRequestDb4637FdResponses[keyof EventadminApproveInvitationRequestDb4637FdResponses];
 
-export type EventadminRejectInvitationRequest4D2C7F01Data = {
+export type EventadminRejectInvitationRequestD9389077Data = {
 	body?: never;
 	path: {
 		/**
@@ -6831,17 +6831,17 @@ export type EventadminRejectInvitationRequest4D2C7F01Data = {
 	url: '/api/event-admin/{event_id}/invitation-requests/{request_id}/reject';
 };
 
-export type EventadminRejectInvitationRequest4D2C7F01Responses = {
+export type EventadminRejectInvitationRequestD9389077Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminRejectInvitationRequest4D2C7F01Response =
-	EventadminRejectInvitationRequest4D2C7F01Responses[keyof EventadminRejectInvitationRequest4D2C7F01Responses];
+export type EventadminRejectInvitationRequestD9389077Response =
+	EventadminRejectInvitationRequestD9389077Responses[keyof EventadminRejectInvitationRequestD9389077Responses];
 
-export type EventadminUpdateEvent669A5A17Data = {
+export type EventadminUpdateEvent3Ad899D2Data = {
 	body: EventEditSchema;
 	path: {
 		/**
@@ -6853,27 +6853,27 @@ export type EventadminUpdateEvent669A5A17Data = {
 	url: '/api/event-admin/{event_id}';
 };
 
-export type EventadminUpdateEvent669A5A17Errors = {
+export type EventadminUpdateEvent3Ad899D2Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: ValidationErrorResponse;
 };
 
-export type EventadminUpdateEvent669A5A17Error =
-	EventadminUpdateEvent669A5A17Errors[keyof EventadminUpdateEvent669A5A17Errors];
+export type EventadminUpdateEvent3Ad899D2Error =
+	EventadminUpdateEvent3Ad899D2Errors[keyof EventadminUpdateEvent3Ad899D2Errors];
 
-export type EventadminUpdateEvent669A5A17Responses = {
+export type EventadminUpdateEvent3Ad899D2Responses = {
 	/**
 	 * OK
 	 */
 	200: EventDetailSchema;
 };
 
-export type EventadminUpdateEvent669A5A17Response =
-	EventadminUpdateEvent669A5A17Responses[keyof EventadminUpdateEvent669A5A17Responses];
+export type EventadminUpdateEvent3Ad899D2Response =
+	EventadminUpdateEvent3Ad899D2Responses[keyof EventadminUpdateEvent3Ad899D2Responses];
 
-export type EventadminUpdateEventStatus9B733B32Data = {
+export type EventadminUpdateEventStatus68Fc4E39Data = {
 	body?: never;
 	path: {
 		/**
@@ -6889,17 +6889,17 @@ export type EventadminUpdateEventStatus9B733B32Data = {
 	url: '/api/event-admin/{event_id}/actions/update-status/{status}';
 };
 
-export type EventadminUpdateEventStatus9B733B32Responses = {
+export type EventadminUpdateEventStatus68Fc4E39Responses = {
 	/**
 	 * OK
 	 */
 	200: EventDetailSchema;
 };
 
-export type EventadminUpdateEventStatus9B733B32Response =
-	EventadminUpdateEventStatus9B733B32Responses[keyof EventadminUpdateEventStatus9B733B32Responses];
+export type EventadminUpdateEventStatus68Fc4E39Response =
+	EventadminUpdateEventStatus68Fc4E39Responses[keyof EventadminUpdateEventStatus68Fc4E39Responses];
 
-export type EventadminUploadLogo97D3C2AeData = {
+export type EventadminUploadLogo0A9764F8Data = {
 	/**
 	 * FileParams
 	 */
@@ -6919,17 +6919,17 @@ export type EventadminUploadLogo97D3C2AeData = {
 	url: '/api/event-admin/{event_id}/upload-logo';
 };
 
-export type EventadminUploadLogo97D3C2AeResponses = {
+export type EventadminUploadLogo0A9764F8Responses = {
 	/**
 	 * OK
 	 */
 	200: EventDetailSchema;
 };
 
-export type EventadminUploadLogo97D3C2AeResponse =
-	EventadminUploadLogo97D3C2AeResponses[keyof EventadminUploadLogo97D3C2AeResponses];
+export type EventadminUploadLogo0A9764F8Response =
+	EventadminUploadLogo0A9764F8Responses[keyof EventadminUploadLogo0A9764F8Responses];
 
-export type EventadminUploadCoverArt3F027833Data = {
+export type EventadminUploadCoverArt83630BfcData = {
 	/**
 	 * FileParams
 	 */
@@ -6949,17 +6949,17 @@ export type EventadminUploadCoverArt3F027833Data = {
 	url: '/api/event-admin/{event_id}/upload-cover-art';
 };
 
-export type EventadminUploadCoverArt3F027833Responses = {
+export type EventadminUploadCoverArt83630BfcResponses = {
 	/**
 	 * OK
 	 */
 	200: EventDetailSchema;
 };
 
-export type EventadminUploadCoverArt3F027833Response =
-	EventadminUploadCoverArt3F027833Responses[keyof EventadminUploadCoverArt3F027833Responses];
+export type EventadminUploadCoverArt83630BfcResponse =
+	EventadminUploadCoverArt83630BfcResponses[keyof EventadminUploadCoverArt83630BfcResponses];
 
-export type EventadminDeleteLogo3967075cData = {
+export type EventadminDeleteLogoE4111774Data = {
 	body?: never;
 	path: {
 		/**
@@ -6971,17 +6971,17 @@ export type EventadminDeleteLogo3967075cData = {
 	url: '/api/event-admin/{event_id}/delete-logo';
 };
 
-export type EventadminDeleteLogo3967075cResponses = {
+export type EventadminDeleteLogoE4111774Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminDeleteLogo3967075cResponse =
-	EventadminDeleteLogo3967075cResponses[keyof EventadminDeleteLogo3967075cResponses];
+export type EventadminDeleteLogoE4111774Response =
+	EventadminDeleteLogoE4111774Responses[keyof EventadminDeleteLogoE4111774Responses];
 
-export type EventadminDeleteCoverArt3F30469fData = {
+export type EventadminDeleteCoverArt509922C1Data = {
 	body?: never;
 	path: {
 		/**
@@ -6993,17 +6993,17 @@ export type EventadminDeleteCoverArt3F30469fData = {
 	url: '/api/event-admin/{event_id}/delete-cover-art';
 };
 
-export type EventadminDeleteCoverArt3F30469fResponses = {
+export type EventadminDeleteCoverArt509922C1Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminDeleteCoverArt3F30469fResponse =
-	EventadminDeleteCoverArt3F30469fResponses[keyof EventadminDeleteCoverArt3F30469fResponses];
+export type EventadminDeleteCoverArt509922C1Response =
+	EventadminDeleteCoverArt509922C1Responses[keyof EventadminDeleteCoverArt509922C1Responses];
 
-export type EventadminClearTags9A9B25CdData = {
+export type EventadminClearTags0650Bd81Data = {
 	body?: never;
 	path: {
 		/**
@@ -7015,17 +7015,17 @@ export type EventadminClearTags9A9B25CdData = {
 	url: '/api/event-admin/{event_id}/tags';
 };
 
-export type EventadminClearTags9A9B25CdResponses = {
+export type EventadminClearTags0650Bd81Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminClearTags9A9B25CdResponse =
-	EventadminClearTags9A9B25CdResponses[keyof EventadminClearTags9A9B25CdResponses];
+export type EventadminClearTags0650Bd81Response =
+	EventadminClearTags0650Bd81Responses[keyof EventadminClearTags0650Bd81Responses];
 
-export type EventadminAddTagsF8D9D0CaData = {
+export type EventadminAddTags9523D639Data = {
 	body: TagUpdateSchema;
 	path: {
 		/**
@@ -7037,7 +7037,7 @@ export type EventadminAddTagsF8D9D0CaData = {
 	url: '/api/event-admin/{event_id}/tags';
 };
 
-export type EventadminAddTagsF8D9D0CaResponses = {
+export type EventadminAddTags9523D639Responses = {
 	/**
 	 * Response
 	 *
@@ -7046,10 +7046,10 @@ export type EventadminAddTagsF8D9D0CaResponses = {
 	200: Array<TagSchema>;
 };
 
-export type EventadminAddTagsF8D9D0CaResponse =
-	EventadminAddTagsF8D9D0CaResponses[keyof EventadminAddTagsF8D9D0CaResponses];
+export type EventadminAddTags9523D639Response =
+	EventadminAddTags9523D639Responses[keyof EventadminAddTags9523D639Responses];
 
-export type EventadminRemoveTags1Eb533CdData = {
+export type EventadminRemoveTags62E32901Data = {
 	body: TagUpdateSchema;
 	path: {
 		/**
@@ -7061,7 +7061,7 @@ export type EventadminRemoveTags1Eb533CdData = {
 	url: '/api/event-admin/{event_id}/tags/remove';
 };
 
-export type EventadminRemoveTags1Eb533CdResponses = {
+export type EventadminRemoveTags62E32901Responses = {
 	/**
 	 * Response
 	 *
@@ -7070,10 +7070,10 @@ export type EventadminRemoveTags1Eb533CdResponses = {
 	200: Array<TagSchema>;
 };
 
-export type EventadminRemoveTags1Eb533CdResponse =
-	EventadminRemoveTags1Eb533CdResponses[keyof EventadminRemoveTags1Eb533CdResponses];
+export type EventadminRemoveTags62E32901Response =
+	EventadminRemoveTags62E32901Responses[keyof EventadminRemoveTags62E32901Responses];
 
-export type EventadminListTicketTiersF0C8F341Data = {
+export type EventadminListTicketTiers59879806Data = {
 	body?: never;
 	path: {
 		/**
@@ -7094,17 +7094,17 @@ export type EventadminListTicketTiersF0C8F341Data = {
 	url: '/api/event-admin/{event_id}/ticket-tiers';
 };
 
-export type EventadminListTicketTiersF0C8F341Responses = {
+export type EventadminListTicketTiers59879806Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaTicketTierDetailSchema;
 };
 
-export type EventadminListTicketTiersF0C8F341Response =
-	EventadminListTicketTiersF0C8F341Responses[keyof EventadminListTicketTiersF0C8F341Responses];
+export type EventadminListTicketTiers59879806Response =
+	EventadminListTicketTiers59879806Responses[keyof EventadminListTicketTiers59879806Responses];
 
-export type EventadminCreateTicketTier03150584Data = {
+export type EventadminCreateTicketTier84Db5110Data = {
 	body: TicketTierCreateSchema;
 	path: {
 		/**
@@ -7116,17 +7116,17 @@ export type EventadminCreateTicketTier03150584Data = {
 	url: '/api/event-admin/{event_id}/ticket-tier';
 };
 
-export type EventadminCreateTicketTier03150584Responses = {
+export type EventadminCreateTicketTier84Db5110Responses = {
 	/**
 	 * OK
 	 */
 	200: TicketTierDetailSchema;
 };
 
-export type EventadminCreateTicketTier03150584Response =
-	EventadminCreateTicketTier03150584Responses[keyof EventadminCreateTicketTier03150584Responses];
+export type EventadminCreateTicketTier84Db5110Response =
+	EventadminCreateTicketTier84Db5110Responses[keyof EventadminCreateTicketTier84Db5110Responses];
 
-export type EventadminDeleteTicketTierA7C3519aData = {
+export type EventadminDeleteTicketTier1D0E7C44Data = {
 	body?: never;
 	path: {
 		/**
@@ -7142,17 +7142,17 @@ export type EventadminDeleteTicketTierA7C3519aData = {
 	url: '/api/event-admin/{event_id}/ticket-tier/{tier_id}';
 };
 
-export type EventadminDeleteTicketTierA7C3519aResponses = {
+export type EventadminDeleteTicketTier1D0E7C44Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminDeleteTicketTierA7C3519aResponse =
-	EventadminDeleteTicketTierA7C3519aResponses[keyof EventadminDeleteTicketTierA7C3519aResponses];
+export type EventadminDeleteTicketTier1D0E7C44Response =
+	EventadminDeleteTicketTier1D0E7C44Responses[keyof EventadminDeleteTicketTier1D0E7C44Responses];
 
-export type EventadminUpdateTicketTierAded0749Data = {
+export type EventadminUpdateTicketTierAe1D4E8aData = {
 	body: TicketTierUpdateSchema;
 	path: {
 		/**
@@ -7168,17 +7168,17 @@ export type EventadminUpdateTicketTierAded0749Data = {
 	url: '/api/event-admin/{event_id}/ticket-tier/{tier_id}';
 };
 
-export type EventadminUpdateTicketTierAded0749Responses = {
+export type EventadminUpdateTicketTierAe1D4E8aResponses = {
 	/**
 	 * OK
 	 */
 	200: TicketTierDetailSchema;
 };
 
-export type EventadminUpdateTicketTierAded0749Response =
-	EventadminUpdateTicketTierAded0749Responses[keyof EventadminUpdateTicketTierAded0749Responses];
+export type EventadminUpdateTicketTierAe1D4E8aResponse =
+	EventadminUpdateTicketTierAe1D4E8aResponses[keyof EventadminUpdateTicketTierAe1D4E8aResponses];
 
-export type EventadminListTickets720A6A89Data = {
+export type EventadminListTickets458061F5Data = {
 	body?: never;
 	path: {
 		/**
@@ -7205,17 +7205,17 @@ export type EventadminListTickets720A6A89Data = {
 	url: '/api/event-admin/{event_id}/tickets';
 };
 
-export type EventadminListTickets720A6A89Responses = {
+export type EventadminListTickets458061F5Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaAdminTicketSchema;
 };
 
-export type EventadminListTickets720A6A89Response =
-	EventadminListTickets720A6A89Responses[keyof EventadminListTickets720A6A89Responses];
+export type EventadminListTickets458061F5Response =
+	EventadminListTickets458061F5Responses[keyof EventadminListTickets458061F5Responses];
 
-export type EventadminGetTicket19Afa38dData = {
+export type EventadminGetTicketCe124C38Data = {
 	body?: never;
 	path: {
 		/**
@@ -7231,17 +7231,17 @@ export type EventadminGetTicket19Afa38dData = {
 	url: '/api/event-admin/{event_id}/tickets/{ticket_id}';
 };
 
-export type EventadminGetTicket19Afa38dResponses = {
+export type EventadminGetTicketCe124C38Responses = {
 	/**
 	 * OK
 	 */
 	200: AdminTicketSchema;
 };
 
-export type EventadminGetTicket19Afa38dResponse =
-	EventadminGetTicket19Afa38dResponses[keyof EventadminGetTicket19Afa38dResponses];
+export type EventadminGetTicketCe124C38Response =
+	EventadminGetTicketCe124C38Responses[keyof EventadminGetTicketCe124C38Responses];
 
-export type EventadminConfirmTicketPaymentD8E41153Data = {
+export type EventadminConfirmTicketPayment73914A92Data = {
 	body?: never;
 	path: {
 		/**
@@ -7257,17 +7257,17 @@ export type EventadminConfirmTicketPaymentD8E41153Data = {
 	url: '/api/event-admin/{event_id}/tickets/{ticket_id}/confirm-payment';
 };
 
-export type EventadminConfirmTicketPaymentD8E41153Responses = {
+export type EventadminConfirmTicketPayment73914A92Responses = {
 	/**
 	 * OK
 	 */
 	200: EventTicketSchema;
 };
 
-export type EventadminConfirmTicketPaymentD8E41153Response =
-	EventadminConfirmTicketPaymentD8E41153Responses[keyof EventadminConfirmTicketPaymentD8E41153Responses];
+export type EventadminConfirmTicketPayment73914A92Response =
+	EventadminConfirmTicketPayment73914A92Responses[keyof EventadminConfirmTicketPayment73914A92Responses];
 
-export type EventadminMarkTicketRefundedBd44B3D6Data = {
+export type EventadminMarkTicketRefunded0Cf0F029Data = {
 	body?: never;
 	path: {
 		/**
@@ -7283,17 +7283,17 @@ export type EventadminMarkTicketRefundedBd44B3D6Data = {
 	url: '/api/event-admin/{event_id}/tickets/{ticket_id}/mark-refunded';
 };
 
-export type EventadminMarkTicketRefundedBd44B3D6Responses = {
+export type EventadminMarkTicketRefunded0Cf0F029Responses = {
 	/**
 	 * OK
 	 */
 	200: EventTicketSchema;
 };
 
-export type EventadminMarkTicketRefundedBd44B3D6Response =
-	EventadminMarkTicketRefundedBd44B3D6Responses[keyof EventadminMarkTicketRefundedBd44B3D6Responses];
+export type EventadminMarkTicketRefunded0Cf0F029Response =
+	EventadminMarkTicketRefunded0Cf0F029Responses[keyof EventadminMarkTicketRefunded0Cf0F029Responses];
 
-export type EventadminCancelTicket1082Aa5bData = {
+export type EventadminCancelTicket14582C4eData = {
 	body?: never;
 	path: {
 		/**
@@ -7309,17 +7309,17 @@ export type EventadminCancelTicket1082Aa5bData = {
 	url: '/api/event-admin/{event_id}/tickets/{ticket_id}/cancel';
 };
 
-export type EventadminCancelTicket1082Aa5bResponses = {
+export type EventadminCancelTicket14582C4eResponses = {
 	/**
 	 * OK
 	 */
 	200: EventTicketSchema;
 };
 
-export type EventadminCancelTicket1082Aa5bResponse =
-	EventadminCancelTicket1082Aa5bResponses[keyof EventadminCancelTicket1082Aa5bResponses];
+export type EventadminCancelTicket14582C4eResponse =
+	EventadminCancelTicket14582C4eResponses[keyof EventadminCancelTicket14582C4eResponses];
 
-export type EventadminCheckInTicket957Dc27bData = {
+export type EventadminCheckInTicket15Ab77B0Data = {
 	body?: never;
 	path: {
 		/**
@@ -7335,27 +7335,27 @@ export type EventadminCheckInTicket957Dc27bData = {
 	url: '/api/event-admin/{event_id}/tickets/{ticket_id}/check-in';
 };
 
-export type EventadminCheckInTicket957Dc27bErrors = {
+export type EventadminCheckInTicket15Ab77B0Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: ValidationErrorResponse;
 };
 
-export type EventadminCheckInTicket957Dc27bError =
-	EventadminCheckInTicket957Dc27bErrors[keyof EventadminCheckInTicket957Dc27bErrors];
+export type EventadminCheckInTicket15Ab77B0Error =
+	EventadminCheckInTicket15Ab77B0Errors[keyof EventadminCheckInTicket15Ab77B0Errors];
 
-export type EventadminCheckInTicket957Dc27bResponses = {
+export type EventadminCheckInTicket15Ab77B0Responses = {
 	/**
 	 * OK
 	 */
 	200: CheckInResponseSchema;
 };
 
-export type EventadminCheckInTicket957Dc27bResponse =
-	EventadminCheckInTicket957Dc27bResponses[keyof EventadminCheckInTicket957Dc27bResponses];
+export type EventadminCheckInTicket15Ab77B0Response =
+	EventadminCheckInTicket15Ab77B0Responses[keyof EventadminCheckInTicket15Ab77B0Responses];
 
-export type EventadminListInvitations8672F3C5Data = {
+export type EventadminListInvitationsF2Bb3Cb9Data = {
 	body?: never;
 	path: {
 		/**
@@ -7380,17 +7380,17 @@ export type EventadminListInvitations8672F3C5Data = {
 	url: '/api/event-admin/{event_id}/invitations';
 };
 
-export type EventadminListInvitations8672F3C5Responses = {
+export type EventadminListInvitationsF2Bb3Cb9Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaEventInvitationListSchema;
 };
 
-export type EventadminListInvitations8672F3C5Response =
-	EventadminListInvitations8672F3C5Responses[keyof EventadminListInvitations8672F3C5Responses];
+export type EventadminListInvitationsF2Bb3Cb9Response =
+	EventadminListInvitationsF2Bb3Cb9Responses[keyof EventadminListInvitationsF2Bb3Cb9Responses];
 
-export type EventadminCreateInvitations626265E4Data = {
+export type EventadminCreateInvitationsF317F105Data = {
 	body: DirectInvitationCreateSchema;
 	path: {
 		/**
@@ -7402,27 +7402,27 @@ export type EventadminCreateInvitations626265E4Data = {
 	url: '/api/event-admin/{event_id}/invitations';
 };
 
-export type EventadminCreateInvitations626265E4Errors = {
+export type EventadminCreateInvitationsF317F105Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: ValidationErrorResponse;
 };
 
-export type EventadminCreateInvitations626265E4Error =
-	EventadminCreateInvitations626265E4Errors[keyof EventadminCreateInvitations626265E4Errors];
+export type EventadminCreateInvitationsF317F105Error =
+	EventadminCreateInvitationsF317F105Errors[keyof EventadminCreateInvitationsF317F105Errors];
 
-export type EventadminCreateInvitations626265E4Responses = {
+export type EventadminCreateInvitationsF317F105Responses = {
 	/**
 	 * OK
 	 */
 	200: DirectInvitationResponseSchema;
 };
 
-export type EventadminCreateInvitations626265E4Response =
-	EventadminCreateInvitations626265E4Responses[keyof EventadminCreateInvitations626265E4Responses];
+export type EventadminCreateInvitationsF317F105Response =
+	EventadminCreateInvitationsF317F105Responses[keyof EventadminCreateInvitationsF317F105Responses];
 
-export type EventadminListPendingInvitations2074D91cData = {
+export type EventadminListPendingInvitations5F282536Data = {
 	body?: never;
 	path: {
 		/**
@@ -7447,17 +7447,17 @@ export type EventadminListPendingInvitations2074D91cData = {
 	url: '/api/event-admin/{event_id}/pending-invitations';
 };
 
-export type EventadminListPendingInvitations2074D91cResponses = {
+export type EventadminListPendingInvitations5F282536Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaPendingEventInvitationListSchema;
 };
 
-export type EventadminListPendingInvitations2074D91cResponse =
-	EventadminListPendingInvitations2074D91cResponses[keyof EventadminListPendingInvitations2074D91cResponses];
+export type EventadminListPendingInvitations5F282536Response =
+	EventadminListPendingInvitations5F282536Responses[keyof EventadminListPendingInvitations5F282536Responses];
 
-export type EventadminDeleteInvitationEndpoint7A5Baf74Data = {
+export type EventadminDeleteInvitationEndpoint38F40Fb9Data = {
 	body?: never;
 	path: {
 		/**
@@ -7477,27 +7477,27 @@ export type EventadminDeleteInvitationEndpoint7A5Baf74Data = {
 	url: '/api/event-admin/{event_id}/invitations/{invitation_type}/{invitation_id}';
 };
 
-export type EventadminDeleteInvitationEndpoint7A5Baf74Errors = {
+export type EventadminDeleteInvitationEndpoint38F40Fb9Errors = {
 	/**
 	 * Not Found
 	 */
 	404: ValidationErrorResponse;
 };
 
-export type EventadminDeleteInvitationEndpoint7A5Baf74Error =
-	EventadminDeleteInvitationEndpoint7A5Baf74Errors[keyof EventadminDeleteInvitationEndpoint7A5Baf74Errors];
+export type EventadminDeleteInvitationEndpoint38F40Fb9Error =
+	EventadminDeleteInvitationEndpoint38F40Fb9Errors[keyof EventadminDeleteInvitationEndpoint38F40Fb9Errors];
 
-export type EventadminDeleteInvitationEndpoint7A5Baf74Responses = {
+export type EventadminDeleteInvitationEndpoint38F40Fb9Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminDeleteInvitationEndpoint7A5Baf74Response =
-	EventadminDeleteInvitationEndpoint7A5Baf74Responses[keyof EventadminDeleteInvitationEndpoint7A5Baf74Responses];
+export type EventadminDeleteInvitationEndpoint38F40Fb9Response =
+	EventadminDeleteInvitationEndpoint38F40Fb9Responses[keyof EventadminDeleteInvitationEndpoint38F40Fb9Responses];
 
-export type EventadminListRsvps7Ad29E6cData = {
+export type EventadminListRsvps8Ad05025Data = {
 	body?: never;
 	path: {
 		/**
@@ -7527,17 +7527,17 @@ export type EventadminListRsvps7Ad29E6cData = {
 	url: '/api/event-admin/{event_id}/rsvps';
 };
 
-export type EventadminListRsvps7Ad29E6cResponses = {
+export type EventadminListRsvps8Ad05025Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaRsvpDetailSchema;
 };
 
-export type EventadminListRsvps7Ad29E6cResponse =
-	EventadminListRsvps7Ad29E6cResponses[keyof EventadminListRsvps7Ad29E6cResponses];
+export type EventadminListRsvps8Ad05025Response =
+	EventadminListRsvps8Ad05025Responses[keyof EventadminListRsvps8Ad05025Responses];
 
-export type EventadminCreateRsvpA0Abb388Data = {
+export type EventadminCreateRsvp6074Fdf2Data = {
 	body: RsvpCreateSchema;
 	path: {
 		/**
@@ -7549,17 +7549,17 @@ export type EventadminCreateRsvpA0Abb388Data = {
 	url: '/api/event-admin/{event_id}/rsvps';
 };
 
-export type EventadminCreateRsvpA0Abb388Responses = {
+export type EventadminCreateRsvp6074Fdf2Responses = {
 	/**
 	 * OK
 	 */
 	200: RsvpDetailSchema;
 };
 
-export type EventadminCreateRsvpA0Abb388Response =
-	EventadminCreateRsvpA0Abb388Responses[keyof EventadminCreateRsvpA0Abb388Responses];
+export type EventadminCreateRsvp6074Fdf2Response =
+	EventadminCreateRsvp6074Fdf2Responses[keyof EventadminCreateRsvp6074Fdf2Responses];
 
-export type EventadminDeleteRsvp111B4Ef4Data = {
+export type EventadminDeleteRsvpBe54BbcfData = {
 	body?: never;
 	path: {
 		/**
@@ -7575,17 +7575,17 @@ export type EventadminDeleteRsvp111B4Ef4Data = {
 	url: '/api/event-admin/{event_id}/rsvps/{rsvp_id}';
 };
 
-export type EventadminDeleteRsvp111B4Ef4Responses = {
+export type EventadminDeleteRsvpBe54BbcfResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventadminDeleteRsvp111B4Ef4Response =
-	EventadminDeleteRsvp111B4Ef4Responses[keyof EventadminDeleteRsvp111B4Ef4Responses];
+export type EventadminDeleteRsvpBe54BbcfResponse =
+	EventadminDeleteRsvpBe54BbcfResponses[keyof EventadminDeleteRsvpBe54BbcfResponses];
 
-export type EventadminGetRsvpB753B6DfData = {
+export type EventadminGetRsvpFfff5A62Data = {
 	body?: never;
 	path: {
 		/**
@@ -7601,17 +7601,17 @@ export type EventadminGetRsvpB753B6DfData = {
 	url: '/api/event-admin/{event_id}/rsvps/{rsvp_id}';
 };
 
-export type EventadminGetRsvpB753B6DfResponses = {
+export type EventadminGetRsvpFfff5A62Responses = {
 	/**
 	 * OK
 	 */
 	200: RsvpDetailSchema;
 };
 
-export type EventadminGetRsvpB753B6DfResponse =
-	EventadminGetRsvpB753B6DfResponses[keyof EventadminGetRsvpB753B6DfResponses];
+export type EventadminGetRsvpFfff5A62Response =
+	EventadminGetRsvpFfff5A62Responses[keyof EventadminGetRsvpFfff5A62Responses];
 
-export type EventadminUpdateRsvp4F4B015cData = {
+export type EventadminUpdateRsvpF8E082B7Data = {
 	body: RsvpUpdateSchema;
 	path: {
 		/**
@@ -7627,34 +7627,34 @@ export type EventadminUpdateRsvp4F4B015cData = {
 	url: '/api/event-admin/{event_id}/rsvps/{rsvp_id}';
 };
 
-export type EventadminUpdateRsvp4F4B015cResponses = {
+export type EventadminUpdateRsvpF8E082B7Responses = {
 	/**
 	 * OK
 	 */
 	200: RsvpDetailSchema;
 };
 
-export type EventadminUpdateRsvp4F4B015cResponse =
-	EventadminUpdateRsvp4F4B015cResponses[keyof EventadminUpdateRsvp4F4B015cResponses];
+export type EventadminUpdateRsvpF8E082B7Response =
+	EventadminUpdateRsvpF8E082B7Responses[keyof EventadminUpdateRsvpF8E082B7Responses];
 
-export type PermissionMyPermissions26660239Data = {
+export type PermissionMyPermissions0B7734E0Data = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/permissions/my-permissions';
 };
 
-export type PermissionMyPermissions26660239Responses = {
+export type PermissionMyPermissions0B7734E0Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationPermissionsSchema;
 };
 
-export type PermissionMyPermissions26660239Response =
-	PermissionMyPermissions26660239Responses[keyof PermissionMyPermissions26660239Responses];
+export type PermissionMyPermissions0B7734E0Response =
+	PermissionMyPermissions0B7734E0Responses[keyof PermissionMyPermissions0B7734E0Responses];
 
-export type EventseriesListEventSeries5C5D600cData = {
+export type EventseriesListEventSeries695C7F05Data = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -7682,17 +7682,17 @@ export type EventseriesListEventSeries5C5D600cData = {
 	url: '/api/event-series/';
 };
 
-export type EventseriesListEventSeries5C5D600cResponses = {
+export type EventseriesListEventSeries695C7F05Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaEventSeriesRetrieveSchema;
 };
 
-export type EventseriesListEventSeries5C5D600cResponse =
-	EventseriesListEventSeries5C5D600cResponses[keyof EventseriesListEventSeries5C5D600cResponses];
+export type EventseriesListEventSeries695C7F05Response =
+	EventseriesListEventSeries695C7F05Responses[keyof EventseriesListEventSeries695C7F05Responses];
 
-export type EventseriesGetEventSeriesBySlugs2Bc4198fData = {
+export type EventseriesGetEventSeriesBySlugs305F958fData = {
 	body?: never;
 	path: {
 		/**
@@ -7708,17 +7708,17 @@ export type EventseriesGetEventSeriesBySlugs2Bc4198fData = {
 	url: '/api/event-series/{org_slug}/{series_slug}';
 };
 
-export type EventseriesGetEventSeriesBySlugs2Bc4198fResponses = {
+export type EventseriesGetEventSeriesBySlugs305F958fResponses = {
 	/**
 	 * OK
 	 */
 	200: EventSeriesRetrieveSchema;
 };
 
-export type EventseriesGetEventSeriesBySlugs2Bc4198fResponse =
-	EventseriesGetEventSeriesBySlugs2Bc4198fResponses[keyof EventseriesGetEventSeriesBySlugs2Bc4198fResponses];
+export type EventseriesGetEventSeriesBySlugs305F958fResponse =
+	EventseriesGetEventSeriesBySlugs305F958fResponses[keyof EventseriesGetEventSeriesBySlugs305F958fResponses];
 
-export type EventseriesGetEventSeries0879D813Data = {
+export type EventseriesGetEventSeriesF286001eData = {
 	body?: never;
 	path: {
 		/**
@@ -7730,17 +7730,17 @@ export type EventseriesGetEventSeries0879D813Data = {
 	url: '/api/event-series/{series_id}';
 };
 
-export type EventseriesGetEventSeries0879D813Responses = {
+export type EventseriesGetEventSeriesF286001eResponses = {
 	/**
 	 * OK
 	 */
 	200: EventSeriesRetrieveSchema;
 };
 
-export type EventseriesGetEventSeries0879D813Response =
-	EventseriesGetEventSeries0879D813Responses[keyof EventseriesGetEventSeries0879D813Responses];
+export type EventseriesGetEventSeriesF286001eResponse =
+	EventseriesGetEventSeriesF286001eResponses[keyof EventseriesGetEventSeriesF286001eResponses];
 
-export type EventseriesListResourcesFc094B71Data = {
+export type EventseriesListResources9E3B380eData = {
 	body?: never;
 	path: {
 		/**
@@ -7766,17 +7766,17 @@ export type EventseriesListResourcesFc094B71Data = {
 	url: '/api/event-series/{series_id}/resources';
 };
 
-export type EventseriesListResourcesFc094B71Responses = {
+export type EventseriesListResources9E3B380eResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaAdditionalResourceSchema;
 };
 
-export type EventseriesListResourcesFc094B71Response =
-	EventseriesListResourcesFc094B71Responses[keyof EventseriesListResourcesFc094B71Responses];
+export type EventseriesListResources9E3B380eResponse =
+	EventseriesListResources9E3B380eResponses[keyof EventseriesListResources9E3B380eResponses];
 
-export type EventseriesadminDeleteEventSeries4342CeaeData = {
+export type EventseriesadminDeleteEventSeriesE0020657Data = {
 	body?: never;
 	path: {
 		/**
@@ -7788,17 +7788,17 @@ export type EventseriesadminDeleteEventSeries4342CeaeData = {
 	url: '/api/event-series-admin/{series_id}/';
 };
 
-export type EventseriesadminDeleteEventSeries4342CeaeResponses = {
+export type EventseriesadminDeleteEventSeriesE0020657Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventseriesadminDeleteEventSeries4342CeaeResponse =
-	EventseriesadminDeleteEventSeries4342CeaeResponses[keyof EventseriesadminDeleteEventSeries4342CeaeResponses];
+export type EventseriesadminDeleteEventSeriesE0020657Response =
+	EventseriesadminDeleteEventSeriesE0020657Responses[keyof EventseriesadminDeleteEventSeriesE0020657Responses];
 
-export type EventseriesadminUpdateEventSeries787B5A6bData = {
+export type EventseriesadminUpdateEventSeries3912324eData = {
 	body: EventSeriesEditSchema;
 	path: {
 		/**
@@ -7810,27 +7810,27 @@ export type EventseriesadminUpdateEventSeries787B5A6bData = {
 	url: '/api/event-series-admin/{series_id}/';
 };
 
-export type EventseriesadminUpdateEventSeries787B5A6bErrors = {
+export type EventseriesadminUpdateEventSeries3912324eErrors = {
 	/**
 	 * Bad Request
 	 */
 	400: ValidationErrorResponse;
 };
 
-export type EventseriesadminUpdateEventSeries787B5A6bError =
-	EventseriesadminUpdateEventSeries787B5A6bErrors[keyof EventseriesadminUpdateEventSeries787B5A6bErrors];
+export type EventseriesadminUpdateEventSeries3912324eError =
+	EventseriesadminUpdateEventSeries3912324eErrors[keyof EventseriesadminUpdateEventSeries3912324eErrors];
 
-export type EventseriesadminUpdateEventSeries787B5A6bResponses = {
+export type EventseriesadminUpdateEventSeries3912324eResponses = {
 	/**
 	 * OK
 	 */
 	200: EventSeriesRetrieveSchema;
 };
 
-export type EventseriesadminUpdateEventSeries787B5A6bResponse =
-	EventseriesadminUpdateEventSeries787B5A6bResponses[keyof EventseriesadminUpdateEventSeries787B5A6bResponses];
+export type EventseriesadminUpdateEventSeries3912324eResponse =
+	EventseriesadminUpdateEventSeries3912324eResponses[keyof EventseriesadminUpdateEventSeries3912324eResponses];
 
-export type EventseriesadminUploadLogoD5A34979Data = {
+export type EventseriesadminUploadLogo454Bc4C2Data = {
 	/**
 	 * FileParams
 	 */
@@ -7850,17 +7850,17 @@ export type EventseriesadminUploadLogoD5A34979Data = {
 	url: '/api/event-series-admin/{series_id}/upload-logo';
 };
 
-export type EventseriesadminUploadLogoD5A34979Responses = {
+export type EventseriesadminUploadLogo454Bc4C2Responses = {
 	/**
 	 * OK
 	 */
 	200: EventSeriesRetrieveSchema;
 };
 
-export type EventseriesadminUploadLogoD5A34979Response =
-	EventseriesadminUploadLogoD5A34979Responses[keyof EventseriesadminUploadLogoD5A34979Responses];
+export type EventseriesadminUploadLogo454Bc4C2Response =
+	EventseriesadminUploadLogo454Bc4C2Responses[keyof EventseriesadminUploadLogo454Bc4C2Responses];
 
-export type EventseriesadminUploadCoverArtCef38D76Data = {
+export type EventseriesadminUploadCoverArt5Eb583C2Data = {
 	/**
 	 * FileParams
 	 */
@@ -7880,17 +7880,17 @@ export type EventseriesadminUploadCoverArtCef38D76Data = {
 	url: '/api/event-series-admin/{series_id}/upload-cover-art';
 };
 
-export type EventseriesadminUploadCoverArtCef38D76Responses = {
+export type EventseriesadminUploadCoverArt5Eb583C2Responses = {
 	/**
 	 * OK
 	 */
 	200: EventSeriesRetrieveSchema;
 };
 
-export type EventseriesadminUploadCoverArtCef38D76Response =
-	EventseriesadminUploadCoverArtCef38D76Responses[keyof EventseriesadminUploadCoverArtCef38D76Responses];
+export type EventseriesadminUploadCoverArt5Eb583C2Response =
+	EventseriesadminUploadCoverArt5Eb583C2Responses[keyof EventseriesadminUploadCoverArt5Eb583C2Responses];
 
-export type EventseriesadminDeleteLogo60503B96Data = {
+export type EventseriesadminDeleteLogo8801A010Data = {
 	body?: never;
 	path: {
 		/**
@@ -7902,17 +7902,17 @@ export type EventseriesadminDeleteLogo60503B96Data = {
 	url: '/api/event-series-admin/{series_id}/delete-logo';
 };
 
-export type EventseriesadminDeleteLogo60503B96Responses = {
+export type EventseriesadminDeleteLogo8801A010Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventseriesadminDeleteLogo60503B96Response =
-	EventseriesadminDeleteLogo60503B96Responses[keyof EventseriesadminDeleteLogo60503B96Responses];
+export type EventseriesadminDeleteLogo8801A010Response =
+	EventseriesadminDeleteLogo8801A010Responses[keyof EventseriesadminDeleteLogo8801A010Responses];
 
-export type EventseriesadminDeleteCoverArtAdacffceData = {
+export type EventseriesadminDeleteCoverArtD482Bb1dData = {
 	body?: never;
 	path: {
 		/**
@@ -7924,17 +7924,17 @@ export type EventseriesadminDeleteCoverArtAdacffceData = {
 	url: '/api/event-series-admin/{series_id}/delete-cover-art';
 };
 
-export type EventseriesadminDeleteCoverArtAdacffceResponses = {
+export type EventseriesadminDeleteCoverArtD482Bb1dResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventseriesadminDeleteCoverArtAdacffceResponse =
-	EventseriesadminDeleteCoverArtAdacffceResponses[keyof EventseriesadminDeleteCoverArtAdacffceResponses];
+export type EventseriesadminDeleteCoverArtD482Bb1dResponse =
+	EventseriesadminDeleteCoverArtD482Bb1dResponses[keyof EventseriesadminDeleteCoverArtD482Bb1dResponses];
 
-export type EventseriesadminClearTags39B860D9Data = {
+export type EventseriesadminClearTags3Be88830Data = {
 	body?: never;
 	path: {
 		/**
@@ -7946,17 +7946,17 @@ export type EventseriesadminClearTags39B860D9Data = {
 	url: '/api/event-series-admin/{series_id}/tags';
 };
 
-export type EventseriesadminClearTags39B860D9Responses = {
+export type EventseriesadminClearTags3Be88830Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type EventseriesadminClearTags39B860D9Response =
-	EventseriesadminClearTags39B860D9Responses[keyof EventseriesadminClearTags39B860D9Responses];
+export type EventseriesadminClearTags3Be88830Response =
+	EventseriesadminClearTags3Be88830Responses[keyof EventseriesadminClearTags3Be88830Responses];
 
-export type EventseriesadminAddTags90D97164Data = {
+export type EventseriesadminAddTagsEdecd586Data = {
 	body: TagUpdateSchema;
 	path: {
 		/**
@@ -7968,7 +7968,7 @@ export type EventseriesadminAddTags90D97164Data = {
 	url: '/api/event-series-admin/{series_id}/tags';
 };
 
-export type EventseriesadminAddTags90D97164Responses = {
+export type EventseriesadminAddTagsEdecd586Responses = {
 	/**
 	 * Response
 	 *
@@ -7977,10 +7977,10 @@ export type EventseriesadminAddTags90D97164Responses = {
 	200: Array<TagSchema>;
 };
 
-export type EventseriesadminAddTags90D97164Response =
-	EventseriesadminAddTags90D97164Responses[keyof EventseriesadminAddTags90D97164Responses];
+export type EventseriesadminAddTagsEdecd586Response =
+	EventseriesadminAddTagsEdecd586Responses[keyof EventseriesadminAddTagsEdecd586Responses];
 
-export type EventseriesadminRemoveTagsDace0E92Data = {
+export type EventseriesadminRemoveTags748118B9Data = {
 	body: TagUpdateSchema;
 	path: {
 		/**
@@ -7992,7 +7992,7 @@ export type EventseriesadminRemoveTagsDace0E92Data = {
 	url: '/api/event-series-admin/{series_id}/tags/remove';
 };
 
-export type EventseriesadminRemoveTagsDace0E92Responses = {
+export type EventseriesadminRemoveTags748118B9Responses = {
 	/**
 	 * Response
 	 *
@@ -8001,10 +8001,10 @@ export type EventseriesadminRemoveTagsDace0E92Responses = {
 	200: Array<TagSchema>;
 };
 
-export type EventseriesadminRemoveTagsDace0E92Response =
-	EventseriesadminRemoveTagsDace0E92Responses[keyof EventseriesadminRemoveTagsDace0E92Responses];
+export type EventseriesadminRemoveTags748118B9Response =
+	EventseriesadminRemoveTags748118B9Responses[keyof EventseriesadminRemoveTags748118B9Responses];
 
-export type PotluckListPotluckItemsF3A8D13fData = {
+export type PotluckListPotluckItems7962228cData = {
 	body?: never;
 	path: {
 		/**
@@ -8016,7 +8016,7 @@ export type PotluckListPotluckItemsF3A8D13fData = {
 	url: '/api/events/{event_id}/potluck/';
 };
 
-export type PotluckListPotluckItemsF3A8D13fResponses = {
+export type PotluckListPotluckItems7962228cResponses = {
 	/**
 	 * Response
 	 *
@@ -8025,10 +8025,10 @@ export type PotluckListPotluckItemsF3A8D13fResponses = {
 	200: Array<PotluckItemRetrieveSchema>;
 };
 
-export type PotluckListPotluckItemsF3A8D13fResponse =
-	PotluckListPotluckItemsF3A8D13fResponses[keyof PotluckListPotluckItemsF3A8D13fResponses];
+export type PotluckListPotluckItems7962228cResponse =
+	PotluckListPotluckItems7962228cResponses[keyof PotluckListPotluckItems7962228cResponses];
 
-export type PotluckCreatePotluckItem74Eaf78eData = {
+export type PotluckCreatePotluckItemC97Ec366Data = {
 	body: PotluckItemCreateSchema;
 	path: {
 		/**
@@ -8040,17 +8040,17 @@ export type PotluckCreatePotluckItem74Eaf78eData = {
 	url: '/api/events/{event_id}/potluck/';
 };
 
-export type PotluckCreatePotluckItem74Eaf78eResponses = {
+export type PotluckCreatePotluckItemC97Ec366Responses = {
 	/**
 	 * OK
 	 */
 	200: PotluckItemRetrieveSchema;
 };
 
-export type PotluckCreatePotluckItem74Eaf78eResponse =
-	PotluckCreatePotluckItem74Eaf78eResponses[keyof PotluckCreatePotluckItem74Eaf78eResponses];
+export type PotluckCreatePotluckItemC97Ec366Response =
+	PotluckCreatePotluckItemC97Ec366Responses[keyof PotluckCreatePotluckItemC97Ec366Responses];
 
-export type PotluckDeletePotluckItem71B5E436Data = {
+export type PotluckDeletePotluckItem743Da4DbData = {
 	body?: never;
 	path: {
 		/**
@@ -8066,17 +8066,17 @@ export type PotluckDeletePotluckItem71B5E436Data = {
 	url: '/api/events/{event_id}/potluck/{item_id}';
 };
 
-export type PotluckDeletePotluckItem71B5E436Responses = {
+export type PotluckDeletePotluckItem743Da4DbResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type PotluckDeletePotluckItem71B5E436Response =
-	PotluckDeletePotluckItem71B5E436Responses[keyof PotluckDeletePotluckItem71B5E436Responses];
+export type PotluckDeletePotluckItem743Da4DbResponse =
+	PotluckDeletePotluckItem743Da4DbResponses[keyof PotluckDeletePotluckItem743Da4DbResponses];
 
-export type PotluckUpdatePotluckItem2Cab8494Data = {
+export type PotluckUpdatePotluckItem95775212Data = {
 	body: PotluckItemCreateSchema;
 	path: {
 		/**
@@ -8092,17 +8092,17 @@ export type PotluckUpdatePotluckItem2Cab8494Data = {
 	url: '/api/events/{event_id}/potluck/{item_id}';
 };
 
-export type PotluckUpdatePotluckItem2Cab8494Responses = {
+export type PotluckUpdatePotluckItem95775212Responses = {
 	/**
 	 * OK
 	 */
 	200: PotluckItemRetrieveSchema;
 };
 
-export type PotluckUpdatePotluckItem2Cab8494Response =
-	PotluckUpdatePotluckItem2Cab8494Responses[keyof PotluckUpdatePotluckItem2Cab8494Responses];
+export type PotluckUpdatePotluckItem95775212Response =
+	PotluckUpdatePotluckItem95775212Responses[keyof PotluckUpdatePotluckItem95775212Responses];
 
-export type PotluckClaimPotluckItemDecef2E5Data = {
+export type PotluckClaimPotluckItem0Ed17079Data = {
 	body?: never;
 	path: {
 		/**
@@ -8118,17 +8118,17 @@ export type PotluckClaimPotluckItemDecef2E5Data = {
 	url: '/api/events/{event_id}/potluck/{item_id}/claim';
 };
 
-export type PotluckClaimPotluckItemDecef2E5Responses = {
+export type PotluckClaimPotluckItem0Ed17079Responses = {
 	/**
 	 * OK
 	 */
 	200: PotluckItemRetrieveSchema;
 };
 
-export type PotluckClaimPotluckItemDecef2E5Response =
-	PotluckClaimPotluckItemDecef2E5Responses[keyof PotluckClaimPotluckItemDecef2E5Responses];
+export type PotluckClaimPotluckItem0Ed17079Response =
+	PotluckClaimPotluckItem0Ed17079Responses[keyof PotluckClaimPotluckItem0Ed17079Responses];
 
-export type PotluckUnclaimPotluckItem7D8B3F84Data = {
+export type PotluckUnclaimPotluckItem75438D08Data = {
 	body?: never;
 	path: {
 		/**
@@ -8144,17 +8144,17 @@ export type PotluckUnclaimPotluckItem7D8B3F84Data = {
 	url: '/api/events/{event_id}/potluck/{item_id}/unclaim';
 };
 
-export type PotluckUnclaimPotluckItem7D8B3F84Responses = {
+export type PotluckUnclaimPotluckItem75438D08Responses = {
 	/**
 	 * OK
 	 */
 	200: PotluckItemRetrieveSchema;
 };
 
-export type PotluckUnclaimPotluckItem7D8B3F84Response =
-	PotluckUnclaimPotluckItem7D8B3F84Responses[keyof PotluckUnclaimPotluckItem7D8B3F84Responses];
+export type PotluckUnclaimPotluckItem75438D08Response =
+	PotluckUnclaimPotluckItem75438D08Responses[keyof PotluckUnclaimPotluckItem75438D08Responses];
 
-export type QuestionnaireListOrgQuestionnaires42A9D3CbData = {
+export type QuestionnaireListOrgQuestionnaires49D842F3Data = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -8186,17 +8186,17 @@ export type QuestionnaireListOrgQuestionnaires42A9D3CbData = {
 	url: '/api/questionnaires/';
 };
 
-export type QuestionnaireListOrgQuestionnaires42A9D3CbResponses = {
+export type QuestionnaireListOrgQuestionnaires49D842F3Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaOrganizationQuestionnaireInListSchema;
 };
 
-export type QuestionnaireListOrgQuestionnaires42A9D3CbResponse =
-	QuestionnaireListOrgQuestionnaires42A9D3CbResponses[keyof QuestionnaireListOrgQuestionnaires42A9D3CbResponses];
+export type QuestionnaireListOrgQuestionnaires49D842F3Response =
+	QuestionnaireListOrgQuestionnaires49D842F3Responses[keyof QuestionnaireListOrgQuestionnaires49D842F3Responses];
 
-export type QuestionnaireCreateOrgQuestionnaire3C5D9045Data = {
+export type QuestionnaireCreateOrgQuestionnaireF91E8483Data = {
 	body: OrganizationQuestionnaireCreateSchema;
 	path: {
 		/**
@@ -8208,27 +8208,27 @@ export type QuestionnaireCreateOrgQuestionnaire3C5D9045Data = {
 	url: '/api/questionnaires/{organization_id}/create-questionnaire';
 };
 
-export type QuestionnaireCreateOrgQuestionnaire3C5D9045Errors = {
+export type QuestionnaireCreateOrgQuestionnaireF91E8483Errors = {
 	/**
 	 * Bad Request
 	 */
 	400: ValidationErrorResponse;
 };
 
-export type QuestionnaireCreateOrgQuestionnaire3C5D9045Error =
-	QuestionnaireCreateOrgQuestionnaire3C5D9045Errors[keyof QuestionnaireCreateOrgQuestionnaire3C5D9045Errors];
+export type QuestionnaireCreateOrgQuestionnaireF91E8483Error =
+	QuestionnaireCreateOrgQuestionnaireF91E8483Errors[keyof QuestionnaireCreateOrgQuestionnaireF91E8483Errors];
 
-export type QuestionnaireCreateOrgQuestionnaire3C5D9045Responses = {
+export type QuestionnaireCreateOrgQuestionnaireF91E8483Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationQuestionnaireSchema;
 };
 
-export type QuestionnaireCreateOrgQuestionnaire3C5D9045Response =
-	QuestionnaireCreateOrgQuestionnaire3C5D9045Responses[keyof QuestionnaireCreateOrgQuestionnaire3C5D9045Responses];
+export type QuestionnaireCreateOrgQuestionnaireF91E8483Response =
+	QuestionnaireCreateOrgQuestionnaireF91E8483Responses[keyof QuestionnaireCreateOrgQuestionnaireF91E8483Responses];
 
-export type QuestionnaireDeleteOrgQuestionnaire80Cd631aData = {
+export type QuestionnaireDeleteOrgQuestionnaireBec1C8C9Data = {
 	body?: never;
 	path: {
 		/**
@@ -8240,17 +8240,17 @@ export type QuestionnaireDeleteOrgQuestionnaire80Cd631aData = {
 	url: '/api/questionnaires/{org_questionnaire_id}';
 };
 
-export type QuestionnaireDeleteOrgQuestionnaire80Cd631aResponses = {
+export type QuestionnaireDeleteOrgQuestionnaireBec1C8C9Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type QuestionnaireDeleteOrgQuestionnaire80Cd631aResponse =
-	QuestionnaireDeleteOrgQuestionnaire80Cd631aResponses[keyof QuestionnaireDeleteOrgQuestionnaire80Cd631aResponses];
+export type QuestionnaireDeleteOrgQuestionnaireBec1C8C9Response =
+	QuestionnaireDeleteOrgQuestionnaireBec1C8C9Responses[keyof QuestionnaireDeleteOrgQuestionnaireBec1C8C9Responses];
 
-export type QuestionnaireGetOrgQuestionnaire6A6547A7Data = {
+export type QuestionnaireGetOrgQuestionnaireFd2Ed8F8Data = {
 	body?: never;
 	path: {
 		/**
@@ -8262,17 +8262,17 @@ export type QuestionnaireGetOrgQuestionnaire6A6547A7Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}';
 };
 
-export type QuestionnaireGetOrgQuestionnaire6A6547A7Responses = {
+export type QuestionnaireGetOrgQuestionnaireFd2Ed8F8Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationQuestionnaireSchema;
 };
 
-export type QuestionnaireGetOrgQuestionnaire6A6547A7Response =
-	QuestionnaireGetOrgQuestionnaire6A6547A7Responses[keyof QuestionnaireGetOrgQuestionnaire6A6547A7Responses];
+export type QuestionnaireGetOrgQuestionnaireFd2Ed8F8Response =
+	QuestionnaireGetOrgQuestionnaireFd2Ed8F8Responses[keyof QuestionnaireGetOrgQuestionnaireFd2Ed8F8Responses];
 
-export type QuestionnaireUpdateOrgQuestionnaire13E422A0Data = {
+export type QuestionnaireUpdateOrgQuestionnaire1812Acc4Data = {
 	body: OrganizationQuestionnaireUpdateSchema;
 	path: {
 		/**
@@ -8284,17 +8284,17 @@ export type QuestionnaireUpdateOrgQuestionnaire13E422A0Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}';
 };
 
-export type QuestionnaireUpdateOrgQuestionnaire13E422A0Responses = {
+export type QuestionnaireUpdateOrgQuestionnaire1812Acc4Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationQuestionnaireSchema;
 };
 
-export type QuestionnaireUpdateOrgQuestionnaire13E422A0Response =
-	QuestionnaireUpdateOrgQuestionnaire13E422A0Responses[keyof QuestionnaireUpdateOrgQuestionnaire13E422A0Responses];
+export type QuestionnaireUpdateOrgQuestionnaire1812Acc4Response =
+	QuestionnaireUpdateOrgQuestionnaire1812Acc4Responses[keyof QuestionnaireUpdateOrgQuestionnaire1812Acc4Responses];
 
-export type QuestionnaireCreateSectionDbdfdf9dData = {
+export type QuestionnaireCreateSection6946F67bData = {
 	body: SectionCreateSchema;
 	path: {
 		/**
@@ -8306,17 +8306,17 @@ export type QuestionnaireCreateSectionDbdfdf9dData = {
 	url: '/api/questionnaires/{org_questionnaire_id}/sections';
 };
 
-export type QuestionnaireCreateSectionDbdfdf9dResponses = {
+export type QuestionnaireCreateSection6946F67bResponses = {
 	/**
 	 * OK
 	 */
 	200: SectionUpdateSchema;
 };
 
-export type QuestionnaireCreateSectionDbdfdf9dResponse =
-	QuestionnaireCreateSectionDbdfdf9dResponses[keyof QuestionnaireCreateSectionDbdfdf9dResponses];
+export type QuestionnaireCreateSection6946F67bResponse =
+	QuestionnaireCreateSection6946F67bResponses[keyof QuestionnaireCreateSection6946F67bResponses];
 
-export type QuestionnaireDeleteSection6935C91eData = {
+export type QuestionnaireDeleteSection01B1Bce7Data = {
 	body?: never;
 	path: {
 		/**
@@ -8332,17 +8332,17 @@ export type QuestionnaireDeleteSection6935C91eData = {
 	url: '/api/questionnaires/{org_questionnaire_id}/sections/{section_id}';
 };
 
-export type QuestionnaireDeleteSection6935C91eResponses = {
+export type QuestionnaireDeleteSection01B1Bce7Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type QuestionnaireDeleteSection6935C91eResponse =
-	QuestionnaireDeleteSection6935C91eResponses[keyof QuestionnaireDeleteSection6935C91eResponses];
+export type QuestionnaireDeleteSection01B1Bce7Response =
+	QuestionnaireDeleteSection01B1Bce7Responses[keyof QuestionnaireDeleteSection01B1Bce7Responses];
 
-export type QuestionnaireUpdateSection0B4561B1Data = {
+export type QuestionnaireUpdateSection2Ae3Ace9Data = {
 	body: SectionUpdateSchema;
 	path: {
 		/**
@@ -8358,17 +8358,17 @@ export type QuestionnaireUpdateSection0B4561B1Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/sections/{section_id}';
 };
 
-export type QuestionnaireUpdateSection0B4561B1Responses = {
+export type QuestionnaireUpdateSection2Ae3Ace9Responses = {
 	/**
 	 * OK
 	 */
 	200: SectionUpdateSchema;
 };
 
-export type QuestionnaireUpdateSection0B4561B1Response =
-	QuestionnaireUpdateSection0B4561B1Responses[keyof QuestionnaireUpdateSection0B4561B1Responses];
+export type QuestionnaireUpdateSection2Ae3Ace9Response =
+	QuestionnaireUpdateSection2Ae3Ace9Responses[keyof QuestionnaireUpdateSection2Ae3Ace9Responses];
 
-export type QuestionnaireCreateMcQuestion06701522Data = {
+export type QuestionnaireCreateMcQuestion20D1Da93Data = {
 	body: MultipleChoiceQuestionCreateSchema;
 	path: {
 		/**
@@ -8380,17 +8380,17 @@ export type QuestionnaireCreateMcQuestion06701522Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/multiple-choice-questions';
 };
 
-export type QuestionnaireCreateMcQuestion06701522Responses = {
+export type QuestionnaireCreateMcQuestion20D1Da93Responses = {
 	/**
 	 * OK
 	 */
 	200: MultipleChoiceQuestionUpdateSchema;
 };
 
-export type QuestionnaireCreateMcQuestion06701522Response =
-	QuestionnaireCreateMcQuestion06701522Responses[keyof QuestionnaireCreateMcQuestion06701522Responses];
+export type QuestionnaireCreateMcQuestion20D1Da93Response =
+	QuestionnaireCreateMcQuestion20D1Da93Responses[keyof QuestionnaireCreateMcQuestion20D1Da93Responses];
 
-export type QuestionnaireDeleteMcQuestionA6713B01Data = {
+export type QuestionnaireDeleteMcQuestion33E11B28Data = {
 	body?: never;
 	path: {
 		/**
@@ -8406,17 +8406,17 @@ export type QuestionnaireDeleteMcQuestionA6713B01Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/multiple-choice-questions/{question_id}';
 };
 
-export type QuestionnaireDeleteMcQuestionA6713B01Responses = {
+export type QuestionnaireDeleteMcQuestion33E11B28Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type QuestionnaireDeleteMcQuestionA6713B01Response =
-	QuestionnaireDeleteMcQuestionA6713B01Responses[keyof QuestionnaireDeleteMcQuestionA6713B01Responses];
+export type QuestionnaireDeleteMcQuestion33E11B28Response =
+	QuestionnaireDeleteMcQuestion33E11B28Responses[keyof QuestionnaireDeleteMcQuestion33E11B28Responses];
 
-export type QuestionnaireUpdateMcQuestionAad6A276Data = {
+export type QuestionnaireUpdateMcQuestion3D37Cc5fData = {
 	body: MultipleChoiceQuestionUpdateSchema;
 	path: {
 		/**
@@ -8432,17 +8432,17 @@ export type QuestionnaireUpdateMcQuestionAad6A276Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/multiple-choice-questions/{question_id}';
 };
 
-export type QuestionnaireUpdateMcQuestionAad6A276Responses = {
+export type QuestionnaireUpdateMcQuestion3D37Cc5fResponses = {
 	/**
 	 * OK
 	 */
 	200: MultipleChoiceQuestionUpdateSchema;
 };
 
-export type QuestionnaireUpdateMcQuestionAad6A276Response =
-	QuestionnaireUpdateMcQuestionAad6A276Responses[keyof QuestionnaireUpdateMcQuestionAad6A276Responses];
+export type QuestionnaireUpdateMcQuestion3D37Cc5fResponse =
+	QuestionnaireUpdateMcQuestion3D37Cc5fResponses[keyof QuestionnaireUpdateMcQuestion3D37Cc5fResponses];
 
-export type QuestionnaireCreateMcOption7714C9DeData = {
+export type QuestionnaireCreateMcOption8006A4E9Data = {
 	body: MultipleChoiceOptionCreateSchema;
 	path: {
 		/**
@@ -8458,17 +8458,17 @@ export type QuestionnaireCreateMcOption7714C9DeData = {
 	url: '/api/questionnaires/{org_questionnaire_id}/multiple-choice-questions/{question_id}/options';
 };
 
-export type QuestionnaireCreateMcOption7714C9DeResponses = {
+export type QuestionnaireCreateMcOption8006A4E9Responses = {
 	/**
 	 * OK
 	 */
 	200: MultipleChoiceOptionUpdateSchema;
 };
 
-export type QuestionnaireCreateMcOption7714C9DeResponse =
-	QuestionnaireCreateMcOption7714C9DeResponses[keyof QuestionnaireCreateMcOption7714C9DeResponses];
+export type QuestionnaireCreateMcOption8006A4E9Response =
+	QuestionnaireCreateMcOption8006A4E9Responses[keyof QuestionnaireCreateMcOption8006A4E9Responses];
 
-export type QuestionnaireDeleteMcOption775Fa06dData = {
+export type QuestionnaireDeleteMcOption61152CdaData = {
 	body?: never;
 	path: {
 		/**
@@ -8484,17 +8484,17 @@ export type QuestionnaireDeleteMcOption775Fa06dData = {
 	url: '/api/questionnaires/{org_questionnaire_id}/multiple-choice-options/{option_id}';
 };
 
-export type QuestionnaireDeleteMcOption775Fa06dResponses = {
+export type QuestionnaireDeleteMcOption61152CdaResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type QuestionnaireDeleteMcOption775Fa06dResponse =
-	QuestionnaireDeleteMcOption775Fa06dResponses[keyof QuestionnaireDeleteMcOption775Fa06dResponses];
+export type QuestionnaireDeleteMcOption61152CdaResponse =
+	QuestionnaireDeleteMcOption61152CdaResponses[keyof QuestionnaireDeleteMcOption61152CdaResponses];
 
-export type QuestionnaireUpdateMcOption5Fc0E101Data = {
+export type QuestionnaireUpdateMcOptionE6Fac541Data = {
 	body: MultipleChoiceOptionUpdateSchema;
 	path: {
 		/**
@@ -8510,17 +8510,17 @@ export type QuestionnaireUpdateMcOption5Fc0E101Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/multiple-choice-options/{option_id}';
 };
 
-export type QuestionnaireUpdateMcOption5Fc0E101Responses = {
+export type QuestionnaireUpdateMcOptionE6Fac541Responses = {
 	/**
 	 * OK
 	 */
 	200: MultipleChoiceOptionUpdateSchema;
 };
 
-export type QuestionnaireUpdateMcOption5Fc0E101Response =
-	QuestionnaireUpdateMcOption5Fc0E101Responses[keyof QuestionnaireUpdateMcOption5Fc0E101Responses];
+export type QuestionnaireUpdateMcOptionE6Fac541Response =
+	QuestionnaireUpdateMcOptionE6Fac541Responses[keyof QuestionnaireUpdateMcOptionE6Fac541Responses];
 
-export type QuestionnaireCreateFtQuestionB4E4BeecData = {
+export type QuestionnaireCreateFtQuestion093Ed38dData = {
 	body: FreeTextQuestionCreateSchema;
 	path: {
 		/**
@@ -8532,17 +8532,17 @@ export type QuestionnaireCreateFtQuestionB4E4BeecData = {
 	url: '/api/questionnaires/{org_questionnaire_id}/free-text-questions';
 };
 
-export type QuestionnaireCreateFtQuestionB4E4BeecResponses = {
+export type QuestionnaireCreateFtQuestion093Ed38dResponses = {
 	/**
 	 * OK
 	 */
 	200: FreeTextQuestionUpdateSchema;
 };
 
-export type QuestionnaireCreateFtQuestionB4E4BeecResponse =
-	QuestionnaireCreateFtQuestionB4E4BeecResponses[keyof QuestionnaireCreateFtQuestionB4E4BeecResponses];
+export type QuestionnaireCreateFtQuestion093Ed38dResponse =
+	QuestionnaireCreateFtQuestion093Ed38dResponses[keyof QuestionnaireCreateFtQuestion093Ed38dResponses];
 
-export type QuestionnaireDeleteFtQuestion49C2E429Data = {
+export type QuestionnaireDeleteFtQuestion996D4F7cData = {
 	body?: never;
 	path: {
 		/**
@@ -8558,17 +8558,17 @@ export type QuestionnaireDeleteFtQuestion49C2E429Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/free-text-questions/{question_id}';
 };
 
-export type QuestionnaireDeleteFtQuestion49C2E429Responses = {
+export type QuestionnaireDeleteFtQuestion996D4F7cResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type QuestionnaireDeleteFtQuestion49C2E429Response =
-	QuestionnaireDeleteFtQuestion49C2E429Responses[keyof QuestionnaireDeleteFtQuestion49C2E429Responses];
+export type QuestionnaireDeleteFtQuestion996D4F7cResponse =
+	QuestionnaireDeleteFtQuestion996D4F7cResponses[keyof QuestionnaireDeleteFtQuestion996D4F7cResponses];
 
-export type QuestionnaireUpdateFtQuestion11774009Data = {
+export type QuestionnaireUpdateFtQuestionE5F3Ee15Data = {
 	body: FreeTextQuestionUpdateSchema;
 	path: {
 		/**
@@ -8584,17 +8584,17 @@ export type QuestionnaireUpdateFtQuestion11774009Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/free-text-questions/{question_id}';
 };
 
-export type QuestionnaireUpdateFtQuestion11774009Responses = {
+export type QuestionnaireUpdateFtQuestionE5F3Ee15Responses = {
 	/**
 	 * OK
 	 */
 	200: FreeTextQuestionUpdateSchema;
 };
 
-export type QuestionnaireUpdateFtQuestion11774009Response =
-	QuestionnaireUpdateFtQuestion11774009Responses[keyof QuestionnaireUpdateFtQuestion11774009Responses];
+export type QuestionnaireUpdateFtQuestionE5F3Ee15Response =
+	QuestionnaireUpdateFtQuestionE5F3Ee15Responses[keyof QuestionnaireUpdateFtQuestionE5F3Ee15Responses];
 
-export type QuestionnaireListSubmissions4C7B40BcData = {
+export type QuestionnaireListSubmissions0C906E39Data = {
 	body?: never;
 	path: {
 		/**
@@ -8627,17 +8627,17 @@ export type QuestionnaireListSubmissions4C7B40BcData = {
 	url: '/api/questionnaires/{org_questionnaire_id}/submissions';
 };
 
-export type QuestionnaireListSubmissions4C7B40BcResponses = {
+export type QuestionnaireListSubmissions0C906E39Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaSubmissionListItemSchema;
 };
 
-export type QuestionnaireListSubmissions4C7B40BcResponse =
-	QuestionnaireListSubmissions4C7B40BcResponses[keyof QuestionnaireListSubmissions4C7B40BcResponses];
+export type QuestionnaireListSubmissions0C906E39Response =
+	QuestionnaireListSubmissions0C906E39Responses[keyof QuestionnaireListSubmissions0C906E39Responses];
 
-export type QuestionnaireGetSubmissionDetailD93F30A9Data = {
+export type QuestionnaireGetSubmissionDetail334A11E6Data = {
 	body?: never;
 	path: {
 		/**
@@ -8653,17 +8653,17 @@ export type QuestionnaireGetSubmissionDetailD93F30A9Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/submissions/{submission_id}';
 };
 
-export type QuestionnaireGetSubmissionDetailD93F30A9Responses = {
+export type QuestionnaireGetSubmissionDetail334A11E6Responses = {
 	/**
 	 * OK
 	 */
 	200: SubmissionDetailSchema;
 };
 
-export type QuestionnaireGetSubmissionDetailD93F30A9Response =
-	QuestionnaireGetSubmissionDetailD93F30A9Responses[keyof QuestionnaireGetSubmissionDetailD93F30A9Responses];
+export type QuestionnaireGetSubmissionDetail334A11E6Response =
+	QuestionnaireGetSubmissionDetail334A11E6Responses[keyof QuestionnaireGetSubmissionDetail334A11E6Responses];
 
-export type QuestionnaireEvaluateSubmission95B64A41Data = {
+export type QuestionnaireEvaluateSubmissionD114F4AdData = {
 	body: EvaluationCreateSchema;
 	path: {
 		/**
@@ -8679,27 +8679,27 @@ export type QuestionnaireEvaluateSubmission95B64A41Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/submissions/{submission_id}/evaluate';
 };
 
-export type QuestionnaireEvaluateSubmission95B64A41Errors = {
+export type QuestionnaireEvaluateSubmissionD114F4AdErrors = {
 	/**
 	 * Bad Request
 	 */
 	400: ValidationErrorResponse;
 };
 
-export type QuestionnaireEvaluateSubmission95B64A41Error =
-	QuestionnaireEvaluateSubmission95B64A41Errors[keyof QuestionnaireEvaluateSubmission95B64A41Errors];
+export type QuestionnaireEvaluateSubmissionD114F4AdError =
+	QuestionnaireEvaluateSubmissionD114F4AdErrors[keyof QuestionnaireEvaluateSubmissionD114F4AdErrors];
 
-export type QuestionnaireEvaluateSubmission95B64A41Responses = {
+export type QuestionnaireEvaluateSubmissionD114F4AdResponses = {
 	/**
 	 * OK
 	 */
 	200: EvaluationResponseSchema;
 };
 
-export type QuestionnaireEvaluateSubmission95B64A41Response =
-	QuestionnaireEvaluateSubmission95B64A41Responses[keyof QuestionnaireEvaluateSubmission95B64A41Responses];
+export type QuestionnaireEvaluateSubmissionD114F4AdResponse =
+	QuestionnaireEvaluateSubmissionD114F4AdResponses[keyof QuestionnaireEvaluateSubmissionD114F4AdResponses];
 
-export type QuestionnaireUpdateQuestionnaireStatusA762B758Data = {
+export type QuestionnaireUpdateQuestionnaireStatus4340C259Data = {
 	body?: never;
 	path: {
 		/**
@@ -8715,17 +8715,17 @@ export type QuestionnaireUpdateQuestionnaireStatusA762B758Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/status/{status}';
 };
 
-export type QuestionnaireUpdateQuestionnaireStatusA762B758Responses = {
+export type QuestionnaireUpdateQuestionnaireStatus4340C259Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationQuestionnaireSchema;
 };
 
-export type QuestionnaireUpdateQuestionnaireStatusA762B758Response =
-	QuestionnaireUpdateQuestionnaireStatusA762B758Responses[keyof QuestionnaireUpdateQuestionnaireStatusA762B758Responses];
+export type QuestionnaireUpdateQuestionnaireStatus4340C259Response =
+	QuestionnaireUpdateQuestionnaireStatus4340C259Responses[keyof QuestionnaireUpdateQuestionnaireStatus4340C259Responses];
 
-export type QuestionnaireReplaceEvents73E6B122Data = {
+export type QuestionnaireReplaceEvents753A3A83Data = {
 	body: EventAssignmentSchema;
 	path: {
 		/**
@@ -8737,17 +8737,17 @@ export type QuestionnaireReplaceEvents73E6B122Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/events';
 };
 
-export type QuestionnaireReplaceEvents73E6B122Responses = {
+export type QuestionnaireReplaceEvents753A3A83Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationQuestionnaireSchema;
 };
 
-export type QuestionnaireReplaceEvents73E6B122Response =
-	QuestionnaireReplaceEvents73E6B122Responses[keyof QuestionnaireReplaceEvents73E6B122Responses];
+export type QuestionnaireReplaceEvents753A3A83Response =
+	QuestionnaireReplaceEvents753A3A83Responses[keyof QuestionnaireReplaceEvents753A3A83Responses];
 
-export type QuestionnaireUnassignEvent7E85350dData = {
+export type QuestionnaireUnassignEvent65E181A3Data = {
 	body?: never;
 	path: {
 		/**
@@ -8763,17 +8763,17 @@ export type QuestionnaireUnassignEvent7E85350dData = {
 	url: '/api/questionnaires/{org_questionnaire_id}/events/{event_id}';
 };
 
-export type QuestionnaireUnassignEvent7E85350dResponses = {
+export type QuestionnaireUnassignEvent65E181A3Responses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type QuestionnaireUnassignEvent7E85350dResponse =
-	QuestionnaireUnassignEvent7E85350dResponses[keyof QuestionnaireUnassignEvent7E85350dResponses];
+export type QuestionnaireUnassignEvent65E181A3Response =
+	QuestionnaireUnassignEvent65E181A3Responses[keyof QuestionnaireUnassignEvent65E181A3Responses];
 
-export type QuestionnaireAssignEventD8Feb5F1Data = {
+export type QuestionnaireAssignEvent6C0D8657Data = {
 	body?: never;
 	path: {
 		/**
@@ -8789,17 +8789,17 @@ export type QuestionnaireAssignEventD8Feb5F1Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/events/{event_id}';
 };
 
-export type QuestionnaireAssignEventD8Feb5F1Responses = {
+export type QuestionnaireAssignEvent6C0D8657Responses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationQuestionnaireSchema;
 };
 
-export type QuestionnaireAssignEventD8Feb5F1Response =
-	QuestionnaireAssignEventD8Feb5F1Responses[keyof QuestionnaireAssignEventD8Feb5F1Responses];
+export type QuestionnaireAssignEvent6C0D8657Response =
+	QuestionnaireAssignEvent6C0D8657Responses[keyof QuestionnaireAssignEvent6C0D8657Responses];
 
-export type QuestionnaireReplaceEventSeriesA98A2508Data = {
+export type QuestionnaireReplaceEventSeries6F47FafeData = {
 	body: EventSeriesAssignmentSchema;
 	path: {
 		/**
@@ -8811,17 +8811,17 @@ export type QuestionnaireReplaceEventSeriesA98A2508Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/event-series';
 };
 
-export type QuestionnaireReplaceEventSeriesA98A2508Responses = {
+export type QuestionnaireReplaceEventSeries6F47FafeResponses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationQuestionnaireSchema;
 };
 
-export type QuestionnaireReplaceEventSeriesA98A2508Response =
-	QuestionnaireReplaceEventSeriesA98A2508Responses[keyof QuestionnaireReplaceEventSeriesA98A2508Responses];
+export type QuestionnaireReplaceEventSeries6F47FafeResponse =
+	QuestionnaireReplaceEventSeries6F47FafeResponses[keyof QuestionnaireReplaceEventSeries6F47FafeResponses];
 
-export type QuestionnaireUnassignEventSeriesA3Cf8D10Data = {
+export type QuestionnaireUnassignEventSeriesC4B9708aData = {
 	body?: never;
 	path: {
 		/**
@@ -8837,17 +8837,17 @@ export type QuestionnaireUnassignEventSeriesA3Cf8D10Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/event-series/{series_id}';
 };
 
-export type QuestionnaireUnassignEventSeriesA3Cf8D10Responses = {
+export type QuestionnaireUnassignEventSeriesC4B9708aResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type QuestionnaireUnassignEventSeriesA3Cf8D10Response =
-	QuestionnaireUnassignEventSeriesA3Cf8D10Responses[keyof QuestionnaireUnassignEventSeriesA3Cf8D10Responses];
+export type QuestionnaireUnassignEventSeriesC4B9708aResponse =
+	QuestionnaireUnassignEventSeriesC4B9708aResponses[keyof QuestionnaireUnassignEventSeriesC4B9708aResponses];
 
-export type QuestionnaireAssignEventSeriesB66Af321Data = {
+export type QuestionnaireAssignEventSeriesE8D3A08fData = {
 	body?: never;
 	path: {
 		/**
@@ -8863,34 +8863,34 @@ export type QuestionnaireAssignEventSeriesB66Af321Data = {
 	url: '/api/questionnaires/{org_questionnaire_id}/event-series/{series_id}';
 };
 
-export type QuestionnaireAssignEventSeriesB66Af321Responses = {
+export type QuestionnaireAssignEventSeriesE8D3A08fResponses = {
 	/**
 	 * OK
 	 */
 	200: OrganizationQuestionnaireSchema;
 };
 
-export type QuestionnaireAssignEventSeriesB66Af321Response =
-	QuestionnaireAssignEventSeriesB66Af321Responses[keyof QuestionnaireAssignEventSeriesB66Af321Responses];
+export type QuestionnaireAssignEventSeriesE8D3A08fResponse =
+	QuestionnaireAssignEventSeriesE8D3A08fResponses[keyof QuestionnaireAssignEventSeriesE8D3A08fResponses];
 
-export type UserpreferencesGetGeneralPreferencesA2Ac890eData = {
+export type UserpreferencesGetGeneralPreferences9Aea63E9Data = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/preferences/general';
 };
 
-export type UserpreferencesGetGeneralPreferencesA2Ac890eResponses = {
+export type UserpreferencesGetGeneralPreferences9Aea63E9Responses = {
 	/**
 	 * OK
 	 */
 	200: GeneralUserPreferencesSchema;
 };
 
-export type UserpreferencesGetGeneralPreferencesA2Ac890eResponse =
-	UserpreferencesGetGeneralPreferencesA2Ac890eResponses[keyof UserpreferencesGetGeneralPreferencesA2Ac890eResponses];
+export type UserpreferencesGetGeneralPreferences9Aea63E9Response =
+	UserpreferencesGetGeneralPreferences9Aea63E9Responses[keyof UserpreferencesGetGeneralPreferences9Aea63E9Responses];
 
-export type UserpreferencesUpdateGlobalPreferencesCa70F70eData = {
+export type UserpreferencesUpdateGlobalPreferencesD739D116Data = {
 	body: GeneralUserPreferencesUpdateSchema;
 	path?: never;
 	query?: {
@@ -8902,17 +8902,17 @@ export type UserpreferencesUpdateGlobalPreferencesCa70F70eData = {
 	url: '/api/preferences/general';
 };
 
-export type UserpreferencesUpdateGlobalPreferencesCa70F70eResponses = {
+export type UserpreferencesUpdateGlobalPreferencesD739D116Responses = {
 	/**
 	 * OK
 	 */
 	200: GeneralUserPreferencesSchema;
 };
 
-export type UserpreferencesUpdateGlobalPreferencesCa70F70eResponse =
-	UserpreferencesUpdateGlobalPreferencesCa70F70eResponses[keyof UserpreferencesUpdateGlobalPreferencesCa70F70eResponses];
+export type UserpreferencesUpdateGlobalPreferencesD739D116Response =
+	UserpreferencesUpdateGlobalPreferencesD739D116Responses[keyof UserpreferencesUpdateGlobalPreferencesD739D116Responses];
 
-export type UserpreferencesGetOrganizationPreferences949D37A6Data = {
+export type UserpreferencesGetOrganizationPreferences88F57589Data = {
 	body?: never;
 	path: {
 		/**
@@ -8924,17 +8924,17 @@ export type UserpreferencesGetOrganizationPreferences949D37A6Data = {
 	url: '/api/preferences/organization/{organization_id}';
 };
 
-export type UserpreferencesGetOrganizationPreferences949D37A6Responses = {
+export type UserpreferencesGetOrganizationPreferences88F57589Responses = {
 	/**
 	 * OK
 	 */
 	200: UserOrganizationPreferencesSchema;
 };
 
-export type UserpreferencesGetOrganizationPreferences949D37A6Response =
-	UserpreferencesGetOrganizationPreferences949D37A6Responses[keyof UserpreferencesGetOrganizationPreferences949D37A6Responses];
+export type UserpreferencesGetOrganizationPreferences88F57589Response =
+	UserpreferencesGetOrganizationPreferences88F57589Responses[keyof UserpreferencesGetOrganizationPreferences88F57589Responses];
 
-export type UserpreferencesUpdateOrganizationPreferencesC6Ac6679Data = {
+export type UserpreferencesUpdateOrganizationPreferences195D88D0Data = {
 	body: UserOrganizationPreferencesUpdateSchema;
 	path: {
 		/**
@@ -8951,17 +8951,17 @@ export type UserpreferencesUpdateOrganizationPreferencesC6Ac6679Data = {
 	url: '/api/preferences/organization/{organization_id}';
 };
 
-export type UserpreferencesUpdateOrganizationPreferencesC6Ac6679Responses = {
+export type UserpreferencesUpdateOrganizationPreferences195D88D0Responses = {
 	/**
 	 * OK
 	 */
 	200: UserOrganizationPreferencesSchema;
 };
 
-export type UserpreferencesUpdateOrganizationPreferencesC6Ac6679Response =
-	UserpreferencesUpdateOrganizationPreferencesC6Ac6679Responses[keyof UserpreferencesUpdateOrganizationPreferencesC6Ac6679Responses];
+export type UserpreferencesUpdateOrganizationPreferences195D88D0Response =
+	UserpreferencesUpdateOrganizationPreferences195D88D0Responses[keyof UserpreferencesUpdateOrganizationPreferences195D88D0Responses];
 
-export type UserpreferencesGetEventSeriesPreferencesAa9Fac27Data = {
+export type UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Data = {
 	body?: never;
 	path: {
 		/**
@@ -8973,17 +8973,17 @@ export type UserpreferencesGetEventSeriesPreferencesAa9Fac27Data = {
 	url: '/api/preferences/event-series/{series_id}';
 };
 
-export type UserpreferencesGetEventSeriesPreferencesAa9Fac27Responses = {
+export type UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Responses = {
 	/**
 	 * OK
 	 */
 	200: UserEventSeriesPreferencesSchema;
 };
 
-export type UserpreferencesGetEventSeriesPreferencesAa9Fac27Response =
-	UserpreferencesGetEventSeriesPreferencesAa9Fac27Responses[keyof UserpreferencesGetEventSeriesPreferencesAa9Fac27Responses];
+export type UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Response =
+	UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Responses[keyof UserpreferencesGetEventSeriesPreferencesEd8B9Ae3Responses];
 
-export type UserpreferencesUpdateEventSeriesPreferences1645B0AaData = {
+export type UserpreferencesUpdateEventSeriesPreferences193210FbData = {
 	body: UserEventSeriesPreferencesUpdateSchema;
 	path: {
 		/**
@@ -9000,17 +9000,17 @@ export type UserpreferencesUpdateEventSeriesPreferences1645B0AaData = {
 	url: '/api/preferences/event-series/{series_id}';
 };
 
-export type UserpreferencesUpdateEventSeriesPreferences1645B0AaResponses = {
+export type UserpreferencesUpdateEventSeriesPreferences193210FbResponses = {
 	/**
 	 * OK
 	 */
 	200: UserEventSeriesPreferencesSchema;
 };
 
-export type UserpreferencesUpdateEventSeriesPreferences1645B0AaResponse =
-	UserpreferencesUpdateEventSeriesPreferences1645B0AaResponses[keyof UserpreferencesUpdateEventSeriesPreferences1645B0AaResponses];
+export type UserpreferencesUpdateEventSeriesPreferences193210FbResponse =
+	UserpreferencesUpdateEventSeriesPreferences193210FbResponses[keyof UserpreferencesUpdateEventSeriesPreferences193210FbResponses];
 
-export type UserpreferencesGetEventPreferences3D6F9189Data = {
+export type UserpreferencesGetEventPreferencesFcb49Eb8Data = {
 	body?: never;
 	path: {
 		/**
@@ -9022,17 +9022,17 @@ export type UserpreferencesGetEventPreferences3D6F9189Data = {
 	url: '/api/preferences/event/{event_id}';
 };
 
-export type UserpreferencesGetEventPreferences3D6F9189Responses = {
+export type UserpreferencesGetEventPreferencesFcb49Eb8Responses = {
 	/**
 	 * OK
 	 */
 	200: UserEventPreferencesSchema;
 };
 
-export type UserpreferencesGetEventPreferences3D6F9189Response =
-	UserpreferencesGetEventPreferences3D6F9189Responses[keyof UserpreferencesGetEventPreferences3D6F9189Responses];
+export type UserpreferencesGetEventPreferencesFcb49Eb8Response =
+	UserpreferencesGetEventPreferencesFcb49Eb8Responses[keyof UserpreferencesGetEventPreferencesFcb49Eb8Responses];
 
-export type UserpreferencesUpdateEventPreferences3Ca1F5D4Data = {
+export type UserpreferencesUpdateEventPreferences501B0Ad6Data = {
 	body: UserEventPreferencesUpdateSchema;
 	path: {
 		/**
@@ -9049,31 +9049,31 @@ export type UserpreferencesUpdateEventPreferences3Ca1F5D4Data = {
 	url: '/api/preferences/event/{event_id}';
 };
 
-export type UserpreferencesUpdateEventPreferences3Ca1F5D4Responses = {
+export type UserpreferencesUpdateEventPreferences501B0Ad6Responses = {
 	/**
 	 * OK
 	 */
 	200: UserEventPreferencesSchema;
 };
 
-export type UserpreferencesUpdateEventPreferences3Ca1F5D4Response =
-	UserpreferencesUpdateEventPreferences3Ca1F5D4Responses[keyof UserpreferencesUpdateEventPreferences3Ca1F5D4Responses];
+export type UserpreferencesUpdateEventPreferences501B0Ad6Response =
+	UserpreferencesUpdateEventPreferences501B0Ad6Responses[keyof UserpreferencesUpdateEventPreferences501B0Ad6Responses];
 
-export type StripewebhookHandleWebhookAb33E84dData = {
+export type StripewebhookHandleWebhook7Ce75AaaData = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/stripe/webhook';
 };
 
-export type StripewebhookHandleWebhookAb33E84dResponses = {
+export type StripewebhookHandleWebhook7Ce75AaaResponses = {
 	/**
 	 * OK
 	 */
 	200: unknown;
 };
 
-export type TagListTagsCa3Ddb22Data = {
+export type TagListTags4B7C76E5Data = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -9093,17 +9093,17 @@ export type TagListTagsCa3Ddb22Data = {
 	url: '/api/tags/';
 };
 
-export type TagListTagsCa3Ddb22Responses = {
+export type TagListTags4B7C76E5Responses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaTagSchema;
 };
 
-export type TagListTagsCa3Ddb22Response =
-	TagListTagsCa3Ddb22Responses[keyof TagListTagsCa3Ddb22Responses];
+export type TagListTags4B7C76E5Response =
+	TagListTags4B7C76E5Responses[keyof TagListTags4B7C76E5Responses];
 
-export type CityListCities6B5493E8Data = {
+export type CityListCitiesEd3A17BdData = {
 	body?: never;
 	path?: never;
 	query?: {
@@ -9127,24 +9127,24 @@ export type CityListCities6B5493E8Data = {
 	url: '/api/cities/';
 };
 
-export type CityListCities6B5493E8Responses = {
+export type CityListCitiesEd3A17BdResponses = {
 	/**
 	 * OK
 	 */
 	200: PaginatedResponseSchemaCitySchema;
 };
 
-export type CityListCities6B5493E8Response =
-	CityListCities6B5493E8Responses[keyof CityListCities6B5493E8Responses];
+export type CityListCitiesEd3A17BdResponse =
+	CityListCitiesEd3A17BdResponses[keyof CityListCitiesEd3A17BdResponses];
 
-export type CityListCountries5Dac3B77Data = {
+export type CityListCountries2Bb24454Data = {
 	body?: never;
 	path?: never;
 	query?: never;
 	url: '/api/cities/countries';
 };
 
-export type CityListCountries5Dac3B77Responses = {
+export type CityListCountries2Bb24454Responses = {
 	/**
 	 * Response
 	 *
@@ -9153,10 +9153,10 @@ export type CityListCountries5Dac3B77Responses = {
 	200: Array<string>;
 };
 
-export type CityListCountries5Dac3B77Response =
-	CityListCountries5Dac3B77Responses[keyof CityListCountries5Dac3B77Responses];
+export type CityListCountries2Bb24454Response =
+	CityListCountries2Bb24454Responses[keyof CityListCountries2Bb24454Responses];
 
-export type CityGetCity7711686bData = {
+export type CityGetCityB0410Ba7Data = {
 	body?: never;
 	path: {
 		/**
@@ -9168,12 +9168,12 @@ export type CityGetCity7711686bData = {
 	url: '/api/cities/{city_id}';
 };
 
-export type CityGetCity7711686bResponses = {
+export type CityGetCityB0410Ba7Responses = {
 	/**
 	 * OK
 	 */
 	200: CitySchema;
 };
 
-export type CityGetCity7711686bResponse =
-	CityGetCity7711686bResponses[keyof CityGetCity7711686bResponses];
+export type CityGetCityB0410Ba7Response =
+	CityGetCityB0410Ba7Responses[keyof CityGetCityB0410Ba7Responses];

--- a/src/lib/components/common/EventCardSkeleton.svelte
+++ b/src/lib/components/common/EventCardSkeleton.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import Skeleton from './Skeleton.svelte';
+	import { cn } from '$lib/utils/cn';
+
+	interface Props {
+		class?: string;
+		variant?: 'compact' | 'standard';
+	}
+
+	let { class: className, variant = 'standard' }: Props = $props();
+</script>
+
+<div
+	class={cn(
+		'overflow-hidden rounded-lg border bg-card',
+		variant === 'compact' && 'flex flex-row md:flex-col',
+		variant === 'standard' && 'flex flex-col',
+		className
+	)}
+	role="status"
+	aria-live="polite"
+>
+	<!-- Image Skeleton -->
+	<div
+		class={cn(
+			'relative',
+			variant === 'compact' && 'w-32 shrink-0 md:aspect-video md:w-full',
+			variant === 'standard' && 'aspect-video'
+		)}
+	>
+		<Skeleton class="h-full w-full rounded-none" />
+	</div>
+
+	<!-- Content Skeleton -->
+	<div class="flex flex-1 flex-col gap-3 p-4">
+		<!-- Title and Organization -->
+		<div class="space-y-2">
+			<Skeleton width="80%" height="1.25rem" />
+			<Skeleton width="50%" height="0.875rem" />
+		</div>
+
+		{#if variant === 'standard'}
+			<!-- Details (date, location, type) -->
+			<div class="space-y-2 border-t pt-3">
+				<div class="flex items-center gap-2">
+					<Skeleton variant="circular" width="1rem" height="1rem" />
+					<Skeleton width="60%" height="0.875rem" />
+				</div>
+				<div class="flex items-center gap-2">
+					<Skeleton variant="circular" width="1rem" height="1rem" />
+					<Skeleton width="45%" height="0.875rem" />
+				</div>
+				<div class="flex items-center gap-2">
+					<Skeleton variant="circular" width="1rem" height="1rem" />
+					<Skeleton width="55%" height="0.875rem" />
+				</div>
+			</div>
+		{/if}
+	</div>
+
+	<span class="sr-only">Loading event card...</span>
+</div>

--- a/src/lib/components/common/HTMLDescription.svelte
+++ b/src/lib/components/common/HTMLDescription.svelte
@@ -24,7 +24,7 @@
 	/**
 	 * Determine if we have valid HTML content to display
 	 */
-	let hasContent = $derived(html !== null && html !== undefined && html.trim().length > 0);
+	let hasContent = $derived(!!html && html.trim().length > 0);
 </script>
 
 {#if hasContent}

--- a/src/lib/components/common/OrganizationCardSkeleton.svelte
+++ b/src/lib/components/common/OrganizationCardSkeleton.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import Skeleton from './Skeleton.svelte';
+	import { cn } from '$lib/utils/cn';
+
+	interface Props {
+		class?: string;
+	}
+
+	let { class: className }: Props = $props();
+</script>
+
+<div
+	class={cn('flex items-center gap-4 rounded-lg border bg-card p-4', className)}
+	role="status"
+	aria-live="polite"
+>
+	<!-- Logo Skeleton -->
+	<Skeleton variant="circular" width="4rem" height="4rem" class="shrink-0" />
+
+	<!-- Content Skeleton -->
+	<div class="flex-1 space-y-2">
+		<Skeleton width="70%" height="1.25rem" />
+		<Skeleton width="90%" height="0.875rem" />
+	</div>
+
+	<!-- Buttons Skeleton -->
+	<div class="flex gap-2">
+		<Skeleton width="7rem" height="2.5rem" />
+		<Skeleton width="6rem" height="2.5rem" />
+	</div>
+
+	<span class="sr-only">Loading organization card...</span>
+</div>

--- a/src/lib/components/common/Skeleton.svelte
+++ b/src/lib/components/common/Skeleton.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { cn } from '$lib/utils/cn';
+
+	interface Props {
+		class?: string;
+		variant?: 'text' | 'circular' | 'rectangular';
+		width?: string;
+		height?: string;
+	}
+
+	let { class: className, variant = 'rectangular', width, height }: Props = $props();
+
+	let variantClasses = $derived(
+		cn(
+			'animate-pulse bg-muted',
+			variant === 'text' && 'h-4 rounded',
+			variant === 'circular' && 'rounded-full',
+			variant === 'rectangular' && 'rounded-lg',
+			className
+		)
+	);
+
+	let styles = $derived.by(() => {
+		const styleObj: Record<string, string> = {};
+		if (width) styleObj.width = width;
+		if (height) styleObj.height = height;
+		return Object.entries(styleObj)
+			.map(([key, value]) => `${key}: ${value}`)
+			.join('; ');
+	});
+</script>
+
+<div class={variantClasses} style={styles} role="status" aria-live="polite" aria-label="Loading">
+	<span class="sr-only">Loading...</span>
+</div>

--- a/static/icon.svg
+++ b/static/icon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Background -->
+  <rect width="512" height="512" fill="#8b5cf6" rx="102.4"/>
+
+  <!-- Safe zone circle (for reference, remove if not needed) -->
+  <!-- <circle cx="256" cy="256" r="204.8" fill="none" stroke="#ffffff22" stroke-width="2"/> -->
+
+  <!-- Letter R -->
+  <g transform="translate(256, 256)">
+    <!-- Main vertical stroke -->
+    <rect x="-80" y="-140" width="40" height="280" fill="#ffffff" rx="8"/>
+
+    <!-- Top horizontal -->
+    <rect x="-80" y="-140" width="120" height="40" fill="#ffffff" rx="8"/>
+
+    <!-- Middle horizontal -->
+    <rect x="-80" y="-20" width="100" height="40" fill="#ffffff" rx="8"/>
+
+    <!-- Top curve -->
+    <path d="M 40 -140 Q 80 -140 100 -100 Q 100 -60 80 -20 L 20 -20 Q 40 -60 40 -100 Z" fill="#ffffff"/>
+
+    <!-- Diagonal leg -->
+    <path d="M 20 -20 L 80 140 L 40 140 L -20 -20 Z" fill="#ffffff"/>
+  </g>
+</svg>

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,65 @@
+{
+	"name": "Revel - Community Events",
+	"short_name": "Revel",
+	"description": "Discover LGBTQ+, queer, and sex-positive community events near you",
+	"start_url": "/",
+	"display": "standalone",
+	"background_color": "#1a0b2e",
+	"theme_color": "#8b5cf6",
+	"orientation": "portrait-primary",
+	"icons": [
+		{
+			"src": "/icon-192.png",
+			"sizes": "192x192",
+			"type": "image/png",
+			"purpose": "any maskable"
+		},
+		{
+			"src": "/icon-512.png",
+			"sizes": "512x512",
+			"type": "image/png",
+			"purpose": "any maskable"
+		}
+	],
+	"categories": ["social", "lifestyle", "entertainment"],
+	"shortcuts": [
+		{
+			"name": "Browse Events",
+			"short_name": "Events",
+			"description": "Discover upcoming events",
+			"url": "/events",
+			"icons": [
+				{
+					"src": "/icon-192.png",
+					"sizes": "192x192"
+				}
+			]
+		},
+		{
+			"name": "My Dashboard",
+			"short_name": "Dashboard",
+			"description": "View your events and organizations",
+			"url": "/dashboard",
+			"icons": [
+				{
+					"src": "/icon-192.png",
+					"sizes": "192x192"
+				}
+			]
+		}
+	],
+	"screenshots": [
+		{
+			"src": "/screenshot-mobile-1.png",
+			"sizes": "750x1334",
+			"type": "image/png",
+			"form_factor": "narrow"
+		},
+		{
+			"src": "/screenshot-desktop-1.png",
+			"sizes": "1920x1080",
+			"type": "image/png",
+			"form_factor": "wide"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Resolves merge conflict mess from stashed changes that conflicted with PR #129's intentional cleanup.

## What Was Fixed

- ✅ Resolved all merge conflicts from stashed changes vs PR #129
- ✅ Accepted deletion of doc files (moved to `.dev-docs/` in #129)
- ✅ Kept main's version for all conflicted code files
- ✅ Regenerated API client types (hash suffix updates)

## What Was Added

- ✅ `Skeleton.svelte` - Base loading skeleton component
- ✅ `EventCardSkeleton.svelte` - Loading state for event cards
- ✅ `OrganizationCardSkeleton.svelte` - Loading state for org cards
- ✅ `static/manifest.json` - PWA manifest
- ✅ `static/icon.svg` - PWA icon

## What Was Changed

- ✅ `HTMLDescription.svelte` - Minor refactor (`!!html` instead of verbose null checks)
- ✅ `src/lib/api/generated/*` - Regenerated with latest backend OpenAPI spec

## Important Note

⚠️ **Pre-existing TypeScript errors (300+) remain from backend schema changes.**

These errors exist on `main` and are NOT caused by this PR. They will be addressed in a separate PR after investigating the backend schema changes that caused the type mismatches.

## Testing

- [x] Git status clean
- [x] Conflicts resolved
- [x] API client regenerated successfully
- [ ] TypeScript errors (300+) pre-existing, not addressed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)