### PR TITLE
fix(build): update svelte to 5.53.10 and increase Docker build heap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN sed -i "s|'http://localhost:8000'|'${PUBLIC_API_URL}'|g" src/lib/api/generat
 # Build the application
 # This creates the production build in the `build` directory
 # SvelteKit will embed PUBLIC_* env vars into the client bundle
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN pnpm build
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.2",
 		"prettier-plugin-tailwindcss": "^0.6.9",
-		"svelte": "^5.0.0",
+		"svelte": "^5.53.10",
 		"svelte-check": "^4.1.1",
 		"tailwindcss": "^3.4.17",
 		"tslib": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
     dependencies:
       '@tanstack/svelte-query':
         specifier: ^6.0.3
-        version: 6.0.3(svelte@5.40.2)
+        version: 6.0.3(svelte@5.53.10)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -38,13 +38,13 @@ importers:
         version: 3.0.0
       lucide-svelte:
         specifier: ^0.469.0
-        version: 0.469.0(svelte@5.40.2)
+        version: 0.469.0(svelte@5.53.10)
       marked:
         specifier: ^17.0.1
         version: 17.0.1
       mode-watcher:
         specifier: ^0.4.1
-        version: 0.4.1(svelte@5.40.2)
+        version: 0.4.1(svelte@5.53.10)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -53,13 +53,13 @@ importers:
         version: 0.1.1(patch_hash=akllwigc5wnxcdr7bddbzgbkji)
       svelte-dnd-action:
         specifier: ^0.9.69
-        version: 0.9.69(svelte@5.40.2)
+        version: 0.9.69(svelte@5.53.10)
       svelte-sonner:
         specifier: ^1.0.5
-        version: 1.0.5(svelte@5.40.2)
+        version: 1.0.5(svelte@5.53.10)
       sveltekit-superforms:
         specifier: ^2.28.1
-        version: 2.28.1(@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(@types/json-schema@7.0.15)(esbuild@0.25.11)(svelte@5.40.2)(typescript@5.9.3)
+        version: 2.28.1(@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(@types/json-schema@7.0.15)(esbuild@0.25.11)(svelte@5.53.10)(typescript@5.9.3)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.0
@@ -78,19 +78,19 @@ importers:
         version: 2.4.0
       '@lucide/svelte':
         specifier: ^0.482.0
-        version: 0.482.0(svelte@5.40.2)
+        version: 0.482.0(svelte@5.53.10)
       '@playwright/test':
         specifier: ^1.49.0
         version: 1.56.1
       '@sveltejs/adapter-node':
         specifier: ^5.4.0
-        version: 5.4.0(@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))
+        version: 5.4.0(@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))
       '@sveltejs/kit':
         specifier: ^2.49.5
-        version: 2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
+        version: 2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
+        version: 5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.18)
@@ -99,7 +99,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.2.8
-        version: 5.2.8(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))(vitest@2.1.9)
+        version: 5.2.8(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))(vitest@2.1.9)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -126,7 +126,7 @@ importers:
         version: 10.4.21(postcss@8.5.6)
       bits-ui:
         specifier: ^1.8.0
-        version: 1.8.0(svelte@5.40.2)
+        version: 1.8.0(svelte@5.53.10)
       eslint:
         specifier: ^9.17.0
         version: 9.37.0(jiti@1.21.7)
@@ -135,7 +135,7 @@ importers:
         version: 9.1.2(eslint@9.37.0(jiti@1.21.7))
       eslint-plugin-svelte:
         specifier: ^2.46.1
-        version: 2.46.1(eslint@9.37.0(jiti@1.21.7))(svelte@5.40.2)
+        version: 2.46.1(eslint@9.37.0(jiti@1.21.7))(svelte@5.53.10)
       globals:
         specifier: ^15.13.0
         version: 15.15.0
@@ -150,16 +150,16 @@ importers:
         version: 3.6.2
       prettier-plugin-svelte:
         specifier: ^3.3.2
