### PR TITLE
fix(questionnaires): resolve stale checkbox state after saving edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.34.0",
+	"version": "1.35.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
@@ -1044,8 +1044,8 @@
 			}
 
 			// Refresh data, re-initialize state from API, and exit edit mode (stay on same page)
-			isInitialized = false; // Reset so initializeFromApi() runs again after data refresh
 			await invalidateAll();
+			initializeFromApi(); // Explicitly re-init with fresh data (avoids race with $effect)
 			isEditMode = false;
 
 			// Scroll to top so user sees the updated questionnaire


### PR DESCRIPTION
## Summary
- Fix race condition where checkboxes appeared unchecked after saving questionnaire edits
- Setting `isInitialized = false` before `await invalidateAll()` caused the `$effect` to re-run with **stale data** during the await, then the fresh data never triggered a re-init
- Now explicitly calls `initializeFromApi()` after `invalidateAll()` resolves, ensuring local state is populated from the fresh API response before switching to read-only mode
- Bumps to v1.35.0

## Test plan
- [ ] Edit a questionnaire, toggle some checkbox fields (e.g. "is correct" on MC options)
- [ ] Save — verify checkboxes display correctly in read-only mode without page reload
- [ ] Reload the page to confirm data persisted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)