### PR TITLE
fix(notifications): flatten heading sizes in notification body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.36.0",
+	"version": "1.36.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -247,10 +247,12 @@
 			</div>
 
 			<!-- Body content -->
-			<MarkdownContent
-				content={notification.body}
-				class={cn('text-sm text-muted-foreground', compact && 'line-clamp-2')}
-			/>
+			<div class="notification-body">
+				<MarkdownContent
+					content={notification.body}
+					class={cn('text-sm text-muted-foreground', compact && 'line-clamp-2')}
+				/>
+			</div>
 		</div>
 
 		<!-- Action button -->
@@ -278,6 +280,19 @@
 	:global(.prose) {
 		word-break: break-word;
 		overflow-wrap: break-word;
+	}
+
+	/* Flatten headings inside notification body to regular text size */
+	.notification-body :global(h1),
+	.notification-body :global(h2),
+	.notification-body :global(h3),
+	.notification-body :global(h4),
+	.notification-body :global(h5),
+	.notification-body :global(h6) {
+		font-size: inherit;
+		font-weight: 600;
+		margin: 0;
+		line-height: inherit;
 	}
 
 	/* Line clamp for compact mode */


### PR DESCRIPTION
## Summary
- Markdown headings (`##`, `#`, etc.) in notification body content were rendering at full heading size, causing oversized text in notification cards
- Wrapped `MarkdownContent` in a scoped `.notification-body` div and added CSS to flatten all `h1`–`h6` elements to inherit surrounding text size
- Bump to v1.36.1

## Test plan
- [ ] Trigger a notification with markdown headings in the body (e.g. event description containing `##`)
- [ ] Verify headings render at the same size as surrounding body text
- [ ] Verify notifications without headings are unaffected
- [ ] Verify markdown headings in other contexts (event pages, org pages) still render at full size

🤖 Generated with [Claude Code](https://claude.com/claude-code)