### PR TITLE
Add Community-First Event Platform Landing Page

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -57,7 +57,8 @@
 		"solutionQueer": "Queere Event-Verwaltung",
 		"solutionKink": "Kink Event-Ticketing",
 		"solutionSelfHosted": "Self-Hosted Plattform",
-		"solutionPrivacy": "Datenschutz-fokussierte Events"
+		"solutionPrivacy": "Datenschutz-fokussierte Events",
+		"solutionCommunity": "Community-First Plattform"
 	},
 	"home": {
 		"welcomeTo": "Willkommen bei",

--- a/messages/en.json
+++ b/messages/en.json
@@ -57,7 +57,8 @@
 		"solutionQueer": "Queer Event Management",
 		"solutionKink": "Kink Event Ticketing",
 		"solutionSelfHosted": "Self-Hosted Platform",
-		"solutionPrivacy": "Privacy-Focused Events"
+		"solutionPrivacy": "Privacy-Focused Events",
+		"solutionCommunity": "Community-First Platform"
 	},
 	"home": {
 		"welcomeTo": "Welcome to",

--- a/messages/it.json
+++ b/messages/it.json
@@ -57,7 +57,8 @@
 		"solutionQueer": "Gestione Eventi Queer",
 		"solutionKink": "Ticketing Eventi Kink",
 		"solutionSelfHosted": "Piattaforma Self-Hosted",
-		"solutionPrivacy": "Eventi Privacy-First"
+		"solutionPrivacy": "Eventi Privacy-First",
+		"solutionCommunity": "Piattaforma Community-First"
 	},
 	"home": {
 		"welcomeTo": "Benvenuti su",

--- a/src/lib/components/common/Footer.svelte
+++ b/src/lib/components/common/Footer.svelte
@@ -23,7 +23,7 @@
 
 <footer class="border-t bg-muted/30">
 	<div class="container mx-auto px-4 py-8 md:py-12">
-		<div class="grid gap-8 md:grid-cols-2 lg:grid-cols-5">
+		<div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
 			<!-- About Section -->
 			<div>
 				<h3 class="mb-4 text-lg font-semibold">{m['footer.aboutTitle']()}</h3>
@@ -147,6 +147,14 @@
 							class="text-muted-foreground transition-colors hover:text-foreground"
 						>
 							{m['footer.solutionPrivacy']()}
+						</a>
+					</li>
+					<li>
+						<a
+							href="{landingPagePrefix}/community-first-event-platform"
+							class="text-muted-foreground transition-colors hover:text-foreground"
+						>
+							{m['footer.solutionCommunity']()}
 						</a>
 					</li>
 				</ul>

--- a/src/lib/data/landing-pages.ts
+++ b/src/lib/data/landing-pages.ts
@@ -64,7 +64,8 @@ export type LandingPageSlug =
 	| 'queer-event-management'
 	| 'kink-event-ticketing'
 	| 'self-hosted-event-platform'
-	| 'privacy-focused-events';
+	| 'privacy-focused-events'
+	| 'community-first-event-platform';
 
 // =============================================================================
 // ENGLISH CONTENT
@@ -593,6 +594,116 @@ const privacyFocusedEventsEN: LandingPageContent = {
 		}
 	],
 	relatedPages: ['self-hosted-event-platform', 'queer-event-management']
