### PR TITLE
fix(security): enforce CSP directives to fix production deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.36.4",
+	"version": "1.36.5",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -23,11 +23,10 @@ const config = {
 			$api: 'src/lib/api'
 		},
 
-		// Content Security Policy — report-only mode for safe rollout.
-		// Once validated (no console violations), move reportOnly -> directives to enforce.
+		// Content Security Policy — enforced
 		csp: {
 			mode: 'auto',
-			reportOnly: {
+			directives: {
 				'default-src': ['self'],
 				'script-src': ['self'],
 				'style-src': ['self', 'unsafe-inline'], // Svelte transitions create inline <style>


### PR DESCRIPTION
## Summary
- Production deploys failing with 500 error after #313 merged CSP in `reportOnly` mode
- SvelteKit requires `report-to` or `report-uri` directives when using `reportOnly`, which were missing
- Switches CSP from `reportOnly` to enforced `directives` with the same policy rules
- Bumps version to 1.36.5

## Test plan
- [ ] Verify production deploy succeeds (health check passes)
- [ ] Verify backend API calls work (`connect-src` allows `https://api.letsrevel.io`)
- [ ] Verify map embeds load on event pages (`frame-src` allows Google Maps, OpenStreetMap, etc.)
- [ ] Verify images from backend load (`img-src` allows `https://api.letsrevel.io`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)