### PR TITLE
hotfix: fix adapter-node envPrefix runtime error

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,8 +12,7 @@ const config = {
 		// Builds a standalone Node.js server
 		adapter: adapter({
 			out: 'build',
-			precompress: false,
-			envPrefix: 'PUBLIC_'
+			precompress: false
 		}),
 
 		alias: {


### PR DESCRIPTION
## Problem

After merging #132 (Docker/CI setup), the production container is crashing on startup with the following error:

```
Error: You should change envPrefix (PUBLIC_) to avoid conflicts with 
existing environment variables — unexpectedly saw PUBLIC_API_URL
```

This prevents the application from starting in production.

## Root Cause

The `envPrefix: 'PUBLIC_'` option in the adapter-node configuration (svelte.config.js) is conflicting with SvelteKit's built-in handling of `PUBLIC_` prefixed environment variables through Vite.

When the container starts and sees `PUBLIC_API_URL` as an environment variable, the adapter throws an error because:
1. SvelteKit already handles `PUBLIC_` prefixed variables via Vite
2. The adapter's `envPrefix` option is redundant and creates a conflict

## Solution

Remove the `envPrefix: 'PUBLIC_'` option from the adapter-node configuration.

SvelteKit correctly handles `PUBLIC_` prefixed environment variables without this option:
- At build time: Vite embeds them into the client bundle
- At runtime: They're accessible via `$env/static/public` and `$env/dynamic/public`

## Changes

**File: `svelte.config.js`**
```diff
adapter: adapter({
  out: 'build',
- precompress: false,
- envPrefix: 'PUBLIC_'
+ precompress: false
}),
```

## Testing

After this fix, the container starts successfully:

```bash
docker build -t revel-frontend:test .
docker run -p 3000:3000 \
  -e PUBLIC_API_URL=https://demo.api.letsrevel.io \
  -e ORIGIN=https://demo.letsrevel.io \
  revel-frontend:test
```

Application should start without errors and be accessible at http://localhost:3000

## Impact

**Severity:** Critical - Production deployment is blocked  
**Scope:** Docker deployments only (dev server not affected)

## Related

- Fixes issues introduced in #132
- Required for production deployment to https://demo.letsrevel.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)