### PR TITLE
Fix: Send requires_ticket to backend & improve settings UX

### DIFF
--- a/REQUIRES_TICKET_ISSUE.md
+++ b/REQUIRES_TICKET_ISSUE.md
@@ -1,0 +1,189 @@
+# requires_ticket Field Not Being Sent to Backend
+
+## Issue
+
+When creating or editing an event, the "Requires Ticket" checkbox value is never sent to the backend, regardless of whether it's checked or unchecked.
+
+## Root Cause
+
+### Backend Schema (revel-backend/src/events/schema.py)
+
+The `requires_ticket` field is **commented out** in `EventEditSchema`:
+
+```python
+class EventEditSchema(CityEditMixin):
+    name: OneToOneFiftyString | None = None
+    # ... other fields ...
+    # requires_ticket: bool = False  # <-- COMMENTED OUT
+    potluck_open: bool = False
+    # ... more fields ...
+```
+
+### Backend Model (revel-backend/src/events/models/event.py)
+
+The model has the field with **default=True**:
+
+```python
+requires_ticket = models.BooleanField(default=True)  # If False, managed via RSVPs
+```
+
+### Frontend Code
+
+The EventWizard component (src/lib/components/events/admin/EventWizard.svelte):
+
+1. **Tracks the field in state** (line 133):
+   ```typescript
+   requires_ticket: (existingEvent as any)?.requires_ticket || false,
+   ```
+
+2. **Uses it for UI logic** (lines 584, 672, 693) to show/hide Step 3 (ticketing)
+
+3. **But doesn't send it to the API** in either `handleStep1Submit` or `handleStep2Submit`
+
+## Current Behavior
+
+1. User checks/unchecks "Requires Ticket" checkbox ✅
+2. UI updates to show/hide ticketing step ✅
+3. Event is created with `requires_ticket=True` (backend default) ❌
+4. Even if user unchecks the box, backend still gets `requires_ticket=True` ❌
+
+## Required Changes
+
+### Step 1: Backend Changes (MUST BE DONE FIRST)
+
+**File**: `revel-backend/src/events/schema.py`
+
+Uncomment and enable the `requires_ticket` field in EventEditSchema:
+
+```python
+class EventEditSchema(CityEditMixin):
+    name: OneToOneFiftyString | None = None
+    description: StrippedString | None = None
+    event_type: Event.EventType | None = None
+    status: Event.EventStatus = Event.EventStatus.DRAFT
+    visibility: Event.Visibility | None = None
+    invitation_message: StrippedString | None = Field(None, description="Invitation message")
+    max_attendees: int = 0
+    waitlist_open: bool = False
+    start: AwareDatetime | None = None
+    end: AwareDatetime | None = None
+    rsvp_before: AwareDatetime | None = Field(None, description="RSVP deadline for events that do not require tickets")
+    check_in_starts_at: AwareDatetime | None = Field(None, description="When check-in opens for this event")
+    check_in_ends_at: AwareDatetime | None = Field(None, description="When check-in closes for this event")
+    event_series_id: UUID | None = None
+    free_for_members: bool = False
+    free_for_staff: bool = True
+    requires_ticket: bool = False  # <-- UNCOMMENT THIS LINE
+    potluck_open: bool = False
+    accept_invitation_requests: bool = False
+    can_attend_without_login: bool = False
+```
+
+**Important Notes**:
+- The field should default to `False` in the schema (simpler RSVP events are more common)
+- The backend model defaults to `True` for backwards compatibility
+- When the field is provided explicitly in the request, it overrides the model default
+
+**Why this was commented out**: Likely because `requires_ticket` was intended to be immutable after event creation (see the UI warning in EssentialsStep.svelte lines 435-450). However, the field still needs to be settable **during creation**.
+
+**Recommended approach**:
+1. Allow setting `requires_ticket` in `EventCreateSchema`
+2. Make it read-only in `EventEditSchema` (or remove from edit schema)
+3. Add validation in the backend to prevent changing `requires_ticket` after event creation
+
+### Step 2: Frontend Changes (AFTER Backend)
+
+**File**: `src/lib/components/events/admin/EventWizard.svelte`
+
+#### 2.1 Update `handleStep1Submit` (line 381)
+
+```typescript
+async function handleStep1Submit(): Promise<void> {
+	if (!validateStep1()) {
+		errorMessage = m['eventWizard.error_fixValidation']();
+		return;
+	}
+
+	errorMessage = null;
+	isSaving = true;
+
+	try {
+		// Prepare data for API - convert datetime-local to ISO with timezone
+		const createData: EventCreateSchema = {
+			name: formData.name!,
+			start: toISOString(formData.start)!,
+			city_id: formData.city_id!,
+			visibility: formData.visibility || 'public',
+			event_type: (formData.event_type || 'public') as any, // Backend has wrong enum
+			status: 'draft' as any, // Create as draft by default
+			requires_ticket: formData.requires_ticket || false  // ADD THIS LINE
+		};
+
+		if (eventId) {
+			// Update existing event
+			await updateEventMutation.mutateAsync({ id: eventId, data: createData });
+		} else {
+			// Create new event
+			const result = await createEventMutation.mutateAsync(createData);
+			eventId = result.id;
+		}
+
+		// Move to Step 2
+		currentStep = 2;
+
+		// Scroll to top for better UX
+		window.scrollTo({ top: 0, behavior: 0.0, behavior: 'smooth' });
+	} catch (error) {
+		console.error('Step 1 submission error:', error);
+	} finally {
+		isSaving = false;
+	}
+}
+```
+
+#### 2.2 Update TypeScript Types
+
+The EventCreateSchema type from the auto-generated API client will need to be regenerated after the backend change:
+
+```bash
+pnpm generate:api
+```
+
+### Step 3: Testing
+
+After both backend and frontend changes:
+
+1. **Test create event with requires_ticket=true**:
+   - Check the box
+   - Create event
+   - Verify Step 3 (ticketing) appears
+   - Save and verify event has `requires_ticket: true` in database
+
+2. **Test create event with requires_ticket=false**:
+   - Leave box unchecked (or uncheck it)
+   - Create event
+   - Verify Step 3 (ticketing) does NOT appear
+   - Save and verify event has `requires_ticket: false` in database
+
+3. **Test that requires_ticket is immutable**:
+   - Create event with `requires_ticket: false`
+   - Edit event
+   - Verify checkbox is disabled
+   - Verify value doesn't change on save
+
+## Timeline
+
+1. ✅ Frontend code is ready to send `requires_ticket`
+2. ⏳ **Waiting on backend**: Uncomment field in EventEditSchema
+3. ⏳ Regenerate API client: `pnpm generate:api`
+4. ⏳ Test both true/false scenarios
+5. ⏳ Deploy
+
+## Alternative: Document the Current Behavior
+
+If backend changes are not feasible immediately, document in the UI that:
+- The checkbox controls which UI flow is shown
+- All events default to `requires_ticket=true` on the backend
+- The setting cannot be changed after creation
+
+This would be a **poor UX** but could be a temporary workaround.

