### PR TITLE
fix(csp): allow runtime PUBLIC_API_URL origin in CSP (1.61.1) (#396)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.61.0",
+	"version": "1.61.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,7 @@ import { env } from '$env/dynamic/private';
 import { i18nHandle } from '$lib/i18n';
 import { tokenRefresh } from '$lib/api/generated';
 import { API_BASE_URL } from '$lib/config/api';
+import { appendCspApiOrigin } from '$lib/server/csp';
 import {
 	getAccessTokenCookieOptions,
 	getRefreshTokenCookieOptions,
@@ -151,6 +152,41 @@ const handlePreloadOptimization: Handle = async ({ event, resolve }) => {
 };
 
 /**
+ * Runtime CSP hook
+ *
+ * The CSP in svelte.config.js is generated at BUILD time and therefore cannot
+ * know the backend API origin, which is configured at RUNTIME via PUBLIC_API_URL
+ * ($env/dynamic/public) — see #396. Without this, a prebuilt image deployed
+ * against a different backend (e.g. the demo at demo-api.letsrevel.io) has that
+ * origin blocked by `connect-src`/`img-src`/`media-src`, breaking API calls and
+ * backend-served images.
+ *
+ * This hook appends the runtime origin (API_BASE_URL) to those directives in the
+ * CSP response header SvelteKit emits. It is a no-op when there is no CSP header
+ * (non-document responses), when the origin is already present (e.g. prod, where
+ * the API origin matches), or when API_BASE_URL is not an http(s) origin.
+ */
+const handleCsp: Handle = async ({ event, resolve }) => {
+	const response = await resolve(event);
+
+	const csp = response.headers.get('content-security-policy');
+	if (!csp) return response;
+
+	const patched = appendCspApiOrigin(csp, API_BASE_URL);
+	if (patched === csp) return response;
+
+	// SvelteKit's response headers are immutable; rebuild the response (same
+	// pattern as handlePreloadOptimization) to set the patched policy.
+	const headers = new Headers(response.headers);
+	headers.set('content-security-policy', patched);
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers
+	});
+};
+
+/**
  * Authentication hook
  */
 const handleAuth: Handle = async ({ event, resolve }) => {
@@ -241,7 +277,8 @@ export const handle = sequence(
 	handleTokenCapture,
 	i18nHandle(),
 	handleAuth,
-	handlePreloadOptimization
+	handlePreloadOptimization,
+	handleCsp
 );
 
 // Unhandled SSR errors → structured error log + SSR error metric (see module).

--- a/src/lib/server/csp.test.ts
+++ b/src/lib/server/csp.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { appendCspApiOrigin } from './csp';
+
+const ORIGIN = 'https://demo-api.letsrevel.io';
+
+describe('appendCspApiOrigin', () => {
+	it('appends the runtime origin to connect-src, img-src and media-src', () => {
+		const csp =
+			"default-src 'self'; connect-src 'self' https://api.github.com; " +
+			"img-src 'self' data: blob:; media-src 'self' blob:";
+		const result = appendCspApiOrigin(csp, ORIGIN);
+
+		expect(result).toContain(`connect-src 'self' https://api.github.com ${ORIGIN}`);
+		expect(result).toContain(`img-src 'self' data: blob: ${ORIGIN}`);
+		expect(result).toContain(`media-src 'self' blob: ${ORIGIN}`);
+	});
+
+	it('leaves unrelated directives (incl. the script nonce) untouched', () => {
+		const csp = "default-src 'self'; script-src 'self' 'nonce-abc123'; connect-src 'self'";
+		const result = appendCspApiOrigin(csp, ORIGIN);
+
+		expect(result).toContain("default-src 'self'");
+		expect(result).toContain("script-src 'self' 'nonce-abc123'");
+		expect(result).toContain(`connect-src 'self' ${ORIGIN}`);
+	});
+
+	it('is idempotent when the origin is already present', () => {
+		const csp = `connect-src 'self' ${ORIGIN}; img-src 'self' ${ORIGIN}; media-src 'self' ${ORIGIN}`;
+		expect(appendCspApiOrigin(csp, ORIGIN)).toBe(csp);
+	});
+
+	it('does not match an origin that is a prefix of another token', () => {
+		// `https://api.letsrevel.io` must not be treated as already-present just
+		// because `https://api.letsrevel.io.evil.com` appears.
+		const csp = "connect-src 'self' https://api.letsrevel.io.evil.com";
+		const result = appendCspApiOrigin(csp, 'https://api.letsrevel.io');
+		expect(result).toBe(
+			"connect-src 'self' https://api.letsrevel.io.evil.com https://api.letsrevel.io"
+		);
+	});
+
+	it('returns the policy unchanged for a non-http(s) origin', () => {
+		const csp = "connect-src 'self'";
+		expect(appendCspApiOrigin(csp, 'localhost:8000')).toBe(csp);
+		expect(appendCspApiOrigin(csp, '')).toBe(csp);
+	});
+});

--- a/src/lib/server/csp.ts
+++ b/src/lib/server/csp.ts
@@ -1,0 +1,38 @@
+/**
+ * Runtime CSP helpers.
+ *
+ * The CSP in svelte.config.js is generated at BUILD time and cannot know the
+ * backend API origin, which is configured at RUNTIME via PUBLIC_API_URL (#396).
+ * `appendCspApiOrigin` augments the build-time policy with the runtime origin so
+ * a single prebuilt image works against any backend.
+ */
+
+/** Directives that must allow the backend API origin (fetches, images, media). */
+export const CSP_API_DIRECTIVES = new Set(['img-src', 'media-src', 'connect-src']);
+
+/**
+ * Append `origin` to the API-dependent directives of a CSP header value.
+ *
+ * Returns the original string unchanged when `origin` is not an http(s) origin or
+ * when every target directive already lists it, so callers can cheaply detect a
+ * no-op. Directives not in {@link CSP_API_DIRECTIVES} are preserved verbatim
+ * (including the SvelteKit script nonce).
+ */
+export function appendCspApiOrigin(csp: string, origin: string): string {
+	if (!/^https?:\/\//.test(origin)) return csp;
+
+	return csp
+		.split(';')
+		.map((directive) => {
+			const trimmed = directive.trim();
+			if (!trimmed) return '';
+			const tokens = trimmed.split(/\s+/);
+			const name = tokens[0];
+			if (CSP_API_DIRECTIVES.has(name) && !tokens.includes(origin)) {
+				return `${trimmed} ${origin}`;
+			}
+			return trimmed;
+		})
+		.filter(Boolean)
+		.join('; ');
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,8 +1,12 @@
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
-const apiUrl = process.env.PUBLIC_API_URL || 'https://api.letsrevel.io';
 const isDev = process.env.NODE_ENV !== 'production';
+
+// NOTE (#396): the backend API origin is configured at RUNTIME (PUBLIC_API_URL via
+// $env/dynamic/public), so it cannot be baked into the CSP here at build time.
+// The runtime origin is appended to the API-dependent directives (img-src,
+// media-src, connect-src) per response in src/hooks.server.ts (handleCsp).
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -45,10 +49,12 @@ const config = {
 							'default-src': ['self'],
 							'script-src': ['self'],
 							'style-src': ['self', 'unsafe-inline'], // Svelte transitions create inline <style>
-							'img-src': ['self', apiUrl, 'data:', 'blob:'],
-							'media-src': ['self', apiUrl, 'blob:'],
+							// The runtime API origin is appended to img-src/media-src/connect-src
+							// in hooks.server.ts (handleCsp) — see #396.
+							'img-src': ['self', 'data:', 'blob:'],
+							'media-src': ['self', 'blob:'],
 							'font-src': ['self', 'data:'],
-							'connect-src': ['self', apiUrl, 'https://api.github.com'],
+							'connect-src': ['self', 'https://api.github.com'],
 							'frame-src': [
 								'https://www.google.com',
 								'https://google.com',


### PR DESCRIPTION
## Problem

Hotfix for a regression from #396 (PR #416). The CSP in `svelte.config.js` is generated at **build time** and read `PUBLIC_API_URL` from `process.env`, which #396 made **runtime-only**. So the build now falls back to `https://api.letsrevel.io`, and any image pointed at a different backend has that API origin **blocked** by `connect-src` / `img-src` / `media-src`.

Observed on the demo (`demo.letsrevel.io` → `demo-api.letsrevel.io`): every API request fails with `Refused to connect … violates the document's Content Security Policy`. Production was unaffected only because its API *is* the fallback origin.

## Fix

SvelteKit's CSP can't read runtime env, so inject the runtime origin into the emitted CSP header instead:

- **`svelte.config.js`** — drop the build-time `PUBLIC_API_URL` from `img-src`/`media-src`/`connect-src` (unknowable at build time).
- **`src/hooks.server.ts`** — new `handleCsp` appends `API_BASE_URL` (runtime, from `$env/dynamic/public`) to those three directives in the response CSP header. No-op when there's no CSP header, the origin is already present (prod), or it isn't an http(s) origin.
- **`src/lib/server/csp.ts`** — extracted pure `appendCspApiOrigin` helper.
- **`src/lib/server/csp.test.ts`** — unit tests (append, nonce untouched, idempotent, prefix-safety, non-http no-op).
- Bump to **1.61.1**.

## Verification

- `make types` → 0 errors; prettier clean.
- Please run `make test` (new `csp.test.ts`).
- After release: load the demo, confirm API calls + backend images load and no CSP errors in console.

Fixes the demo breakage from #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)