+};
+
+const communityFirstEventPlatformEN: LandingPageContent = {
+	slug: 'community-first-event-platform',
+	locale: 'en',
+	meta: {
+		title: 'Community-First Event Platform – Beyond Ticketing | Revel',
+		description:
+			'Build lasting communities, not just events. Organizations, membership tiers, potluck coordination, and more. Self-host for free or use our hosted version.',
+		keywords:
+			'community event platform, membership management, organization events, potluck coordination, community building, meetup alternative'
+	},
+	hero: {
+		headline: 'Build Communities, Not Just Events',
+		subheadline:
+			'Organizations, memberships, and unique tools like potluck coordination. Revel helps you foster lasting community connections.'
+	},
+	intro: {
+		paragraphs: [
+			'Most event platforms treat every gathering as a one-off transaction. But real communities need more than that—they need structure, continuity, and tools that support ongoing relationships.',
+			'Revel is built for communities first. Create organizations with membership tiers, assign roles and permissions, and use features like our unique potluck coordination system to make events more collaborative and less work for organizers.',
+			"Whether you're running a book club, hobby group, professional network, or maker space, Revel gives you the infrastructure to grow from casual meetups into a thriving community—without expensive subscriptions or platform lock-in."
+		]
+	},
+	features: [
+		{
+			icon: 'users',
+			title: 'Organization Structure',
+			description:
+				'Create community hubs with membership tiers, not just event listings. Owner, staff, and member roles with granular permissions.'
+		},
+		{
+			icon: 'clipboard',
+			title: 'Potluck Coordination',
+			description:
+				'Built-in system for coordinating who brings what. Handle dietary restrictions, quantities, and item management—no more messy spreadsheets.'
+		},
+		{
+			icon: 'shield',
+			title: 'Member-Only Events',
+			description:
+				'Restrict events to members, specific tiers, or keep them public. Build exclusive spaces for your community.'
+		},
+		{
+			icon: 'ticket',
+			title: 'Integrated Ticketing',
+			description:
+				'Free events, paid tickets, RSVP-only, or hybrid. Handle everything from casual meetups to professional conferences.'
+		},
+		{
+			icon: 'eye',
+			title: 'No Ads, Ever',
+			description:
+				'Your community deserves better than being shown ads. Self-host for free or use our ad-free hosted version.'
+		},
+		{
+			icon: 'code',
+			title: 'Open Source (MIT)',
+			description:
+				'Free to use, modify, and deploy. No vendor lock-in. Run on your own servers with complete control.'
+		}
+	],
+	benefits: {
+		title: 'Why Community Organizers Choose Revel',
+		items: [
+			'Build lasting membership structures, not just event-by-event lists',
+			'Coordinate potlucks and shared responsibilities effortlessly',
+			'No expensive subscriptions like Meetup ($540/year)',
+			'Ad-free experience for your members',
+			'Member-only events for building exclusive communities',
+			'Self-host for complete control and zero platform fees'
+		]
+	},
+	cta: {
+		title: 'Ready to Build Your Community?',
+		description: 'See Revel in action or deploy it yourself. No credit card required.',
+		buttons: [
+			{ text: 'Try the Live Demo', href: 'https://demo.letsrevel.io', variant: 'primary' },
+			{ text: 'Self-Host (GitHub)', href: 'https://github.com/letsrevel', variant: 'secondary' },
+			{ text: 'Contact Us', href: 'mailto:contact@letsrevel.io', variant: 'outline' }
+		]
+	},
+	faq: [
+		{
+			question: 'How is this different from Meetup?',
+			answer:
+				'Meetup charges $540/year and shows ads to your members. Revel is free to self-host and ad-free on our hosted version. We also integrate full ticketing capabilities and unique features like potluck coordination that Meetup lacks.'
+		},
+		{
+			question: 'What is potluck coordination?',
+			answer:
+				"It's a built-in system that lets attendees coordinate who brings what to events. Handle dietary restrictions, quantity management, and item assignments—no more messy spreadsheets or external tools. It's great for potlucks, equipment sharing, volunteer coordination, and more."
+		},
+		{
+			question: 'Can I create member-only events?',
+			answer:
+				'Yes. You can create organizations with membership tiers and restrict events to members only, specific membership levels, or keep them public. You have complete control over visibility and access.'
+		},
+		{
+			question: 'Is Revel really free?',
+			answer:
+				'Yes for self-hosting (MIT licensed). Our hosted version charges a small fee only for paid ticket sales (1.5% + €0.25 per ticket). Free events and RSVP-only events have zero platform fees on either version.'
+		},
+		{
+			question: 'What types of communities use Revel?',
+			answer:
+				"Book clubs, running groups, maker spaces, professional networks, hobby communities, special interest groups, and more. Any community that wants more than just basic event listings benefits from Revel's organization and membership features."
+		}
+	],
+	relatedPages: ['eventbrite-alternative', 'self-hosted-event-platform']
 };
 
 // =============================================================================
@@ -1140,6 +1251,120 @@ const privacyFocusedEventsDE: LandingPageContent = {
 	relatedPages: ['self-hosted-event-platform', 'queer-event-management']
 };
 
