### PR TITLE
feat(admin): add all nav sections to dashboard quick actions

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -545,6 +545,22 @@
 				"settings": {
 					"title": "Einstellungen",
 					"description": "Organisationseinstellungen konfigurieren"
+				},
+				"questionnaires": {
+					"title": "Fragebögen",
+					"description": "Fragebögen erstellen und verwalten"
+				},
+				"resources": {
+					"title": "Ressourcen",
+					"description": "Dateien und Ressourcen verwalten"
+				},
+				"blacklist": {
+					"title": "Sperrliste",
+					"description": "Gesperrte Benutzer verwalten"
+				},
+				"venues": {
+					"title": "Veranstaltungsorte",
+					"description": "Veranstaltungsorte verwalten"
 				}
 			},
 			"orgDetails": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -545,6 +545,22 @@
 				"settings": {
 					"title": "Settings",
 					"description": "Configure organization settings"
+				},
+				"questionnaires": {
+					"title": "Questionnaires",
+					"description": "Create and manage questionnaires"
+				},
+				"resources": {
+					"title": "Resources",
+					"description": "Manage files and resources"
+				},
+				"blacklist": {
+					"title": "Blacklist",
+					"description": "Manage blocked users"
+				},
+				"venues": {
+					"title": "Venues",
+					"description": "Manage event venues"
 				}
 			},
 			"orgDetails": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -545,6 +545,22 @@
 				"settings": {
 					"title": "Impostazioni",
 					"description": "Configura le impostazioni dell'organizzazione"
+				},
+				"questionnaires": {
+					"title": "Questionari",
+					"description": "Crea e gestisci questionari"
+				},
+				"resources": {
+					"title": "Risorse",
+					"description": "Gestisci file e risorse"
+				},
+				"blacklist": {
+					"title": "Lista nera",
+					"description": "Gestisci utenti bloccati"
+				},
+				"venues": {
+					"title": "Luoghi",
+					"description": "Gestisci i luoghi degli eventi"
 				}
 			},
 			"orgDetails": {

--- a/src/routes/(auth)/org/[slug]/admin/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/+page.svelte
@@ -3,7 +3,18 @@
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import type { PageData } from './$types';
-	import { Calendar, Repeat, Users, Settings, FileText, Plus } from 'lucide-svelte';
+	import {
+		Calendar,
+		Repeat,
+		Users,
+		Settings,
+		FileText,
+		Plus,
+		ClipboardList,
+		FolderOpen,
+		Ban,
+		MapPin
+	} from 'lucide-svelte';
 	import { OrganizationDescription } from '$lib/components/organizations';
 
 	let { data }: { data: PageData } = $props();
@@ -13,6 +24,7 @@
 
 	// Quick action cards (derived to properly track organization reactivity)
 	const quickActions = $derived([
+		// Row 1 - Primary actions
 		{
 			title: m['orgAdmin.dashboard.quickActions.events.title'](),
 			description: m['orgAdmin.dashboard.quickActions.events.description'](),
@@ -47,6 +59,43 @@
 			href: `/org/${organization.slug}/admin/settings`,
 			color: 'text-purple-600 dark:text-purple-400',
 			bgColor: 'bg-purple-50 dark:bg-purple-950',
+			badge: undefined as string | undefined
+		},
+		// Row 2 - Secondary actions
+		{
+			title: m['orgAdmin.dashboard.quickActions.questionnaires.title'](),
+			description: m['orgAdmin.dashboard.quickActions.questionnaires.description'](),
+			icon: ClipboardList,
+			href: `/org/${organization.slug}/admin/questionnaires`,
+			color: 'text-orange-600 dark:text-orange-400',
+			bgColor: 'bg-orange-50 dark:bg-orange-950',
+			badge: undefined as string | undefined
+		},
+		{
+			title: m['orgAdmin.dashboard.quickActions.resources.title'](),
+			description: m['orgAdmin.dashboard.quickActions.resources.description'](),
+			icon: FolderOpen,
+			href: `/org/${organization.slug}/admin/resources`,
+			color: 'text-cyan-600 dark:text-cyan-400',
+			bgColor: 'bg-cyan-50 dark:bg-cyan-950',
+			badge: undefined as string | undefined
+		},
+		{
+			title: m['orgAdmin.dashboard.quickActions.blacklist.title'](),
+			description: m['orgAdmin.dashboard.quickActions.blacklist.description'](),
+			icon: Ban,
+			href: `/org/${organization.slug}/admin/blacklist`,
+			color: 'text-red-600 dark:text-red-400',
+			bgColor: 'bg-red-50 dark:bg-red-950',
+			badge: undefined as string | undefined
+		},
+		{
+			title: m['orgAdmin.dashboard.quickActions.venues.title'](),
+			description: m['orgAdmin.dashboard.quickActions.venues.description'](),
+			icon: MapPin,
+			href: `/org/${organization.slug}/admin/venues`,
+			color: 'text-pink-600 dark:text-pink-400',
+			bgColor: 'bg-pink-50 dark:bg-pink-950',
 			badge: undefined as string | undefined
 		}
 	]);


### PR DESCRIPTION
## Summary

- Add 4 additional quick action cards to the organization admin dashboard for improved mobile UX
- New quick actions: Questionnaires, Resources, Blacklist, Venues
- Each section now has a dedicated card with appropriate icon and color

## Changes

**Dashboard page (`src/routes/(auth)/org/[slug]/admin/+page.svelte`):**
- Added 4 new quick action cards in a second row
- Imported new Lucide icons: `ClipboardList`, `FolderOpen`, `Ban`, `MapPin`

**Translations (EN, DE, IT):**
- Added translation keys for new quick action titles and descriptions

## Quick Actions Layout

**Row 1 (primary):**
- Events (blue, Calendar)
- Event Series (indigo, Repeat)
- Members (green, Users)
- Settings (purple, Settings)

**Row 2 (secondary):**
- Questionnaires (orange, ClipboardList)
- Resources (cyan, FolderOpen)
- Blacklist (red, Ban)
- Venues (pink, MapPin)

## Why

On mobile, the navigation tabs collapse into a hamburger menu. Having all admin sections as quick actions on the dashboard provides immediate visibility and easier access to all features.

## Test plan

- [ ] Verify all 8 quick action cards display correctly on desktop (4x2 grid)
- [ ] Verify cards stack properly on tablet (2 columns) and mobile (1 column)
- [ ] Test navigation to each section via quick action cards
- [ ] Verify translations display correctly in DE and IT locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)