### PR TITLE
fix(events): show attendee count in sidebar even without capacity limit

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1260,6 +1260,7 @@
 		"staffOnly": "Nur für Mitarbeitende",
 		"event": "Event",
 		"spotsTaken": "{current} / {max} Plätze belegt",
+		"attendeeCount": "{count} Teilnehmende",
 		"rsvpClosed": "Anmeldung geschlossen",
 		"rsvpBy": "Anmeldung bis {deadline}",
 		"openInMaps": "In Karten öffnen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1260,6 +1260,7 @@
 		"staffOnly": "Staff Only",
 		"event": "Event",
 		"spotsTaken": "{current} / {max} spots taken",
+		"attendeeCount": "{count} attending",
 		"rsvpClosed": "RSVP closed",
 		"rsvpBy": "RSVP by {deadline}",
 		"openInMaps": "Open in Maps",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1260,6 +1260,7 @@
 		"staffOnly": "Solo per staff",
 		"event": "Evento",
 		"spotsTaken": "{current} / {max} posti occupati",
+		"attendeeCount": "{count} partecipanti",
 		"rsvpClosed": "RSVP chiuso",
 		"rsvpBy": "RSVP entro {deadline}",
 		"openInMaps": "Apri in Mappe",

--- a/src/lib/components/events/EventQuickInfo.svelte
+++ b/src/lib/components/events/EventQuickInfo.svelte
@@ -89,11 +89,18 @@
 	});
 
 	let capacityDisplay = $derived.by(() => {
-		if (!event.max_attendees || event.max_attendees === 0) return null;
-		return m['eventQuickInfo.spotsTaken']({
-			current: event.attendee_count,
-			max: event.max_attendees
-		});
+		// Show "X / Y spots taken" when there's a max limit
+		if (event.max_attendees && event.max_attendees > 0) {
+			return m['eventQuickInfo.spotsTaken']({
+				current: event.attendee_count,
+				max: event.max_attendees
+			});
+		}
+		// Show "X attending" when there's no limit but there are attendees
+		if (event.attendee_count > 0) {
+			return m['eventQuickInfo.attendeeCount']({ count: event.attendee_count });
+		}
+		return null;
 	});
 
 	let isNearCapacity = $derived.by(() => {


### PR DESCRIPTION
## Summary

- **Fix:** Event sidebar now shows participant count even when there's no max capacity limit
- Previously only displayed "X/Y spots taken" when `max_attendees` was set
- Now shows "X attending" when there's no limit but attendees exist

## Changes

- Updated `EventQuickInfo.svelte` to show attendee count regardless of capacity limit
- Added `attendeeCount` translation key to EN, DE, and IT

## Test plan

- [ ] Open an event detail page for an event **without** a max capacity set
- [ ] Verify the sidebar shows "X attending" (with the Users icon)
- [ ] Open an event detail page for an event **with** a max capacity set
- [ ] Verify it still shows "X / Y spots taken"

🤖 Generated with [Claude Code](https://claude.com/claude-code)