### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,17 +22,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read version from package.json
         id: get_version
         run: echo "VERSION=$(jq -r '.version' package.json)" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,14 @@ jobs:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-        with:
-          version: 9.15.0
+        # Version is read from the "packageManager" field in package.json
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -43,10 +42,10 @@ jobs:
     name: Translation Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -67,15 +66,14 @@ jobs:
     needs: [i18n]
     if: always()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-        with:
-          version: 9.15.0
+        # Version is read from the "packageManager" field in package.json
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,20 +15,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push Demo Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -47,20 +47,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push Production Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Summary

CI logs already emit GitHub's Node 20 deprecation warning:

> Node.js 20 actions are deprecated. … `actions/checkout@v4`, `actions/setup-node@v4`, `pnpm/action-setup@…` … Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

This mirrors the backend hygiene done in letsrevel/revel-backend#501 — bump every action to its current latest major (all Node 24):

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `pnpm/action-setup` | v2.4.1 (SHA-pinned) | **v6** |
| `docker/login-action` | v3 | **v4** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/build-push-action` | v6 | **v7** |

## Notes

- **pnpm `version` input dropped.** `pnpm/action-setup@v4+` errors (`Multiple versions of pnpm specified`) when the `version` input is passed alongside a `packageManager` field in `package.json`. Since `package.json` already pins `"packageManager": "pnpm@9.15.0"`, the redundant `version: 9.15.0` input is removed — the action reads the same version from `packageManager`.
- **`node-version: '20'` left unchanged.** Those inputs set the app's *build/runtime* Node version (`engines.node` is `>=20.0.0`), which is independent of the action-runtime deprecation this PR addresses.

## Test plan

- [ ] CI passes on this branch (lint, i18n, build)
- [ ] No more Node.js 20 deprecation warnings in the run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)