### PR TITLE
fix(events): RSVP buttons render on ticketed events from list views

### DIFF
--- a/src/lib/components/events/EligibilityStatusDisplay.svelte
+++ b/src/lib/components/events/EligibilityStatusDisplay.svelte
@@ -36,6 +36,8 @@
 		applyBefore?: string | null;
 		onInvitationRequestSuccess?: () => void;
 		onWhitelistRequestSuccess?: () => void;
+		/** Opens the ticket-tier purchase modal (for the `purchase_ticket` step). */
+		onGetTicketsClick?: () => void;
 		class?: string;
 	}
 
@@ -50,6 +52,7 @@
 		applyBefore,
 		onInvitationRequestSuccess,
 		onWhitelistRequestSuccess,
+		onGetTicketsClick,
 		class: className
 	}: Props = $props();
 
@@ -278,6 +281,7 @@
 						retryOn={eligibility.retry_on}
 						{onInvitationRequestSuccess}
 						{onWhitelistRequestSuccess}
+						{onGetTicketsClick}
 					/>
 				</div>
 			{/if}

--- a/src/lib/components/events/EventActionSidebar.svelte
+++ b/src/lib/components/events/EventActionSidebar.svelte
@@ -490,8 +490,13 @@
 
 		<!-- Primary Action (if not attending) -->
 		{#if !isAttending}
-			<!-- RSVP Flow for non-ticketed events -->
-			{#if !event.requires_ticket}
+			<!-- RSVP Flow for non-ticketed events.
+			     Fail closed: only show RSVP when the event is explicitly known to
+			     be non-ticketed. `requires_ticket` is `boolean | null` on
+			     list/summary-built event objects, where null means unknown; a null
+			     value is treated as ticketed so RSVP is never shown on a ticketed
+			     event reached from a list surface (issue #430). -->
+			{#if event.requires_ticket === false}
 				<EventRSVP
 					eventId={event.id}
 					eventName={event.name}
@@ -521,6 +526,7 @@
 							applyBefore={event.apply_before}
 							{onInvitationRequestSuccess}
 							{onWhitelistRequestSuccess}
+							{onGetTicketsClick}
 						/>
 					</div>
 				{:else}

--- a/src/lib/components/events/EventRSVP.svelte
+++ b/src/lib/components/events/EventRSVP.svelte
@@ -19,7 +19,12 @@
 		eventName: string;
 		userStatus: UserEventStatus | null;
 		isAuthenticated: boolean;
-		requiresTicket: boolean;
+		/**
+		 * Whether the event requires a ticket. Non-null on EventDetailSchema but
+		 * `boolean | null` on list/summary schemas, where `null` means unknown.
+		 * The RSVP gate fails closed on null (treats it as ticketed).
+		 */
+		requiresTicket: boolean | null;
 		event?: EventDetailSchema;
 		eventTokenDetails?: EventTokenSchema | null;
 		onGuestRsvpClick?: () => void;
@@ -292,10 +297,12 @@
 		return eligibilityStatus && !eligibilityStatus.allowed && !showSuccess;
 	});
 
-	// Show RSVP if:
-	// 1. Event doesn't require tickets
-	// 2. Always show for non-ticketed events (to display login prompt if needed)
-	const shouldRender = $derived(!requiresTicket);
+	// Show RSVP only when the event is explicitly known to be non-ticketed.
+	// `requiresTicket` is non-null on EventDetailSchema, but list/summary
+	// schemas type it as `boolean | null`. A null value means "unknown", so we
+	// fail closed (treat as ticketed) to avoid rendering RSVP on a ticketed
+	// event reached from a list surface, which would 400 on submit (issue #430).
+	const shouldRender = $derived(requiresTicket === false);
 
 	// Check if we should show guest button instead of regular RSVP
 	const shouldShowGuestButton = $derived(

--- a/src/lib/components/events/IneligibilityActionButton.svelte
+++ b/src/lib/components/events/IneligibilityActionButton.svelte
@@ -41,6 +41,8 @@
 		eventTokenDetails?: EventTokenSchema | null;
 		onInvitationRequestSuccess?: () => void;
 		onWhitelistRequestSuccess?: () => void;
+		/** Opens the ticket-tier purchase modal (for the `purchase_ticket` step). */
+		onGetTicketsClick?: () => void;
 		class?: string;
 	}
 
@@ -56,6 +58,7 @@
 		eventTokenDetails,
 		onInvitationRequestSuccess,
 		onWhitelistRequestSuccess,
+		onGetTicketsClick,
 		class: className
 	}: Props = $props();
 
@@ -163,6 +166,21 @@
 				if (organizationSlug && eventSlug) {
 					window.location.href = `/events/${organizationSlug}/${eventSlug}`;
 				}
+			}
+			return;
+		}
+
+		// User is eligible to buy a ticket: open the ticket-tier purchase modal.
+		if (nextStep === 'purchase_ticket') {
+			onGetTicketsClick?.();
+			return;
+		}
+
+		// User is eligible to RSVP: route them to the event page where the RSVP
+		// controls live (this button can appear on summary/eligibility surfaces).
+		if (nextStep === 'rsvp') {
+			if (organizationSlug && eventSlug) {
+				window.location.href = `/events/${organizationSlug}/${eventSlug}`;
 			}
 			return;
 		}


