### PR TITLE
fix(tickets): route PWYC tiers to correct endpoint in TierCard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.36.8",
+	"version": "1.36.9",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/tickets/TierCard.svelte
+++ b/src/lib/components/tickets/TierCard.svelte
@@ -190,18 +190,23 @@
 		isClaiming = true;
 		try {
 			const { amount, tickets } = payload;
+			const isPwyc = tier.price_type === 'pwyc';
 
-			// Free tickets or offline/at-the-door (reservation)
-			if (
+			// PWYC tiers require the PWYC endpoint regardless of payment method
+			if (isPwyc && onCheckout) {
+				await onCheckout(tier.id, true, amount, tickets);
+			}
+			// Free tickets or offline/at-the-door (reservation) - non-PWYC
+			else if (
 				tier.payment_method === 'free' ||
 				tier.payment_method === 'offline' ||
 				tier.payment_method === 'at_the_door'
 			) {
 				await onClaimTicket(tier.id, tickets);
 			}
-			// Online payment (with or without PWYC)
+			// Online payment (fixed price)
 			else if (tier.payment_method === 'online' && onCheckout) {
-				await onCheckout(tier.id, tier.price_type === 'pwyc', amount, tickets);
+				await onCheckout(tier.id, false, undefined, tickets);
 			}
 
 			// Close dialog on success


### PR DESCRIPTION
## Summary

- **Fixes PWYC checkout calling wrong endpoint** in `TierCard.svelte` (inline tier cards via `TicketTierList`)
- PR #232 fixed this in `TicketTierModal` but missed applying the same fix to `TierCard`
- PWYC tiers with non-online payment methods (`offline`, `at_the_door`) were calling `onClaimTicket` (regular checkout endpoint) instead of `onCheckout` with `isPwyc=true` (PWYC checkout endpoint)
- Now checks `price_type === 'pwyc'` **first** before `payment_method`, matching `TicketTierModal` logic

## Test plan

- [ ] Create a PWYC tier with `payment_method: offline` and verify the PWYC checkout endpoint is called (not the regular claim endpoint)
- [ ] Verify fixed-price online tiers still route to regular checkout
- [ ] Verify free tiers still route to claim endpoint
- [ ] Verify PWYC tiers with `payment_method: online` still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)