### PR TITLE
feat(auth): auto-claim invitation tokens on login with toast notifications

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -593,7 +593,9 @@
 		"text_tbd": "Noch offen",
 		"errors_refreshPage": "Bitte aktualisiere die Seite oder schau später wieder vorbei.",
 		"errors_tryAgain": "Bitte versuche es erneut.",
-		"accessibility_skipTo": "Zu {section} springen"
+		"accessibility_skipTo": "Zu {section} springen",
+		"claimSuccess_organization": "Du wurdest zu {name} hinzugefügt!",
+		"claimSuccess_event": "Du wurdest zu {name} eingeladen!"
 	},
 	"confirmDeletionPage": {
 		"title": "Kontolöschung bestätigen - Revel",

--- a/messages/en.json
+++ b/messages/en.json
@@ -593,7 +593,9 @@
 		"text_tbd": "TBD",
 		"errors_refreshPage": "Please try refreshing the page or check back later.",
 		"errors_tryAgain": "Please try again.",
-		"accessibility_skipTo": "Skip to {section}"
+		"accessibility_skipTo": "Skip to {section}",
+		"claimSuccess_organization": "You've been added to {name}!",
+		"claimSuccess_event": "You've been invited to {name}!"
 	},
 	"confirmDeletionPage": {
 		"title": "Confirm Account Deletion - Revel",

--- a/messages/it.json
+++ b/messages/it.json
@@ -593,7 +593,9 @@
 		"text_tbd": "Da definire",
 		"errors_refreshPage": "Prova a ricaricare la pagina o riprova più tardi.",
 		"errors_tryAgain": "Riprova.",
-		"accessibility_skipTo": "Passa a {section}"
+		"accessibility_skipTo": "Passa a {section}",
+		"claimSuccess_organization": "Sei stato aggiunto a {name}!",
+		"claimSuccess_event": "Sei stato invitato a {name}!"
 	},
 	"confirmDeletionPage": {
 		"title": "Conferma Eliminazione Account - Revel",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.31.0",
+	"version": "1.32.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/server/token-claim.ts
+++ b/src/lib/server/token-claim.ts
@@ -1,0 +1,159 @@
+import type { Cookies } from '@sveltejs/kit';
+import {
+	organizationClaimInvitation,
+	eventpublicdiscoveryClaimInvitation
+} from '$lib/api/generated/sdk.gen';
+
+/**
+ * Result of attempting to claim an invitation token
+ */
+export interface ClaimResult {
+	type: 'organization' | 'event';
+	success: boolean;
+	name?: string;
+	slug?: string;
+}
+
+/**
+ * Results from claiming all pending tokens
+ */
+export interface ClaimResults {
+	organization?: ClaimResult;
+	event?: ClaimResult;
+}
+
+/**
+ * Cookie options for the claim flash cookie
+ */
+const CLAIM_FLASH_COOKIE_OPTIONS = {
+	path: '/',
+	httpOnly: false, // Needs to be readable by client JS
+	secure: process.env.NODE_ENV === 'production',
+	sameSite: 'lax' as const,
+	maxAge: 60 // 1 minute - just needs to survive the redirect
+};
+
+/**
+ * Attempt to claim pending invitation tokens after authentication.
+ * Handles errors silently and gracefully - failures won't interrupt the auth flow.
+ *
+ * @param cookies - SvelteKit cookies object
+ * @param accessToken - The user's access token
+ * @param fetchFn - Fetch function to use for API calls
+ * @returns ClaimResults with success/failure info and org/event names
+ */
+export async function claimPendingTokens(
+	cookies: Cookies,
+	accessToken: string,
+	fetchFn: typeof fetch
+): Promise<ClaimResults> {
+	const results: ClaimResults = {};
+
+	// Check for pending organization token
+	const orgToken = cookies.get('pending_org_token');
+	if (orgToken) {
+		console.log('[TOKEN-CLAIM] Attempting to claim organization token:', orgToken);
+		try {
+			const response = await organizationClaimInvitation({
+				path: { token: orgToken },
+				headers: { Authorization: `Bearer ${accessToken}` },
+				fetch: fetchFn
+			});
+
+			if (response.response.ok && response.data) {
+				console.log(
+					'[TOKEN-CLAIM] Successfully claimed organization invitation:',
+					response.data.name
+				);
+				results.organization = {
+					type: 'organization',
+					success: true,
+					name: response.data.name,
+					slug: response.data.slug
+				};
+			} else {
+				console.warn('[TOKEN-CLAIM] Failed to claim organization token (may be expired/invalid)');
+				results.organization = {
+					type: 'organization',
+					success: false
+				};
+			}
+		} catch (error) {
+			console.warn('[TOKEN-CLAIM] Error claiming organization token:', error);
+			results.organization = {
+				type: 'organization',
+				success: false
+			};
+		}
+
+		// Always delete the cookie to prevent retry loops
+		cookies.delete('pending_org_token', { path: '/' });
+	}
+
+	// Check for pending event token
+	const eventToken = cookies.get('pending_event_token');
+	if (eventToken) {
+		console.log('[TOKEN-CLAIM] Attempting to claim event token:', eventToken);
+		try {
+			const response = await eventpublicdiscoveryClaimInvitation({
+				path: { token: eventToken },
+				headers: { Authorization: `Bearer ${accessToken}` },
+				fetch: fetchFn
+			});
+
+			if (response.response.ok && response.data) {
+				console.log('[TOKEN-CLAIM] Successfully claimed event invitation:', response.data.name);
+				results.event = {
+					type: 'event',
+					success: true,
+					name: response.data.name,
+					slug: response.data.slug
+				};
+			} else {
+				console.warn('[TOKEN-CLAIM] Failed to claim event token (may be expired/invalid)');
+				results.event = {
+					type: 'event',
+					success: false
+				};
+			}
+		} catch (error) {
+			console.warn('[TOKEN-CLAIM] Error claiming event token:', error);
+			results.event = {
+				type: 'event',
+				success: false
+			};
+		}
+
+		// Always delete the cookie to prevent retry loops
+		cookies.delete('pending_event_token', { path: '/' });
+	}
+
+	return results;
+}
+
+/**
+ * Store claim results in a flash cookie for the client to read and display.
+ * Only stores successful claims.
+ *
+ * @param cookies - SvelteKit cookies object
+ * @param results - Results from claimPendingTokens
+ */
+export function setClaimFlashCookie(cookies: Cookies, results: ClaimResults): void {
+	// Only set cookie if there are successful claims to report
+	const successfulClaims: ClaimResult[] = [];
+
+	if (results.organization?.success) {
+		successfulClaims.push(results.organization);
+	}
+	if (results.event?.success) {
+		successfulClaims.push(results.event);
+	}
+
+	if (successfulClaims.length > 0) {
+		// Base64 encode the JSON to handle special characters safely in cookie value
+		const jsonString = JSON.stringify(successfulClaims);
+		const encodedValue = Buffer.from(jsonString).toString('base64');
+		cookies.set('claim_flash', encodedValue, CLAIM_FLASH_COOKIE_OPTIONS);
+		console.log('[TOKEN-CLAIM] Set claim_flash cookie with', successfulClaims.length, 'claims');
+	}
+}

--- a/src/routes/(auth)/org/[slug]/admin/members/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/members/+page.svelte
@@ -593,6 +593,8 @@
 				queryKey: ['organization', organization.slug, 'tokens']
 			});
 			isCreateTokenModalOpen = false;