+const communityFirstEventPlatformDE: LandingPageContent = {
+	slug: 'community-first-event-platform',
+	locale: 'de',
+	meta: {
+		title: 'Community-First Event-Plattform – Mehr als Ticketing | Revel',
+		description:
+			'Baue dauerhafte Communities, nicht nur Events. Organisationen, Mitgliedschaftsstufen, Potluck-Koordination und mehr. Selbst hosten oder gehostete Version nutzen.',
+		keywords:
+			'community event plattform, mitgliederverwaltung, organisation events, potluck koordination, community aufbau, meetup alternative'
+	},
+	hero: {
+		headline: 'Baue Communities, Nicht Nur Events',
+		subheadline:
+			'Organisationen, Mitgliedschaften und einzigartige Tools wie Potluck-Koordination. Revel hilft dir, dauerhafte Community-Verbindungen aufzubauen.'
+	},
+	intro: {
+		paragraphs: [
+			'Die meisten Event-Plattformen behandeln jedes Treffen als einmalige Transaktion. Aber echte Communities brauchen mehr—sie brauchen Struktur, Kontinuität und Tools, die fortlaufende Beziehungen unterstützen.',
+			'Revel ist zuerst für Communities gebaut. Erstelle Organisationen mit Mitgliedschaftsstufen, weise Rollen und Berechtigungen zu und nutze Features wie unser einzigartiges Potluck-Koordinationssystem, um Events kollaborativer zu machen und weniger Arbeit für Organisatoren.',
+			'Egal ob du einen Buchclub, eine Hobbygruppe, ein professionelles Netzwerk oder einen Makerspace leitest, Revel gibt dir die Infrastruktur, um von lockeren Meetups zu einer florierenden Community zu wachsen—ohne teure Abos oder Plattform-Lock-in.'
+		]
+	},
+	features: [
+		{
+			icon: 'users',
+			title: 'Organisationsstruktur',
+			description:
+				'Erstelle Community-Hubs mit Mitgliedschaftsstufen, nicht nur Event-Listings. Owner-, Staff- und Member-Rollen mit granularen Berechtigungen.'
+		},
+		{
+			icon: 'clipboard',
+			title: 'Potluck-Koordination',
+			description:
+				'Integriertes System zur Koordination, wer was mitbringt. Verwalte Ernährungseinschränkungen, Mengen und Items—keine chaotischen Spreadsheets mehr.'
+		},
+		{
+			icon: 'shield',
+			title: 'Nur-Mitglieder Events',
+			description:
+				'Beschränke Events auf Mitglieder, spezifische Stufen oder halte sie öffentlich. Baue exklusive Räume für deine Community.'
+		},
+		{
+			icon: 'ticket',
+			title: 'Integriertes Ticketing',
+			description:
+				'Gratis-Events, bezahlte Tickets, nur RSVP oder hybrid. Verwalte alles von lockeren Meetups bis zu professionellen Konferenzen.'
+		},
+		{
+			icon: 'eye',
+			title: 'Niemals Werbung',
+			description:
+				'Deine Community verdient besser als Werbung zu sehen. Selbst hosten gratis oder nutze unsere werbefreie gehostete Version.'
+		},
+		{
+			icon: 'code',
+			title: 'Open Source (MIT)',
+			description:
+				'Kostenlos zu nutzen, modifizieren und deployen. Kein Vendor Lock-in. Betreibe auf eigenen Servern mit vollständiger Kontrolle.'
+		}
+	],
+	benefits: {
+		title: 'Warum Community-Organisatoren Revel Wählen',
+		items: [
+			'Baue dauerhafte Mitgliedschaftsstrukturen, nicht nur Event-Listen',
+			'Koordiniere Potlucks und geteilte Verantwortlichkeiten mühelos',
+			'Keine teuren Abos wie Meetup (540€/Jahr)',
+			'Werbefreie Erfahrung für deine Mitglieder',
+			'Nur-Mitglieder Events zum Aufbau exklusiver Communities',
+			'Selbst hosten für komplette Kontrolle und null Plattformgebühren'
+		]
+	},
+	cta: {
+		title: 'Bereit, Deine Community Aufzubauen?',
+		description: 'Sieh Revel in Aktion oder deploye es selbst. Keine Kreditkarte erforderlich.',
+		buttons: [
+			{ text: 'Live Demo Testen', href: 'https://demo.letsrevel.io', variant: 'primary' },
+			{
+				text: 'Selbst Hosten (GitHub)',
+				href: 'https://github.com/letsrevel',
+				variant: 'secondary'
+			},
+			{ text: 'Kontakt', href: 'mailto:contact@letsrevel.io', variant: 'outline' }
+		]
+	},
+	faq: [
+		{
+			question: 'Wie unterscheidet sich das von Meetup?',
+			answer:
+				'Meetup kostet 540€/Jahr und zeigt deinen Mitgliedern Werbung. Revel ist kostenlos zum Selbst-Hosten und werbefrei in unserer gehosteten Version. Wir integrieren auch vollständige Ticketing-Funktionen und einzigartige Features wie Potluck-Koordination, die Meetup fehlen.'
+		},
+		{
+			question: 'Was ist Potluck-Koordination?',
+			answer:
+				'Es ist ein integriertes System, das Teilnehmern ermöglicht zu koordinieren, wer was zu Events mitbringt. Verwalte Ernährungseinschränkungen, Mengen-Management und Item-Zuweisungen—keine chaotischen Spreadsheets oder externe Tools mehr. Es ist großartig für Potlucks, Equipment-Sharing, Freiwilligen-Koordination und mehr.'
+		},
+		{
+			question: 'Kann ich Nur-Mitglieder Events erstellen?',
+			answer:
+				'Ja. Du kannst Organisationen mit Mitgliedschaftsstufen erstellen und Events auf nur Mitglieder, spezifische Stufen beschränken oder sie öffentlich halten. Du hast vollständige Kontrolle über Sichtbarkeit und Zugang.'
+		},
+		{
+			question: 'Ist Revel wirklich kostenlos?',
+			answer:
+				'Ja für Selbst-Hosting (MIT-lizenziert). Unsere gehostete Version berechnet eine kleine Gebühr nur für bezahlte Ticket-Verkäufe (1,5% + 0,25€ pro Ticket). Gratis-Events und Nur-RSVP Events haben null Plattformgebühren in beiden Versionen.'
+		},
+		{
+			question: 'Welche Arten von Communities nutzen Revel?',
+			answer:
+				'Buchclubs, Laufgruppen, Makerspaces, professionelle Netzwerke, Hobby-Communities, Spezialinteressengruppen und mehr. Jede Community, die mehr als nur einfache Event-Listings will, profitiert von Revels Organisations- und Mitgliedschafts-Features.'
+		}
+	],
+	relatedPages: ['eventbrite-alternative', 'self-hosted-event-platform']
+};
+
 // =============================================================================
 // ITALIAN CONTENT
 // =============================================================================
