### PR TITLE
feat(events): add feedback questionnaire CTA for past events

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1216,7 +1216,12 @@
 		"manageTickets": "Tickets verwalten",
 		"manageAttendees": "Teilnehmende verwalten",
 		"manageInvitations": "Einladungen verwalten",
-		"pendingPaymentDescription": "Schließe deine Zahlung ab, um dein Ticket zu bestätigen. Deine Reservierung verfällt, wenn die Zahlung nicht abgeschlossen wird."
+		"pendingPaymentDescription": "Schließe deine Zahlung ab, um dein Ticket zu bestätigen. Deine Reservierung verfällt, wenn die Zahlung nicht abgeschlossen wird.",
+		"feedbackAvailable": "Feedback verfügbar",
+		"feedbackDescription": "Teile deine Erfahrungen mit den Organisatoren",
+		"giveFeedback": "Feedback geben",
+		"feedbackQuestionnaires": "{count} Feedback-Fragebogen verfügbar",
+		"feedbackQuestionnaires_plural": "{count} Feedback-Fragebögen verfügbar"
 	},
 	"eventQuickInfo": {
 		"limitedSpots": "Begrenzte Plätze verfügbar",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1216,7 +1216,12 @@
 		"manageTickets": "Manage Tickets",
 		"manageAttendees": "Manage Attendees",
 		"manageInvitations": "Manage Invitations",
-		"pendingPaymentDescription": "Complete your payment to confirm your ticket. Your reservation will expire if payment is not completed."
+		"pendingPaymentDescription": "Complete your payment to confirm your ticket. Your reservation will expire if payment is not completed.",
+		"feedbackAvailable": "Feedback Available",
+		"feedbackDescription": "Share your experience with the organizers",
+		"giveFeedback": "Give Feedback",
+		"feedbackQuestionnaires": "{count} feedback questionnaire available",
+		"feedbackQuestionnaires_plural": "{count} feedback questionnaires available"
 	},
 	"eventQuickInfo": {
 		"limitedSpots": "Limited spots remaining",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1216,7 +1216,12 @@
 		"manageTickets": "Gestisci biglietti",
 		"manageAttendees": "Gestisci partecipanti",
 		"manageInvitations": "Gestisci inviti",
-		"pendingPaymentDescription": "Completa il pagamento per confermare il tuo biglietto. La tua prenotazione scadrà se il pagamento non viene completato."
+		"pendingPaymentDescription": "Completa il pagamento per confermare il tuo biglietto. La tua prenotazione scadrà se il pagamento non viene completato.",
+		"feedbackAvailable": "Feedback disponibile",
+		"feedbackDescription": "Condividi la tua esperienza con gli organizzatori",
+		"giveFeedback": "Lascia un feedback",
+		"feedbackQuestionnaires": "{count} questionario di feedback disponibile",
+		"feedbackQuestionnaires_plural": "{count} questionari di feedback disponibili"
 	},
 	"eventQuickInfo": {
 		"limitedSpots": "Posti limitati disponibili",

--- a/src/lib/api/generated/types.gen.ts
+++ b/src/lib/api/generated/types.gen.ts
@@ -4489,6 +4489,7 @@ export type SectionSchema = {
  * - RSVP: User's RSVP status (for non-ticketed events)
  * - Eligibility: Whether user can purchase tickets and why not
  * - Purchase limits: How many more tickets can be purchased
+ * - Feedback questionnaires: Available after event ends for attendees
  */
 export type EventUserStatusResponse = {
 	/**
@@ -4504,6 +4505,12 @@ export type EventUserStatusResponse = {
 	 * Remaining Tickets
 	 */
 	remaining_tickets?: number | null;
+	/**
+	 * Feedback Questionnaires
+	 *
+	 * List of questionnaire IDs available for feedback (only after event ends)
+	 */
+	feedback_questionnaires?: Array<string>;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add support for feedback questionnaires that become available after an event ends
- The backend now returns `feedback_questionnaires` in the my-status endpoint for attendees
- Blue-styled notification box appears in the sidebar for past events with feedback questionnaires available
- Hide irrelevant CTAs ("Buy More Tickets", "Change RSVP") for past events
- Keep "Show Ticket" button visible for past events (proof of attendance)

## Changes

### API Types
- Updated `EventUserStatusResponse` to include `feedback_questionnaires: Array<string>` field

### EventActionSidebar Component
- Added `feedbackQuestionnaires` computed to extract questionnaire IDs from user status
- Added `eventHasEnded` computed to check if event end date is in the past
- Added feedback CTA section with link to questionnaire submission page
- Conditionally hide "Buy More Tickets" when event has ended
- Conditionally hide "Change RSVP" when event has ended
- Keep "Show Ticket" visible for past events

### Translations (EN, DE, IT)
- `feedbackAvailable`: "Feedback Available"
- `feedbackDescription`: "Share your experience with the organizers"
- `giveFeedback`: "Give Feedback"

## Screenshots

The feedback CTA appears in the sidebar for past events when feedback questionnaires are available:
- Blue notification box with MessageSquare icon
- Link to existing questionnaire submission page

## Test plan

- [ ] Verify feedback CTA appears for past events with feedback questionnaires
- [ ] Verify "Buy More Tickets" is hidden for past events
- [ ] Verify "Change RSVP" is hidden for past events
- [ ] Verify "Show Ticket" is still visible for past events
- [ ] Verify feedback link navigates to questionnaire page correctly
- [ ] Test in all three languages (EN, DE, IT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)