### PR TITLE
chore: fix Prettier formatting in hooks.server.ts (failing CI from #398)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -268,9 +268,7 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
 	// never hit this because Caddy/Cloudflare buffer the request and restore
 	// Content-Length; the direct internal path talks to gunicorn unbuffered.
 	const body =
-		request.method === 'GET' || request.method === 'HEAD'
-			? undefined
-			: await request.arrayBuffer();
+		request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.arrayBuffer();
 	const rewritten = new Request(internalApiUrl + request.url.slice(API_BASE_URL.length), {
 		method: request.method,
 		headers: request.headers,


### PR DESCRIPTION
## Summary

PR #398 (the prod-incident login fix) was merged with the **Lint & Type Check** CI job failing — `src/hooks.server.ts` didn't pass `prettier --check`. This follow-up restores formatting compliance.

- Ran `pnpm prettier --write src/hooks.server.ts` — a single ternary rejoined onto one line, no behavior change
- `make format-check` ✅ and `make types` ✅ (0 errors) locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)