@@ -1669,6 +1894,116 @@ const privacyFocusedEventsIT: LandingPageContent = {
 	relatedPages: ['self-hosted-event-platform', 'queer-event-management']
 };
 
+const communityFirstEventPlatformIT: LandingPageContent = {
+	slug: 'community-first-event-platform',
+	locale: 'it',
+	meta: {
+		title: 'Piattaforma Eventi Community-First – Oltre il Ticketing | Revel',
+		description:
+			'Costruisci community durature, non solo eventi. Organizzazioni, livelli membership, coordinamento potluck e altro. Self-host gratis o usa la versione hosted.',
+		keywords:
+			'piattaforma eventi community, gestione membri, eventi organizzazione, coordinamento potluck, costruzione community, alternativa meetup'
+	},
+	hero: {
+		headline: 'Costruisci Community, Non Solo Eventi',
+		subheadline:
+			'Organizzazioni, membership e strumenti unici come il coordinamento potluck. Revel ti aiuta a creare connessioni community durature.'
+	},
+	intro: {
+		paragraphs: [
+			'La maggior parte delle piattaforme eventi tratta ogni incontro come transazione singola. Ma le vere community hanno bisogno di più—struttura, continuità e strumenti che supportano relazioni continuative.',
+			'Revel è costruito prima di tutto per le community. Crea organizzazioni con livelli membership, assegna ruoli e permessi, e usa funzionalità come il nostro sistema unico di coordinamento potluck per rendere gli eventi più collaborativi e meno lavoro per gli organizzatori.',
+			"Che tu gestisca un club del libro, gruppo hobby, network professionale o makerspace, Revel ti dà l'infrastruttura per crescere da meetup casuali a community fiorenti—senza abbonamenti costosi o lock-in della piattaforma."
+		]
+	},
+	features: [
+		{
+			icon: 'users',
+			title: 'Struttura Organizzazione',
+			description:
+				'Crea hub community con livelli membership, non solo listing eventi. Ruoli owner, staff e member con permessi granulari.'
+		},
+		{
+			icon: 'clipboard',
+			title: 'Coordinamento Potluck',
+			description:
+				'Sistema integrato per coordinare chi porta cosa. Gestisci restrizioni dietetiche, quantità e item—basta con spreadsheet caotici.'
+		},
+		{
+			icon: 'shield',
+			title: 'Eventi Solo-Membri',
+			description:
+				'Limita eventi a membri, livelli specifici o mantienili pubblici. Costruisci spazi esclusivi per la tua community.'
+		},
+		{
+			icon: 'ticket',
+			title: 'Ticketing Integrato',
+			description:
+				'Eventi gratis, biglietti a pagamento, solo RSVP o ibrido. Gestisci tutto dai meetup casuali alle conferenze professionali.'
+		},
+		{
+			icon: 'eye',
+			title: 'Mai Pubblicità',
+			description:
+				'La tua community merita meglio che vedere pubblicità. Self-host gratis o usa la nostra versione hosted senza pubblicità.'
+		},
+		{
+			icon: 'code',
+			title: 'Open Source (MIT)',
+			description:
+				'Gratuito da usare, modificare e deployare. Nessun vendor lock-in. Esegui sui tuoi server con controllo completo.'
+		}
+	],
+	benefits: {
+		title: 'Perché Gli Organizzatori Community Scelgono Revel',
+		items: [
+			'Costruisci strutture membership durature, non solo liste evento-per-evento',
+			'Coordina potluck e responsabilità condivise senza sforzo',
+			'Nessun abbonamento costoso come Meetup (540€/anno)',
+			'Esperienza senza pubblicità per i tuoi membri',
+			'Eventi solo-membri per costruire community esclusive',
+			'Self-host per controllo completo e zero commissioni piattaforma'
+		]
+	},
+	cta: {
+		title: 'Pronto a Costruire La Tua Community?',
+		description: 'Vedi Revel in azione o deployalo tu stesso. Nessuna carta di credito richiesta.',
+		buttons: [
+			{ text: 'Prova la Demo Live', href: 'https://demo.letsrevel.io', variant: 'primary' },
+			{ text: 'Self-Host (GitHub)', href: 'https://github.com/letsrevel', variant: 'secondary' },
+			{ text: 'Contattaci', href: 'mailto:contact@letsrevel.io', variant: 'outline' }
+		]
+	},
+	faq: [
+		{
+			question: 'Come si differenzia da Meetup?',
+			answer:
+				'Meetup costa 540€/anno e mostra pubblicità ai tuoi membri. Revel è gratuito per self-host e senza pubblicità nella nostra versione hosted. Integriamo anche funzionalità ticketing complete e feature uniche come coordinamento potluck che Meetup non ha.'
+		},
+		{
+			question: "Cos'è il coordinamento potluck?",
+			answer:
+				'È un sistema integrato che permette ai partecipanti di coordinare chi porta cosa agli eventi. Gestisci restrizioni dietetiche, gestione quantità e assegnazioni item—niente più spreadsheet caotici o strumenti esterni. È ottimo per potluck, condivisione equipment, coordinamento volontari e altro.'
+		},
+		{
+			question: 'Posso creare eventi solo-membri?',
+			answer:
+				'Sì. Puoi creare organizzazioni con livelli membership e limitare eventi a solo membri, livelli specifici o mantenerli pubblici. Hai controllo completo su visibilità e accesso.'
+		},
+		{
+			question: 'Revel è davvero gratuito?',
+			answer:
+				'Sì per self-hosting (licenza MIT). La nostra versione hosted addebita una piccola commissione solo per vendite biglietti a pagamento (1,5% + 0,25€ per biglietto). Eventi gratuiti e solo-RSVP hanno zero commissioni piattaforma in entrambe le versioni.'
+		},
+		{
+			question: 'Quali tipi di community usano Revel?',
+			answer:
+				'Club del libro, gruppi running, makerspace, network professionali, community hobby, gruppi interesse speciale e altro. Qualsiasi community che vuole più dei semplici listing eventi beneficia delle funzionalità organizzazione e membership di Revel.'
+		}
+	],
+	relatedPages: ['eventbrite-alternative', 'self-hosted-event-platform']
+};
+
 // =============================================================================
 // EXPORTS
 // =============================================================================
