### PR TITLE
fix(rsvp): refresh page data after RSVP to update visibility-dependent fields

### DIFF
--- a/src/lib/components/events/EventRSVP.svelte
+++ b/src/lib/components/events/EventRSVP.svelte
@@ -10,6 +10,7 @@
 	import IneligibilityMessage from './IneligibilityMessage.svelte';
 	import { Check, AlertCircle } from 'lucide-svelte';
 	import { browser } from '$app/environment';
+	import { invalidateAll } from '$app/navigation';
 
 	import type { EventDetailSchema, EventTokenSchema } from '$lib/api/generated/types.gen';
 
@@ -123,6 +124,10 @@
 
 			// Invalidate queries to refresh data
 			queryClient.invalidateQueries({ queryKey: ['event', eventId, 'status'] });
+
+			// Refresh page data to update visibility-dependent fields (address, maps URLs, etc.)
+			// This re-runs the +page.server.ts load function with the new RSVP status
+			invalidateAll();
 
 			// Auto-hide success message after 5 seconds
 			setTimeout(() => {


### PR DESCRIPTION
## Summary

- Adds `invalidateAll()` call after successful RSVP to refresh server-loaded page data
- Ensures visibility-dependent fields (address, maps URLs) update immediately after RSVP status change

## Problem

When a user RSVPs "yes" to an event with restricted address visibility (e.g., `ATTENDEES_ONLY`), the backend returns the actual address. However, the frontend only invalidated the RSVP status cache, not the main event data loaded via `+page.server.ts`. This caused stale data to display (e.g., "Address visible to attendees only" instead of the actual address) until a manual page refresh.

## Solution

Call `invalidateAll()` from SvelteKit after a successful RSVP mutation. This re-runs the `+page.server.ts` load function, fetching fresh event data that reflects the user's new relationship with the event.

**Affected fields that now properly refresh:**
- `address` - Shows actual address or visibility message
- `location_maps_url` - Shows maps URL or null
- `location_maps_embed` - Shows embed URL or null

## Test plan

- [ ] RSVP "yes" to an event with `address_visibility = ATTENDEES_ONLY`
- [ ] Verify address changes from "Address visible to attendees only" to actual address
- [ ] Change RSVP to "no" and verify address reverts to visibility message
- [ ] Test RSVP to event with `address_visibility = PUBLIC` (no change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)