### PR TITLE
fix(auth): clear navbar on logout, adapt homepage CTAs, disable CSP in dev

### DIFF
--- a/src/lib/components/common/UserMenu.svelte
+++ b/src/lib/components/common/UserMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import { createQuery } from '@tanstack/svelte-query';
+	import { createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import { dashboardDashboardOrganizations } from '$lib/api/generated/sdk.gen';
 	import {
 		User,
@@ -23,6 +23,7 @@
 
 	let { mobile = false, onItemClick }: Props = $props();
 
+	const queryClient = useQueryClient();
 	let dropdownOpen = $state(false);
 	let user = $derived(authStore.user);
 	let accessToken = $derived(authStore.accessToken);
@@ -101,8 +102,10 @@
 
 	function handleLogout() {
 		if (onItemClick) onItemClick();
-		// Navigate to logout endpoint which clears cookies and redirects
-		// The $effect in root layout will handle clearing client-side state
+		// Clear client-side state immediately so navbar updates in the same tick
+		authStore.logout();
+		queryClient.clear();
+		// Then navigate to server endpoint to clear cookies
 		goto('/logout');
 	}
 

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { generateHomeMeta, generateWebSiteStructuredData, toJsonLd } from '$lib/utils/seo';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import { getLocale } from '$lib/paraglide/runtime.js';
 	import { onMount } from 'svelte';
@@ -91,6 +92,8 @@
 		}).format(amount);
 	}
 
+	let isAuthenticated = $derived(authStore.isAuthenticated);
+
 	// Landing page URLs based on current locale
 	// Landing pages are NOT paraglide-translated, they use /de/ and /it/ prefixes
 	let landingPagePrefix = $derived(getLocale() === 'en' ? '' : `/${getLocale()}`);
@@ -158,18 +161,32 @@
 			>
 				{m['nav.browseEvents']()}
 			</a>
