### PR TITLE
fix(sitemap): cap page_size at backend max (200) — 1.58.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.58.0",
+	"version": "1.58.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/routes/sitemap-events-[page].xml/+server.ts
+++ b/src/routes/sitemap-events-[page].xml/+server.ts
@@ -3,7 +3,7 @@ import { eventpublicdiscoveryListEvents } from '$lib/api';
 import { getBackendUrl } from '$lib/config/api';
 import type { RequestHandler } from './$types';
 
-const PAGE_SIZE = 5000;
+const PAGE_SIZE = 200;
 
 function escapeXml(s: string): string {
 	return s

--- a/src/routes/sitemap-orgs-[page].xml/+server.ts
+++ b/src/routes/sitemap-orgs-[page].xml/+server.ts
@@ -3,7 +3,7 @@ import { organizationListOrganizations } from '$lib/api';
 import { getBackendUrl } from '$lib/config/api';
 import type { RequestHandler } from './$types';
 
-const PAGE_SIZE = 5000;
+const PAGE_SIZE = 200;
 
 function escapeXml(s: string): string {
 	return s

--- a/src/routes/sitemap-series-[page].xml/+server.ts
+++ b/src/routes/sitemap-series-[page].xml/+server.ts
@@ -3,7 +3,7 @@ import { eventseriesListEventSeries } from '$lib/api';
 import { getBackendUrl } from '$lib/config/api';
 import type { RequestHandler } from './$types';
 
-const PAGE_SIZE = 5000;
+const PAGE_SIZE = 200;
 
 function escapeXml(s: string): string {
 	return s

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -5,7 +5,7 @@ import {
 } from '$lib/api';
 import type { RequestHandler } from './$types';
 
-const PAGE_SIZE = 5000;
+const PAGE_SIZE = 200;
 
 function pages(total: number): number {
 	return Math.max(1, Math.ceil(total / PAGE_SIZE));


### PR DESCRIPTION
## Summary
- Sitemap endpoints (`/sitemap-orgs-N.xml`, `/sitemap-events-N.xml`, `/sitemap-series-N.xml`) requested `page_size=5000`, but the backend caps `page_size < 201`. Every crawler hit produced a 422 in prod logs, surfaced as `OrganizationController[list_organizations]` validation errors (and equivalents for events/series).
- Drop `PAGE_SIZE` from 5000 → 200 across all four sitemap files. The index divisor in `sitemap.xml` must match the per-page request size so the sub-sitemap count stays correct.
- Bumps to 1.58.1.

## Test plan
- [ ] `curl https://<host>/sitemap.xml` returns a sitemapindex with the expected number of sub-sitemap entries
- [ ] `curl https://<host>/sitemap-orgs-1.xml` returns populated `<url>` entries (no longer empty)
- [ ] Backend prod logs no longer show `less_than` validation errors on list endpoints from the sitemap fetch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.58.1
  * Sitemap pagination parameters adjusted across all core content types including events, organizations, and event series. Changes distribute content across more individual sitemap pages using optimized per-page item limits, refining the overall sitemap structure and ensuring comprehensive content organization across the sitemap index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->