### PR TITLE
fix: use image thumbnails for profile pictures and logo displays

### DIFF
--- a/src/lib/components/events/EventHeader.svelte
+++ b/src/lib/components/events/EventHeader.svelte
@@ -3,7 +3,6 @@
 	import type { EventDetailSchema } from '$lib/api/generated/types.gen';
 	import { formatEventDateRange } from '$lib/utils/date';
 	import { getEventFallbackGradient, getEventCoverArt, getEventLogo } from '$lib/utils/event';
-	import { getBackendUrl } from '$lib/config/api';
 	import { getImageUrl } from '$lib/utils/url';
 	import { downloadRevelEventICalFile } from '$lib/utils/ical';
 	import { MapPin, Calendar, Share2, ExternalLink } from 'lucide-svelte';
@@ -152,8 +151,9 @@
 			class="group -mt-8 inline-flex items-center gap-3 rounded-lg bg-background p-3 shadow-lg ring-1 ring-border transition-all hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 		>
 			{#if event.organization.logo}
+				{@const org = event.organization as any}
 				<img
-					src={getImageUrl(event.organization.logo) || ''}
+					src={getImageUrl(org.logo_thumbnail_url || event.organization.logo) || ''}
 					alt="{event.organization.name} logo"
 					class="h-12 w-12 rounded-md object-cover"
 				/>

--- a/src/lib/components/events/OrganizationInfo.svelte
+++ b/src/lib/components/events/OrganizationInfo.svelte
@@ -39,8 +39,9 @@
 		return getBackendUrl(path);
 	}
 
-	// Compute full logo URL
-	const logoUrl = $derived(getImageUrl(organization.logo));
+	// Compute full logo URL - prefer thumbnail for small display sizes
+	const org = $derived(organization as any);
+	const logoUrl = $derived(getImageUrl(org.logo_thumbnail_url || organization.logo));
 </script>
 
 <section aria-labelledby="organizer-heading" class={cn('space-y-4', className)}>

