### PR TITLE
fix(ui): display tags on organization detail page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.35.0",
+	"version": "1.35.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -603,6 +603,22 @@
 			{/if}
 		</section>
 
+		<!-- Tags Section -->
+		{#if organization.tags && organization.tags.length > 0}
+			<section aria-labelledby="tags-heading" class="border-t pt-8">
+				<h2 id="tags-heading" class="mb-4 text-xl font-semibold">
+					{m['eventDetails.tags_heading']()}
+				</h2>
+				<div class="flex flex-wrap gap-2">
+					{#each organization.tags as tag (tag)}
+						<span class="rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+							{tag}
+						</span>
+					{/each}
+				</div>
+			</section>
+		{/if}
+
 		<!-- Announcements Section -->
 		<OrgAnnouncements organizationSlug={organization.slug} />
 	</div>


### PR DESCRIPTION
## Summary
- Tags were displayed on event and series detail pages but missing from the organization detail page
- Added a tags section to the org page matching the existing event page styling (pill badges, border-top separator, `aria-labelledby` for accessibility)
- Bumped version to 1.35.1

## Test plan
- [ ] Navigate to an organization that has tags and verify they appear below the Events section
- [ ] Verify organizations without tags show no empty section
- [ ] Confirm tag styling matches the event detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)