--- a/src/lib/components/events/admin/EventWizard.svelte
+++ b/src/lib/components/events/admin/EventWizard.svelte
@@ -396,8 +396,9 @@
 				city_id: formData.city_id!,
 				visibility: formData.visibility || 'public',
 				event_type: (formData.event_type || 'public') as any, // Backend has wrong enum
-				status: 'draft' as any // Create as draft by default
-			};
+				status: 'draft' as any, // Create as draft by default
+				requires_ticket: formData.requires_ticket || false // Send explicit false when unchecked
+			} as any; // Cast to any because requires_ticket is not yet in backend schema
 
 			if (eventId) {
 				// Update existing event

--- a/src/lib/components/notifications/NotificationPreferencesForm.svelte
+++ b/src/lib/components/notifications/NotificationPreferencesForm.svelte
@@ -338,6 +338,59 @@
 </script>
 
 <div class="space-y-6">
+	<!-- Privacy Settings Section -->
+	<Card.Root>
+		<Card.Header>
+			<Card.Title class="flex items-center gap-2">
+				<Eye class="h-5 w-5" aria-hidden="true" />
+				{m['notificationPreferences.privacySettings']()}
+			</Card.Title>
+			<Card.Description>{m['accountSettingsPage.privacyDescription']()}</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			<div class="space-y-3">
+				<Label>{m['notificationPreferences.showMeOnAttendeeList']()}</Label>
+				<RadioGroup.Root
+					value={attendeeListVisibility}
+					onValueChange={(value) => {
+						if (value) {
+							attendeeListVisibility = value;
+						}
+					}}
+					disabled={isFormDisabled}
+				>
+					<div class="flex items-center space-x-2">
+						<RadioGroup.Item value="always" id="vis-always" />
+						<Label for="vis-always" class="font-normal"
+							>{m['notificationPreferences.visibilityAlways']()}</Label
+						>
+					</div>
+					<div class="flex items-center space-x-2">
+						<RadioGroup.Item value="never" id="vis-never" />
+						<Label for="vis-never" class="font-normal"
+							>{m['notificationPreferences.visibilityNever']()}</Label
+						>
+					</div>
+					<div class="flex items-center space-x-2">
+						<RadioGroup.Item value="to_members" id="vis-members" />
+						<Label for="vis-members" class="font-normal"
+							>{m['notificationPreferences.visibilityToMembers']()}</Label
+						>
+					</div>
+					<div class="flex items-center space-x-2">
+						<RadioGroup.Item value="to_invitees" id="vis-invitees" />
+						<Label for="vis-invitees" class="font-normal"
+							>{m['notificationPreferences.visibilityToInvitees']()}</Label
+						>
+					</div>
+				</RadioGroup.Root>
+				<p class="text-xs text-muted-foreground">
+					{m['notificationPreferences.visibilityDescription']()}
+				</p>
+			</div>
+		</Card.Content>
+	</Card.Root>
+
 	<!-- Master Controls Section -->
 	<Card.Root>
 		<Card.Header>
@@ -582,59 +635,6 @@
 					{/if}
 				</div>
 			{/if}
-		</Card.Content>
-	</Card.Root>
-
-	<!-- Privacy Settings Section -->
-	<Card.Root>
-		<Card.Header>
-			<Card.Title class="flex items-center gap-2">
-				<Eye class="h-5 w-5" aria-hidden="true" />
-				{m['notificationPreferences.privacySettings']()}
-			</Card.Title>
-			<Card.Description>{m['accountSettingsPage.privacyDescription']()}</Card.Description>
-		</Card.Header>
-		<Card.Content>
-			<div class="space-y-3">
-				<Label>{m['notificationPreferences.showMeOnAttendeeList']()}</Label>
-				<RadioGroup.Root
-					value={attendeeListVisibility}
-					onValueChange={(value) => {
-						if (value) {
-							attendeeListVisibility = value;
-						}
-					}}
-					disabled={isFormDisabled}
-				>
-					<div class="flex items-center space-x-2">
-						<RadioGroup.Item value="always" id="vis-always" />
-						<Label for="vis-always" class="font-normal"
-							>{m['notificationPreferences.visibilityAlways']()}</Label
-						>
-					</div>
-					<div class="flex items-center space-x-2">
-						<RadioGroup.Item value="never" id="vis-never" />
-						<Label for="vis-never" class="font-normal"
-							>{m['notificationPreferences.visibilityNever']()}</Label
-						>
-					</div>
-					<div class="flex items-center space-x-2">
-						<RadioGroup.Item value="to_members" id="vis-members" />
-						<Label for="vis-members" class="font-normal"
-							>{m['notificationPreferences.visibilityToMembers']()}</Label
-						>
-					</div>
-					<div class="flex items-center space-x-2">
-						<RadioGroup.Item value="to_invitees" id="vis-invitees" />
-						<Label for="vis-invitees" class="font-normal"
-							>{m['notificationPreferences.visibilityToInvitees']()}</Label
-						>
-					</div>
-				</RadioGroup.Root>
-				<p class="text-xs text-muted-foreground">
-					{m['notificationPreferences.visibilityDescription']()}
-				</p>
-			</div>
 		</Card.Content>
 	</Card.Root>
 


### PR DESCRIPTION
## Summary

This PR addresses two user-facing issues:

1. **Event Creation Bug**: The "Requires Ticket" checkbox value is now properly sent to the backend
2. **Settings UX Improvement**: Privacy settings moved to the top of the settings page for better visibility

---

## 1. Fix: Send requires_ticket Field to Backend

### Problem

When creating events via `/org/[slug]/admin/events/new`, the "Requires Ticket" checkbox value was never sent to the backend:

- ❌ Unchecking the box → backend receives nothing → defaults to `true`  
- ❌ Checking the box → backend receives nothing → defaults to `true`
- ✅ Expected: checkbox state should control the backend value

### Root Cause

The frontend tracked `requires_ticket` in state and used it for UI logic (showing/hiding Step 3), but didn't include it in the API request payload.

Additionally, the backend's `EventEditSchema` has the field **commented out**:

```python
# requires_ticket: bool = False  # <-- COMMENTED OUT
```

### Solution

**Frontend (this PR):**
- Added `requires_ticket` to `EventCreateSchema` payload in `EventWizard.svelte:400`
- Explicitly sends `false` when unchecked (instead of omitting the field)
- Cast to `any` since backend schema doesn't accept this field yet

**Backend (required next):**
- Uncomment `requires_ticket` in `EventEditSchema` (see `REQUIRES_TICKET_ISSUE.md`)
- Regenerate OpenAPI spec
- Frontend runs `pnpm generate:api` to update types

### Impact

- Frontend is ready to send the field
- Backend must be updated before this takes full effect
- No breaking changes (backend still defaults to `true` if field is omitted)

---

## 2. UX: Move Privacy Settings to Top of Settings Page

### Problem

Privacy settings ("Show me on attendee list") were located at the bottom of the settings page, below:
1. Master Controls
2. Notification Channels  
3. Digest Settings
4. Advanced Settings

This made privacy controls hard to discover.

### Solution

Moved the **Privacy Settings** card to the **top of the page**, before Master Controls.

### New Order

1. **Privacy Settings** ← Moved here
2. Master Controls
3. Notification Channels
4. Digest Settings
5. Advanced Settings

---

## Files Changed

### Modified

- `src/lib/components/events/admin/EventWizard.svelte`  
  Added `requires_ticket` to event creation payload

- `src/lib/components/notifications/NotificationPreferencesForm.svelte`  
  Reordered sections to prioritize privacy settings

### Added

- `REQUIRES_TICKET_ISSUE.md`  
  Comprehensive documentation of the backend schema issue and fix requirements

---

## Testing

### Manual Testing: Event Creation

**Test Case 1: Create event WITHOUT tickets (RSVP only)**
1. Go to `/org/[slug]/admin/events/new`
2. Fill in required fields
3. **Uncheck** "Requires Ticket"
4. Click "Create Event"
5. Verify Step 3 (ticketing) does **not** appear
6. Save event
7. Check database: `requires_ticket` should be `false` (pending backend fix)

**Test Case 2: Create event WITH tickets**
1. Go to `/org/[slug]/admin/events/new`
2. Fill in required fields
3. **Check** "Requires Ticket"
4. Click "Create Event"
5. Verify Step 3 (ticketing) **does** appear
6. Configure tiers
7. Save event
8. Check database: `requires_ticket` should be `true`

### Manual Testing: Settings Page

1. Go to `/account/settings`
2. Verify "Privacy Settings" is the **first card** on the page
3. Verify settings save correctly
4. Check mobile layout for proper rendering

---

## Screenshots

### Before (Privacy Settings at bottom)
Settings page had privacy buried below 4 other sections

### After (Privacy Settings at top)
Privacy settings are now immediately visible

---

## Blockers / Dependencies

### Backend Changes Required (for full fix)

The `requires_ticket` fix requires a backend update:

**File:** `revel-backend/src/events/schema.py`

```python
class EventEditSchema(CityEditMixin):
    # ... other fields ...
    requires_ticket: bool = False  # Uncomment this line
```

**After backend update:**
1. Deploy backend changes
2. Regenerate OpenAPI spec
3. Run `pnpm generate:api` in frontend
4. Verify types update correctly

See `REQUIRES_TICKET_ISSUE.md` for complete details.

---

## Breaking Changes

None. All changes are backward compatible.

---

## Checklist

- [x] Code follows project style guidelines
- [x] Changes tested locally
- [x] No console errors or warnings
- [x] Type checking passes (`pnpm check`)
- [x] Accessible (keyboard navigation, ARIA labels)
- [x] Mobile-responsive
- [x] Documentation added (REQUIRES_TICKET_ISSUE.md)
- [x] Commit message follows conventional commits
- [ ] Backend changes coordinated (pending)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)