### PR TITLE
fix(markdown-editor): interpolate empty-preview message (#379)

### DIFF
--- a/src/lib/components/forms/MarkdownEditor.svelte
+++ b/src/lib/components/forms/MarkdownEditor.svelte
@@ -76,7 +76,7 @@
 	 */
 	function convertMarkdownToHtml(markdown: string): string {
 		if (!markdown)
-			return `<p class="text-muted-foreground">{m['markdownEditor.nothingToPreview']()}</p>`;
+			return `<p class="text-muted-foreground">${m['markdownEditor.nothingToPreview']()}</p>`;
 
 		let html = markdown;
 


### PR DESCRIPTION
## Summary
- Fixes #379: previewing an event/venue with empty description rendered the raw string `{m['markdownEditor.nothingToPreview']()}` instead of the translated "Nothing to preview" message.
- Root cause: a JS template literal in \`convertMarkdownToHtml\` used \`{...}\` instead of \`\${...}\`, so the placeholder was treated as literal text.
- One-character change: \`{\` → \`\${\` at \`src/lib/components/forms/MarkdownEditor.svelte:79\`.

## Test plan
- [ ] Open an event/venue editor, leave the description empty, toggle the markdown preview, and verify the localized "Nothing to preview" message appears (not the raw template string).
- [ ] Verify the preview still works correctly when description is non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)