+			// Switch to Invite Links tab to show the newly created token
+			activeTab = 'tokens';
 			toast.success('Invitation link created successfully');
 		},
 		onError: () => {

--- a/src/routes/(public)/login/+page.server.ts
+++ b/src/routes/(public)/login/+page.server.ts
@@ -8,6 +8,7 @@ import {
 	getRememberMeCookieOptions
 } from '$lib/utils/cookies';
 import { extractErrorMessage } from '$lib/utils/errors';
+import { claimPendingTokens, setClaimFlashCookie } from '$lib/server/token-claim';
 
 export const actions = {
 	// Standard email/password login
@@ -70,6 +71,10 @@ export const actions = {
 					data.rememberMe ? 'true' : 'false',
 					getRememberMeCookieOptions(data.rememberMe)
 				);
+
+				// Claim any pending invitation tokens (org/event)
+				const claimResults = await claimPendingTokens(cookies, access, fetch);
+				setClaimFlashCookie(cookies, claimResults);
 
 				// Redirect to returnUrl or dashboard
 				const returnUrl = url.searchParams.get('returnUrl') || '/dashboard';
@@ -157,6 +162,10 @@ export const actions = {
 					data.rememberMe ? 'true' : 'false',
 					getRememberMeCookieOptions(data.rememberMe)
 				);
+
+				// Claim any pending invitation tokens (org/event)
+				const claimResults = await claimPendingTokens(cookies, access, fetch);
+				setClaimFlashCookie(cookies, claimResults);
 
 				// Redirect to returnUrl or dashboard
 				const returnUrl = url.searchParams.get('returnUrl') || '/dashboard';


### PR DESCRIPTION
## Summary

- Add automatic token claiming after login (matching signup behavior)
- Show toast notifications when users are added to organizations or events
- Bump version to 1.32.0

## Changes

- **New file: `src/lib/server/token-claim.ts`** - Shared utility for token claiming
  - `ClaimResult` and `ClaimResults` interfaces
  - `claimPendingTokens()` - Claims pending tokens and returns results with names
  - `setClaimFlashCookie()` - Stores successful claims for client display

- **`src/routes/(public)/login/+page.server.ts`** - Both `login` and `verify2FA` actions now claim tokens

- **`src/routes/(public)/verify/+page.server.ts`** - Refactored to use shared utility

- **`src/routes/+layout.svelte`** - Handle flash cookie and display toast notifications

- **i18n messages** - Added claim success messages in en, de, it

## User Flow

1. User visits invitation link (e.g., `/org/test-org?ot=token`) while not logged in
2. Token gets stored in `pending_org_token` or `pending_event_token` cookie
3. User logs in (standard or 2FA flow)
4. After successful login, tokens are automatically claimed
5. User sees toast notification: "You've been added to {org name}!" or "You've been invited to {event name}!"

## Test plan

- [ ] Login with pending org token → claim + toast
- [ ] Login with pending event token → claim + toast
- [ ] Login with both tokens → claim both + two toasts
- [ ] Login with no tokens → normal login (no toast)
- [ ] 2FA login with tokens → same behavior
- [ ] Expired/invalid token → silent failure, login proceeds
- [ ] Login with returnUrl → redirect works + toast shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)