@@ -1679,21 +2014,24 @@ export const landingPages: Record<string, Record<string, LandingPageContent>> = 
 		'queer-event-management': queerEventManagementEN,
 		'kink-event-ticketing': kinkEventTicketingEN,
 		'self-hosted-event-platform': selfHostedEventPlatformEN,
-		'privacy-focused-events': privacyFocusedEventsEN
+		'privacy-focused-events': privacyFocusedEventsEN,
+		'community-first-event-platform': communityFirstEventPlatformEN
 	},
 	de: {
 		'eventbrite-alternative': eventbriteAlternativeDE,
 		'queer-event-management': queerEventManagementDE,
 		'kink-event-ticketing': kinkEventTicketingDE,
 		'self-hosted-event-platform': selfHostedEventPlatformDE,
-		'privacy-focused-events': privacyFocusedEventsDE
+		'privacy-focused-events': privacyFocusedEventsDE,
+		'community-first-event-platform': communityFirstEventPlatformDE
 	},
 	it: {
 		'eventbrite-alternative': eventbriteAlternativeIT,
 		'queer-event-management': queerEventManagementIT,
 		'kink-event-ticketing': kinkEventTicketingIT,
 		'self-hosted-event-platform': selfHostedEventPlatformIT,
-		'privacy-focused-events': privacyFocusedEventsIT
+		'privacy-focused-events': privacyFocusedEventsIT,
+		'community-first-event-platform': communityFirstEventPlatformIT
 	}
 };
 
