### PR TITLE
fix(security): use dynamic API URL in CSP directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.36.5",
+	"version": "1.36.6",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,6 +1,8 @@
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+const apiUrl = process.env.PUBLIC_API_URL || 'https://api.letsrevel.io';
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
@@ -30,9 +32,9 @@ const config = {
 				'default-src': ['self'],
 				'script-src': ['self'],
 				'style-src': ['self', 'unsafe-inline'], // Svelte transitions create inline <style>
-				'img-src': ['self', 'https://api.letsrevel.io', 'data:', 'blob:'],
+				'img-src': ['self', apiUrl, 'data:', 'blob:'],
 				'font-src': ['self', 'data:'],
-				'connect-src': ['self', 'https://api.letsrevel.io'],
+				'connect-src': ['self', apiUrl],
 				'frame-src': [
 					'https://www.google.com',
 					'https://google.com',


### PR DESCRIPTION
## Summary
- CSP had `https://api.letsrevel.io` hardcoded in `connect-src` and `img-src`
- This blocked all API calls on demo (`https://demo-api.letsrevel.io`) and local dev
- Now reads `PUBLIC_API_URL` env var at build time, falling back to `https://api.letsrevel.io`
- Bumps version to 1.36.6

## Test plan
- [ ] Production: API calls and image loading still work
- [ ] Demo: `demo-api.letsrevel.io` requests no longer blocked by CSP
- [ ] Local dev: `localhost:8000` requests work

🤖 Generated with [Claude Code](https://claude.com/claude-code)