### PR TITLE
fix(tickets): preserve backend tier ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.35.1",
+	"version": "1.35.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/tickets/TicketTierList.svelte
+++ b/src/lib/components/tickets/TicketTierList.svelte
@@ -63,16 +63,8 @@
 		return tierRemainingTickets?.find((t) => t.tier_id === tierId);
 	}
 
-	// Filter out hidden tiers and sort by price
-	let visibleTiers = $derived(
-		tiers
-			.filter((tier) => tier.payment_method !== 'hidden')
-			.sort((a, b) => {
-				const priceA = typeof a.price === 'string' ? parseFloat(a.price) : a.price;
-				const priceB = typeof b.price === 'string' ? parseFloat(b.price) : b.price;
-				return priceA - priceB;
-			})
-	);
+	// Filter out hidden tiers (preserve backend ordering)
+	let visibleTiers = $derived(tiers.filter((tier) => tier.payment_method !== 'hidden'));
 
 	let hasTiers = $derived(visibleTiers.length > 0);
 


### PR DESCRIPTION
## Summary
- Removed client-side price sorting from the public-facing ticket tier list
- Tiers now display in the order provided by the backend, respecting organizer-configured ordering

## Test plan
- [ ] Verify tiers on an event page display in backend order, not sorted by price
- [ ] Verify hidden tiers are still filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)