### PR TITLE
fix(csp): add media-src directive for audio playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.39.0",
+	"version": "1.39.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -38,6 +38,7 @@ const config = {
 							'script-src': ['self'],
 							'style-src': ['self', 'unsafe-inline'], // Svelte transitions create inline <style>
 							'img-src': ['self', apiUrl, 'data:', 'blob:'],
+							'media-src': ['self', apiUrl, 'blob:'],
 							'font-src': ['self', 'data:'],
 							'connect-src': ['self', apiUrl, 'https://api.github.com'],
 							'frame-src': [


### PR DESCRIPTION
## Summary
- Add `media-src: 'self' apiUrl 'blob:'` to CSP directives in `svelte.config.js`
- The missing directive caused `default-src: 'self'` to block `<video>`/`<audio>` elements from loading files hosted on `api.letsrevel.io`
- This is why the questionnaire audio player was permanently disabled in production (CSP is disabled in dev, so it worked locally)

## Test plan
- [ ] Deploy to staging and verify the audio player loads and plays WebM recordings on the questionnaire submission review page
- [ ] Verify no CSP violations in browser console for media playback
- [ ] Confirm download button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.39.1

* **Security**
  * Updated production Content Security Policy to include media resource directives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->