### PR TITLE
fix(announcements): fetch full announcement data when editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.32.0",
+	"version": "1.32.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/announcements/AnnouncementCard.svelte
+++ b/src/lib/components/announcements/AnnouncementCard.svelte
@@ -12,20 +12,22 @@
 		Calendar,
 		Layers,
 		MoreHorizontal,
-		Eye
+		Eye,
+		Loader2
 	} from 'lucide-svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { formatRelativeTime } from '$lib/utils/time';
 
 	interface Props {
 		announcement: AnnouncementListSchema;
+		isLoadingEdit?: boolean;
 		onView?: () => void;
 		onEdit?: () => void;
 		onDelete?: () => void;
 		onSend?: () => void;
 	}
 
-	let { announcement, onView, onEdit, onDelete, onSend }: Props = $props();
+	let { announcement, isLoadingEdit = false, onView, onEdit, onDelete, onSend }: Props = $props();
 
 	let isDraft = $derived(announcement.status === 'draft');
 
@@ -104,8 +106,12 @@
 	<div class="flex shrink-0 items-center gap-2">
 		{#if isDraft}
 			<!-- Quick actions for drafts -->
-			<Button variant="outline" size="sm" onclick={onEdit}>
-				<Edit class="mr-1.5 h-4 w-4" aria-hidden="true" />
+			<Button variant="outline" size="sm" onclick={onEdit} disabled={isLoadingEdit}>
+				{#if isLoadingEdit}
+					<Loader2 class="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
+				{:else}
+					<Edit class="mr-1.5 h-4 w-4" aria-hidden="true" />
+				{/if}
 				{m['announcements.edit']()}
 			</Button>
 			<Button variant="default" size="sm" onclick={onSend}>

--- a/src/lib/components/announcements/AnnouncementModal.svelte
+++ b/src/lib/components/announcements/AnnouncementModal.svelte
@@ -67,7 +67,7 @@
 		if (open) {
 			if (announcement) {
 				title = announcement.title;
-				body = announcement.body;
+				body = announcement.body ?? '';
 				pastVisibility = announcement.past_visibility ?? true;
 
 				// Determine target type from announcement


### PR DESCRIPTION
## Summary

- Fixed bug where editing an announcement showed an empty body field
- Fixed `props_invalid_value` Svelte error when opening the edit modal

## Problem

The announcement list uses `AnnouncementListSchema` which is a lightweight schema that **doesn't include the `body` field**. When clicking "Edit", the code was casting this to `AnnouncementSchema` without fetching the full data, resulting in:
1. Empty body textarea in the edit modal
2. `props_invalid_value` error from Svelte when binding undefined to MarkdownEditor

## Solution

- Modified `openEditModal` to fetch the full announcement details via `organizationadminannouncementsGetAnnouncement` before opening the modal (matching the pattern used by `openViewDialog`)
- Added `editingAnnouncementId` state and loading indicator on the edit button for UX feedback
- Added defensive fallback `body = announcement.body ?? ''` in the modal

## Test plan

- [ ] Open announcements admin page
- [ ] Click "Edit Announcement" on a draft with existing body content
- [ ] Verify the body content is loaded correctly in the modal
- [ ] Verify loading spinner appears on the edit button while fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)