-        version: 3.4.0(prettier@3.6.2)(svelte@5.40.2)
+        version: 3.4.0(prettier@3.6.2)(svelte@5.53.10)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.9
-        version: 0.6.14(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.40.2))(prettier@3.6.2)
+        version: 0.6.14(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.53.10))(prettier@3.6.2)
       svelte:
-        specifier: ^5.0.0
-        version: 5.40.2
+        specifier: ^5.53.10
+        version: 5.53.10
       svelte-check:
         specifier: ^4.1.1
-        version: 4.3.3(picomatch@4.0.3)(svelte@5.40.2)(typescript@5.9.3)
+        version: 4.3.3(picomatch@4.0.3)(svelte@5.53.10)(typescript@5.9.3)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.18
@@ -1291,6 +1291,10 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -1574,6 +1578,9 @@ packages:
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
 
+  devalue@5.6.4:
+    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -1710,8 +1717,8 @@ packages:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
 
-  esrap@2.1.0:
-    resolution: {integrity: sha512-yzmPNpl7TBbMRC5Lj2JlJZNPml0tzqoqP5B1JXycNUwtqma9AKCO0M2wHrdgsHcy1WRW7S9rJknAMtByg3usgA==}
+  esrap@2.2.3:
+    resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -2699,8 +2706,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
 
-  svelte@5.40.2:
-    resolution: {integrity: sha512-wr/SwBVCVfeHU8FZr48vRrzSpWdBBzGo5mlErjGzeW4reJhK/CWutLZbk/eHwhKqO17ccjeTcvsqjrT4aK3wZA==}
+  svelte@5.53.10:
+    resolution: {integrity: sha512-UcNfWzbrjvYXYSk+U2hME25kpb87oq6/WVLeBF4khyQrb3Ob/URVlN23khal+RbdCUTMfg4qWjI9KZjCNFtYMQ==}
     engines: {node: '>=18'}
 
   sveltekit-superforms@2.28.1:
@@ -3574,9 +3581,9 @@ snapshots:
 
   '@lix-js/server-protocol-schema@0.1.1': {}
 
-  '@lucide/svelte@0.482.0(svelte@5.40.2)':
+  '@lucide/svelte@0.482.0(svelte@5.53.10)':
     dependencies:
-      svelte: 5.40.2
+      svelte: 5.53.10
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3725,19 +3732,19 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-node@5.4.0(@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))':
+  '@sveltejs/adapter-node@5.4.0(@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))':
     dependencies:
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.52.4)
       '@rollup/plugin-json': 6.1.0(rollup@4.52.4)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.52.4)
-      '@sveltejs/kit': 2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
+      '@sveltejs/kit': 2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
       rollup: 4.52.4
 
-  '@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))':
+  '@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.7.0
@@ -3749,28 +3756,28 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
-      svelte: 5.40.2
+      svelte: 5.53.10
       vite: 6.4.0(@types/node@22.18.11)(jiti@1.21.7)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
       debug: 4.4.3