--- a/src/routes/(auth)/dashboard/+page.svelte
+++ b/src/routes/(auth)/dashboard/+page.svelte
@@ -817,7 +817,7 @@
 						>
 							{#if org.logo}
 								<img
-									src={getImageUrl(org.logo)}
+									src={getImageUrl((org as any).logo_thumbnail_url || org.logo)}
 									alt=""
 									class="h-16 w-16 rounded-full border object-cover"
 								/>

--- a/src/routes/(auth)/dashboard/following/+page.svelte
+++ b/src/routes/(auth)/dashboard/following/+page.svelte
@@ -283,7 +283,7 @@
 							<div class="mb-3 flex items-start gap-3">
 								{#if org.logo}
 									<img
-										src={getImageUrl(org.logo)}
+										src={getImageUrl((org as any).logo_thumbnail_url || org.logo)}
 										alt={org.name}
 										class="h-12 w-12 rounded-lg object-cover"
 									/>
@@ -416,7 +416,7 @@
 							<div class="mb-3 flex items-start gap-3">
 								{#if series.logo}
 									<img
-										src={getImageUrl(series.logo)}
+										src={getImageUrl((series as any).logo_thumbnail_url || series.logo)}
 										alt={series.name}
 										class="h-12 w-12 rounded-lg object-cover"
 									/>

--- a/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
@@ -5,6 +5,7 @@
 	import type { PageData } from './$types';
 	import type { EventSeriesRetrieveSchema } from '$lib/api/generated/types.gen';
 	import { Repeat, Calendar, Edit, Eye, Tag, Plus } from 'lucide-svelte';
+	import { getImageUrl } from '$lib/utils/url';
 
 	let { data }: { data: PageData } = $props();
 
@@ -102,7 +103,7 @@
 						<div class="flex items-start gap-3">
 							{#if series.logo}
 								<img
-									src={series.logo}
+									src={getImageUrl((series as any).logo_thumbnail_url || series.logo)}
 									alt="{series.name} logo"
 									class="h-12 w-12 flex-shrink-0 rounded-lg object-cover"
 								/>

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
@@ -6,7 +6,8 @@
 	import QuestionAnswerDisplay from '$lib/components/questionnaires/QuestionAnswerDisplay.svelte';
 	import AutoEvalRecommendation from '$lib/components/questionnaires/AutoEvalRecommendation.svelte';
 	import EvaluationForm from '$lib/components/questionnaires/EvaluationForm.svelte';
-	import { ArrowLeft, User, Mail, Calendar, CalendarDays, ExternalLink } from 'lucide-svelte';
+	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
+	import { ArrowLeft, Mail, Calendar, CalendarDays, ExternalLink } from 'lucide-svelte';
 	import {
 		isPendingReview,
 		type QuestionnaireEvaluationStatus
@@ -149,13 +150,17 @@
 				</h3>
 
 				<div class="space-y-4">
-					<!-- Display Name -->
+					<!-- Display Name with Profile Picture -->
 					<div class="flex items-start gap-3">
-						<div
-							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10"
-						>
-							<User class="h-5 w-5 text-primary" aria-hidden="true" />
-						</div>
+						<UserAvatar
+							profilePictureUrl={data.submission.user.profile_picture_url}
+							thumbnailUrl={data.submission.user.profile_picture_thumbnail_url}
+							displayName={data.submission.user.display_name}
+							firstName={data.submission.user.first_name}
+							lastName={data.submission.user.last_name}
+							size="md"
+							class="shrink-0"
+						/>
 						<div class="flex-1">
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['questionnaireSubmissionDetailPage.nameLabel']()}

--- a/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
@@ -25,8 +25,11 @@
 
 	// Compute full image URLs
 	const coverUrl = $derived(getImageUrl(series.cover_art));
-	const logoUrl = $derived(getImageUrl(series.logo));
-	const orgLogoUrl = $derived(getImageUrl(series.organization.logo));
+	// Prefer thumbnail for logo display (64-80px size)
+	const s = $derived(series as any);
+	const o = $derived(series.organization as any);
+	const logoUrl = $derived(getImageUrl(s.logo_thumbnail_url || series.logo));
+	const orgLogoUrl = $derived(getImageUrl(o.logo_thumbnail_url || series.organization.logo));
 
 	// Fallback gradient
 	function getSeriesFallbackGradient(seriesId: string): string {

--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -45,7 +45,9 @@
 	const pageSize = 6;
 
 	// Compute full image URLs
-	const logoUrl = $derived(getImageUrl(organization.logo));
+	// Prefer thumbnail for logo display (64-80px size)
+	const org = $derived(organization as any);
+	const logoUrl = $derived(getImageUrl(org.logo_thumbnail_url || organization.logo));
 	const coverUrl = $derived(getImageUrl(organization.cover_art));
 
 	// Compute location display


### PR DESCRIPTION
## Summary

- Fixed profile picture not displaying in questionnaire submission review page by adding `UserAvatar` component
- Updated multiple components across the codebase to use optimized image variants (`_thumbnail`) for small displays instead of full resolution images

## Changes

### Questionnaire Submission Detail Page
- Added `UserAvatar` component to display submitter's profile picture with proper thumbnail support
- Removed unused `User` icon import

### Image Variant Optimization
Updated the following components to use `logo_thumbnail_url` for small display sizes (48-80px):
- `EventHeader.svelte` - Organization badge (48x48)
- `OrganizationInfo.svelte` - Logo display (64x64)
- `dashboard/+page.svelte` - Organization cards (64x64)
- `dashboard/following/+page.svelte` - Org and series cards (48x48)
- `org/[slug]/admin/event-series/+page.svelte` - Series list (48x48)
- `events/[org_slug]/series/[series_slug]/+page.svelte` - Logo display (64-80px)
- `org/[slug]/+page.svelte` - Logo display (64-80px)

## Why This Matters

- **Performance**: Thumbnails are significantly smaller files (optimized for display size)
- **Bandwidth**: Reduces data transfer, especially important for mobile users
- **Load time**: Pages load faster with smaller images

## Test plan

- [ ] Check questionnaire submission review page shows profile picture
- [ ] Verify profile picture opens in preview/larger view when clicked
- [ ] Check EventHeader organization badge loads properly
- [ ] Verify dashboard organization cards load correctly
- [ ] Check dashboard following page shows org/series logos
- [ ] Verify event series detail page shows logos
- [ ] Check organization profile page shows logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)