### PR TITLE
feat(org): calendar view shortcut on org page + ticket fix — 1.55.0

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -3766,6 +3766,7 @@
 		"events_oldestFirst": "Älteste zuerst",
 		"events_sortNewestLabel": "Zeige neueste zuerst",
 		"events_sortOldestLabel": "Zeige älteste zuerst",
+		"events_calendar": "Kalender",
 		"events_browseAll": "Alle durchsuchen",
 		"events_loading": "Veranstaltungen werden geladen...",
 		"events_failed": "Fehler beim Laden der Veranstaltungen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3766,6 +3766,7 @@
 		"events_oldestFirst": "Oldest First",
 		"events_sortNewestLabel": "Showing newest first",
 		"events_sortOldestLabel": "Showing oldest first",
+		"events_calendar": "Calendar",
 		"events_browseAll": "Browse All",
 		"events_loading": "Loading events...",
 		"events_failed": "Failed to load events",

--- a/messages/it.json
+++ b/messages/it.json
@@ -3766,6 +3766,7 @@
 		"events_oldestFirst": "Prima i Meno Recenti",
 		"events_sortNewestLabel": "Mostra prima i più recenti",
 		"events_sortOldestLabel": "Mostra prima i meno recenti",
+		"events_calendar": "Calendario",
 		"events_browseAll": "Sfoglia Tutti",
 		"events_loading": "Caricamento eventi...",
 		"events_failed": "Errore nel caricamento degli eventi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.54.0",
+	"version": "1.55.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/utils/ticket-helpers.ts
+++ b/src/lib/utils/ticket-helpers.ts
@@ -73,10 +73,7 @@ export function needsPaymentConfirmation(ticket: any): boolean {
  */
 export function canConfirmPayment(ticket: any): boolean {
 	const method = ticket.tier?.payment_method;
-	return (
-		(ticket.status === 'pending' || ticket.status === 'cancelled') &&
-		(method === 'offline' || method === 'at_the_door')
-	);
+	return ticket.status === 'pending' && (method === 'offline' || method === 'at_the_door');
 }
 
 /**

--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -5,6 +5,7 @@
 		MapPin,
 		Settings,
 		Calendar,
+		CalendarDays,
 		ArrowRight,
 		Repeat,
 		ArrowDownUp,
@@ -500,6 +501,17 @@
 							? m['organizationProfile.events_newestFirst']()
 							: m['organizationProfile.events_oldestFirst']()}
 					</button>
+
+					<!-- Calendar View Shortcut -->
+					<a
+						href="/events?organization={organization.id}&organization_name={encodeURIComponent(
+							organization.name
+						)}&organization_slug={organization.slug}&viewMode=calendar"
+						class="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+					>
+						<CalendarDays class="h-4 w-4" aria-hidden="true" />
+						{m['organizationProfile.events_calendar']()}
+					</a>
 
 					<!-- Browse All Button -->
 					<a


### PR DESCRIPTION
## Summary

Two small changes bundled together for 1.55.0:

### 1. Calendar view shortcut on org page (#380)
Adds a "Calendar" link in the actions row of the Events section on the public org page (between "Newest First" and "Browse All"). It points to `/events` pre-filtered by the current org with `viewMode=calendar`, reusing the existing calendar view.

Delivers the "Good" tier of #380 with a zero-risk shortcut — no new components, no backend work, no API changes. Tiers 2 (aggregated calendar for followed orgs), 3 (RSVP overlay), and the separate ICS-subscription request from the thread are deferred to follow-up issues.

### 2. Hotfix: hide Confirm Payment action on cancelled tickets
`canConfirmPayment()` in `src/lib/utils/ticket-helpers.ts` returned `true` for both `pending` **and** `cancelled` tickets with offline / at-the-door payment methods, exposing the "Confirm Payment" button on the organizer's ticket list view (`/org/[slug]/admin/events/[event_id]/tickets`) for tickets that had already been cancelled. Restricted to `status === 'pending'` only — now hidden in both `TicketTable.svelte` (desktop) and `TicketCardList.svelte` (mobile).

## Changes
- New i18n key `organizationProfile.events_calendar` in en/it/de (100% completion preserved)
- New `<a>` link in `src/routes/(public)/org/[slug]/+page.svelte` using `CalendarDays` icon
- `src/lib/utils/ticket-helpers.ts`: drop `ticket.status === 'cancelled'` from `canConfirmPayment`
- Version bump `1.54.0` → `1.55.0`

Refs #380. Supersedes #383.

## Test plan
- [ ] Visit any public org page; verify the new "Calendar" link appears between "Newest First" and "Browse All"
- [ ] Click it; verify it lands on `/events` filtered to that org with calendar view active
- [ ] Verify the list/calendar toggle in the events page still works
- [ ] Verify on mobile viewport that the buttons wrap cleanly
- [ ] Verify localization in `it` and `de`
- [ ] Cancel an offline/at-the-door ticket as the organizer; verify the "Confirm Payment" button no longer appears for that row (desktop table + mobile card)
- [ ] Verify the button still appears for `pending` offline/at-the-door tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)