### PR TITLE
fix: small UX quick wins from Oskar feedback (Q3, D3, CI3)

### DIFF
--- a/src/lib/components/events/filters/SearchInput.svelte
+++ b/src/lib/components/events/filters/SearchInput.svelte
@@ -7,6 +7,7 @@
 		value: string;
 		onSearch: (value: string) => void;
 		placeholder?: string;
+		ariaLabel?: string;
 		debounceMs?: number;
 		class?: string;
 	}
@@ -15,6 +16,7 @@
 		value = '',
 		onSearch,
 		placeholder = m['filters.search.eventsPlaceholder'](),
+		ariaLabel = m['filters.search.eventsLabel'](),
 		debounceMs = 300,
 		class: className
 	}: Props = $props();
@@ -64,7 +66,7 @@
 			oninput={handleInput}
 			{placeholder}
 			class="h-10 w-full rounded-md border border-input bg-background pl-9 pr-9 text-sm ring-offset-background transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-			aria-label={m['filters.search.eventsLabel']()}
+			aria-label={ariaLabel}
 		/>
 		{#if inputValue}
 			<button

--- a/src/lib/components/tickets/TicketFilters.svelte
+++ b/src/lib/components/tickets/TicketFilters.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { Search } from 'lucide-svelte';
-	import { Input } from '$lib/components/ui/input';
+	import SearchInput from '$lib/components/events/filters/SearchInput.svelte';
 
 	interface Props {
 		searchQuery: string;
 		selectedStatus: string | null;
 		selectedPaymentMethod: string | null;
-		onSearch: (e: Event) => void;
+		onSearch: (value: string) => void;
 		onStatusFilter: (status: string | null) => void;
 		onPaymentMethodFilter: (method: string | null) => void;
 	}
@@ -24,20 +23,12 @@
 
 <div class="mt-6 space-y-4">
 	<!-- Search -->
-	<div class="relative">
-		<Search
-			class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-			aria-hidden="true"
-		/>
-		<Input
-			type="search"
-			placeholder={m['eventTicketsAdmin.searchPlaceholder']()}
-			value={searchQuery}
-			oninput={onSearch}
-			class="pl-10"
-			aria-label="Search tickets"
-		/>
-	</div>
+	<SearchInput
+		value={searchQuery}
+		{onSearch}
+		placeholder={m['eventTicketsAdmin.searchPlaceholder']()}
+		ariaLabel={m['eventTicketsAdmin.searchPlaceholder']()}
+	/>
 
 	<!-- Status Filters -->
 	<div>

--- a/src/lib/components/tokens/EventTokenCard.svelte
+++ b/src/lib/components/tokens/EventTokenCard.svelte
@@ -7,6 +7,7 @@
 	import {
 		getEventTokenStatus,
 		formatTokenUsage,
+		getExpirationDate,
 		getExpirationDisplay,
 		getEventTokenUrl
 	} from '$lib/utils/tokens';
@@ -25,7 +26,8 @@
 
 	const status = $derived(getEventTokenStatus(token));
 	const usageDisplay = $derived(formatTokenUsage(token.uses, token.max_uses));
-	const expirationDisplay = $derived(getExpirationDisplay(token.expires_at));
+	const expirationDate = $derived(getExpirationDate(token.expires_at));
+	const expirationCountdown = $derived(getExpirationDisplay(token.expires_at));
 
 	async function copyLink() {
 		if (!token.id) {
@@ -72,7 +74,7 @@
 				</div>
 				<div>
 					<span class="font-medium">{m['eventTokenCard.expires']()}</span>
-					{expirationDisplay}
+					<span title={expirationCountdown}>{expirationDate}</span>
 				</div>
 			</div>
 

--- a/src/lib/utils/tokens.ts
+++ b/src/lib/utils/tokens.ts
@@ -1,4 +1,5 @@
 import type { OrganizationTokenSchema, EventTokenSchema } from '$lib/api/generated/types.gen';
+import { formatDateTime } from '$lib/utils/date';
 
 /**
  * Determine the status of an organization token
@@ -99,6 +100,17 @@ export function getExpirationDisplay(expiresAt: string | null | undefined): stri
 	} else {
 		return 'Less than 1 hour';
 	}
+}
+
+/**
+ * Format the absolute expiration date for display.
+ * Returns 'Never' when there is no expiration.
+ */
+export function getExpirationDate(expiresAt: string | null | undefined): string {
+	if (!expiresAt) {
+		return 'Never';
+	}
+	return formatDateTime(expiresAt);
 }
 
 /**

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
@@ -17,7 +17,6 @@
 	import { getUserDisplayName } from '$lib/utils/user-display';
 	import { getRsvpStatusColor, getRsvpStatusLabel } from '$lib/utils/status-colors';
 	import {
-		Search,
 		Users,
 		Edit,
 		Trash2,
@@ -30,8 +29,8 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
 	import { Badge } from '$lib/components/ui/badge';
+	import SearchInput from '$lib/components/events/filters/SearchInput.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import ExportButton from '$lib/components/common/ExportButton.svelte';
 	import MakeMemberModal from '$lib/components/members/MakeMemberModal.svelte';
@@ -290,17 +289,11 @@
 	/**
 	 * Handle search input with debounce
 	 */
-	let searchTimeout: ReturnType<typeof setTimeout>;
-	function handleSearchInput(e: Event) {
-		const target = e.target as HTMLInputElement;
-		searchInput = target.value;
-
-		// Debounce search
-		clearTimeout(searchTimeout);
-		searchTimeout = setTimeout(() => {
-			searchQuery = searchInput;
-			applyFilters();
-		}, 500);
+	function handleSearch(value: string) {
+		// SearchInput debounces internally, so apply filters immediately.
+		searchInput = value;
+		searchQuery = value;
+		applyFilters();
 	}
 
 	/**
@@ -507,19 +500,12 @@
 	<!-- Filters & Search -->
 	<div class="space-y-4">
 		<!-- Search bar -->
-		<div class="relative">
-			<Search
-				class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-				aria-hidden="true"
-			/>
-			<Input
-				type="search"
-				placeholder={m['attendeesAdmin.searchPlaceholder']()}
-				value={searchInput}
-				oninput={handleSearchInput}
-				class="pl-10"
-			/>
-		</div>
+		<SearchInput
+			value={searchInput}
+			onSearch={handleSearch}
+			placeholder={m['attendeesAdmin.searchPlaceholder']()}
+			ariaLabel={m['attendeesAdmin.searchPlaceholder']()}
+		/>
 
 		<!-- Filter buttons -->
 		<div class="flex flex-wrap gap-2">

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.svelte
@@ -40,7 +40,6 @@
 
 	// Search state
 	let searchQuery = $state(data.filters.search || '');
-	let searchTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	// Filter states
 	let selectedStatus = $state<string | null>(data.filters.status || null);
@@ -367,18 +366,10 @@
 	/**
 	 * Handle search input
 	 */
-	function handleSearch(event: Event) {
-		const target = event.target as HTMLInputElement;
-		searchQuery = target.value;
-
-		// Debounce search
-		if (searchTimeout) {
-			clearTimeout(searchTimeout);
-		}
-
-		searchTimeout = setTimeout(() => {
-			applyFilters();
-		}, 300);
+	function handleSearch(value: string) {
+		searchQuery = value;
+		// SearchInput debounces internally, so apply filters immediately.
+		applyFilters();
 	}
 
 	/**

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
@@ -435,9 +435,16 @@
 						</p>
 					</div>
 				</div>
-				<Button variant="outline" size="sm" onclick={() => (isEditMode = false)} class="shrink-0">
-					Cancel Editing
-				</Button>
+				<div class="flex shrink-0 gap-2">
+					<Button variant="outline" size="sm" onclick={() => (isEditMode = false)}>
+						Cancel Editing
+					</Button>
+					<Button size="sm" onclick={saveQuestionnaire} disabled={isSaving || !canEdit}>
+						{isSaving
+							? m['questionnaireEditPage.savingButton']()
+							: m['questionnaireEditPage.saveButton']()}
+					</Button>
+				</div>
 			</div>
 		</div>
 	{:else}


### PR DESCRIPTION
Three FE-only UX quick wins from Oskar's feedback.

## Changes

**Q3 — Save next to 'Cancel Editing' (questionnaire editor)**
Adds a primary Save button into the edit-mode banner row, next to "Cancel Editing", wired to `saveQuestionnaire` with the existing `isSaving`/`canEdit` state. Editors no longer need to scroll to the bottom Actions row to save. The bottom Save button is kept as a secondary affordance.

**D3 — Absolute expiration date in invite-link list**
`EventTokenCard` now renders the absolute expiration date via `formatDateTime` instead of a relative countdown. New `getExpirationDate` helper preserves the "Never" case for null expiry; the countdown is kept as a `title` tooltip.

**CI3 — Clear button on check-in / attendee search**
Reuses `SearchInput` (which has a built-in, translatable clear button) in the attendees page and the ticket filters, replacing bare `Input` fields that had no way to clear the query. `SearchInput`'s aria-label is now a prop so each usage stays accessible and translatable.

## Verification (manual)
- Questionnaire editor: enter edit mode, confirm Save appears in the green banner, respects disabled state while saving, and saves correctly; bottom Save still works.
- Invite-link list: confirm cards show an absolute date (and "Never" for tokens with no expiry); hover shows the countdown tooltip.
- Attendees + ticket filters: type a query, confirm the X clear button appears, clears the field on click, is keyboard-focusable with an accessible name, and re-applies filters.

Closes #421
Closes #425
Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)