### PR TITLE
feat(ui): polish footer with two-column solutions and version tooltips

### DIFF
--- a/src/lib/components/common/Footer.svelte
+++ b/src/lib/components/common/Footer.svelte
@@ -4,6 +4,7 @@
 	import { Github, Bug } from 'lucide-svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import { getLocale } from '$lib/paraglide/runtime.js';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 
 	// Frontend version from build-time environment variable (set in Dockerfile)
 	// Falls back to 'dev' for local development
@@ -19,6 +20,41 @@
 	// Landing page URLs based on current locale
 	// Landing pages are NOT paraglide-translated, they use /de/ and /it/ prefixes
 	let landingPagePrefix = $derived(getLocale() === 'en' ? '' : `/${getLocale()}`);
+
+	// Cache for release notes
+	let releaseNotesCache = $state<Record<string, string[] | null>>({});
+	let loadingNotes = $state<Record<string, boolean>>({});
+
+	async function fetchReleaseNotes(repo: 'frontend' | 'backend', version: string) {
+		const cacheKey = `${repo}-${version}`;
+		if (releaseNotesCache[cacheKey] !== undefined || loadingNotes[cacheKey]) return;
+
+		loadingNotes[cacheKey] = true;
+		try {
+			const repoName = repo === 'frontend' ? 'revel-frontend' : 'revel-backend';
+			const response = await fetch(
+				`https://api.github.com/repos/letsrevel/${repoName}/releases/tags/v${version}`
+			);
+			if (!response.ok) throw new Error('Not found');
+
+			const data = await response.json();
+			releaseNotesCache[cacheKey] = parseReleaseNotes(data.body);
+		} catch {
+			releaseNotesCache[cacheKey] = null;
+		} finally {
+			loadingNotes[cacheKey] = false;
+		}
+	}
+
+	function parseReleaseNotes(body: string | null): string[] {
+		if (!body) return [];
+		// Extract bullet points, strip author/PR links
+		return body
+			.split('\n')
+			.filter((line) => line.startsWith('* '))
+			.map((line) => line.replace(/^\* /, '').replace(/ by @.+$/, ''))
+			.filter(Boolean);
+	}
 </script>
 
 <footer class="border-t bg-muted/30">
@@ -105,102 +141,134 @@
 				</ul>
 			</div>
 
-			<!-- Solutions / Use Cases -->
+			<!-- Solutions / Use Cases - 2 columns -->
 			<div>
 				<h3 class="mb-4 text-lg font-semibold">{m['footer.solutionsTitle']()}</h3>
-				<ul class="space-y-2 text-sm">
-					<li>
-						<a
-							href="{landingPagePrefix}/eventbrite-alternative"
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
-							{m['footer.solutionEventbrite']()}
-						</a>
-					</li>
-					<li>
-						<a
-							href="{landingPagePrefix}/queer-event-management"
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
-							{m['footer.solutionQueer']()}
-						</a>
-					</li>
-					<li>
-						<a
-							href="{landingPagePrefix}/kink-event-ticketing"
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
-							{m['footer.solutionKink']()}
-						</a>
-					</li>
-					<li>
-						<a
-							href="{landingPagePrefix}/self-hosted-event-platform"
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
-							{m['footer.solutionSelfHosted']()}
-						</a>
-					</li>
-					<li>
-						<a
-							href="{landingPagePrefix}/privacy-focused-events"
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
-							{m['footer.solutionPrivacy']()}
-						</a>
-					</li>
-					<li>
-						<a
-							href="{landingPagePrefix}/community-first-event-platform"
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
-							{m['footer.solutionCommunity']()}
-						</a>
-					</li>
-				</ul>
+				<div class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+					<a
+						href="{landingPagePrefix}/eventbrite-alternative"
+						class="text-muted-foreground transition-colors hover:text-foreground"
+					>
+						{m['footer.solutionEventbrite']()}
+					</a>
+					<a
+						href="{landingPagePrefix}/self-hosted-event-platform"
+						class="text-muted-foreground transition-colors hover:text-foreground"
+					>
+						{m['footer.solutionSelfHosted']()}
+					</a>
+					<a
+						href="{landingPagePrefix}/queer-event-management"
+						class="text-muted-foreground transition-colors hover:text-foreground"
+					>
+						{m['footer.solutionQueer']()}
+					</a>
+					<a
+						href="{landingPagePrefix}/privacy-focused-events"
+						class="text-muted-foreground transition-colors hover:text-foreground"
+					>
+						{m['footer.solutionPrivacy']()}
+					</a>
+					<a
+						href="{landingPagePrefix}/kink-event-ticketing"
+						class="text-muted-foreground transition-colors hover:text-foreground"
+					>
+						{m['footer.solutionKink']()}
+					</a>
+					<a
+						href="{landingPagePrefix}/community-first-event-platform"
+						class="text-muted-foreground transition-colors hover:text-foreground"
+					>
+						{m['footer.solutionCommunity']()}
+					</a>
+				</div>
 			</div>
 
 			<!-- Version Info -->
 			<div>
 				<h3 class="mb-4 text-lg font-semibold">{m['footer.versionInfoTitle']()}</h3>
