### PR TITLE
fix(tickets): improve pending ticket UX and styling

### DIFF
--- a/src/lib/components/events/EventActionSidebar.svelte
+++ b/src/lib/components/events/EventActionSidebar.svelte
@@ -359,8 +359,15 @@
 			</div>
 		{:else if isAttending && attendanceStatusText}
 			<!-- Attendance Status Display (if user is attending) -->
+			{@const hasPendingTicket =
+				userTickets.length > 0 && userTickets.some((t) => t.status === 'pending')}
 			<div
-				class="flex items-center gap-2 rounded-md bg-green-50 p-3 text-green-900 dark:bg-green-950/50 dark:text-green-100"
+				class={cn(
+					'flex items-center gap-2 rounded-md p-3',
+					hasPendingTicket
+						? 'bg-orange-50 text-orange-900 dark:bg-orange-950/50 dark:text-orange-100'
+						: 'bg-green-50 text-green-900 dark:bg-green-950/50 dark:text-green-100'
+				)}
 				role="status"
 				aria-live="polite"
 			>

--- a/src/lib/components/tickets/TicketConfirmationDialog.svelte
+++ b/src/lib/components/tickets/TicketConfirmationDialog.svelte
@@ -19,17 +19,13 @@
 		AlertCircle,
 		CreditCard,
 		Wallet,
-		Info,
 		Plus,
 		Minus,
 		User,
-		MapPin,
 		Shuffle,
 		DoorOpen,
 		Armchair,
-		Loader2,
-		Accessibility,
-		EyeOff
+		Loader2
 	} from 'lucide-svelte';
 	import type { TierSchemaWithId } from '$lib/types/tickets';
 	import type {
@@ -794,17 +790,6 @@
 						</div>
 					</div>
 				</div>
-			{/if}
-
-			<!-- Payment Instructions for Non-Online Payment Methods -->
-			{#if !isOnlinePayment && tier.manual_payment_instructions}
-				<Alert>
-					<Info class="h-4 w-4" />
-					<AlertDescription>
-						<p class="font-medium">{m['ticketConfirmationDialog.paymentInstructions']()}</p>
-						<p class="mt-1 text-sm">{tier.manual_payment_instructions}</p>
-					</AlertDescription>
-				</Alert>
 			{/if}
 
 			<!-- Online Payment Notice -->

--- a/src/lib/components/tickets/TicketTierModal.svelte
+++ b/src/lib/components/tickets/TicketTierModal.svelte
@@ -286,16 +286,6 @@
 											{getQuantityDisplay(tier)}
 										</div>
 									</div>
-
-									<!-- Payment Method & Instructions -->
-									{#if (tier as any).manual_payment_instructions}
-										<div class="mt-2 rounded-md border border-border bg-muted/50 p-2 text-xs">
-											<p class="font-medium text-muted-foreground">
-												{m['ticketTierModal.paymentInstructions']()}
-											</p>
-											<p class="mt-1">{(tier as any).manual_payment_instructions}</p>
-										</div>
-									{/if}
 								</div>
 
 								<!-- Action Button -->


### PR DESCRIPTION
## Summary

- Remove payment instructions from tier selection and confirmation dialogs (instructions now only shown after ticket is reserved in pending status)
- Fix pending ticket status badge to show orange instead of green in event sidebar (matches pending payment banner styling)
- Clean up unused icon imports from TicketConfirmationDialog

## Changes

### Payment Instructions Timing
For offline/at-the-door tickets, custom payment instructions were being shown before the ticket was reserved. Now they only appear **after** the ticket is in "pending" status, when the user views their ticket in `MyTicket` or `MyTicketModal` components.

**Files changed:**
- `TicketTierModal.svelte` - Removed payment instructions from tier list
- `TicketConfirmationDialog.svelte` - Removed payment instructions from confirmation dialog

### Pending Status Styling
The event sidebar was showing green styling for pending tickets (same as active tickets). Now pending tickets correctly show orange styling to indicate payment is still required.

**File changed:**
- `EventActionSidebar.svelte` - Added conditional styling based on ticket status

## Test plan

- [ ] Reserve an offline/at-the-door ticket
- [ ] Verify payment instructions are NOT shown during tier selection
- [ ] Verify payment instructions are NOT shown in the confirmation dialog
- [ ] Verify payment instructions ARE shown after reservation (in ticket view with pending status)
- [ ] Verify event sidebar shows orange styling for pending tickets
- [ ] Verify event sidebar shows green styling for active tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)