### PR TITLE
feat(questionnaires): improve editing workflow and add auto-refresh on focus

### DIFF
--- a/src/lib/components/event-series/admin/SeriesResourceAssignmentModal.svelte
+++ b/src/lib/components/event-series/admin/SeriesResourceAssignmentModal.svelte
@@ -5,7 +5,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Search, Loader2, Box, AlertCircle, FileText, Link, File } from 'lucide-svelte';
+	import { Search, Loader2, Box, AlertCircle, FileText, Link, File, Plus } from 'lucide-svelte';
 	import {
 		organizationadminresourcesListResources,
 		organizationadminresourcesUpdateResource,
@@ -185,15 +185,49 @@
 		if (originalIds.size !== selectedIds.size) return true;
 		return ![...originalIds].every((id) => selectedIds.has(id));
 	});
+
+	// Track last fetch time for debounced refresh on focus
+	let lastFetchTime = $state(Date.now());
+
+	// Refresh resources when window regains focus (user returns from new tab after creating a resource)
+	$effect(() => {
+		if (!open) return;
+
+		function handleFocus() {
+			// Debounce: only refresh if modal is open and 2+ seconds have passed
+			if (Date.now() - lastFetchTime > 2000) {
+				loadResources();
+				lastFetchTime = Date.now();
+			}
+		}
+
+		window.addEventListener('focus', handleFocus);
+		return () => window.removeEventListener('focus', handleFocus);
+	});
 </script>
 
 <Dialog bind:open>
 	<DialogContent class="max-h-[90vh] max-w-2xl overflow-hidden p-0">
 		<DialogHeader class="border-b p-6 pb-4">
-			<DialogTitle>{m['seriesResourceAssignmentModal.assignResources']()}</DialogTitle>
-			<p class="mt-1 text-sm text-muted-foreground">
-				Select which resources should be available for events in "{series.name}"
-			</p>
+			<div class="flex items-start justify-between">
+				<div>
+					<DialogTitle>{m['seriesResourceAssignmentModal.assignResources']()}</DialogTitle>
+					<p class="mt-1 text-sm text-muted-foreground">
+						Select which resources should be available for events in "{series.name}"
+					</p>
+				</div>
+				<Button
+					href="/org/{organizationSlug}/admin/resources/new"
+					target="_blank"
+					rel="noopener noreferrer"
+					variant="outline"
+					size="sm"
+					class="gap-2"
+				>
+					<Plus class="h-4 w-4" />
+					New Resource
+				</Button>
+			</div>
 		</DialogHeader>
 
 		<!-- Warning Banner -->

--- a/src/lib/components/events/admin/EventQuestionnaireAssignmentModal.svelte
+++ b/src/lib/components/events/admin/EventQuestionnaireAssignmentModal.svelte
@@ -170,6 +170,25 @@
 		if (originalIds.size !== selectedIds.size) return true;
 		return ![...originalIds].every((id) => selectedIds.has(id));
 	});
+
+	// Track last fetch time for debounced refresh on focus
+	let lastFetchTime = $state(Date.now());
+
+	// Refresh questionnaires when window regains focus (user returns from new tab)
+	$effect(() => {
+		if (!open) return;
+
+		function handleFocus() {
+			// Debounce: only refresh if modal is open and 2+ seconds have passed
+			if (Date.now() - lastFetchTime > 2000) {
+				loadQuestionnaires();
+				lastFetchTime = Date.now();
+			}
+		}
+
+		window.addEventListener('focus', handleFocus);
+		return () => window.removeEventListener('focus', handleFocus);
+	});
 </script>
 
 <Dialog bind:open>
@@ -184,6 +203,8 @@
 				</div>
 				<Button
 					href="/org/{organizationSlug}/admin/questionnaires/new"
+					target="_blank"
+					rel="noopener noreferrer"
 					variant="outline"
 					size="sm"
 					class="gap-2"

--- a/src/lib/components/events/admin/EventResources.svelte
+++ b/src/lib/components/events/admin/EventResources.svelte
@@ -87,6 +87,23 @@
 	const resources = $derived(resourcesQuery.data || []);
 	const isLoading = $derived(resourcesQuery.isLoading);
 	const error = $derived(resourcesQuery.error);
+
+	// Track last fetch time for debounced refresh on focus
+	let lastFetchTime = $state(Date.now());
+
+	// Refresh resources when window regains focus (user returns from new tab after creating a resource)
+	$effect(() => {
+		function handleFocus() {
+			// Debounce: only refresh if 2+ seconds have passed since last fetch
+			if (Date.now() - lastFetchTime > 2000) {
+				resourcesQuery.refetch();
+				lastFetchTime = Date.now();
+			}
+		}
+
+		window.addEventListener('focus', handleFocus);
+		return () => window.removeEventListener('focus', handleFocus);
+	});
 </script>
 
 <div class="space-y-4">

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte
@@ -665,8 +665,8 @@
 				throw new Error('Failed to create questionnaire');
 			}
 
-			// Redirect to questionnaire list
-			await goto(`/org/${data.organization.slug}/admin/questionnaires`);
+			// Redirect to the edit page of the newly created questionnaire
+			await goto(`/org/${data.organization.slug}/admin/questionnaires/${response.data.id}`);
 		} catch (err) {
 			console.error('Failed to save questionnaire:', err);
 			saveError = 'Failed to save questionnaire. Please try again.';


### PR DESCRIPTION
## Summary

- **New tab for questionnaire creation**: "Create New Questionnaire" button in event assignment modal now opens in a new tab, with auto-refresh when returning
- **Stay on edit page after creation**: After saving a new questionnaire, redirect to its edit page (not the list) so users can immediately publish
- **Edit any questionnaire**: Decoupled edit mode from draft status - any questionnaire can now be edited with explicit Edit/Cancel buttons
- **Scroll to top after save**: Page scrolls up after saving so users see the updated status
- **Resource modal improvements**: Added focus-based auto-refresh to resource assignment modals and "New Resource" button to series resource modal

## Test plan

- [ ] Go to event edit → Advanced → Assign Questionnaires → click "Create New" → verify opens in new tab
- [ ] Create questionnaire in new tab → return to modal → verify list refreshes automatically  
- [ ] Create a new questionnaire → verify redirect goes to edit page (not list)
- [ ] Open a published questionnaire → verify "Edit Questionnaire" button appears
- [ ] Click "Edit Questionnaire" → make changes → save → verify stays on page and scrolls to top
- [ ] Open series edit → Resources → click "New Resource" → verify opens in new tab
- [ ] Create resource in new tab → return to modal → verify list refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)