-      svelte: 5.40.2
+      svelte: 5.53.10
       vite: 6.4.0(@types/node@22.18.11)(jiti@1.21.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.19
-      svelte: 5.40.2
+      svelte: 5.53.10
       vite: 6.4.0(@types/node@22.18.11)(jiti@1.21.7)
       vitefu: 1.1.1(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
     transitivePeerDependencies:
@@ -3787,10 +3794,10 @@ snapshots:
 
   '@tanstack/query-core@5.90.5': {}
 
-  '@tanstack/svelte-query@6.0.3(svelte@5.40.2)':
+  '@tanstack/svelte-query@6.0.3(svelte@5.53.10)':
     dependencies:
       '@tanstack/query-core': 5.90.5
-      svelte: 5.40.2
+      svelte: 5.53.10
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -3812,10 +3819,10 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/svelte@5.2.8(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))(vitest@2.1.9)':
+  '@testing-library/svelte@5.2.8(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))(vitest@2.1.9)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      svelte: 5.40.2
+      svelte: 5.53.10
     optionalDependencies:
       vite: 6.4.0(@types/node@22.18.11)(jiti@1.21.7)
       vitest: 2.1.9(@types/node@22.18.11)(@vitest/ui@3.2.4)(jsdom@27.0.0(postcss@8.5.6))
@@ -3846,8 +3853,7 @@ snapshots:
     dependencies:
       '@testing-library/jest-dom': 6.9.1
 
-  '@types/trusted-types@2.0.7':
-    optional: true
+  '@types/trusted-types@2.0.7': {}
 
   '@types/validator@13.15.10':
     optional: true
@@ -4172,6 +4178,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  aria-query@5.3.1: {}
+
   aria-query@5.3.2: {}
 
   arkregex@0.0.3:
@@ -4212,16 +4220,16 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.8.0(svelte@5.40.2):
+  bits-ui@1.8.0(svelte@5.53.10):
     dependencies:
       '@floating-ui/core': 1.7.3
       '@floating-ui/dom': 1.7.4
       '@internationalized/date': 3.10.0
       css.escape: 1.5.1
       esm-env: 1.2.2
-      runed: 0.23.4(svelte@5.40.2)
-      svelte: 5.40.2
-      svelte-toolbelt: 0.7.1(svelte@5.40.2)
+      runed: 0.23.4(svelte@5.53.10)
+      svelte: 5.53.10
+      svelte-toolbelt: 0.7.1(svelte@5.53.10)
       tabbable: 6.2.0
 
   brace-expansion@1.1.12:
@@ -4444,6 +4452,8 @@ snapshots:
 
   devalue@5.6.3: {}
 
+  devalue@5.6.4: {}
+
   didyoumean@1.2.2: {}
 
   dijkstrajs@1.0.3: {}
@@ -4553,7 +4563,7 @@ snapshots:
     dependencies:
       eslint: 9.37.0(jiti@1.21.7)
 
-  eslint-plugin-svelte@2.46.1(eslint@9.37.0(jiti@1.21.7))(svelte@5.40.2):
+  eslint-plugin-svelte@2.46.1(eslint@9.37.0(jiti@1.21.7))(svelte@5.53.10):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@1.21.7))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4566,9 +4576,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       semver: 7.7.3
-      svelte-eslint-parser: 0.43.0(svelte@5.40.2)
+      svelte-eslint-parser: 0.43.0(svelte@5.53.10)
     optionalDependencies:
-      svelte: 5.40.2
+      svelte: 5.53.10
     transitivePeerDependencies:
       - ts-node
 
@@ -4648,7 +4658,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.1.0:
+  esrap@2.2.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -5030,9 +5040,9 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
-  lucide-svelte@0.469.0(svelte@5.40.2):
+  lucide-svelte@0.469.0(svelte@5.53.10):
     dependencies:
-      svelte: 5.40.2
+      svelte: 5.53.10
 
   lz-string@1.5.0: {}
 
@@ -5067,9 +5077,9 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mode-watcher@0.4.1(svelte@5.40.2):
+  mode-watcher@0.4.1(svelte@5.53.10):
     dependencies:
-      svelte: 5.40.2
+      svelte: 5.53.10
 
   mri@1.2.0: {}
 
@@ -5266,16 +5276,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.40.2):
+  prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.53.10):
     dependencies:
       prettier: 3.6.2
-      svelte: 5.40.2
+      svelte: 5.53.10
 
-  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.40.2))(prettier@3.6.2):
+  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.53.10))(prettier@3.6.2):
     dependencies:
       prettier: 3.6.2
     optionalDependencies:
-      prettier-plugin-svelte: 3.4.0(prettier@3.6.2)(svelte@5.40.2)
+      prettier-plugin-svelte: 3.4.0(prettier@3.6.2)(svelte@5.53.10)
 
   prettier@3.6.2: {}
 
@@ -5375,15 +5385,15 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.23.4(svelte@5.40.2):
+  runed@0.23.4(svelte@5.53.10):
     dependencies:
       esm-env: 1.2.2
-      svelte: 5.40.2
+      svelte: 5.53.10
 
