### PR TITLE
chore(ci): collapse demo/prod into a single frontend image (#396)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,9 +42,9 @@ jobs:
           push: false
           # Load into the local Docker daemon so the scan step can read it.
           load: true
-          # PUBLIC_API_URL is set at RUNTIME (see #396), not baked at build time.
+          # PUBLIC_API_URL and ORIGIN are set at RUNTIME (see #396), not baked at
+          # build time. Only PUBLIC_VERSION is embedded into the bundle.
           build-args: |
-            ORIGIN=https://demo.letsrevel.io
             PUBLIC_VERSION=${{ env.VERSION }}
           tags: |
             ghcr.io/letsrevel/revel-frontend:latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,9 +9,9 @@ permissions:
   packages: write
 
 jobs:
-  publish-demo:
+  publish:
     runs-on: ubuntu-latest
-    name: Publish Demo Image
+    name: Publish Docker Image
 
     steps:
       - name: Checkout code
@@ -27,7 +27,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - name: Build and push Demo Docker image
+      # One image for all deployments. PUBLIC_API_URL and ORIGIN are set at
+      # RUNTIME (#396), so they are not build args; demo/prod differ only by the
+      # runtime env in their respective compose files. Only PUBLIC_VERSION (shown
+      # in the footer) is embedded at build time.
+      - name: Build and push Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
@@ -36,44 +40,7 @@ jobs:
           # Supply-chain attestations published alongside the image to GHCR.
           sbom: true
           provenance: mode=max
-          # PUBLIC_API_URL is set at RUNTIME (see #396), not baked at build time.
           build-args: |
-            ORIGIN=https://demo.letsrevel.io
-            PUBLIC_VERSION=${{ github.event.release.tag_name }}
-          tags: |
-            ghcr.io/letsrevel/revel-frontend:latest-demo
-            ghcr.io/letsrevel/revel-frontend:${{ github.event.release.tag_name }}-demo
-
-  publish-prod:
-    runs-on: ubuntu-latest
-    name: Publish Production Image
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Build and push Production Docker image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          # Supply-chain attestations published alongside the image to GHCR.
-          sbom: true
-          provenance: mode=max
-          # PUBLIC_API_URL is set at RUNTIME (see #396), not baked at build time.
-          build-args: |
-            ORIGIN=https://letsrevel.io
             PUBLIC_VERSION=${{ github.event.release.tag_name }}
           tags: |
             ghcr.io/letsrevel/revel-frontend:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,14 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
 # Copy source code
 COPY . .
 
-# Accept build arguments for environment variables that MUST be embedded at
-# build time (Vite inlines $env/static/public values into the bundle).
-# Note: PUBLIC_API_URL is intentionally NOT here — it is read at RUNTIME via
-# $env/dynamic/public so one prebuilt image can target any backend (see #396).
-ARG ORIGIN
+# Accept build arguments for values that MUST be embedded at build time (Vite
+# inlines $env/static/public values into the bundle). Only PUBLIC_VERSION
+# qualifies. PUBLIC_API_URL and ORIGIN are read at RUNTIME (PUBLIC_API_URL via
+# $env/dynamic/public, ORIGIN by adapter-node), so one prebuilt image can target
+# any backend (see #396).
 ARG PUBLIC_VERSION
 
 # Set as environment variables for the build process
-ENV ORIGIN=${ORIGIN}
 ENV PUBLIC_VERSION=${PUBLIC_VERSION}
 
 # Compile Paraglide i18n translations


### PR DESCRIPTION
## Summary

Follow-up cleanup enabled by #396. The demo (`:latest-demo`) and prod (`:latest`) images are now **byte-identical**:
- `PUBLIC_API_URL` → runtime (`$env/dynamic/public`)
- `ORIGIN` → read at runtime by adapter-node; it's not `PUBLIC_`-prefixed, so Vite never baked it (the build-arg was inert)
- `PUBLIC_VERSION` → same value for both

So the separate `-demo` build was pure redundancy. This collapses to one image; demo vs prod now differ **only** by the runtime env in their compose files.

## Changes
- **`publish.yaml`** — one `publish` job building/pushing `:latest` + `:<tag>`; drop the `-demo` job/tags and the inert `ORIGIN` build-arg.
- **`build.yaml`** — drop the inert `ORIGIN` build-arg.
- **`Dockerfile`** — drop `ARG`/`ENV ORIGIN` from the builder (runtime `ORIGIN` is unaffected — it comes from the container env).

CI-only; no app code or version change.

## ⚠️ Rollout order (important)

This changes which tags releases produce. Do **not** merge/release this until the demo is moved off `:latest-demo`:

1. Ship the CSP hotfix **#417** (1.61.1) first — that release still builds `:latest-demo`, so the demo recovers.
2. Merge this PR.
3. Repoint the demo compose (`personal/infra/revel`) `:latest-demo` → `:latest`, redeploy.
4. From the next release on, only `:latest`/`:<tag>` are published.

(After a few releases the stale `:latest-demo` tag in GHCR can be deleted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)