### PR TITLE
fix(tickets): handle errors and eligibility in guest checkout dialogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.36.1",
+	"version": "1.36.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/utils/guestAttendance.ts
+++ b/src/lib/utils/guestAttendance.ts
@@ -87,6 +87,10 @@ export function extractErrorMessage(error: unknown): string {
 			if ('detail' in body && typeof body.detail === 'string') {
 				return body.detail;
 			}
+			// Handle EventUserEligibility format (e.g. { allowed: false, reason: "..." })
+			if ('reason' in body && typeof body.reason === 'string') {
+				return body.reason;
+			}
 			if ('message' in body && typeof body.message === 'string') {
 				return body.message;
 			}


### PR DESCRIPTION
## Summary

- Fix guest checkout dialogs (`GuestTicketDialog`, `GuestRsvpDialog`) silently showing success screen on API 400 errors instead of displaying the error message
- Add reactive auth guard that closes guest dialogs when the user becomes authenticated mid-session (e.g. token refresh after page load)
- Show contextual "Log in or create an account" prompt when the backend returns an eligibility `next_step` that requires authentication (e.g. `complete_questionnaire`, `become_member`, `complete_profile`)
- Update shared `extractErrorMessage` utility to handle `EventUserEligibility` response format (`reason` field)

## Root cause

The `@hey-api` client returns `{ data, error }` without throwing on HTTP errors. The guest dialogs only checked `response.data`, so on a 400 none of the conditions matched and the fallback `else` set `showSuccess = true`.

## Test plan

- [ ] As unauthenticated guest on an event with `can_attend_without_login`, attempt checkout with invalid data — error alert should appear
- [ ] Trigger an eligibility 400 (e.g. missing questionnaire) — error shows reason + "Log in or create an account" links
- [ ] Open guest dialog, then have auth refresh in background — dialog should close automatically
- [ ] Happy path: successful guest checkout still shows email confirmation / redirects to Stripe

🤖 Generated with [Claude Code](https://claude.com/claude-code)