### PR TITLE
fix(check-in): enable confirm button for pending tickets requiring payment

### DIFF
--- a/src/lib/components/tickets/CheckInDialog.svelte
+++ b/src/lib/components/tickets/CheckInDialog.svelte
@@ -205,9 +205,13 @@
 
 	/**
 	 * Check if ticket can be checked in
+	 * Allows check-in for active tickets, or pending tickets if payment confirmation is needed
+	 * (organizer confirms offline payment was received)
 	 */
-	function canCheckIn(status: string): boolean {
-		return status === 'active';
+	function canCheckIn(status: string, needsPayment: boolean): boolean {
+		if (status === 'active') return true;
+		if (status === 'pending' && needsPayment) return true;
+		return false;
 	}
 </script>
 
@@ -351,7 +355,7 @@
 				<Button
 					variant="default"
 					onclick={onConfirm}
-					disabled={isLoading || !canCheckIn(ticket.status)}
+					disabled={isLoading || !canCheckIn(ticket.status, needsPaymentConfirmation)}
 				>
 					{#if isLoading}
 						Checking In...


### PR DESCRIPTION
## Summary

- Fixed the "Confirm Payment & Check In" button being incorrectly disabled for tickets with pending payment status
- Updated `canCheckIn()` to allow check-in for pending tickets when payment confirmation is needed (offline payments)

## Problem

The button was always disabled for tickets with `pending` status because `canCheckIn()` only returned `true` for `active` tickets. However, when `needsPaymentConfirmation` is true, the organizer needs to be able to confirm offline payment and check in the attendee.

## Solution

Modified `canCheckIn(status, needsPayment)` to return `true` for:
- Active tickets (existing behavior)
- Pending tickets when `needsPaymentConfirmation` is true (new behavior)

## Test plan

- [ ] Open check-in dialog for a ticket with pending payment status (offline payment)
- [ ] Verify the "Confirm Payment & Check In" button is now enabled
- [ ] Verify clicking the button processes the check-in correctly
- [ ] Verify the button remains disabled for cancelled tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)