### PR TITLE
feat(invitations): add waives_apply_deadline field to event invitation modal

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1515,7 +1515,8 @@
 		"maxUses": "Maximale Nutzungen",
 		"noTicketTier": "Keine Ticketstufe",
 		"advancedOptions": "Erweiterte Einladungsoptionen",
-		"waiveDeadline": "Zusagefrist aufheben"
+		"waiveDeadline": "Zusagefrist aufheben",
+		"waiveApplyDeadline": "Bewerbungsfrist aufheben"
 	},
 	"eventWizard": {
 		"eventCreatedSuccess": "Event created successfully!",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1515,7 +1515,8 @@
 		"maxUses": "Maximum Uses",
 		"noTicketTier": "No ticket tier",
 		"advancedOptions": "Advanced Invitation Options",
-		"waiveDeadline": "Waive RSVP deadline"
+		"waiveDeadline": "Waive RSVP deadline",
+		"waiveApplyDeadline": "Waive application deadline"
 	},
 	"eventWizard": {
 		"eventCreatedSuccess": "Event created successfully!",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1515,7 +1515,8 @@
 		"maxUses": "Utilizzi Massimi",
 		"noTicketTier": "Nessun livello biglietto",
 		"advancedOptions": "Opzioni Invito Avanzate",
-		"waiveDeadline": "Esonera dalla scadenza RSVP"
+		"waiveDeadline": "Esonera dalla scadenza RSVP",
+		"waiveApplyDeadline": "Esonera dalla scadenza di candidatura"
 	},
 	"eventWizard": {
 		"eventCreatedSuccess": "Event created successfully!",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.30.6",
+	"version": "1.30.7",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/tokens/EventTokenModal.svelte
+++ b/src/lib/components/tokens/EventTokenModal.svelte
@@ -58,6 +58,7 @@
 	let overridesMaxAttendees = $state(false);
 	let waivesMembershipRequired = $state(false);
 	let waivesRsvpDeadline = $state(false);
+	let waivesApplyDeadline = $state(false);
 
 	// Reset form
 	$effect(() => {
@@ -77,6 +78,7 @@
 				overridesMaxAttendees = invitation?.overrides_max_attendees ?? false;
 				waivesMembershipRequired = invitation?.waives_membership_required ?? false;
 				waivesRsvpDeadline = invitation?.waives_rsvp_deadline ?? false;
+				waivesApplyDeadline = invitation?.waives_apply_deadline ?? false;
 			} else {
 				name = '';
 				duration = '1440';
@@ -92,6 +94,7 @@
 				overridesMaxAttendees = false;
 				waivesMembershipRequired = false;
 				waivesRsvpDeadline = false;
+				waivesApplyDeadline = false;
 			}
 		}
 	});
@@ -105,7 +108,8 @@
 					waives_purchase: waivesPurchase,
 					overrides_max_attendees: overridesMaxAttendees,
 					waives_membership_required: waivesMembershipRequired,
-					waives_rsvp_deadline: waivesRsvpDeadline
+					waives_rsvp_deadline: waivesRsvpDeadline,
+					waives_apply_deadline: waivesApplyDeadline
 				}
 			: null;
 
@@ -367,6 +371,24 @@
 									>
 									<p class="text-xs text-muted-foreground">
 										Users can RSVP even after the RSVP deadline has passed
+									</p>
+								</div>
+							</div>
+
+							<!-- Waives Apply Deadline -->
+							<div class="flex items-start space-x-2">
+								<input
+									type="checkbox"
+									id="waives-apply-deadline"
+									bind:checked={waivesApplyDeadline}
+									class="mt-0.5 h-4 w-4 rounded border-gray-300"
+								/>
+								<div class="flex-1">
+									<Label for="waives-apply-deadline" class="font-normal"
+										>{m['eventTokenModal.waiveApplyDeadline']()}</Label
+									>
+									<p class="text-xs text-muted-foreground">
+										Users can apply even after the application deadline has passed
 									</p>
 								</div>
 							</div>


### PR DESCRIPTION
## Summary

Adds the missing `waives_apply_deadline` field to the event invitation create/edit modal form, matching the existing backend API schema.

## Changes

- Add `waivesApplyDeadline` state variable to EventTokenModal
- Include `waives_apply_deadline` in `invitation_payload` when saving
- Load existing value from `token.invitation_payload` when editing
- Reset value when creating new tokens
- Add checkbox UI in the Advanced Invitation Options section
- Add i18n translations for English, German, and Italian

## Test plan

- [ ] Create a new event invitation link
- [ ] Expand "Advanced Invitation Options"
- [ ] Verify "Waive application deadline" checkbox appears
- [ ] Toggle the checkbox and save
- [ ] Edit the same link and verify the checkbox state persists
- [ ] Verify the checkbox label is translated in DE and IT locales

## Version

Bumped to 1.30.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)