### PR TITLE
feat(questionnaires): enable feedback questionnaire type in creation form

### DIFF
--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte
@@ -666,8 +666,8 @@
 					type="single"
 					value={questionnaireType}
 					onValueChange={(v) => {
-						// Only allow admission for now
-						if (v === 'admission') {
+						// Allow admission and feedback types
+						if (v === 'admission' || v === 'feedback') {
 							questionnaireType = v;
 						}
 					}}
@@ -684,6 +684,14 @@
 								</div>
 							</div>
 						</SelectItem>
+						<SelectItem value="feedback" label="Feedback">
+							<div class="flex flex-col gap-0.5">
+								<div class="font-medium">Feedback</div>
+								<div class="text-xs text-muted-foreground">
+									Collect post-event feedback from attendees
+								</div>
+							</div>
+						</SelectItem>
 						<SelectItem value="membership" label="Membership" disabled>
 							<div class="flex flex-col gap-0.5">
 								<div class="flex items-center gap-2 font-medium">
@@ -695,20 +703,6 @@
 								</div>
 								<div class="text-xs text-muted-foreground">
 									Gate organization membership - required for joining
-								</div>
-							</div>
-						</SelectItem>
-						<SelectItem value="feedback" label="Feedback" disabled>
-							<div class="flex flex-col gap-0.5">
-								<div class="flex items-center gap-2 font-medium">
-									Feedback
-									<span
-										class="rounded bg-muted px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground"
-										>Coming soon</span
-									>
-								</div>
-								<div class="text-xs text-muted-foreground">
-									Collect post-event feedback from attendees
 								</div>
 							</div>
 						</SelectItem>


### PR DESCRIPTION
## Summary

Enable the "Feedback" questionnaire type option in the questionnaire creation form, allowing organization admins to create feedback questionnaires for collecting post-event surveys.

## Changes

- Remove `disabled` attribute from the Feedback SelectItem
- Remove "Coming soon" badge from Feedback option
- Update `onValueChange` handler to allow selecting `feedback` type

## Context

This completes the feedback questionnaire feature by enabling admins to create feedback questionnaires. The CTA for users to fill out feedback was added in PR #255.

## Test plan

- [ ] Navigate to Organization Admin > Questionnaires > Create Questionnaire
- [ ] Verify "Feedback" option is now selectable in the Type dropdown
- [ ] Create a feedback questionnaire and verify it saves correctly
- [ ] Assign feedback questionnaire to an event and verify it appears after the event ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)