### PR TITLE
fix(tickets): hide confirm-payment action for cancelled tickets — 1.54.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.54.0",
+	"version": "1.54.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/utils/ticket-helpers.ts
+++ b/src/lib/utils/ticket-helpers.ts
@@ -73,10 +73,7 @@ export function needsPaymentConfirmation(ticket: any): boolean {
  */
 export function canConfirmPayment(ticket: any): boolean {
 	const method = ticket.tier?.payment_method;
-	return (
-		(ticket.status === 'pending' || ticket.status === 'cancelled') &&
-		(method === 'offline' || method === 'at_the_door')
-	);
+	return ticket.status === 'pending' && (method === 'offline' || method === 'at_the_door');
 }
 
 /**


### PR DESCRIPTION
## Summary

`canConfirmPayment()` in `src/lib/utils/ticket-helpers.ts` returned `true` for both `pending` **and** `cancelled` tickets with offline / at-the-door payment methods. As a result, the organizer's ticket list view (`/org/[slug]/admin/events/[event_id]/tickets`) was exposing the "Confirm Payment" button on tickets that had already been cancelled.

This restricts the helper to `status === 'pending'` only, so the button is hidden for cancelled tickets in both `TicketTable.svelte` (desktop) and `TicketCardList.svelte` (mobile).

## Changes
- `src/lib/utils/ticket-helpers.ts`: drop `ticket.status === 'cancelled'` from `canConfirmPayment`
- Version bump `1.54.0` → `1.54.1`

## Test plan
- [ ] Cancel an offline/at-the-door ticket as the organizer
- [ ] Verify the "Confirm Payment" button no longer appears for that row in the admin ticket list (desktop table + mobile card)
- [ ] Verify the button still appears for `pending` offline/at-the-door tickets
- [ ] Verify other actions (cancel, unconfirm payment, make member) behave unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)