### PR TITLE
fix(i18n): add missing translations and improve SEO page language switching

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1168,27 +1168,43 @@
 		"available": "Verfügbar"
 	},
 	"eventActionSidebar": {
-		"youreAttending": "You're attending",
-		"youreCheckedIn": "You're checked in",
-		"ticketPending": "Your ticket is pending",
-		"youHaveTicket": "You have a ticket",
-		"ticketPendingPayment": "Ticket Pending Payment",
-		"eligibilityStatus": "Eligibility Status",
-		"manageEvent": "Manage Event",
-		"eventDetails": "Event Details"
+		"youreAttending": "Du nimmst teil",
+		"youreCheckedIn": "Du bist eingecheckt",
+		"ticketPending": "Dein Ticket ist ausstehend",
+		"youHaveTicket": "Du hast ein Ticket",
+		"ticketPendingPayment": "Ticket wartet auf Zahlung",
+		"eligibilityStatus": "Teilnahmeberechtigung",
+		"manageEvent": "Event verwalten",
+		"eventDetails": "Event-Details",
+		"processing": "Wird verarbeitet...",
+		"resumePayment": "Zahlung fortsetzen",
+		"viewAllTickets": "Alle {count} Tickets anzeigen",
+		"viewTicket": "Ticket anzeigen",
+		"showTicket": "Ticket zeigen",
+		"showTickets": "Tickets zeigen ({count})",
+		"hideRsvp": "Antwort ausblenden",
+		"changeRsvp": "Antwort ändern",
+		"buyMoreTickets": "Weitere Tickets kaufen",
+		"ticketsLeft": "({count} übrig)",
+		"addToCalendar": "Zum Kalender hinzufügen",
+		"editEvent": "Event bearbeiten",
+		"manageTickets": "Tickets verwalten",
+		"manageAttendees": "Teilnehmende verwalten",
+		"manageInvitations": "Einladungen verwalten",
+		"pendingPaymentDescription": "Schließe deine Zahlung ab, um dein Ticket zu bestätigen. Deine Reservierung verfällt, wenn die Zahlung nicht abgeschlossen wird."
 	},
 	"eventQuickInfo": {
 		"limitedSpots": "Begrenzte Plätze verfügbar",
 		"closesSoon": "Schließt bald!",
-		"locationTbd": "Location TBD",
-		"publicEvent": "Public Event",
-		"privateEvent": "Private Event",
-		"membersOnly": "Members Only",
-		"staffOnly": "Staff Only",
+		"locationTbd": "Ort noch offen",
+		"publicEvent": "Öffentliches Event",
+		"privateEvent": "Privates Event",
+		"membersOnly": "Nur für Mitglieder",
+		"staffOnly": "Nur für Mitarbeitende",
 		"event": "Event",
-		"spotsTaken": "{current} / {max} spots taken",
-		"rsvpClosed": "RSVP closed",
-		"rsvpBy": "RSVP by {deadline}"
+		"spotsTaken": "{current} / {max} Plätze belegt",
+		"rsvpClosed": "Anmeldung geschlossen",
+		"rsvpBy": "Anmeldung bis {deadline}"
 	},
 	"eventRSVP": {
 		"goingTo": "You're going to {eventName}!",
@@ -1204,7 +1220,8 @@
 		"series": "Serie"
 	},
 	"organizationInfo": {
-		"aboutOrganizer": "Über die Organisierenden"
+		"aboutOrganizer": "Über die Organisierenden",
+		"viewProfile": "Organisationsprofil anzeigen"
 	},
 	"potluckItemEditModal": {
 		"addPotluckItem": "Potluck-Artikel hinzufügen",
@@ -1640,7 +1657,24 @@
 	},
 	"requestMembershipButton": {
 		"requestSubmitted": "Anfrage gesendet!",
-		"requestMembership": "Mitgliedschaft anfragen"
+		"requestMembership": "Mitgliedschaft anfragen",
+		"owner": "Inhaber",
+		"staff": "Mitarbeitende",
+		"member": "Mitglied",
+		"messageOptional": "Nachricht (Optional)",
+		"messagePlaceholder": "Erzähle den Organisierenden, warum du beitreten möchtest...",
+		"characters": "Zeichen",
+		"requestSubmittedDesc": "Deine Mitgliedschaftsanfrage wurde an {organizationName} gesendet. Du wirst benachrichtigt, wenn sie geprüft wurde.",
+		"requestDesc": "Sende eine Anfrage, um Mitglied von {organizationName} zu werden. Mitglieder haben möglicherweise Zugang zu exklusiven Events und Inhalten.",
+		"cancel": "Abbrechen",
+		"submitting": "Wird gesendet...",
+		"submitRequest": "Anfrage senden",
+		"ownerAriaLabel": "Du bist Inhaber dieser Organisation",
+		"staffAriaLabel": "Du bist Mitarbeitende dieser Organisation",
+		"memberAriaLabel": "Du bist Mitglied dieser Organisation",
+		"membershipStatusAriaLabel": "Mitgliedschaftsstatus: {status}",
+		"membershipTierAriaLabel": "Mitgliedschaftsstufe: {tier}",
+		"submitError": "Anfrage konnte nicht gesendet werden. Bitte versuche es erneut."
 	},
 	"stripeConnect": {
 		"paymentProcessing": "Zahlungsabwicklung",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1175,7 +1175,23 @@
 		"ticketPendingPayment": "Ticket Pending Payment",
 		"eligibilityStatus": "Eligibility Status",
 		"manageEvent": "Manage Event",
-		"eventDetails": "Event Details"
+		"eventDetails": "Event Details",
+		"processing": "Processing...",
+		"resumePayment": "Resume Payment",
+		"viewAllTickets": "View All {count} Tickets",
+		"viewTicket": "View Ticket",
+		"showTicket": "Show Ticket",
+		"showTickets": "Show Tickets ({count})",
+		"hideRsvp": "Hide RSVP",
+		"changeRsvp": "Change RSVP",
+		"buyMoreTickets": "Buy More Tickets",
+		"ticketsLeft": "({count} left)",
+		"addToCalendar": "Add to Calendar",
+		"editEvent": "Edit Event",
+		"manageTickets": "Manage Tickets",
+		"manageAttendees": "Manage Attendees",
+		"manageInvitations": "Manage Invitations",
+		"pendingPaymentDescription": "Complete your payment to confirm your ticket. Your reservation will expire if payment is not completed."
 	},
 	"eventQuickInfo": {
 		"limitedSpots": "Limited spots remaining",
@@ -1204,7 +1220,8 @@
 		"series": "Series"
 	},
 	"organizationInfo": {
-		"aboutOrganizer": "About the organizer"
+		"aboutOrganizer": "About the organizer",
+		"viewProfile": "View organization profile"
 	},
 	"potluckItemEditModal": {
 		"addPotluckItem": "Add potluck item",
@@ -1640,7 +1657,24 @@
 	},
 	"requestMembershipButton": {
 		"requestSubmitted": "Request Submitted!",
-		"requestMembership": "Request Membership"
+		"requestMembership": "Request Membership",
+		"owner": "Owner",
+		"staff": "Staff",
+		"member": "Member",
+		"messageOptional": "Message (Optional)",
+		"messagePlaceholder": "Tell the organizers why you'd like to join...",
+		"characters": "characters",
+		"requestSubmittedDesc": "Your membership request has been sent to {organizationName}. You'll be notified when it's reviewed.",
+		"requestDesc": "Submit a request to become a member of {organizationName}. Members may have access to exclusive events and content.",
+		"cancel": "Cancel",
+		"submitting": "Submitting...",
+		"submitRequest": "Submit Request",
+		"ownerAriaLabel": "You are the owner of this organization",
+		"staffAriaLabel": "You are a staff member of this organization",
+		"memberAriaLabel": "You are a member of this organization",
+		"membershipStatusAriaLabel": "Membership status: {status}",
+		"membershipTierAriaLabel": "Membership tier: {tier}",
+		"submitError": "Failed to submit request. Please try again."
 	},
 	"stripeConnect": {
 		"paymentProcessing": "Payment Processing",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1168,27 +1168,43 @@
 		"available": "Disponibile"
 	},
 	"eventActionSidebar": {
-		"youreAttending": "You're attending",
-		"youreCheckedIn": "You're checked in",
-		"ticketPending": "Your ticket is pending",
-		"youHaveTicket": "You have a ticket",
-		"ticketPendingPayment": "Ticket Pending Payment",
-		"eligibilityStatus": "Eligibility Status",
-		"manageEvent": "Manage Event",
-		"eventDetails": "Event Details"
+		"youreAttending": "Stai partecipando",
+		"youreCheckedIn": "Sei registrato",
+		"ticketPending": "Il tuo biglietto è in sospeso",
+		"youHaveTicket": "Hai un biglietto",
+		"ticketPendingPayment": "Biglietto in attesa di pagamento",
+		"eligibilityStatus": "Stato idoneità",
+		"manageEvent": "Gestisci evento",
+		"eventDetails": "Dettagli dell'evento",
+		"processing": "Elaborazione...",
+		"resumePayment": "Riprendi pagamento",
+		"viewAllTickets": "Visualizza tutti i {count} biglietti",
+		"viewTicket": "Visualizza biglietto",
+		"showTicket": "Mostra biglietto",
+		"showTickets": "Mostra biglietti ({count})",
+		"hideRsvp": "Nascondi RSVP",
+		"changeRsvp": "Modifica RSVP",
+		"buyMoreTickets": "Acquista altri biglietti",
+		"ticketsLeft": "({count} rimasti)",
+		"addToCalendar": "Aggiungi al calendario",
+		"editEvent": "Modifica evento",
+		"manageTickets": "Gestisci biglietti",
+		"manageAttendees": "Gestisci partecipanti",
+		"manageInvitations": "Gestisci inviti",
+		"pendingPaymentDescription": "Completa il pagamento per confermare il tuo biglietto. La tua prenotazione scadrà se il pagamento non viene completato."
 	},
 	"eventQuickInfo": {
 		"limitedSpots": "Posti limitati disponibili",
 		"closesSoon": "Chiude presto!",
-		"locationTbd": "Location TBD",
-		"publicEvent": "Public Event",
-		"privateEvent": "Private Event",
-		"membersOnly": "Members Only",
-		"staffOnly": "Staff Only",
-		"event": "Event",
-		"spotsTaken": "{current} / {max} spots taken",
-		"rsvpClosed": "RSVP closed",
-		"rsvpBy": "RSVP by {deadline}"
+		"locationTbd": "Luogo da definire",
+		"publicEvent": "Evento pubblico",
+		"privateEvent": "Evento privato",
+		"membersOnly": "Solo per membri",
+		"staffOnly": "Solo per staff",
+		"event": "Evento",
+		"spotsTaken": "{current} / {max} posti occupati",
+		"rsvpClosed": "RSVP chiuso",
+		"rsvpBy": "RSVP entro {deadline}"
 	},
 	"eventRSVP": {
 		"goingTo": "You're going to {eventName}!",
@@ -1204,7 +1220,8 @@
 		"series": "Serie"
 	},
 	"organizationInfo": {
-		"aboutOrganizer": "Informazioni sull'organizzatore"
+		"aboutOrganizer": "Informazioni sull'organizzatore",
+		"viewProfile": "Visualizza profilo organizzazione"
 	},
 	"potluckItemEditModal": {
 		"addPotluckItem": "Aggiungi elemento potluck",
@@ -1640,7 +1657,24 @@
 	},
 	"requestMembershipButton": {
 		"requestSubmitted": "Richiesta Inviata!",
-		"requestMembership": "Richiedi Iscrizione"
+		"requestMembership": "Richiedi Iscrizione",
+		"owner": "Proprietario",
+		"staff": "Staff",
+		"member": "Membro",
+		"messageOptional": "Messaggio (Opzionale)",
+		"messagePlaceholder": "Racconta agli organizzatori perché vorresti unirti...",
+		"characters": "caratteri",
+		"requestSubmittedDesc": "La tua richiesta di iscrizione è stata inviata a {organizationName}. Sarai avvisato quando verrà esaminata.",
+		"requestDesc": "Invia una richiesta per diventare membro di {organizationName}. I membri potrebbero avere accesso a eventi e contenuti esclusivi.",
+		"cancel": "Annulla",
+		"submitting": "Invio in corso...",
+		"submitRequest": "Invia richiesta",
+		"ownerAriaLabel": "Sei il proprietario di questa organizzazione",
+		"staffAriaLabel": "Sei un membro dello staff di questa organizzazione",
+		"memberAriaLabel": "Sei un membro di questa organizzazione",
+		"membershipStatusAriaLabel": "Stato dell'iscrizione: {status}",
+		"membershipTierAriaLabel": "Livello di iscrizione: {tier}",
+		"submitError": "Impossibile inviare la richiesta. Per favore riprova."
 	},
 	"stripeConnect": {
 		"paymentProcessing": "Elaborazione Pagamenti",

--- a/src/lib/components/events/EventActionSidebar.svelte
+++ b/src/lib/components/events/EventActionSidebar.svelte
@@ -329,8 +329,7 @@
 					</div>
 				</div>
 				<p class="text-sm">
-					Complete your payment to confirm your ticket. Your reservation will expire if payment is
-					not completed.
+					{m['eventActionSidebar.pendingPaymentDescription']()}
 				</p>
 				<button
 					type="button"
@@ -338,7 +337,9 @@
 					disabled={isResumingPayment}
 					class="w-full rounded-md border-2 border-orange-600 bg-orange-600 px-4 py-2 font-semibold text-white transition-colors hover:bg-orange-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-orange-500 dark:bg-orange-500"
 				>
-					{isResumingPayment ? 'Processing...' : 'Resume Payment'}
+					{isResumingPayment
+						? m['eventActionSidebar.processing']()
+						: m['eventActionSidebar.resumePayment']()}
 				</button>
 				{#if onShowTicketClick}
 					<button
@@ -347,9 +348,9 @@
 						class="w-full rounded-md border border-orange-300 bg-transparent px-4 py-2 text-sm font-medium text-orange-700 transition-colors hover:bg-orange-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:border-orange-700 dark:text-orange-300 dark:hover:bg-orange-900/30"
 					>
 						{#if userTickets.length > 1}
-							View All {userTickets.length} Tickets
+							{m['eventActionSidebar.viewAllTickets']({ count: userTickets.length })}
 						{:else}
-							View Ticket
+							{m['eventActionSidebar.viewTicket']()}
 						{/if}
 					</button>
 				{/if}
@@ -432,10 +433,14 @@
 					{#if userTickets.length > 0}
 						<span class="flex items-center justify-center gap-2">
 							<Ticket class="h-4 w-4" aria-hidden="true" />
-							{userTickets.length === 1 ? 'Show Ticket' : `Show Tickets (${userTickets.length})`}
+							{userTickets.length === 1
+								? m['eventActionSidebar.showTicket']()
+								: m['eventActionSidebar.showTickets']({ count: userTickets.length })}
 						</span>
 					{:else}
-						{showManageRSVP ? 'Hide' : 'Change'} RSVP
+						{showManageRSVP
+							? m['eventActionSidebar.hideRsvp']()
+							: m['eventActionSidebar.changeRsvp']()}
 					{/if}
 				</button>
 
@@ -448,9 +453,11 @@
 					>
 						<span class="flex items-center justify-center gap-2">
 							<Ticket class="h-4 w-4" aria-hidden="true" />
-							Buy More Tickets
+							{m['eventActionSidebar.buyMoreTickets']()}
 							{#if remainingTickets !== null}
-								<span class="text-xs opacity-75">({remainingTickets} left)</span>
+								<span class="text-xs opacity-75"
+									>{m['eventActionSidebar.ticketsLeft']({ count: remainingTickets })}</span
+								>
 							{/if}
 						</span>
 					</button>
@@ -465,7 +472,7 @@
 				>
 					<span class="flex items-center justify-center gap-2">
 						<CalendarDays class="h-4 w-4" aria-hidden="true" />
-						Add to Calendar
+						{m['eventActionSidebar.addToCalendar']()}
 					</span>
 				</button>
 			</div>
@@ -501,7 +508,7 @@
 						class="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<Settings class="h-4 w-4" aria-hidden="true" />
-						Edit Event
+						{m['eventActionSidebar.editEvent']()}
 					</a>
 					{#if event.requires_ticket}
 						<a
@@ -509,7 +516,7 @@
 							class="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 						>
 							<Users class="h-4 w-4" aria-hidden="true" />
-							Manage Tickets
+							{m['eventActionSidebar.manageTickets']()}
 						</a>
 					{:else}
 						<a
@@ -517,7 +524,7 @@
 							class="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 						>
 							<Users class="h-4 w-4" aria-hidden="true" />
-							Manage Attendees
+							{m['eventActionSidebar.manageAttendees']()}
 						</a>
 					{/if}
 					<a
@@ -525,7 +532,7 @@
 						class="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<Mail class="h-4 w-4" aria-hidden="true" />
-						Manage Invitations
+						{m['eventActionSidebar.manageInvitations']()}
 					</a>
 				</div>
 			</div>
@@ -547,7 +554,7 @@
 			>
 				<span class="flex items-center justify-center gap-2">
 					<CalendarDays class="h-4 w-4" aria-hidden="true" />
-					Add to Calendar
+					{m['eventActionSidebar.addToCalendar']()}
 				</span>
 			</button>
 		</div>

--- a/src/lib/components/events/OrganizationInfo.svelte
+++ b/src/lib/components/events/OrganizationInfo.svelte
@@ -81,7 +81,7 @@
 				href="/org/{organization.slug}"
 				class="inline-flex rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 			>
-				View organization profile
+				{m['organizationInfo.viewProfile']()}
 			</a>
 
 			<!-- Request Membership Button (if org accepts members and user is not a member) -->

--- a/src/lib/components/organization/RequestMembershipButton.svelte
+++ b/src/lib/components/organization/RequestMembershipButton.svelte
@@ -115,20 +115,20 @@
 	<div
 		class="inline-flex items-center gap-2 rounded-md border border-primary bg-primary/10 px-4 py-2 text-sm font-medium text-primary dark:border-primary dark:bg-primary/20 {className}"
 		role="status"
-		aria-label="You are the owner of this organization"
+		aria-label={m['requestMembershipButton.ownerAriaLabel']()}
 	>
 		<Crown class="h-4 w-4" aria-hidden="true" />
-		Owner
+		{m['requestMembershipButton.owner']()}
 	</div>
 {:else if isStaff}
 	<!-- Staff Badge -->
 	<div
 		class="inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 {className}"
 		role="status"
-		aria-label="You are a staff member of this organization"
+		aria-label={m['requestMembershipButton.staffAriaLabel']()}
 	>
 		<Shield class="h-4 w-4" aria-hidden="true" />
-		Staff
+		{m['requestMembershipButton.staff']()}
 	</div>
 {:else if isMember}
 	<!-- Member Badge (with status and tier) -->
@@ -139,7 +139,9 @@
 				class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium {statusStyles[
 					membershipStatus
 				]}"
-				aria-label="Membership status: {membershipStatus}"
+				aria-label={m['requestMembershipButton.membershipStatusAriaLabel']({
+					status: membershipStatus
+				})}
 			>
 				<Check class="h-3 w-3" aria-hidden="true" />
 				{m[`memberStatus.${membershipStatus}`]()}
@@ -150,7 +152,9 @@
 		{#if membershipTier}
 			<span
 				class="inline-flex items-center gap-1.5 rounded-full bg-blue-100 px-3 py-1.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-100"
-				aria-label="Membership tier: {membershipTier.name}"
+				aria-label={m['requestMembershipButton.membershipTierAriaLabel']({
+					tier: membershipTier.name
+				})}
 			>
 				<Award class="h-3 w-3" aria-hidden="true" />
 				{membershipTier.name}
@@ -159,10 +163,10 @@
 			<!-- Fallback if no status or tier -->
 			<span
 				class="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-100"
-				aria-label="You are a member of this organization"
+				aria-label={m['requestMembershipButton.memberAriaLabel']()}
 			>
 				<Check class="h-3 w-3" aria-hidden="true" />
-				Member
+				{m['requestMembershipButton.member']()}
 			</span>
 		{/if}
 	</div>
@@ -201,8 +205,7 @@
 						>{m['requestMembershipButton.requestSubmitted']()}</Dialog.Title
 					>
 					<Dialog.Description class="mt-2">
-						Your membership request has been sent to {organizationName}. You'll be notified when
-						it's reviewed.
+						{m['requestMembershipButton.requestSubmittedDesc']({ organizationName })}
 					</Dialog.Description>
 				</div>
 			{:else}
@@ -210,8 +213,7 @@
 				<Dialog.Header>
 					<Dialog.Title>{m['requestMembershipButton.requestMembership']()}</Dialog.Title>
 					<Dialog.Description>
-						Submit a request to become a member of {organizationName}. Members may have access to
-						exclusive events and content.
+						{m['requestMembershipButton.requestDesc']({ organizationName })}
 					</Dialog.Description>
 				</Dialog.Header>
 
@@ -223,17 +225,19 @@
 					class="space-y-4"
 				>
 					<div>
-						<label for="message" class="block text-sm font-medium"> Message (Optional) </label>
+						<label for="message" class="block text-sm font-medium">
+							{m['requestMembershipButton.messageOptional']()}
+						</label>
 						<textarea
 							id="message"
 							bind:value={message}
-							placeholder="Tell the organizers why you'd like to join..."
+							placeholder={m['requestMembershipButton.messagePlaceholder']()}
 							rows="4"
 							maxlength="500"
 							class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
 						></textarea>
 						<p class="mt-1 text-xs text-muted-foreground">
-							{message.length}/500 characters
+							{message.length}/500 {m['requestMembershipButton.characters']()}
 						</p>
 					</div>
 
@@ -242,7 +246,7 @@
 							class="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
 							role="alert"
 						>
-							{requestMutation.error?.message || 'Failed to submit request. Please try again.'}
+							{requestMutation.error?.message || m['requestMembershipButton.submitError']()}
 						</div>
 					{/if}
 
@@ -253,7 +257,7 @@
 							onclick={() => (showDialog = false)}
 							disabled={requestMutation.isPending}
 						>
-							Cancel
+							{m['requestMembershipButton.cancel']()}
 						</Button>
 						<Button type="submit" disabled={requestMutation.isPending}>
 							{#if requestMutation.isPending}
@@ -261,10 +265,10 @@
 									class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent"
 									aria-hidden="true"
 								></div>
-								Submitting...
+								{m['requestMembershipButton.submitting']()}
 							{:else}
 								<Send class="mr-2 h-4 w-4" aria-hidden="true" />
-								Submit Request
+								{m['requestMembershipButton.submitRequest']()}
 							{/if}
 						</Button>
 					</Dialog.Footer>

--- a/src/lib/utils/seo-routes.ts
+++ b/src/lib/utils/seo-routes.ts
@@ -1,0 +1,100 @@
+/**
+ * SEO Routes Utility
+ *
+ * Manages language-specific routing for hardcoded SEO landing pages.
+ * These pages have static content in each language and can't use dynamic translations,
+ * so we need to navigate to different URLs when switching languages.
+ */
+
+/**
+ * List of SEO page slugs that have language-specific versions.
+ * These pages exist at:
+ * - English: /{slug}
+ * - German: /de/{slug}
+ * - Italian: /it/{slug}
+ */
+export const SEO_PAGE_SLUGS = [
+	'eventbrite-alternative',
+	'queer-event-management',
+	'kink-event-ticketing',
+	'self-hosted-event-platform',
+	'privacy-focused-events',
+	'community-first-event-platform'
+] as const;
+
+export type SeoPageSlug = (typeof SEO_PAGE_SLUGS)[number];
+
+/**
+ * Language prefixes for SEO routes.
+ * English has no prefix (root), others have their language code.
+ */
+const LANGUAGE_PREFIXES: Record<string, string> = {
+	en: '',
+	de: '/de',
+	it: '/it'
+};
+
+/**
+ * Check if a pathname is an SEO landing page and extract its info.
+ *
+ * @param pathname - The current URL pathname (e.g., "/de/eventbrite-alternative")
+ * @returns Object with slug and current language, or null if not an SEO page
+ */
+export function parseSeoRoute(pathname: string): { slug: SeoPageSlug; language: string } | null {
+	// Remove trailing slash if present
+	const normalizedPath = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+
+	// Check for language-prefixed routes (e.g., /de/eventbrite-alternative)
+	for (const [lang, prefix] of Object.entries(LANGUAGE_PREFIXES)) {
+		if (prefix && normalizedPath.startsWith(prefix + '/')) {
+			const slug = normalizedPath.slice(prefix.length + 1);
+			if (SEO_PAGE_SLUGS.includes(slug as SeoPageSlug)) {
+				return { slug: slug as SeoPageSlug, language: lang };
+			}
+		}
+	}
+
+	// Check for English (root) routes (e.g., /eventbrite-alternative)
+	const slug = normalizedPath.slice(1); // Remove leading slash
+	if (SEO_PAGE_SLUGS.includes(slug as SeoPageSlug)) {
+		return { slug: slug as SeoPageSlug, language: 'en' };
+	}
+
+	return null;
+}
+
+/**
+ * Get the URL for an SEO page in a specific language.
+ *
+ * @param slug - The SEO page slug
+ * @param targetLanguage - The target language code
+ * @returns The URL path for the page in the target language
+ */
+export function getSeoPageUrl(slug: SeoPageSlug, targetLanguage: string): string {
+	const prefix = LANGUAGE_PREFIXES[targetLanguage] ?? '';
+	return `${prefix}/${slug}`;
+}
+
+/**
+ * Get the URL to navigate to when switching languages on the current page.
+ * If we're on an SEO page, returns the language-specific variant.
+ * Otherwise, returns null (language switch doesn't require navigation).
+ *
+ * @param currentPathname - The current URL pathname
+ * @param targetLanguage - The language to switch to
+ * @returns The URL to navigate to, or null if no navigation needed
+ */
+export function getLanguageSwitchUrl(
+	currentPathname: string,
+	targetLanguage: string
+): string | null {
+	const seoRoute = parseSeoRoute(currentPathname);
+
+	if (seoRoute) {
+		// We're on an SEO page - return the URL for the target language
+		return getSeoPageUrl(seoRoute.slug, targetLanguage);
+	}
+
+	// Not an SEO page - no navigation needed (Paraglide handles it)
+	return null;
+}


### PR DESCRIPTION
## Summary

- Add missing German and Italian translations for event page components
- Create utility for SEO landing page language detection
- Fix LanguageSwitcher to properly navigate SEO pages without race conditions

## Changes

### Translation Additions
- **EventActionSidebar**: Get Tickets, Manage Event, Edit Event, Manage Tickets, Manage Invitations, Add to Calendar, Public Event, processing states
- **RequestMembershipButton**: Owner, Staff, Member badges, form labels, dialog content, aria-labels
- **OrganizationInfo**: View Profile button text

### New Utility: `seo-routes.ts`
- `parseSeoRoute()` - Detects if current path is an SEO landing page
- `getSeoPageUrl()` - Gets the URL for an SEO page in a target language
- `getLanguageSwitchUrl()` - Returns the redirect URL when switching languages on SEO pages
- Supports all 6 SEO landing pages: eventbrite-alternative, queer-event-management, kink-event-ticketing, self-hosted-event-platform, privacy-focused-events, community-first-event-platform

### LanguageSwitcher Fix
- Use `window.location.href` for full page navigation on SEO pages
- Avoid calling `setLocale()` for SEO pages (cookie handles language preference)
- Fixes race condition that caused navigation to bounce back to `/`

## Test plan

- [ ] Verify German event page shows translated button labels
- [ ] Verify Italian event page shows translated button labels
- [ ] Test language switching on SEO pages (e.g., `/kink-event-ticketing`)
- [ ] Confirm switching to German navigates to `/de/kink-event-ticketing` and stays there
- [ ] Confirm switching to Italian navigates to `/it/kink-event-ticketing` and stays there
- [ ] Confirm switching back to English navigates to `/kink-event-ticketing` and stays there
- [ ] Verify language switching still works on regular (non-SEO) pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)