### PR TITLE
fix(ssr): buffer request body in handleFetch — restores login (prod incident)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.59.2",
+	"version": "1.59.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -260,7 +260,22 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
 		return fetch(request);
 	}
 
-	const rewritten = new Request(internalApiUrl + request.url.slice(API_BASE_URL.length), request);
+	// Buffer the body instead of re-wrapping the Request directly:
+	// `new Request(url, request)` turns the body into a stream, which undici
+	// sends with `Transfer-Encoding: chunked` and no Content-Length. Django's
+	// WSGI layer reads `CONTENT_LENGTH or 0` bytes, so every POST/PATCH body
+	// arrived empty (422 "Field required" on login/register). The public path
+	// never hit this because Caddy/Cloudflare buffer the request and restore
+	// Content-Length; the direct internal path talks to gunicorn unbuffered.
+	const body =
+		request.method === 'GET' || request.method === 'HEAD'
+			? undefined
+			: await request.arrayBuffer();
+	const rewritten = new Request(internalApiUrl + request.url.slice(API_BASE_URL.length), {
+		method: request.method,
+		headers: request.headers,
+		body
+	});
 	// The visitor's request is always HTTPS in production; without this header
 	// Django's SECURE_SSL_REDIRECT 301s internal plain-HTTP calls to
 	// https://web:8000, where TLS meets gunicorn's plaintext port and times


### PR DESCRIPTION
## Incident

**Login (and registration) down in production** — every credentialed POST through the SvelteKit server returned 422 `Field required` despite a fully filled form. All failing requests in Loki carry `user_agent=node`, i.e. they go through the SSR internal API path introduced in #393/#394 + infra#5.

## Root cause

`handleFetch` rewrote SSR API calls to `INTERNAL_API_URL` with:

```ts
const rewritten = new Request(internalApiUrl + path, request);
```

Re-wrapping a `Request` turns its body into a stream, which undici sends with `Transfer-Encoding: chunked` and **no `Content-Length`**. Django's WSGI layer reads `CONTENT_LENGTH or 0` bytes, so the body arrives **empty** → Pydantic 422 `Field required` on every POST/PATCH with a JSON body.

The public path never hit this because Caddy/Cloudflare buffer the request and restore `Content-Length`. GETs have no body, so SSR pages kept working — which is why the regression only surfaced as broken login/registration.

## Evidence

- Loki: 0 × 200 on `POST /api/auth/token/pair` since the internal path went live; 19 × 422, all `user_agent=node`.
- Direct probe of `api.letsrevel.io` with `{username, password}` → 401 (backend healthy).
- Minimal repro against a local echo server: the rewrapped request arrives `Content-Length=None`, `Transfer-Encoding=chunked`, body unread by WSGI semantics.
- Repro against a live backend with test credentials: plain fetch → **200** token pair; rewrapped request → **422** `Field required`; buffered rewrap (this fix) → **200**.

## Fix

Buffer the body (`await request.arrayBuffer()`) and rebuild the rewritten `Request` from `{method, headers, body}` so undici sets `Content-Length`. GET/HEAD keep an `undefined` body (constructing a bodyful GET `Request` throws).

`svelte-check`: 0 errors.

## Deploy note

Until this image is live, the documented rollback switch (unset `INTERNAL_API_URL` on the frontend service) restores login immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 1.59.3

* **Bug Fixes**
  * Fixed an issue where POST and PATCH request bodies were not being properly transmitted to internal API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->