@@ -1702,7 +2040,8 @@ export const landingPageSlugs: LandingPageSlug[] = [
 	'queer-event-management',
 	'kink-event-ticketing',
 	'self-hosted-event-platform',
-	'privacy-focused-events'
+	'privacy-focused-events',
+	'community-first-event-platform'
 ];
 
 export function getLandingPage(locale: string, slug: string): LandingPageContent | undefined {

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -680,6 +680,26 @@
 					Learn more <ArrowRight class="h-4 w-4" aria-hidden="true" />
 				</span>
 			</a>
+
+			<a
+				href="{landingPagePrefix}/community-first-event-platform"
+				class="group rounded-lg border bg-card p-6 transition-all hover:border-primary hover:shadow-md"
+			>
+				<div class="mb-3 flex items-center gap-3">
+					<div class="rounded-full bg-teal-100 p-2 dark:bg-teal-900/30">
+						<Users class="h-5 w-5 text-teal-600 dark:text-teal-400" aria-hidden="true" />
+					</div>
+					<h3 class="font-semibold">{m['footer.solutionCommunity']()}</h3>
+				</div>
+				<p class="mb-3 text-sm text-muted-foreground">
+					Build communities with membership tiers, potluck coordination, and more.
+				</p>
+				<span
+					class="inline-flex items-center gap-1 text-sm font-medium text-primary group-hover:underline"
+				>
+					Learn more <ArrowRight class="h-4 w-4" aria-hidden="true" />
+				</span>
+			</a>
 		</div>
 	</div>
 

--- a/src/routes/(public)/community-first-event-platform/+page.svelte
+++ b/src/routes/(public)/community-first-event-platform/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { getLandingPage } from '$lib/data/landing-pages';
+	import { LandingPageTemplate } from '$lib/components/landing';
+	import { toJsonLd, generateBreadcrumbStructuredData } from '$lib/utils/seo';
+
+	const content = getLandingPage('en', 'community-first-event-platform')!;
+
+	// Generate breadcrumb structured data
+	let breadcrumbData = $derived(
+		generateBreadcrumbStructuredData([
+			{ name: 'Home', url: page.url.origin },
+			{
+				name: content.hero.headline,
+				url: `${page.url.origin}/community-first-event-platform`
+			}
+		])
+	);
+	let breadcrumbJsonLd = $derived(toJsonLd(breadcrumbData));
+
+	// Generate FAQ structured data
+	let faqStructuredData = $derived({
+		'@context': 'https://schema.org',
+		'@type': 'FAQPage',
+		mainEntity: content.faq.map((item) => ({
+			'@type': 'Question',
+			name: item.question,
+			acceptedAnswer: {
+				'@type': 'Answer',
+				text: item.answer
+			}
+		}))
+	});
+	let faqJsonLd = $derived(JSON.stringify(faqStructuredData));
+
+	// Generate WebPage structured data
+	let webPageStructuredData = $derived({
+		'@context': 'https://schema.org',
+		'@type': 'WebPage',
+		name: content.meta.title,
+		description: content.meta.description,
+		url: `${page.url.origin}/community-first-event-platform`,
+		inLanguage: 'en',
+		isPartOf: {
+			'@type': 'WebSite',
+			name: 'Revel',
+			url: page.url.origin
+		}
+	});
+	let webPageJsonLd = $derived(JSON.stringify(webPageStructuredData));
+</script>
+
+<svelte:head>
+	<title>{content.meta.title}</title>
+	<meta name="description" content={content.meta.description} />
+	<meta name="keywords" content={content.meta.keywords} />
+	<link rel="canonical" href="{page.url.origin}/community-first-event-platform" />
+
+	<!-- Open Graph -->
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content={content.meta.title} />
+	<meta property="og:description" content={content.meta.description} />
+	<meta property="og:url" content="{page.url.origin}/community-first-event-platform" />
+	<meta property="og:site_name" content="Revel" />
+	<meta property="og:locale" content="en_US" />
+
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={content.meta.title} />
+	<meta name="twitter:description" content={content.meta.description} />
+
+	<!-- Alternate language versions -->
+	<link rel="alternate" hreflang="en" href="{page.url.origin}/community-first-event-platform" />
+	<link rel="alternate" hreflang="de" href="{page.url.origin}/de/community-first-event-platform" />
+	<link rel="alternate" hreflang="it" href="{page.url.origin}/it/community-first-event-platform" />
+	<link
+		rel="alternate"
+		hreflang="x-default"
+		href="{page.url.origin}/community-first-event-platform"
+	/>
+
+	<!-- Structured Data -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + breadcrumbJsonLd + '</script>'}
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + faqJsonLd + '</script>'}
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + webPageJsonLd + '</script>'}
+</svelte:head>
+
+<LandingPageTemplate {content} />

