### PR TITLE
fix(security): allow GitHub API in CSP connect-src

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.36.6",
+	"version": "1.36.7",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -34,7 +34,7 @@ const config = {
 				'style-src': ['self', 'unsafe-inline'], // Svelte transitions create inline <style>
 				'img-src': ['self', apiUrl, 'data:', 'blob:'],
 				'font-src': ['self', 'data:'],
-				'connect-src': ['self', apiUrl],
+				'connect-src': ['self', apiUrl, 'https://api.github.com'],
 				'frame-src': [
 					'https://www.google.com',
 					'https://google.com',


### PR DESCRIPTION
## Summary
- Footer fetches release info from `https://api.github.com` which was blocked by CSP `connect-src`
- Added `https://api.github.com` to the allowed origins
- Bumps version to 1.36.7

## Test plan
- [ ] Footer version/release links load without CSP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)