### PR TITLE
feat(ssr): route SSR API calls internally with the real visitor IP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.59.0",
+	"version": "1.59.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,9 @@
-import type { Handle } from '@sveltejs/kit';
+import type { Handle, HandleFetch } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
+import { env } from '$env/dynamic/private';
 import { i18nHandle } from '$lib/i18n';
 import { tokenRefresh } from '$lib/api/generated';
+import { API_BASE_URL } from '$lib/config/api';
 import {
 	getAccessTokenCookieOptions,
 	getRefreshTokenCookieOptions,
@@ -233,3 +235,38 @@ export const handle = sequence(
 	handleAuth,
 	handlePreloadOptimization
 );
+
+/**
+ * SSR fetch interception
+ *
+ * When INTERNAL_API_URL is set (production: http://web:8000), API calls made
+ * during SSR via the event-scoped `fetch` are rewritten from the public API
+ * origin to the internal docker network — skipping the Cloudflare/Caddy
+ * round-trip — and carry the real visitor IP in X-Real-IP / X-Forwarded-For,
+ * so the backend geolocates ("nearest first"), logs, and rate-limits the
+ * visitor instead of this server's egress IP.
+ *
+ * The public path cannot forward the IP: Caddy deliberately overwrites those
+ * headers on any request arriving from outside (anti-spoofing). The visitor IP
+ * comes from getClientAddress(), which adapter-node reads from the header
+ * configured via ADDRESS_HEADER (set by Caddy on the frontend proxy).
+ *
+ * When INTERNAL_API_URL is unset (local dev, or as a rollback switch), SSR
+ * fetches keep using the public API URL unchanged. See backend issue #487.
+ */
+export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
+	const internalApiUrl = env.INTERNAL_API_URL;
+	if (!internalApiUrl || !request.url.startsWith(API_BASE_URL)) {
+		return fetch(request);
+	}
+
+	const rewritten = new Request(internalApiUrl + request.url.slice(API_BASE_URL.length), request);
+	try {
+		const clientIp = event.getClientAddress();
+		rewritten.headers.set('x-real-ip', clientIp);
+		rewritten.headers.set('x-forwarded-for', clientIp);
+	} catch {
+		// getClientAddress() throws during prerendering — send without the IP
+	}
+	return fetch(rewritten);
+};


### PR DESCRIPTION
## What

Frontend half of letsrevel/revel-backend#487 — SSR-rendered pages (e.g. `/events` "Nearest First") geolocate to the **server's egress IP** instead of the visitor's, because the API only ever sees the SSR fetch's origin.

Adds a `handleFetch` hook in `hooks.server.ts`:

- When `INTERNAL_API_URL` is set (production: `http://web:8000`, see letsrevel/infra#5), SSR API calls made via the event-scoped `fetch` are rewritten from `PUBLIC_API_URL` to the internal docker network.
- The rewritten request carries the real visitor IP (`event.getClientAddress()`, provided by Caddy → `ADDRESS_HEADER=x-real-ip`) in both `X-Real-IP` (backend geolocation/logging/audit) and `X-Forwarded-For` (ninja throttling keys on it — anonymous SSR requests get per-visitor throttle buckets instead of sharing one per server).
- `getClientAddress()` is guarded — it throws during prerendering; those requests go through without the headers.
- **No-op when `INTERNAL_API_URL` is unset** (local dev unchanged; unsetting it in prod is the rollback switch).

Why not forward the IP over the public path: Caddy deliberately overwrites `X-Real-IP`/`X-Forwarded-For` on anything arriving from outside (anti-spoofing, infra#4) — only internal traffic can carry it. Side benefit: SSR API calls skip the full Cloudflare round-trip (lower SSR latency, less egress).

This only affects load functions that pass the event `fetch` to the API client (the discovery pages do). Calls using global fetch (e.g. the token refresh in `handleAuth`) keep today's public-path behavior — degraded, not broken.

Version bumped 1.59.0 → 1.59.1.

## Deploy order
1. Merge letsrevel/infra#5 + deploy (env vars + Caddy header; inert by itself)
2. Merge this + release; frontend container picks up `INTERNAL_API_URL` on recreate

## Verify after deploy
- Logged-out visit to `/events` from a residential IP: backend logs show the visitor IP with `user_agent: "node"` (was `116.203.x.x`)
- "Nearest First" actually sorts by distance from the visitor (Vienna user → Vienna events first)

`pnpm lint` and `pnpm check`: 0 errors (warnings pre-existing).

Refs letsrevel/revel-backend#487, letsrevel/infra#5, letsrevel/infra#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
