### PR TITLE
feat(admin): add Preview button to draft event cards

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -619,6 +619,7 @@
 				"publish": "Veröffentlichen",
 				"delete": "Löschen",
 				"view": "Ansehen",
+				"preview": "Vorschau",
 				"tickets": "Tickets",
 				"attendees": "Teilnehmer",
 				"invitations": "Einladungen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -619,6 +619,7 @@
 				"publish": "Publish",
 				"delete": "Delete",
 				"view": "View",
+				"preview": "Preview",
 				"tickets": "Tickets",
 				"attendees": "Attendees",
 				"invitations": "Invitations",

--- a/messages/it.json
+++ b/messages/it.json
@@ -619,6 +619,7 @@
 				"publish": "Pubblica",
 				"delete": "Elimina",
 				"view": "Visualizza",
+				"preview": "Anteprima",
 				"tickets": "Biglietti",
 				"attendees": "Partecipanti",
 				"invitations": "Inviti",

--- a/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
@@ -290,6 +290,14 @@
 								<div class="flex flex-wrap gap-2 border-t border-border pt-3">
 									<button
 										type="button"
+										onclick={() => viewEvent(event.slug)}
+										class="inline-flex items-center gap-1 rounded-md bg-secondary px-3 py-1 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80"
+									>
+										<Eye class="h-4 w-4" aria-hidden="true" />
+										{m['orgAdmin.events.actions.preview']()}
+									</button>
+									<button
+										type="button"
 										onclick={() => editEvent(event.id)}
 										class="inline-flex items-center gap-1 rounded-md bg-secondary px-3 py-1 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80"
 									>


### PR DESCRIPTION
## Summary

Adds a **Preview** button to draft event cards in the organization admin events page, allowing staff members to view draft events as they will appear when published.

## Changes

### UI Enhancement
- Added Preview button to draft event cards
- Button appears before Edit button in the action row
- Uses Eye icon (same as View button for published events)
- Styled consistently with other secondary action buttons

### Button Order in Draft Events
1. **Preview** - View draft as it will appear when published
2. **Edit** - Modify event details
3. **Publish** - Make event public
4. **Delete** - Remove event

### Translations
- **EN**: "Preview"
- **DE**: "Vorschau"  
- **IT**: "Anteprima"

## Technical Details

- Preview button calls `viewEvent(event.slug)` which navigates to `/events/{org_slug}/{event_slug}`
- Staff members already have permission to view draft events
- No backend changes required - uses existing permissions

## Benefits

- Staff can preview how events will look before publishing
- Easier to review event appearance and formatting
- Consistent with published events having a View button
- Improves admin workflow and reduces need to publish/unpublish for previewing

## Testing

- ✅ Translations compiled successfully
- ✅ Button appears correctly on draft event cards
- ✅ Navigation to event page works as expected

## Screenshots

Before: Draft events had Edit, Publish, Delete buttons
After: Draft events now have Preview, Edit, Publish, Delete buttons

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)