### PR TITLE
feat(venues): add venue info modal and markdown description support

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -4597,6 +4597,15 @@
 		"clearSelection": "Auswahl löschen",
 		"help": "Wähle den Veranstaltungsort für dieses Event"
 	},
+	"venueInfo": {
+		"moreInfo": "Mehr Infos zum Veranstaltungsort",
+		"modalTitle": "Veranstaltungsort-Details",
+		"address": "Adresse",
+		"capacity": "Kapazität",
+		"capacityPeople": "{count} Personen",
+		"viewOnMaps": "Auf Google Maps ansehen",
+		"about": "Über diesen Veranstaltungsort"
+	},
 	"verifyPage": {
 		"emailVerified": "E-Mail verifiziert!",
 		"verificationFailed": "Verifizierung fehlgeschlagen"

--- a/messages/en.json
+++ b/messages/en.json
@@ -4597,6 +4597,15 @@
 		"clearSelection": "Clear selection",
 		"help": "Select the venue where this event will be held"
 	},
+	"venueInfo": {
+		"moreInfo": "More info about the venue",
+		"modalTitle": "Venue Details",
+		"address": "Address",
+		"capacity": "Capacity",
+		"capacityPeople": "{count} people",
+		"viewOnMaps": "View on Google Maps",
+		"about": "About this venue"
+	},
 	"verifyPage": {
 		"emailVerified": "Email verified!",
 		"verificationFailed": "Verification failed"

--- a/messages/it.json
+++ b/messages/it.json
@@ -4597,6 +4597,15 @@
 		"clearSelection": "Cancella selezione",
 		"help": "Seleziona la sede in cui si terrà questo evento"
 	},
