### PR TITLE
fix(events): prevent infinite loop when claiming invitation with questionnaire

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.39.1",
+	"version": "1.39.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/events/ClaimInvitationButton.svelte
+++ b/src/lib/components/events/ClaimInvitationButton.svelte
@@ -52,9 +52,13 @@
 
 			onSuccess?.();
 
-			// Reload page after a short delay to show updated status
+			// Strip the ?et= token from the URL before reloading so the claim
+			// button doesn't reappear on the next page load
+			const url = new URL(window.location.href);
+			url.searchParams.delete('et');
+
 			setTimeout(() => {
-				window.location.reload();
+				window.location.replace(url.toString());
 			}, 1000);
 		} catch (err: any) {
 			console.error('Failed to claim invitation:', err);


### PR DESCRIPTION
## Summary

- After claiming an invitation via `?et=` token, the page reloaded with the token still in the URL
- Since `grants_invitation` is a static property of the token, the claim button kept reappearing instead of showing the next eligibility step (e.g. "complete questionnaire")
- This caused an infinite loop on mobile: toast "invitation claimed" → reload → claim button again
- Fix: strip `?et=` from the URL after successful claim using `window.location.replace()`, so the reload fetches fresh eligibility without the token

## Test plan

- [ ] Visit an event with `?et=<token>` that requires both invitation and questionnaire
- [ ] Click "Claim invitation" — should succeed and redirect to page without `?et=`
- [ ] After reload, the CTA should show "Complete questionnaire" (not "Claim invitation")
- [ ] Browser back button should not return to the `?et=` URL (replaced, not pushed)
- [ ] Unauthenticated flow still redirects to login with `?et=` preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the invitation claiming process to prevent the claim button from reappearing after a successful claim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->