### PR TITLE
fix(resources): clarify private visibility for event-specific access

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1603,6 +1603,8 @@
 		"membersOnly": "Nur Mitglieder - Erfordert Mitgliedschaft",
 		"staffOnly": "Nur Personal - Nur Personal und Admins",
 		"private": "Privat - Nur Admins",
+		"privateInvitedAttendees": "Nur eingeladene Benutzer oder Teilnehmer",
+		"privateVisibilityHelp": "Nur sichtbar für Benutzer, die zur zugewiesenen Veranstaltung eingeladen sind oder daran teilnehmen",
 		"controlsVisibility": "Kontrolliert, wer diese Ressource sehen kann"
 	},
 	"resourceModal": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1603,6 +1603,8 @@
 		"membersOnly": "Members Only - Requires membership",
 		"staffOnly": "Staff Only - Staff and admins only",
 		"private": "Private - Admins only",
+		"privateInvitedAttendees": "Invited users or attendees only",
+		"privateVisibilityHelp": "Only visible to users who are invited to or attending the assigned event(s)",
 		"controlsVisibility": "Controls who can view this resource"
 	},
 	"resourceModal": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -1603,6 +1603,8 @@
 		"membersOnly": "Solo Membri - Richiede iscrizione",
 		"staffOnly": "Solo Staff - Solo staff e admin",
 		"private": "Privato - Solo admin",
+		"privateInvitedAttendees": "Solo utenti invitati o partecipanti",
+		"privateVisibilityHelp": "Visibile solo agli utenti invitati o che partecipano all'evento assegnato",
 		"controlsVisibility": "Controlla chi può visualizzare questa risorsa"
 	},
 	"resourceModal": {

--- a/src/lib/components/resources/ResourceForm.svelte
+++ b/src/lib/components/resources/ResourceForm.svelte
@@ -343,9 +343,13 @@
 			<option value="public">{m['resourceForm.public']()}</option>
 			<option value="members-only">{m['resourceForm.membersOnly']()}</option>
 			<option value="staff-only">{m['resourceForm.staffOnly']()}</option>
-			<option value="private">{m['resourceForm.private']()}</option>
+			<option value="private">{m['resourceForm.privateInvitedAttendees']()}</option>
 		</select>
-		<p class="text-xs text-muted-foreground">{m['resourceForm.controlsVisibility']()}</p>
+		<p class="text-xs text-muted-foreground">
+			{visibility === 'private'
+				? m['resourceForm.privateVisibilityHelp']()
+				: m['resourceForm.controlsVisibility']()}
+		</p>
 	</div>
 
 	<!-- Display on Organization Page -->


### PR DESCRIPTION
## Summary

Improves UX for resource visibility by clarifying that 'private' visibility means the resource is only visible to users invited to or attending the assigned event(s).

This is a **KISS solution** that clarifies existing functionality rather than adding new backend features. The backend already supports event-specific resources via `PRIVATE` visibility + event assignment.

## Changes

- **Updated visibility dropdown label**: Changed "Private - Admins only" to "Invited users or attendees only"
- **Added contextual help text**: Shows explanation when "private" is selected: _"Only visible to users who are invited to or attending the assigned event(s)"_
- **Implemented across all languages**: EN, DE, IT

## UI Example

**Before:**
```
Visibility: [Private - Admins only]
Help text: Controls who can view this resource
```

**After:**
```
Visibility: [Invited users or attendees only]
Help text: Only visible to users who are invited to or attending the assigned event(s)
```

## Technical Notes

- No backend changes required - the functionality already exists
- The backend's `PRIVATE` visibility + event assignment already filters resources to event invitees/attendees
- This is purely a UX improvement to make the behavior more intuitive

## Testing

- [x] Type checking passes (`pnpm check`)
- [x] Code formatted (`pnpm format`)
- [x] Translations compiled (`pnpm paraglide:compile`)
- [x] All three languages updated (EN, DE, IT)

## Addresses

User feedback issue #6: _"When adding a resource I am missing the option to make it only visible to attendees of a certain event"_

🤖 Generated with [Claude Code](https://claude.com/claude-code)