### PR DESCRIPTION
## Root cause

On a ticketed event reached from a **list/summary surface** (dashboard, org page, series), the event object is built from a list schema (`EventInListSchema`, etc.) where `requires_ticket` is typed `boolean | null` — unlike `EventDetailSchema`, where it is non-null `boolean`.

The RSVP gate used `!requires_ticket` (`EventRSVP.svelte`, `EventActionSidebar.svelte`). When `requires_ticket` is `null`, `!null` is `true`, so RSVP buttons rendered on a **ticketed** event. Clicking RSVP then hit `POST /{event_id}/rsvp/{answer}` and returned `400 — "You must get a ticket for this event."` The backend is correct; this was an FE gating bug caused by the nullable field.

Separately, `IneligibilityActionButton.handleClick` had **no branch** for `next_step === 'purchase_ticket'` (or `'rsvp'`) and fell through to `console.log`, so the "Buy Tickets" CTA could be inert.

## Fix (FE-only)

1. **Fail closed on null.** Treat unknown/null `requires_ticket` as **ticketed** (hide RSVP):
   - `EventRSVP.svelte`: gate on `requiresTicket === false`; prop widened to `boolean | null` so the null case is preserved (not coerced upstream).
   - `EventActionSidebar.svelte`: RSVP branch gated on `event.requires_ticket === false`.
2. **Make the Buy CTA work.** Added a `purchase_ticket` branch to `IneligibilityActionButton.handleClick` that opens the ticket-tier purchase modal via a threaded `onGetTicketsClick` callback (`EventActionSidebar → EligibilityStatusDisplay → IneligibilityActionButton`), plus an `rsvp` branch that routes to the event page. The existing `onGetTicketsClick` wiring (`openTicketTierModal` on the detail page) is reused.

`AdminEventCard.svelte` was not touched (already correct since #337).

## Manual verification

- From `/dashboard` (or an org page / series), open a **ticketed** event you have **no** ticket for: you should see **Buy Tickets**, never RSVP.
- Clicking **Buy Tickets** opens the ticket-tier modal — no 400.
- A **free** (non-ticketed) event still shows RSVP buttons and RSVP succeeds.

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated direct ticket purchase action into the event eligibility status display for seamless ticket acquisition.

* **Bug Fixes**
  * Enhanced RSVP flow logic to correctly show RSVP options only for explicitly non-ticketed events.
  * Improved event eligibility flows to properly handle events with unknown ticket requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->