### PR TITLE
fix(tickets): clarify €0 refund copy + ISO-code language selector (#397)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -2591,6 +2591,7 @@
 		"refundFlatFeeNote": "Eine Bearbeitungsgebühr von {fee} wurde abgezogen.",
 		"refundCurrentWindowLabel": "Aktuelle Rückerstattung: {pct}% bis {deadline}",
 		"refundNoRefundShort": "Keine Rückerstattung",
+		"refundExpiredWindow": "Das letzte Erstattungsfenster ({pct}% bis {deadline}) ist abgelaufen.",
 		"deadlineLabel": "Stornierung möglich bis",
 		"deadlineNoDeadline": "Keine Frist gesetzt",
 		"refundScheduleTitle": "Rückerstattungsplan",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2591,6 +2591,7 @@
 		"refundFlatFeeNote": "A {fee} processing fee has been deducted.",
 		"refundCurrentWindowLabel": "Current refund: {pct}% until {deadline}",
 		"refundNoRefundShort": "No refund",
+		"refundExpiredWindow": "The last refund window ({pct}% until {deadline}) has passed.",
 		"deadlineLabel": "Cancellation closes",
 		"deadlineNoDeadline": "No deadline set",
 		"refundScheduleTitle": "Refund schedule",

--- a/messages/it.json
+++ b/messages/it.json
@@ -2591,6 +2591,7 @@
 		"refundFlatFeeNote": "È stata trattenuta una commissione di {fee}.",
 		"refundCurrentWindowLabel": "Rimborso attuale: {pct}% fino al {deadline}",
 		"refundNoRefundShort": "Nessun rimborso",
+		"refundExpiredWindow": "L'ultima finestra di rimborso ({pct}% fino al {deadline}) è scaduta.",
 		"deadlineLabel": "Annullamento possibile fino al",
 		"deadlineNoDeadline": "Nessuna scadenza impostata",
 		"refundScheduleTitle": "Scadenze rimborsi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.60.0",
+	"version": "1.60.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/common/LanguageSwitcher.svelte
+++ b/src/lib/components/common/LanguageSwitcher.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { getLocale, setLocale, locales } from '$lib/paraglide/runtime.js';
+	import { getLocale, setLocale } from '$lib/paraglide/runtime.js';
 	import { invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
-	import { Globe } from 'lucide-svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { accountUpdateLanguage } from '$lib/api/client';
 	import { getLanguageSwitchUrl } from '$lib/utils/seo-routes';
@@ -11,11 +10,12 @@
 	// Current locale
 	const currentLocale = $derived(getLocale());
 
-	// Language options with flags
+	// Language options. We surface the ISO code (en/de/it) rather than a flag —
+	// flags map to countries, not languages, and read poorly at small sizes.
 	const languages = [
-		{ code: 'en', name: 'English', flag: '🇬🇧' },
-		{ code: 'de', name: 'Deutsch', flag: '🇩🇪' },
-		{ code: 'it', name: 'Italiano', flag: '🇮🇹' }
+		{ code: 'en', name: 'English' },
+		{ code: 'de', name: 'Deutsch' },
+		{ code: 'it', name: 'Italiano' }
 	] as const;
 
 	type SupportedLanguage = 'en' | 'de' | 'it';
@@ -75,17 +75,17 @@
 
 <!-- Language Switcher Dropdown -->
 <div class="relative">
-	<!-- Trigger Button - Just the flag -->
+	<!-- Trigger Button - ISO language code -->
 	<button
 		type="button"
 		onclick={() => (isOpen = !isOpen)}
-		class="flex items-center justify-center rounded-md p-2 text-2xl transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+		class="flex items-center justify-center rounded-md px-2.5 py-2 text-sm font-semibold lowercase tracking-wide transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
 		aria-label={m['languageSwitcher.selectLanguage']({ name: currentLanguage.name })}
 		aria-expanded={isOpen}
 		aria-haspopup="true"
 		title={currentLanguage.name}
 	>
-		{currentLanguage.flag}
+		{currentLanguage.code}
 	</button>
 
 	<!-- Dropdown Menu -->
@@ -94,7 +94,7 @@
 			class="absolute right-0 top-full z-50 mt-2 w-48 rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
 			role="menu"
 		>
-			{#each languages as lang}
+			{#each languages as lang (lang.code)}
 				<button
 					type="button"
 					onclick={() => switchLanguage(lang.code)}
@@ -104,7 +104,7 @@
 						: ''}"
 					role="menuitem"
 				>
-					<span class="text-lg">{lang.flag}</span>
+					<span class="w-6 text-xs font-semibold uppercase text-muted-foreground">{lang.code}</span>
 					<span>{lang.name}</span>
 					{#if currentLocale === lang.code}
 						<span class="ml-auto text-xs text-muted-foreground">✓</span>

--- a/src/lib/components/tickets/CancelTicketDialog.svelte
+++ b/src/lib/components/tickets/CancelTicketDialog.svelte
@@ -163,13 +163,16 @@
 		});
 	}
 
-	function paymentMethodNote(method: PaymentMethod | undefined): string | null {
+	function paymentMethodNote(method: PaymentMethod | undefined, hasRefund: boolean): string | null {
 		if (!method) return null;
 		switch (method) {
+			// online/offline notes describe how a refund is delivered — they
+			// contradict a "No refund" quote, so suppress them when there's nothing
+			// to refund (see issue #397).
 			case 'online':
-				return m['cancelTicket.paymentMethodOnline']();
+				return hasRefund ? m['cancelTicket.paymentMethodOnline']() : null;
 			case 'offline':
-				return m['cancelTicket.paymentMethodOffline']();
+				return hasRefund ? m['cancelTicket.paymentMethodOffline']() : null;
 			case 'at_the_door':
 				return m['cancelTicket.paymentMethodAtTheDoor']();
 			case 'free':
@@ -199,6 +202,30 @@
 		const now = new Date().getTime();
 		return preview.windows.filter((w) => new Date(w.effective_until).getTime() > now);
 	});
+
+	// The most recent window that has already closed. When the quote is 0, the
+	// upcoming-windows list is empty and "No refund" looks like a bug; this lets
+	// us explain *why* — the last refund bracket has expired (issue #397).
+	const lastExpiredWindow = $derived.by((): RefundWindowSchema | null => {
+		if (!preview?.windows || preview.windows.length === 0) return null;
+		const now = new Date().getTime();
+		const past = preview.windows.filter((w) => new Date(w.effective_until).getTime() <= now);
+		if (past.length === 0) return null;
+		return past.reduce((latest, w) =>
+			new Date(w.effective_until).getTime() > new Date(latest.effective_until).getTime()
+				? w
+				: latest
+		);
+	});
+
+	// Show the "last window has passed" explanation only when there's genuinely
+	// nothing to refund on a paid ticket and we have an expired window to point to.
+	const showExpiredWindowNote = $derived(
+		!!preview &&
+			refundAmountNum === 0 &&
+			preview.payment_method !== 'free' &&
+			lastExpiredWindow !== null
+	);
 
 	function handleClose(): void {
 		if (cancelMutation.isPending) return;
@@ -274,6 +301,15 @@
 						</p>
 					{/if}
 
+					{#if showExpiredWindowNote && lastExpiredWindow}
+						<p class="mt-2 text-xs text-muted-foreground">
+							{m['cancelTicket.refundExpiredWindow']({
+								pct: lastExpiredWindow.refund_percentage,
+								deadline: formatDeadline(lastExpiredWindow.effective_until)
+							})}
+						</p>
+					{/if}
+
 					{#if preview.deadline}
 						<p class="mt-3 text-xs text-muted-foreground">
 							<span class="font-medium">{m['cancelTicket.deadlineLabel']()}:</span>
@@ -281,9 +317,9 @@
 						</p>
 					{/if}
 
-					{#if paymentMethodNote(preview.payment_method)}
+					{#if paymentMethodNote(preview.payment_method, refundAmountNum > 0)}
 						<p class="mt-3 text-xs text-muted-foreground">
-							{paymentMethodNote(preview.payment_method)}
+							{paymentMethodNote(preview.payment_method, refundAmountNum > 0)}
 						</p>
 					{/if}
 				</div>


### PR DESCRIPTION
Closes #397.

## What & why

### Issue #397 — `CancelTicketDialog.svelte`
When a paid **online** ticket previewed a **€0** refund, the dialog showed *"No refund"* immediately followed by *"Refunded automatically to your original payment method…"* — a direct contradiction — and never explained *why* the refund was 0.

1. **Removed the contradiction.** `paymentMethodNote()` now takes a `hasRefund` flag; the `online` **and** `offline` notes (both describe how a refund is *delivered*) are suppressed when the quote is 0. `at_the_door` / `free` notes are purely informational and remain.
2. **Explained the €0.** New `lastExpiredWindow` derived picks the most recent *closed* window from `preview.windows` (the backend already returns all tiers, past + future). When the quote is 0 on a paid ticket and a window has expired, we render:
   > The last refund window (50% until Wed, Jun 10, 12:00 PM) has passed.

### Folded-in tweak — `LanguageSwitcher.svelte`
- Replaced country flag emojis with the **ISO language code** (`en` / `de` / `it`). Flags map to countries, not languages, and read poorly at small sizes.
- Trigger shows the lowercase code; dropdown shows an uppercase code badge + language name.
- Removed two dead imports (`Globe`, `locales`) and added the missing `{#each}` key.

## i18n
Added `cancelTicket.refundExpiredWindow` to **en / it / de** (i18n-check: placeholders consistent, 100% completion).

## Version
`1.60.0 → 1.60.1`

## Checks
- `make types` — 0 errors
- `make i18n-check` — pass
- `make format-check` — pass (changed files)
- ESLint — 0 errors on changed files
- `svelte-autofixer` — clean on both components

## Notes
- The contradiction guard was extended to `offline` as well as `online`; the issue named only `online`, but `offline`'s "Contact the organizer to arrange your refund" is the same contradiction at €0.
- No tests added: neither component has an existing test and the component-test harness is on a known-red baseline (svelte-query v6). Happy to add focused tests on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification message indicating when the final refund window has expired during ticket cancellation, displaying applicable refund percentage and deadline information.

* **Improvements**
  * Language selector now displays ISO language codes instead of country flags.
  * Refined refund explanation in the ticket cancellation dialog to provide more relevant information based on refund availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->