--- a/src/routes/(public)/de/community-first-event-platform/+page.svelte
+++ b/src/routes/(public)/de/community-first-event-platform/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { getLandingPage } from '$lib/data/landing-pages';
+	import { LandingPageTemplate } from '$lib/components/landing';
+	import { toJsonLd, generateBreadcrumbStructuredData } from '$lib/utils/seo';
+
+	const content = getLandingPage('de', 'community-first-event-platform')!;
+
+	// Generate breadcrumb structured data
+	let breadcrumbData = $derived(
+		generateBreadcrumbStructuredData([
+			{ name: 'Home', url: page.url.origin },
+			{
+				name: content.hero.headline,
+				url: `${page.url.origin}/de/community-first-event-platform`
+			}
+		])
+	);
+	let breadcrumbJsonLd = $derived(toJsonLd(breadcrumbData));
+
+	// Generate FAQ structured data
+	let faqStructuredData = $derived({
+		'@context': 'https://schema.org',
+		'@type': 'FAQPage',
+		mainEntity: content.faq.map((item) => ({
+			'@type': 'Question',
+			name: item.question,
+			acceptedAnswer: {
+				'@type': 'Answer',
+				text: item.answer
+			}
+		}))
+	});
+	let faqJsonLd = $derived(JSON.stringify(faqStructuredData));
+
+	// Generate WebPage structured data
+	let webPageStructuredData = $derived({
+		'@context': 'https://schema.org',
+		'@type': 'WebPage',
+		name: content.meta.title,
+		description: content.meta.description,
+		url: `${page.url.origin}/de/community-first-event-platform`,
+		inLanguage: 'de',
+		isPartOf: {
+			'@type': 'WebSite',
+			name: 'Revel',
+			url: page.url.origin
+		}
+	});
+	let webPageJsonLd = $derived(JSON.stringify(webPageStructuredData));
+</script>
+
+<svelte:head>
+	<title>{content.meta.title}</title>
+	<meta name="description" content={content.meta.description} />
+	<meta name="keywords" content={content.meta.keywords} />
+	<link rel="canonical" href="{page.url.origin}/de/community-first-event-platform" />
+
+	<!-- Open Graph -->
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content={content.meta.title} />
+	<meta property="og:description" content={content.meta.description} />
+	<meta property="og:url" content="{page.url.origin}/de/community-first-event-platform" />
+	<meta property="og:site_name" content="Revel" />
+	<meta property="og:locale" content="de_DE" />
+
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={content.meta.title} />
+	<meta name="twitter:description" content={content.meta.description} />
+
+	<!-- Alternate language versions -->
+	<link rel="alternate" hreflang="en" href="{page.url.origin}/community-first-event-platform" />
+	<link rel="alternate" hreflang="de" href="{page.url.origin}/de/community-first-event-platform" />
+	<link rel="alternate" hreflang="it" href="{page.url.origin}/it/community-first-event-platform" />
+	<link
+		rel="alternate"
+		hreflang="x-default"
+		href="{page.url.origin}/community-first-event-platform"
+	/>
+
+	<!-- Structured Data -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + breadcrumbJsonLd + '</script>'}
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + faqJsonLd + '</script>'}
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + webPageJsonLd + '</script>'}
+</svelte:head>
+
+<LandingPageTemplate {content} />

