### PR TITLE
fix(resources): render markdown in resource descriptions

### DIFF
--- a/src/lib/components/events/EventResources.svelte
+++ b/src/lib/components/events/EventResources.svelte
@@ -3,6 +3,7 @@
 	import type { AdditionalResourceSchema } from '$lib/api/generated/types.gen';
 	import { FileText, Link as LinkIcon, AlignLeft, ExternalLink, Download } from 'lucide-svelte';
 	import { getBackendUrl } from '$lib/config/api';
+	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 
 	interface Props {
 		resources: AdditionalResourceSchema[];
@@ -60,9 +61,11 @@
 							{resource.name || 'Untitled Resource'}
 						</h3>
 						{#if resource.description}
-							<p class="mt-1 line-clamp-2 text-sm text-muted-foreground">
-								{resource.description}
-							</p>
+							<MarkdownContent
+								content={resource.description}
+								inline
+								class="!prose-sm mt-1 line-clamp-2 text-muted-foreground [&>*]:m-0"
+							/>
 						{/if}
 
 						{#if resource.resource_type === 'text' && resource.text}

--- a/src/lib/components/resources/ResourceCard.svelte
+++ b/src/lib/components/resources/ResourceCard.svelte
@@ -17,6 +17,7 @@
 	} from 'lucide-svelte';
 	import { cn } from '$lib/utils/cn';
 	import { getBackendUrl } from '$lib/config/api';
+	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 
 	interface Props {
 		resource: AdditionalResourceSchema;
@@ -187,10 +188,11 @@
 
 	<!-- Description -->
 	{#if resource.description}
-		<p class="line-clamp-2 text-sm text-muted-foreground">
-			{resource.description}
-		</p>
-	{/if}
+		<MarkdownContent
+			content={resource.description}
+			inline
+			class="!prose-sm line-clamp-2 text-muted-foreground [&>*]:m-0"
+		/>{/if}
 
 	<!-- Content Preview -->
 	{#if isClickable}


### PR DESCRIPTION
## Summary
- Resource descriptions in `EventResources.svelte` and `ResourceCard.svelte` now render markdown formatting
- Uses existing `MarkdownContent` component with `inline` mode for compact rendering
- Markdown like **bold**, *italic*, and links will now display properly instead of raw syntax

## Test plan
- [ ] View an event with resources that have markdown in descriptions
- [ ] Verify bold, italic, and links render correctly
- [ ] Verify text still respects `line-clamp-2` truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)