### PR TITLE
fix(admin): show RSVPs and tickets for past events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.32.2",
+	"version": "1.32.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.server.ts
@@ -83,7 +83,8 @@ export const load: PageServerLoad = async ({ parent, params, locals, fetch, url 
 				status: status as any,
 				search,
 				page,
-				page_size: pageSize
+				page_size: pageSize,
+				include_past: true // Always show RSVPs in admin, even for past events
 			},
 			headers
 		});

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.server.ts
@@ -85,7 +85,8 @@ export const load: PageServerLoad = async ({ parent, params, locals, fetch, url 
 				tier__payment_method: paymentMethod as any,
 				search,
 				page,
-				page_size: pageSize
+				page_size: pageSize,
+				include_past: true // Always show tickets in admin, even for past events
 			},
 			headers
 		});


### PR DESCRIPTION
## Summary
- Fixed admin attendees page showing 0 RSVPs for past events
- Fixed admin tickets page showing 0 tickets for past events

## Root Cause
The backend `RSVPFilterSchema` and `TicketFilterSchema` have `include_past=False` by default, which filters out RSVPs/tickets for events where `event.end < now()`. The admin pages weren't passing `include_past=true`, so past events showed empty lists.

## Changes
- `attendees/+page.server.ts`: Added `include_past: true` to the RSVPs query
- `tickets/+page.server.ts`: Added `include_past: true` to the tickets query

Note: Invitations don't have this issue as they query directly by event_id without date filtering.

## Test plan
- [ ] Navigate to a past event's attendees page → should show all RSVPs
- [ ] Navigate to a past event's tickets page → should show all tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)