--- a/src/routes/(public)/it/community-first-event-platform/+page.svelte
+++ b/src/routes/(public)/it/community-first-event-platform/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { getLandingPage } from '$lib/data/landing-pages';
+	import { LandingPageTemplate } from '$lib/components/landing';
+	import { toJsonLd, generateBreadcrumbStructuredData } from '$lib/utils/seo';
+
+	const content = getLandingPage('it', 'community-first-event-platform')!;
+
+	// Generate breadcrumb structured data
+	let breadcrumbData = $derived(
+		generateBreadcrumbStructuredData([
+			{ name: 'Home', url: page.url.origin },
+			{
+				name: content.hero.headline,
+				url: `${page.url.origin}/it/community-first-event-platform`
+			}
+		])
+	);
+	let breadcrumbJsonLd = $derived(toJsonLd(breadcrumbData));
+
+	// Generate FAQ structured data
+	let faqStructuredData = $derived({
+		'@context': 'https://schema.org',
+		'@type': 'FAQPage',
+		mainEntity: content.faq.map((item) => ({
+			'@type': 'Question',
+			name: item.question,
+			acceptedAnswer: {
+				'@type': 'Answer',
+				text: item.answer
+			}
+		}))
+	});
+	let faqJsonLd = $derived(JSON.stringify(faqStructuredData));
+
+	// Generate WebPage structured data
+	let webPageStructuredData = $derived({
+		'@context': 'https://schema.org',
+		'@type': 'WebPage',
+		name: content.meta.title,
+		description: content.meta.description,
+		url: `${page.url.origin}/it/community-first-event-platform`,
+		inLanguage: 'it',
+		isPartOf: {
+			'@type': 'WebSite',
+			name: 'Revel',
+			url: page.url.origin
+		}
+	});
+	let webPageJsonLd = $derived(JSON.stringify(webPageStructuredData));
+</script>
+
+<svelte:head>
+	<title>{content.meta.title}</title>
+	<meta name="description" content={content.meta.description} />
+	<meta name="keywords" content={content.meta.keywords} />
+	<link rel="canonical" href="{page.url.origin}/it/community-first-event-platform" />
+
+	<!-- Open Graph -->
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content={content.meta.title} />
+	<meta property="og:description" content={content.meta.description} />
+	<meta property="og:url" content="{page.url.origin}/it/community-first-event-platform" />
+	<meta property="og:site_name" content="Revel" />
+	<meta property="og:locale" content="it_IT" />
+
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={content.meta.title} />
+	<meta name="twitter:description" content={content.meta.description} />
+
+	<!-- Alternate language versions -->
+	<link rel="alternate" hreflang="en" href="{page.url.origin}/community-first-event-platform" />
+	<link rel="alternate" hreflang="de" href="{page.url.origin}/de/community-first-event-platform" />
+	<link rel="alternate" hreflang="it" href="{page.url.origin}/it/community-first-event-platform" />
+	<link
+		rel="alternate"
+		hreflang="x-default"
+		href="{page.url.origin}/community-first-event-platform"
+	/>
+
+	<!-- Structured Data -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + breadcrumbJsonLd + '</script>'}
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + faqJsonLd + '</script>'}
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html '<script type="application/ld+json">' + webPageJsonLd + '</script>'}
+</svelte:head>
+
+<LandingPageTemplate {content} />


### PR DESCRIPTION
## Summary

Add 6th landing page highlighting community building features, positioning Revel as a **community-first alternative to Meetup** ($540/year + ads).

### Key Features Highlighted
- 🏢 **Organizations** with membership tiers and role-based permissions
- 🍲 **Potluck coordination system** (unique differentiator in the market)
- 🔒 **Member-only events** for exclusive communities  
- 🎟️ **Integrated ticketing** (free, paid, RSVP, hybrid)
- 🚫 **Ad-free experience** vs. competitors
- 🛠️ **Self-hosting option** (MIT licensed, zero fees)

## Changes

### 1. New Landing Page (EN, DE, IT)
- Routes: `/community-first-event-platform` + DE/IT versions
- Full SEO optimization with structured data (FAQ, breadcrumbs, WebPage)
- Multilingual support with hreflang tags
- Open Graph and Twitter Card meta tags

### 2. Footer Redesign
- Changed grid from 5-column to **3-column** layout (`lg:grid-cols-3`)
- Better responsive design: 2 rows × 3 items
- Added 6th solution link

### 3. Homepage Enhancement
- Added 6th card in use cases section
- Teal color scheme with Users icon
- Highlights community features and potluck coordination

### 4. i18n Translations
- Added `footer.solutionCommunity` in EN, DE, IT
- Compiled with Paraglide

## Technical Details
- ✅ Build passes (verified)
- ✅ Lint/format checks pass
- ✅ Type checking clean (pre-existing warnings only)
- ✅ All routes include proper SEO meta tags
- ✅ Responsive design (mobile-first)
- ✅ Structured data for search engines

## Why This Matters

This landing page fills a gap in our SEO strategy by targeting users looking for **community management platforms** rather than just event ticketing. The potluck coordination feature is a unique differentiator that no competitor has.

### Target Audience
- Book clubs, running groups, maker spaces
- Professional networks and special interest groups
- Hobby communities that want more than basic event listings

### Competitive Positioning
- **vs. Meetup**: Free to self-host vs. $540/year, no ads
- **vs. Eventbrite**: Community features (memberships, roles, permissions)
- **vs. All**: Unique potluck coordination system

## Screenshots
The new landing page follows the same template as existing pages with community-specific content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)