-				<ul class="space-y-2 text-sm text-muted-foreground">
-					<li class="flex items-center gap-2">
-						<a
-							href={FRONTEND_REPO}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="flex items-center gap-2 transition-colors hover:text-foreground"
-							aria-label="{m['footer.frontend']()} repository on GitHub"
-						>
-							<Github class="h-4 w-4" aria-hidden="true" />
-							<span>{m['footer.frontend']()}: v{FRONTEND_VERSION}</span>
-						</a>
-					</li>
-					<li class="flex items-center gap-2">
-						<a
-							href={BACKEND_REPO}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="flex items-center gap-2 transition-colors hover:text-foreground"
-							aria-label="{m['footer.backend']()} repository on GitHub"
-						>
-							<Github class="h-4 w-4" aria-hidden="true" />
-							<span>{m['footer.backend']()}: v{backendVersion}{isDemoMode ? ' (demo)' : ''}</span>
-						</a>
-					</li>
-					<li class="flex items-center gap-2">
-						<a
-							href="https://forms.gle/c6ovKV92nMQEbR877"
-							target="_blank"
-							rel="noopener noreferrer"
-							class="flex items-center gap-2 transition-colors hover:text-foreground"
-							aria-label={m['footer.reportBug']()}
-						>
-							<Bug class="h-4 w-4" aria-hidden="true" />
-							<span>{m['footer.reportBug']()}</span>
-						</a>
-					</li>
-				</ul>
+				<Tooltip.Provider>
+					<ul class="space-y-2 text-sm text-muted-foreground">
+						<li class="flex items-center gap-2">
+							<Tooltip.Root>
+								<Tooltip.Trigger
+									onmouseenter={() => fetchReleaseNotes('frontend', FRONTEND_VERSION)}
+									onfocus={() => fetchReleaseNotes('frontend', FRONTEND_VERSION)}
+								>
+									<a
+										href={FRONTEND_REPO}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="flex items-center gap-2 transition-colors hover:text-foreground"
+										aria-label="{m['footer.frontend']()} repository on GitHub"
+									>
+										<Github class="h-4 w-4" aria-hidden="true" />
+										<span>{m['footer.frontend']()}: v{FRONTEND_VERSION}</span>
+									</a>
+								</Tooltip.Trigger>
+								<Tooltip.Content class="max-w-xs">
+									{#if loadingNotes[`frontend-${FRONTEND_VERSION}`]}
+										<p class="text-xs">Loading...</p>
+									{:else if releaseNotesCache[`frontend-${FRONTEND_VERSION}`]?.length}
+										<ul class="space-y-1 text-xs">
+											{#each releaseNotesCache[`frontend-${FRONTEND_VERSION}`] as note, i (i)}
+												<li>- {note}</li>
+											{/each}
+										</ul>
+									{:else}
+										<p class="text-xs">No release notes</p>
+									{/if}
+								</Tooltip.Content>
+							</Tooltip.Root>
+						</li>
+						<li class="flex items-center gap-2">
+							<Tooltip.Root>
+								<Tooltip.Trigger
+									onmouseenter={() => fetchReleaseNotes('backend', backendVersion)}
+									onfocus={() => fetchReleaseNotes('backend', backendVersion)}
+								>
+									<a
+										href={BACKEND_REPO}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="flex items-center gap-2 transition-colors hover:text-foreground"
+										aria-label="{m['footer.backend']()} repository on GitHub"
+									>
+										<Github class="h-4 w-4" aria-hidden="true" />
+										<span
+											>{m['footer.backend']()}: v{backendVersion}{isDemoMode ? ' (demo)' : ''}</span
+										>
+									</a>
+								</Tooltip.Trigger>
+								<Tooltip.Content class="max-w-xs">
+									{#if loadingNotes[`backend-${backendVersion}`]}
+										<p class="text-xs">Loading...</p>
+									{:else if releaseNotesCache[`backend-${backendVersion}`]?.length}
+										<ul class="space-y-1 text-xs">
+											{#each releaseNotesCache[`backend-${backendVersion}`] as note, i (i)}
+												<li>- {note}</li>
+											{/each}
+										</ul>
+									{:else}
+										<p class="text-xs">No release notes</p>
+									{/if}
+								</Tooltip.Content>
+							</Tooltip.Root>
+						</li>
+						<li class="flex items-center gap-2">
+							<a
+								href="https://forms.gle/c6ovKV92nMQEbR877"
+								target="_blank"
+								rel="noopener noreferrer"
+								class="flex items-center gap-2 transition-colors hover:text-foreground"
+								aria-label={m['footer.reportBug']()}
+							>
+								<Bug class="h-4 w-4" aria-hidden="true" />
+								<span>{m['footer.reportBug']()}</span>
+							</a>
+						</li>
+					</ul>
+				</Tooltip.Provider>
 			</div>
 		</div>
 


### PR DESCRIPTION
## Summary

- Split Solutions section into 2 columns (3 items each) to reduce footer height by ~50% for that section
- Add hover tooltips to version links showing recent changes from GitHub releases
- Lazy-load release notes on hover/focus with client-side caching

## Changes

### Two-Column Solutions
Changed from vertical `<ul>` list to `grid grid-cols-2` layout, distributing 6 solution links across 2 columns.

### Version Tooltips
- Fetch release notes from GitHub API on hover/focus
- Parse release body to extract bullet points, stripping author/PR links
- Cache fetched results to avoid re-fetching
- Display "Loading..." during fetch, "No release notes" as fallback

## Test plan

- [ ] Verify Solutions section displays in 2 columns on desktop
- [ ] Verify footer is less tall overall
- [ ] Hover over "Frontend: vX.X.X" link - tooltip should show release notes
- [ ] Hover over "Backend: vX.X.X" link - tooltip should show release notes
- [ ] Tab to version links - tooltip should appear on focus (keyboard accessible)
- [ ] Hover again - should not re-fetch (caching works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)