### PR TITLE
fix(ssr): send X-Forwarded-Proto on internal API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.59.1",
+	"version": "1.59.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -261,6 +261,12 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
 	}
 
 	const rewritten = new Request(internalApiUrl + request.url.slice(API_BASE_URL.length), request);
+	// The visitor's request is always HTTPS in production; without this header
+	// Django's SECURE_SSL_REDIRECT 301s internal plain-HTTP calls to
+	// https://web:8000, where TLS meets gunicorn's plaintext port and times
+	// out — which took every SSR page down on first deploy. Set it
+	// unconditionally (not inside the getClientAddress() guard).
+	rewritten.headers.set('x-forwarded-proto', 'https');
 	try {
 		const clientIp = event.getClientAddress();
 		rewritten.headers.set('x-real-ip', clientIp);


### PR DESCRIPTION
## What

One-line fix for the SSR outage after deploying #393: the internal API requests are plain HTTP, and without `X-Forwarded-Proto: https` Django's `SECURE_SSL_REDIRECT` 301'd every one of them to `https://web:8000` — TLS against gunicorn's plaintext port, hanging until undici's 10s connect timeout. Every SSR page died. (`/api/healthcheck` kept working because it's in `SECURE_REDIRECT_EXEMPT`, which made the diagnosis look like flaky networking at first.)

The header is truthful — the visitor's request is always HTTPS in production — and Django only honors it via `SECURE_PROXY_SSL_HEADER`, reachable only from the internal network (Caddy overwrites it on the public path). Set unconditionally, outside the `getClientAddress()` guard.

## Verified against production

From the live frontend container:
```
fetch('http://web:8000/api/events/?page=1', {headers: {'x-forwarded-proto': 'https', 'x-real-ip': '<Vienna IPv6>'}})
→ STATUS 200 | first city: Vienna
```
i.e. the full #487 chain (internal path → X-Real-IP → geo DB → nearest-first) works with this header.

Prod is currently safe: `INTERNAL_API_URL` is unset on the server (the designed rollback switch), so SSR uses the public path. After this merges + image builds: redeploy frontend, restore `INTERNAL_API_URL` (git state already has it — `git checkout docker-compose.yml` on the server), recreate frontend, and verify `/events` end-to-end **on the events page itself this time**.

Version 1.59.1 → 1.59.2.

Refs letsrevel/revel-backend#487, #393, letsrevel/infra#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced server-side rendering stability to prevent potential redirect issues and improve reliability during initial page loads and prerendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->