+	"venueInfo": {
+		"moreInfo": "Più info sulla sede",
+		"modalTitle": "Dettagli sede",
+		"address": "Indirizzo",
+		"capacity": "Capienza",
+		"capacityPeople": "{count} persone",
+		"viewOnMaps": "Visualizza su Google Maps",
+		"about": "Informazioni sulla sede"
+	},
 	"verifyPage": {
 		"emailVerified": "Email verificata!",
 		"verificationFailed": "Verifica fallita"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.30.7",
+	"version": "1.31.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/events/EventQuickInfo.svelte
+++ b/src/lib/components/events/EventQuickInfo.svelte
@@ -3,7 +3,17 @@
 	import type { EventDetailSchema } from '$lib/api/generated/types.gen';
 	import { formatEventDate, getRSVPDeadlineRelative, isRSVPClosingSoon } from '$lib/utils/date';
 	import { cn } from '$lib/utils/cn';
-	import { Calendar, MapPin, Users, Clock, Globe, Building2, ExternalLink } from 'lucide-svelte';
+	import {
+		Calendar,
+		MapPin,
+		Users,
+		Clock,
+		Globe,
+		Building2,
+		ExternalLink,
+		Info
+	} from 'lucide-svelte';
+	import VenueInfoModal from '$lib/components/venues/VenueInfoModal.svelte';
 
 	interface Props {
 		event: EventDetailSchema;
@@ -142,6 +152,19 @@
 
 	// Text wrapper classes
 	let textClasses = $derived('flex-1 min-w-0');
+
+	// Venue info modal state
+	let venueInfoModalOpen = $state(false);
+
+	// Check if venue has meaningful additional info worth showing in modal
+	let hasVenueAdditionalInfo = $derived.by(() => {
+		if (!event.venue) return false;
+		return !!(
+			event.venue.description?.trim() ||
+			(event.venue.capacity && event.venue.capacity > 0) ||
+			event.venue.location_maps_embed
+		);
+	});
 </script>
 
 <div class={containerClasses} role="list" aria-label="Event quick information">
@@ -187,6 +210,16 @@
 				{#if locationDisplay.secondary}
 					<span class="block text-xs text-muted-foreground">{locationDisplay.secondary}</span>
 				{/if}
+			{/if}
+			{#if hasVenueAdditionalInfo && event.venue}
+				<button
+					type="button"
+					onclick={() => (venueInfoModalOpen = true)}
+					class="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+				>
+					<Info class="h-3 w-3" aria-hidden="true" />
+					{m['venueInfo.moreInfo']()}
+				</button>
 			{/if}
 		</div>
 	</div>
@@ -254,3 +287,12 @@
 		</div>
 	{/if}
 </div>
+
+<!-- Venue Info Modal -->
+{#if event.venue && hasVenueAdditionalInfo}
+	<VenueInfoModal
+		bind:open={venueInfoModalOpen}
+		venue={event.venue}
+		onClose={() => (venueInfoModalOpen = false)}
+	/>
+{/if}

--- a/src/lib/components/venues/VenueCard.svelte
+++ b/src/lib/components/venues/VenueCard.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { VenueDetailSchema, CitySchema } from '$lib/api/generated/types.gen';
 	import { MapPin, Users, Edit, Trash2, LayoutGrid } from 'lucide-svelte';
+	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 
 	interface Props {
 		venue: VenueDetailSchema;
@@ -29,7 +30,9 @@
 		<div class="min-w-0 flex-1">
 			<h3 class="truncate text-lg font-semibold">{venue.name}</h3>
 			{#if venue.description}
-				<p class="mt-1 line-clamp-2 text-sm text-muted-foreground">{venue.description}</p>
+				<div class="mt-1 line-clamp-2 text-sm text-muted-foreground">
+					<MarkdownContent content={venue.description} inline={true} class="!prose-sm" />
+				</div>
 			{/if}
 
 			<div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">

--- a/src/lib/components/venues/VenueInfoModal.svelte
+++ b/src/lib/components/venues/VenueInfoModal.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import type { VenueSchema } from '$lib/api/generated/types.gen';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import { ExternalLink, MapPin, Users } from 'lucide-svelte';
+
+	interface Props {
+		open: boolean;
+		venue: VenueSchema;
+		onClose: () => void;
+	}
+
+	let { open = $bindable(), venue, onClose }: Props = $props();
+
+	// Build the full address display
+	let fullAddress = $derived.by(() => {
+		const parts: string[] = [];
+
+		if (venue.address) {
+			parts.push(venue.address);
+		}
+
+		if (venue.city) {
+			const cityPart = venue.city.country
+				? `${venue.city.name}, ${venue.city.country}`
+				: venue.city.name;
+			parts.push(cityPart);
+		}
+
+		return parts.join(', ');
+	});
+
+	// Check if venue has meaningful additional info
+	let hasDescription = $derived(!!venue.description?.trim());
+	let hasCapacity = $derived(!!venue.capacity && venue.capacity > 0);
+	let hasMapEmbed = $derived(!!venue.location_maps_embed);
+	let hasMapsUrl = $derived(!!venue.location_maps_url);
+
+	function handleOpenChange(newOpen: boolean) {
+		if (!newOpen) {
+			onClose();
+		}
+		open = newOpen;
+	}
+</script>
+
+<Dialog.Root bind:open onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+		<Dialog.Header>
+			<Dialog.Title>{venue.name}</Dialog.Title>
+		</Dialog.Header>
+
+		<div class="space-y-4">
+			<!-- Address -->
+			{#if fullAddress}
+				<div class="flex items-start gap-3">
+					<MapPin class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+					<div>
+						<p class="text-sm font-medium text-muted-foreground">
+							{m['venueInfo.address']()}
+						</p>
+						<p class="text-sm">{fullAddress}</p>
+					</div>
+				</div>
+			{/if}
+
+			<!-- Capacity -->
+			{#if hasCapacity}
+				<div class="flex items-start gap-3">
+					<Users class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+					<div>
+						<p class="text-sm font-medium text-muted-foreground">
+							{m['venueInfo.capacity']()}
+						</p>
+						<p class="text-sm">
+							{m['venueInfo.capacityPeople']({ count: venue.capacity! })}
+						</p>
+					</div>
+				</div>
+			{/if}
+
+			<!-- Google Maps Link -->
+			{#if hasMapsUrl}
+				<a
+					href={venue.location_maps_url}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="inline-flex items-center gap-2 text-sm text-primary hover:underline"
+				>
+					<ExternalLink class="h-4 w-4" aria-hidden="true" />
+					{m['venueInfo.viewOnMaps']()}
+				</a>
+			{/if}
+
+			<!-- Map Embed -->
+			{#if hasMapEmbed}
+				<div class="overflow-hidden rounded-lg border">
+					<iframe
+						src={venue.location_maps_embed}
+						width="100%"
+						height="200"
+						style="border:0;"
+						allowfullscreen
+						loading="lazy"
+						referrerpolicy="no-referrer-when-downgrade"
+						title="Map of {venue.name}"
+					></iframe>
+				</div>
+			{/if}
+
+			<!-- Description -->
+			{#if hasDescription}
+				<div class="border-t pt-4">
+					<p class="mb-2 text-sm font-medium text-muted-foreground">
+						{m['venueInfo.about']()}
+					</p>
+					<MarkdownContent content={venue.description} class="text-sm" />
+				</div>
+			{/if}
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/venues/VenueModal.svelte
+++ b/src/lib/components/venues/VenueModal.svelte
@@ -13,6 +13,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { X, ChevronDown, ChevronRight, Map, HelpCircle } from 'lucide-svelte';
 	import CityAutocomplete from '$lib/components/forms/CityAutocomplete.svelte';
+	import MarkdownEditor from '$lib/components/forms/MarkdownEditor.svelte';
 	import { toast } from 'svelte-sonner';
 
 	interface Props {
@@ -224,16 +225,13 @@
 
 				<!-- Description -->
 				<div>
-					<label for="venue-description" class="mb-1.5 block text-sm font-medium">
-						{m['orgAdmin.venues.form.descriptionLabel']()}
-					</label>
-					<textarea
-						id="venue-description"
+					<MarkdownEditor
 						bind:value={description}
+						id="venue-description"
+						label={m['orgAdmin.venues.form.descriptionLabel']()}
 						placeholder={m['orgAdmin.venues.form.descriptionPlaceholder']()}
-						rows="3"
-						class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-					></textarea>
+						rows={4}
+					/>
 				</div>
 
 				<!-- Capacity -->


### PR DESCRIPTION
## Summary
- Add VenueInfoModal component to display detailed venue information when clicking "More info" on event pages
- Enable markdown support for venue descriptions in the create/edit form
- Render venue descriptions as markdown in VenueCard

## Changes
- **New component:** `VenueInfoModal.svelte` - displays venue name, address, capacity, Google Maps link, embedded map, and markdown-rendered description
- **EventQuickInfo:** Added "More info" button that opens VenueInfoModal when venue has additional details (description, capacity, or map embed)
- **VenueModal:** Replaced plain textarea with MarkdownEditor for venue description
- **VenueCard:** Updated to render description as markdown using MarkdownContent
- **Translations:** Added `venueInfo.*` keys for the modal UI

## Test plan
- [ ] Navigate to an event with a venue that has description/capacity/maps
- [ ] Click "More info" link below the location
- [ ] Verify modal opens with all venue details
- [ ] Verify markdown renders correctly in description
- [ ] Verify map embed loads
- [ ] Verify external maps link opens in new tab
- [ ] Go to org admin → Venues
- [ ] Create or edit a venue
- [ ] Verify MarkdownEditor shows with toolbar (Bold, Italic, Link, List)
- [ ] Enter markdown in description and verify preview works
- [ ] Save and verify description renders as markdown in VenueCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)