-			<a
-				href="/register"
-				class="rounded-md border border-primary px-6 py-3 text-base font-semibold text-primary hover:bg-primary/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-			>
-				{m['home.getStarted']()}
-			</a>
+			{#if isAuthenticated}
+				<a
+					href="/dashboard"
+					class="rounded-md border border-primary px-6 py-3 text-base font-semibold text-primary hover:bg-primary/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+				>
+					{m['userMenu.dashboard']()}
+				</a>
+			{:else}
+				<a
+					href="/register"
+					class="rounded-md border border-primary px-6 py-3 text-base font-semibold text-primary hover:bg-primary/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+				>
+					{m['home.getStarted']()}
+				</a>
+			{/if}
 		</div>
-		<div class="mt-4">
-			<a href="/login" class="text-sm text-muted-foreground hover:text-foreground hover:underline">
-				{m['home.alreadyHaveAccount']()}
-			</a>
-		</div>
+		{#if !isAuthenticated}
+			<div class="mt-4">
+				<a
+					href="/login"
+					class="text-sm text-muted-foreground hover:text-foreground hover:underline"
+				>
+					{m['home.alreadyHaveAccount']()}
+				</a>
+			</div>
+		{/if}
 	</div>
 
 	<!-- Features Section -->

--- a/src/routes/(public)/logout/+page.server.ts
+++ b/src/routes/(public)/logout/+page.server.ts
@@ -5,14 +5,11 @@ import type { PageServerLoad } from './$types';
  * Logout page - clears auth cookies and redirects to home
  * This is a GET endpoint (not a form action) to allow simple navigation-based logout
  *
- * The client-side +page.svelte will clear authStore immediately on mount,
- * then this server load will clear cookies and redirect.
+ * Client-side state (authStore, query cache) is cleared in UserMenu.svelte
+ * before navigating here. This server load only handles cookie cleanup.
  */
-export const load: PageServerLoad = async ({ cookies, depends }) => {
+export const load: PageServerLoad = async ({ cookies }) => {
 	console.log('[LOGOUT] Clearing authentication cookies');
-
-	// Mark this as dependent on auth so it invalidates properly
-	depends('auth:logout');
 
 	// Clear access token cookie
 	cookies.delete('access_token', { path: '/' });
@@ -22,10 +19,6 @@ export const load: PageServerLoad = async ({ cookies, depends }) => {
 
 	// Clear "remember me" preference cookie
 	cookies.delete('remember_me', { path: '/' });
-
-	// Small delay to ensure client-side auth state is cleared first
-	// This prevents race conditions where the redirect happens before onMount
-	await new Promise((resolve) => setTimeout(resolve, 100));
 
 	// Redirect to home page with full page reload to ensure layout re-runs
 	throw redirect(303, '/?logged_out=true');

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -130,6 +130,7 @@
 		else if (!serverAccessToken && currentAccessToken) {
 			console.log('[ROOT LAYOUT] No server token, clearing auth state (logout)');
 			authStore.logout();
+			queryClient.clear();
 			initializationPromise = null;
 		}
 		// Case 3: Both have tokens - check if they're different (e.g., impersonation)

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -26,42 +26,42 @@ const config = {
 			$api: 'src/lib/api'
 		},
 
-		// Content Security Policy — enforced
-		csp: {
-			mode: 'auto',
-			directives: {
-				'default-src': ['self'],
-				'script-src': ['self'],
-				'style-src': ['self', 'unsafe-inline'], // Svelte transitions create inline <style>
-				'img-src': ['self', apiUrl, 'data:', 'blob:'],
-				'font-src': ['self', 'data:'],
-				'connect-src': [
-					'self',
-					apiUrl,
-					'https://api.github.com',
-					...(isDev ? ['http://localhost:*', 'ws://localhost:*'] : [])
-				],
-				'frame-src': [
-					'https://www.google.com',
-					'https://google.com',
-					'https://maps.google.com',
-					'https://www.openstreetmap.org',
-					'https://openstreetmap.org',
-					'https://www.bing.com',
-					'https://bing.com',
-					'https://maps.app.goo.gl',
-					'https://goo.gl',
-					'https://yandex.com',
-					'https://yandex.ru',
-					'https://map.baidu.com'
-				],
-				'manifest-src': ['self'],
-				'base-uri': ['self'],
-				'form-action': ['self'],
-				'frame-ancestors': ['none'],
-				'object-src': ['none']
-			}
-		}
+		// Content Security Policy — only enforced in production
+		// In dev, Vite's HMR injects inline scripts without the CSP nonce, which breaks the page
+		...(isDev
+			? {}
+			: {
+					csp: {
+						mode: 'auto',
+						directives: {
+							'default-src': ['self'],
+							'script-src': ['self'],
+							'style-src': ['self', 'unsafe-inline'], // Svelte transitions create inline <style>
+							'img-src': ['self', apiUrl, 'data:', 'blob:'],
+							'font-src': ['self', 'data:'],
+							'connect-src': ['self', apiUrl, 'https://api.github.com'],
+							'frame-src': [
+								'https://www.google.com',
+								'https://google.com',
+								'https://maps.google.com',
+								'https://www.openstreetmap.org',
+								'https://openstreetmap.org',
+								'https://www.bing.com',
+								'https://bing.com',
+								'https://maps.app.goo.gl',
+								'https://goo.gl',
+								'https://yandex.com',
+								'https://yandex.ru',
+								'https://map.baidu.com'
+							],
+							'manifest-src': ['self'],
+							'base-uri': ['self'],
+							'form-action': ['self'],
+							'frame-ancestors': ['none'],
+							'object-src': ['none']
+						}
+					}
+				})
 	}
 };
 


### PR DESCRIPTION
## Summary

- **Logout fix**: Clear `authStore` and TanStack Query cache synchronously in `handleLogout()` before navigating to `/logout`, so the navbar updates instantly instead of showing stale authenticated UI
- **Homepage CTAs**: Show "Dashboard" button instead of "Get Started" when logged in; hide "Already have an account? Login" link for authenticated users
- **CSP dev fix**: Disable CSP entirely in dev mode — Vite's HMR injects inline scripts without the server-generated nonce, which CSP blocks, breaking the page on every file save

## Changes

| File | Change |
|------|--------|
| `UserMenu.svelte` | Call `authStore.logout()` + `queryClient.clear()` before `goto('/logout')` |
| `+layout.svelte` | Add `queryClient.clear()` to Case 2 (server-side session expiry) |
| `logout/+page.server.ts` | Remove dead `setTimeout(100)` delay and unused `depends()` |
| `(public)/+page.svelte` | Conditionally show Dashboard vs Get Started based on auth state |
| `svelte.config.js` | Skip `csp` config block when `isDev` is true |

## Test plan

- [ ] Log in, confirm navbar shows user info
- [ ] Click Logout — navbar should **instantly** show Login/Sign Up (no flash of stale UI)
- [ ] Check DevTools cookies — `access_token`, `refresh_token`, `remember_me` deleted
- [ ] Navigate to `/dashboard` after logout — should redirect to login
- [ ] Visit homepage while logged in — should show "Dashboard" button, no login link
- [ ] Visit homepage while logged out — should show "Get Started" and login link
- [ ] Edit a `.svelte` file with dev server running — HMR should work without CSP errors
- [ ] Production build (`pnpm build`) — CSP headers should still be present

🤖 Generated with [Claude Code](https://claude.com/claude-code)