### PR TITLE
feat(questionnaires): add include past events checkbox to assignment modal

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -3538,7 +3538,8 @@
 		"assigningToSeries": "Zuweisung zu einer Serie wendet den Fragebogen auf",
 		"allEvents": "alle Veranstaltungen",
 		"loadingEventSeries": "Veranstaltungsserien werden geladen...",
-		"cancel": "Abbrechen"
+		"cancel": "Abbrechen",
+		"includePastEvents": "Vergangene Veranstaltungen einbeziehen"
 	},
 	"questionnaireCard": {
 		"type_admission": "Admission",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3538,7 +3538,8 @@
 		"assigningToSeries": "Assigning to a series applies the questionnaire to",
 		"allEvents": "all events",
 		"loadingEventSeries": "Loading event series...",
-		"cancel": "Cancel"
+		"cancel": "Cancel",
+		"includePastEvents": "Include past events"
 	},
 	"questionnaireCard": {
 		"type_admission": "Admission",

--- a/messages/it.json
+++ b/messages/it.json
@@ -3538,7 +3538,8 @@
 		"assigningToSeries": "Assegnare a una serie applica il questionario a",
 		"allEvents": "tutti gli eventi",
 		"loadingEventSeries": "Caricamento serie eventi...",
-		"cancel": "Annulla"
+		"cancel": "Annulla",
+		"includePastEvents": "Includi eventi passati"
 	},
 	"questionnaireCard": {
 		"type_admission": "Admission",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.32.3",
+	"version": "1.32.4",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/questionnaires/QuestionnaireAssignmentModal.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireAssignmentModal.svelte
@@ -36,6 +36,7 @@
 	let isLoadingEvents = $state(true);
 	let allEvents = $state<EventInListSchema[]>([]);
 	let selectedEventIds = $state<Set<string>>(new Set());
+	let includePastEvents = $state(false);
 
 	// Series state
 	let searchQuerySeries = $state('');
@@ -63,13 +64,24 @@
 		}
 	});
 
+	// Re-fetch events when includePastEvents changes
+	$effect(() => {
+		// Track the includePastEvents value
+		const _ = includePastEvents;
+		// Only re-fetch if modal is open and we've already loaded once
+		if (open && !isLoadingEvents) {
+			loadEvents();
+		}
+	});
+
 	async function loadEvents() {
 		isLoadingEvents = true;
 		try {
 			const response = await eventpublicdiscoveryListEvents({
 				query: {
 					organization: organizationId,
-					page_size: 100 // Fetch all org events
+					page_size: 100, // Fetch all org events
+					include_past: includePastEvents
 				},
 				headers: { Authorization: `Bearer ${accessToken}` }
 			});
@@ -256,6 +268,18 @@
 
 			<!-- Events Tab -->
 			<TabsContent value="events">
+				<!-- Include past events checkbox -->
+				<div class="mx-6 mt-4 flex items-center gap-2">
+					<Checkbox
+						id="include-past-events"
+						checked={includePastEvents}
+						onCheckedChange={(checked) => (includePastEvents = !!checked)}
+					/>
+					<label for="include-past-events" class="cursor-pointer text-sm text-muted-foreground">
+						{m['questionnaireAssignmentModal.includePastEvents']()}
+					</label>
+				</div>
+
 				<!-- Search Bar -->
 				<div class="border-b px-6 py-4">
 					<div class="relative">


### PR DESCRIPTION
## Summary
- Add "Include past events" checkbox to questionnaire assignment modal
- Enables assigning feedback questionnaires to past events for post-event feedback collection
- Checkbox toggles the `include_past` API parameter and re-fetches events

## Test plan
- [ ] Open questionnaire assignment modal from organization admin
- [ ] Verify only upcoming events are shown initially
- [ ] Check "Include past events" checkbox
- [ ] Verify past events now appear in the list
- [ ] Uncheck the checkbox and verify past events are removed
- [ ] Verify checkbox label is properly translated (EN/IT/DE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)