### PR TITLE
fix(events): use backend-provided display_name in AttendeeList

### DIFF
--- a/src/lib/components/events/AttendeeList.svelte
+++ b/src/lib/components/events/AttendeeList.svelte
@@ -2,7 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { eventGetEventAttendees } from '$lib/api';
-	import type { MinimalRevelUserSchema } from '$lib/api/generated/types.gen';
+	import type { AttendeeSchema } from '$lib/api/generated/types.gen';
 	import { Users, ChevronDown, Loader2 } from 'lucide-svelte';
 
 	interface Props {
@@ -41,19 +41,6 @@
 	let visibleCount = $derived(attendees.length);
 	let hasMore = $derived(!!attendeesQuery.data?.next);
 	let hiddenCount = $derived(totalAttendees - visibleCount);
-
-	// Format attendee name
-	function formatAttendeeName(attendee: MinimalRevelUserSchema): string {
-		if (attendee.preferred_name) {
-			return attendee.preferred_name;
-		}
-
-		const parts: string[] = [];
-		if (attendee.first_name) parts.push(attendee.first_name);
-		if (attendee.last_name) parts.push(attendee.last_name);
-
-		return parts.length > 0 ? parts.join(' ') : m['attendeeList.anonymous']();
-	}
 
 	// Load next page
 	function loadMore() {
@@ -96,12 +83,12 @@
 								class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary"
 								aria-hidden="true"
 							>
-								{formatAttendeeName(attendee).charAt(0).toUpperCase()}
+								{attendee.display_name.charAt(0).toUpperCase()}
 							</div>
 
 							<!-- Attendee info -->
 							<div class="min-w-0 flex-1">
-								<p class="truncate font-medium">{formatAttendeeName(attendee)}</p>
+								<p class="truncate font-medium">{attendee.display_name}</p>
 								{#if attendee.pronouns}
 									<p class="truncate text-sm text-muted-foreground">{attendee.pronouns}</p>
 								{/if}
@@ -117,12 +104,12 @@
 								class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary"
 								aria-hidden="true"
 							>
-								{formatAttendeeName(attendee).charAt(0).toUpperCase()}
+								{attendee.display_name.charAt(0).toUpperCase()}
 							</div>
 
 							<!-- Attendee info -->
 							<div class="min-w-0 flex-1">
-								<p class="truncate font-medium">{formatAttendeeName(attendee)}</p>
+								<p class="truncate font-medium">{attendee.display_name}</p>
 								{#if attendee.pronouns}
 									<p class="truncate text-sm text-muted-foreground">{attendee.pronouns}</p>
 								{/if}


### PR DESCRIPTION
## Summary

Simplifies the `AttendeeList` component to use the `display_name` attribute directly from the backend's `AttendeeSchema` instead of attempting to construct names from multiple fields on the frontend.

## Problem

The component was previously:
- Using `MinimalRevelUserSchema` type instead of the correct `AttendeeSchema`
- Manually constructing names from `preferred_name`, `first_name`, and `last_name`
- Falling back to "anonymous" when no name fields were available
- Duplicating business logic that should live on the backend

## Solution

- Changed import from `MinimalRevelUserSchema` to `AttendeeSchema`
- Removed `formatAttendeeName()` helper function
- Updated template to use `attendee.display_name` directly
- The backend already provides the correctly formatted display name

## Changes

**Modified:**
- `src/lib/components/events/AttendeeList.svelte`
  - Updated type import (line 5)
  - Removed name-formatting function (removed lines 46-56)
  - Updated template to use `attendee.display_name` (lines 86, 91, 107, 112)

## Benefits

✅ Cleaner, more maintainable code  
✅ Single source of truth for name formatting (backend)  
✅ No more frontend fallback logic  
✅ Reduced code duplication  
✅ Follows backend-first principle  

## Testing

- ✅ Svelte autofixer validation passed
- ✅ TypeScript type checking passed
- ✅ ESLint validation passed
- ✅ Prettier formatting passed
- ✅ No new errors or warnings introduced

## Type Safety

The `AttendeeSchema` type includes:
```typescript
{
  display_name: string;  // Backend-provided, always present
  preferred_name?: string | null;
  pronouns?: string | null;
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)