-  runed@0.28.0(svelte@5.40.2):
+  runed@0.28.0(svelte@5.53.10):
     dependencies:
       esm-env: 1.2.2
-      svelte: 5.40.2
+      svelte: 5.53.10
 
   sade@1.8.1:
     dependencies:
@@ -5487,25 +5497,25 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.3.3(picomatch@4.0.3)(svelte@5.40.2)(typescript@5.9.3):
+  svelte-check@4.3.3(picomatch@4.0.3)(svelte@5.53.10)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.40.2
+      svelte: 5.53.10
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
   svelte-crop-window@0.1.1(patch_hash=akllwigc5wnxcdr7bddbzgbkji): {}
 
-  svelte-dnd-action@0.9.69(svelte@5.40.2):
+  svelte-dnd-action@0.9.69(svelte@5.53.10):
     dependencies:
-      svelte: 5.40.2
+      svelte: 5.53.10
 
-  svelte-eslint-parser@0.43.0(svelte@5.40.2):
+  svelte-eslint-parser@0.43.0(svelte@5.53.10):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -5513,43 +5523,45 @@ snapshots:
       postcss: 8.5.6
       postcss-scss: 4.0.9(postcss@8.5.6)
     optionalDependencies:
-      svelte: 5.40.2
+      svelte: 5.53.10
 
-  svelte-sonner@1.0.5(svelte@5.40.2):
+  svelte-sonner@1.0.5(svelte@5.53.10):
     dependencies:
-      runed: 0.28.0(svelte@5.40.2)
-      svelte: 5.40.2
+      runed: 0.28.0(svelte@5.53.10)
+      svelte: 5.53.10
 
-  svelte-toolbelt@0.7.1(svelte@5.40.2):
+  svelte-toolbelt@0.7.1(svelte@5.53.10):
     dependencies:
       clsx: 2.1.1
-      runed: 0.23.4(svelte@5.40.2)
+      runed: 0.23.4(svelte@5.53.10)
       style-to-object: 1.0.11
-      svelte: 5.40.2
+      svelte: 5.53.10
 
-  svelte@5.40.2:
+  svelte@5.53.10:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
       '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
       acorn: 8.15.0
-      aria-query: 5.3.2
+      aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
+      devalue: 5.6.4
       esm-env: 1.2.2
-      esrap: 2.1.0
+      esrap: 2.2.3
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.19
       zimmerframe: 1.1.4
 
-  sveltekit-superforms@2.28.1(@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(@types/json-schema@7.0.15)(esbuild@0.25.11)(svelte@5.40.2)(typescript@5.9.3):
+  sveltekit-superforms@2.28.1(@sveltejs/kit@2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(@types/json-schema@7.0.15)(esbuild@0.25.11)(svelte@5.53.10)(typescript@5.9.3):
     dependencies:
-      '@sveltejs/kit': 2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.40.2)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.40.2)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
+      '@sveltejs/kit': 2.49.5(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.10)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7)))(svelte@5.53.10)(typescript@5.9.3)(vite@6.4.0(@types/node@22.18.11)(jiti@1.21.7))
       devalue: 5.6.3
       memoize-weak: 1.0.2
-      svelte: 5.40.2
+      svelte: 5.53.10
       ts-deepmerge: 7.0.3
     optionalDependencies:
       '@exodus/schemasafe': 1.3.0


### PR DESCRIPTION
## Summary
- **Update svelte from 5.40.2 to 5.53.10** — `@sveltejs/kit@2.49.5` requires the `fork` export introduced in svelte 5.42.0, but the lockfile pinned svelte at 5.40.2, causing `"fork" is not exported` errors at build time
- **Set `NODE_OPTIONS=--max-old-space-size=4096`** in the Dockerfile builder stage to prevent OOM crashes during CI builds

## Test plan
- [ ] CI build job passes (the main fix)
- [ ] Verify dev server starts without errors (`pnpm dev`)
- [ ] Verify production build completes locally (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Svelte framework dependency to the latest patch version.
  * Optimized build process memory allocation for improved performance during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->