### PR TITLE
fix(pricing): add VAT exclusion note to pricing card and fee calculator

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -2190,7 +2190,8 @@
 		},
 		"eeaCards": "EWR-Karten",
 		"pricingExcludingStripeFees": "exklusive Stripe-Gebühren",
-		"pricingHappyToNegotiate": "Wir verhandeln gerne"
+		"pricingHappyToNegotiate": "Wir verhandeln gerne",
+		"feesExcludeVat": "Plattformgebühren verstehen sich zzgl. MwSt., sofern anwendbar."
 	},
 	"learnMore.startOrganizing": "Jetzt organisieren",
 	"learnMore.startOrganizingDescription": "Erstelle deine Organisation und beginne, großartige Veranstaltungen für deine Community zu veranstalten.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2190,7 +2190,8 @@
 		},
 		"eeaCards": "EEA cards",
 		"pricingExcludingStripeFees": "excluding Stripe's fees",
-		"pricingHappyToNegotiate": "We're happy to negotiate"
+		"pricingHappyToNegotiate": "We're happy to negotiate",
+		"feesExcludeVat": "Platform fees are exclusive of VAT, where applicable."
 	},
 	"learnMore.startOrganizing": "Start Organizing",
 	"learnMore.startOrganizingDescription": "Create your organization and start hosting amazing events for your community.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -2190,7 +2190,8 @@
 		},
 		"eeaCards": "carte SEE",
 		"pricingExcludingStripeFees": "escluse le commissioni Stripe",
-		"pricingHappyToNegotiate": "Siamo disponibili a trattare"
+		"pricingHappyToNegotiate": "Siamo disponibili a trattare",
+		"feesExcludeVat": "Le commissioni della piattaforma sono al netto dell'IVA, ove applicabile."
 	},
 	"learnMore.startOrganizing": "Inizia a Organizzare",
 	"learnMore.startOrganizingDescription": "Crea la tua organizzazione e inizia a ospitare eventi straordinari per la tua comunità.",

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -575,6 +575,9 @@
 							{m['learnMore.pricingHappyToNegotiate']()}
 						</a>
 					</div>
+					<p class="mt-2 text-xs text-muted-foreground/70">
+						{m['learnMore.feesExcludeVat']()}
+					</p>
 				</div>
 			</div>
 		</div>
@@ -893,6 +896,9 @@
 						fees: formatCurrency(totalFees),
 						percentage: ((totalFees / ticketPrice) * 100).toFixed(1)
 					})}
+				</p>
+				<p class="text-center text-xs text-muted-foreground/70">
+					{m['learnMore.feesExcludeVat']()}
 				</p>
 			</div>
 


### PR DESCRIPTION
## Summary
- Add "Platform fees are exclusive of VAT, where applicable" note to the **homepage pricing card** (Hosted online payments) and the **fee calculator modal** summary
- Add i18n translations for EN, DE, and IT

## Test plan
- [ ] Verify the note appears below the "happy to negotiate" link in the pricing card
- [ ] Verify the note appears below the total fees summary in the fee calculator modal
- [ ] Check all 3 languages (EN, DE, IT) display the correct translation
- [ ] Confirm the note styling is subtle (`text-xs text-muted-foreground/70`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)