### PR TITLE
feat(notifications): validate Telegram connection before enabling notifications

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -2846,6 +2846,8 @@
 		"channelEmailDescription": "Benachrichtigungen per E-Mail erhalten",
 		"channelTelegram": "Telegram",
 		"channelTelegramDescription": "Benachrichtigungen über Telegram erhalten",
+		"telegramNotConnected": "Telegram nicht verbunden.",
+		"connectTelegram": "Konto verbinden",
 		"selectAtLeastOneChannel": "Bitte wählen Sie mindestens einen Benachrichtigungskanal",
 		"digestSettings": "Digest-Einstellungen",
 		"digestFrequency": "Digest-Häufigkeit",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2846,6 +2846,8 @@
 		"channelEmailDescription": "Receive notifications via email",
 		"channelTelegram": "Telegram",
 		"channelTelegramDescription": "Get notifications on Telegram",
+		"telegramNotConnected": "Telegram not connected.",
+		"connectTelegram": "Connect your account",
 		"selectAtLeastOneChannel": "Please select at least one notification channel",
 		"digestSettings": "Digest Settings",
 		"digestFrequency": "Digest frequency",

--- a/messages/it.json
+++ b/messages/it.json
@@ -2846,6 +2846,8 @@
 		"channelEmailDescription": "Ricevi notifiche tramite email",
 		"channelTelegram": "Telegram",
 		"channelTelegramDescription": "Ricevi notifiche su Telegram",
+		"telegramNotConnected": "Telegram non connesso.",
+		"connectTelegram": "Collega il tuo account",
 		"selectAtLeastOneChannel": "Seleziona almeno un canale di notifica",
 		"digestSettings": "Impostazioni Digest",
 		"digestFrequency": "Frequenza digest",


### PR DESCRIPTION
## Summary

Implement UX improvement to prevent users from enabling Telegram notifications when their Telegram account is not connected. The feature now provides clear guidance with a direct link to connect their account.

This addresses user feedback: _"In notifications you can tick the box with telegram notifications even without being connected via telegram, would be great if it would advise you/redirect you to where you can connect your telegram account"_

## Changes

### NotificationPreferencesForm Component

**Connection Status Check:**
- Added `telegramGetLinkStatus` API query to check Telegram connection status
- Query caches status for 5 minutes to optimize performance
- Only runs in authenticated mode (not in unsubscribe flow)

**Main Channels Section:**
- Telegram checkbox is disabled when account is not connected
- Helpful message appears below checkbox: "Telegram not connected. **Connect your account**"
- Message includes clickable link to `/account/profile` where TelegramConnectionManager is located
- Proper ARIA attributes for accessibility

**Advanced Settings (Per-Notification-Type):**
- All Telegram channel checkboxes in advanced settings also disabled when not connected
- Consistent behavior across the entire form

### i18n Translations

Added translations in all 3 languages:

**English:**
- `telegramNotConnected`: "Telegram not connected."
- `connectTelegram`: "Connect your account"

**German:**
- `telegramNotConnected`: "Telegram nicht verbunden."
- `connectTelegram`: "Konto verbinden"

**Italian:**
- `telegramNotConnected`: "Telegram non connesso."
- `connectTelegram`: "Collega il tuo account"

## User Experience

### Before
- ❌ Users could enable Telegram notifications without connecting account
- ❌ No guidance or feedback about missing connection
- ❌ Confusing experience

### After
- ✅ Telegram checkbox disabled when not connected
- ✅ Clear message: "Telegram not connected. Connect your account"
- ✅ Direct link to profile page for easy connection
- ✅ Consistent across all notification settings sections
- ✅ Works in all 3 languages (EN, DE, IT)

## Technical Details

- **Query Management:** Uses TanStack Query with 5-minute cache
- **Conditional Rendering:** Only in authenticated mode (respects unsubscribe flow)
- **Accessibility:** Proper `aria-describedby` and disabled states
- **Performance:** Minimal API calls with intelligent caching
- **Code Quality:** Follows existing patterns, formatted with Prettier

## Files Modified

1. `src/lib/components/notifications/NotificationPreferencesForm.svelte`
2. `messages/en.json`
3. `messages/de.json`
4. `messages/it.json`

## Testing

- ✅ Static checks pass (type check, lint, format)
- ✅ Translations compiled successfully with Paraglide
- ✅ Component renders without errors
- ✅ Follows existing code patterns and accessibility standards

## Screenshots

_Users can now see the disabled Telegram checkbox with a helpful message and link to connect their account._

🤖 Generated with [Claude Code](https://claude.com/claude-code)