### PR TITLE
fix: behavioral quick wins from Oskar feedback (A2, P3, E3)

### DIFF
--- a/src/lib/components/announcements/AnnouncementPublicCard.svelte
+++ b/src/lib/components/announcements/AnnouncementPublicCard.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { AnnouncementPublicSchema } from '$lib/api/generated/types.gen';
 	import { formatRelativeTime } from '$lib/utils/time';
+	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import { Megaphone } from 'lucide-svelte';
 
 	interface Props {
@@ -10,57 +11,6 @@
 	}
 
 	const { announcement, showSource = false }: Props = $props();
-
-	/**
-	 * Simple markdown to HTML converter (same as MarkdownEditor)
-	 */
-	function convertMarkdownToHtml(markdown: string): string {
-		if (!markdown) return '';
-
-		let html = markdown;
-
-		// Escape HTML to prevent XSS
-		html = html
-			.replace(/&/g, '&amp;')
-			.replace(/</g, '&lt;')
-			.replace(/>/g, '&gt;')
-			.replace(/"/g, '&quot;')
-			.replace(/'/g, '&#039;');
-
-		// Headers
-		html = html.replace(/^### (.*$)/gim, '<h3 class="text-lg font-semibold mt-4 mb-2">$1</h3>');
-		html = html.replace(/^## (.*$)/gim, '<h2 class="text-xl font-bold mt-6 mb-3">$1</h2>');
-		html = html.replace(/^# (.*$)/gim, '<h1 class="text-2xl font-bold mt-8 mb-4">$1</h1>');
-
-		// Bold and Italic
-		html = html.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
-		html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-		html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
-
-		// Links
-		html = html.replace(
-			/\[([^\]]+)\]\(([^)]+)\)/g,
-			'<a href="$2" class="text-primary underline" target="_blank" rel="noopener noreferrer">$1</a>'
-		);
-
-		// Unordered lists
-		html = html.replace(/^\* (.+)$/gim, '<li class="ml-4">$1</li>');
-		html = html.replace(/(<li class="ml-4">.*<\/li>)/s, '<ul class="list-disc my-2">$1</ul>');
-
-		// Ordered lists
-		html = html.replace(/^\d+\. (.+)$/gim, '<li class="ml-4">$1</li>');
-
-		// Line breaks
-		html = html.replace(/\n\n/g, '</p><p class="mb-2">');
-		html = html.replace(/\n/g, '<br>');
-
-		// Wrap in paragraph
-		html = `<p class="mb-2">${html}</p>`;
-
-		return html;
-	}
-
-	const htmlBody = $derived(convertMarkdownToHtml(announcement.body));
 </script>
 
 <article class="rounded-lg border bg-card p-4">
@@ -94,7 +44,5 @@
 	</div>
 
 	<!-- Body -->
-	<div class="prose prose-sm max-w-none dark:prose-invert">
-		{@html htmlBody}
-	</div>
+	<MarkdownContent content={announcement.body} ariaLabel="Announcement content" />
 </article>

--- a/src/lib/components/events/admin/EventEditor.svelte
+++ b/src/lib/components/events/admin/EventEditor.svelte
@@ -510,6 +510,11 @@
 			// Invalidate queries
 			queryClient.invalidateQueries({ queryKey: ['events'] });
 			queryClient.invalidateQueries({ queryKey: ['event', eventId] });
+			// Keep the dashboard truthful after create/update (prefix match covers
+			// the parameterised "Your Events" / calendar keys).
+			queryClient.invalidateQueries({ queryKey: ['dashboard-your-events'] });
+			queryClient.invalidateQueries({ queryKey: ['dashboard-has-events'] });
+			queryClient.invalidateQueries({ queryKey: ['dashboard-calendar'] });
 
 			toast.success(m['eventWizard.eventUpdatedSuccess']());
 

--- a/src/lib/components/tickets/TicketConfirmationDialog.svelte
+++ b/src/lib/components/tickets/TicketConfirmationDialog.svelte
@@ -237,8 +237,9 @@
 	// Whether to show quantity selector (more than 1 ticket allowed)
 	const showQuantitySelector = $derived(effectiveMaxQuantity > 1);
 
-	// Always show guest name inputs so users can verify/edit their name
-	const showGuestNames = true;
+	// Only ask for guest names when purchasing multiple tickets.
+	// For a single ticket we default to the buyer's profile name (see handleConfirm).
+	const showGuestNames = $derived(quantity > 1);
 
 	// Check if all guest names are filled (at least the first character)
 	const allGuestNamesFilled = $derived(guestNames.every((name) => name.trim().length > 0));
@@ -334,9 +335,18 @@
 		return false;
 	}
 
+	// Default guest name for a hidden single-ticket input.
+	// Backend requires a non-empty guest_name (min_length 1); the buyer's profile
+	// name is used, mirroring getDefaultGuestName() on the non-dialog purchase path.
+	function getDefaultGuestName(): string {
+		return userName.trim();
+	}
+
 	// Set guest name error message based on validation state
 	function setGuestNameErrorMessage(): boolean {
 		guestNameError = '';
+		// When the name input is hidden (single ticket), we auto-fill in handleConfirm.
+		if (!showGuestNames) return true;
 		const emptyIndex = guestNames.findIndex((name) => !name.trim());
 		if (emptyIndex >= 0) {
 			guestNameError =
@@ -381,9 +391,11 @@
 		}
 		seatSelectionError = '';
 
-		// Build tickets array
+		// Build tickets array. For a hidden single-ticket name input, fall back to
+		// the buyer's profile name so guest_name is always non-empty.
 		const tickets: TicketPurchaseItem[] = guestNames.map((name, index) => {
-			const ticket: TicketPurchaseItem = { guest_name: name.trim() };
+			const trimmed = name.trim() || (!showGuestNames ? getDefaultGuestName() : '');
+			const ticket: TicketPurchaseItem = { guest_name: trimmed };
 			if (isUserChoiceSeat && selectedSeatIds[index]) {
 				ticket.seat_id = selectedSeatIds[index];
 			}


### PR DESCRIPTION
Three small, focused behavioral fixes from Oskar's feedback.

## A2 — Announcement markdown rendering
Public announcement bodies used a hand-rolled regex markdown converter that never closed lists, leaving paragraphs after a list indented. Now rendered via the shared `MarkdownContent` component (marked + DOMPurify + prose), matching the admin preview.

## P3 — Only ask for guest name when buying multiple tickets
The guest-name input is now hidden for single-ticket purchases; `guest_name` is defaulted to the buyer's profile name (non-empty, as the backend requires). Per-ticket name inputs still appear for 2+ tickets.

## E3 — Invalidate dashboard queries after event create/update
After saving an event, the dashboard "Your Events", has-events, and calendar queries are invalidated so a new event appears on `/dashboard` without a hard refresh.

Closes #424
Closes #426
Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)