### PR TITLE
fix(tickets): reset processing state after non-online PWYC checkout

### DIFF
--- a/src/lib/components/tickets/TicketTierModal.svelte
+++ b/src/lib/components/tickets/TicketTierModal.svelte
@@ -243,9 +243,15 @@
 						isProcessing = false;
 					}
 				}, 10000);
+			} else {
+				// For non-online payments (free, offline, at_the_door):
+				// reset processing state and close the confirmation dialog.
+				// The parent's onSuccess handler already closed the tier modal
+				// and showed a toast, but the confirmation dialog is a separate
+				// Dialog instance that must be closed explicitly.
+				isProcessing = false;
+				closeConfirmation();
 			}
-			// For non-online payments, the parent's onSuccess handler closes
-			// the tier modal (which tears down this component), so no cleanup needed here.
 		} catch (error) {
 			// On error, reset state so user can try again
 			isProcessing = false;


### PR DESCRIPTION
## Summary

- Fixes spinner hanging indefinitely after reserving a PWYC ticket with offline/at-the-door payment
- The `TicketConfirmationDialog` is a separate Dialog from the tier selection one — closing the tier modal did not close it, and `isProcessing` was never reset for non-online paths
- Adds an `else` branch to reset `isProcessing` and call `closeConfirmation()` for all non-online checkout paths

## Test plan

- [ ] Reserve a PWYC tier with offline/at-the-door payment — confirm dialog closes, toast shows, no hanging spinner
- [ ] Reserve a free tier through the modal — same expected behavior
- [ ] Checkout a PWYC tier with online payment — confirm Stripe redirect still works with spinner visible until redirect
- [ ] Verify error path still works: trigger an API error and confirm the dialog stays open for retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)