### PR TITLE
fix(events): validate step 2 before navigating to ticketing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.30.0",
+	"version": "1.30.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/events/admin/EventWizard.svelte
+++ b/src/lib/components/events/admin/EventWizard.svelte
@@ -809,6 +809,12 @@
 					type="button"
 					onclick={() => {
 						if (formData.requires_ticket && eventId) {
+							// Validate step 2 before navigating to ticketing
+							if (!validateStep2()) {
+								errorMessage = m['eventWizard.error_fixValidation']();
+								return;
+							}
+							errorMessage = null;
 							currentStep = 3;
 						} else {
 							handleStep2Submit();


### PR DESCRIPTION
## Summary

- Fixes confusing validation error when editing ticketed events
- Now validates step 2 (Details) fields before navigating to step 3 (Ticketing)
- Error messages appear on the correct step where the issue exists

## Problem

When editing a ticketed event:
1. User clears a required field in step 2 (e.g., city)
2. Clicks "Continue to Ticketing →" - navigates to step 3 without validation
3. Makes changes to tier settings (or just clicks "Save and Exit")
4. Gets error "Please fix the validation errors" on step 3
5. User thinks the error is about their ticketing changes, but it's actually about the missing city in step 2

## Solution

Added validation check before navigating from step 2 to step 3. If validation fails, the error is shown immediately on step 2 where the user can fix it.

## Test plan

- [x] Reproduced the bug using Playwright before the fix
- [x] Verified the fix works - error now appears on step 2
- [x] Ran `pnpm check` - 0 errors
- [x] Ran `pnpm lint` - 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)