### PR TITLE
fix(tickets): guard empty guest_name and make token countdown accessible

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -5112,7 +5112,8 @@
 		"selectSeats": "Wähle deine Plätze",
 		"seatsSelected": "ausgewählt",
 		"loadingSeats": "Verfügbare Plätze werden geladen...",
-		"noSeatsAvailable": "Keine Plätze zur Auswahl verfügbar."
+		"noSeatsAvailable": "Keine Plätze zur Auswahl verfügbar.",
+		"defaultGuestName": "Gast"
 	},
 	"ticketConfirmationDialog.selectMoreSeats": "Bitte wähle noch {count} Sitzplatz/Sitzplätze",
 	"ticketListCard": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -5112,7 +5112,8 @@
 		"selectSeats": "Select Your Seats",
 		"seatsSelected": "selected",
 		"loadingSeats": "Loading available seats...",
-		"noSeatsAvailable": "No seats available for selection."
+		"noSeatsAvailable": "No seats available for selection.",
+		"defaultGuestName": "Guest"
 	},
 	"ticketConfirmationDialog.selectMoreSeats": "Please select {count} more seat(s)",
 	"ticketListCard": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -5112,7 +5112,8 @@
 		"selectSeats": "Seleziona i tuoi posti",
 		"seatsSelected": "selezionati",
 		"loadingSeats": "Caricamento posti disponibili...",
-		"noSeatsAvailable": "Nessun posto disponibile per la selezione."
+		"noSeatsAvailable": "Nessun posto disponibile per la selezione.",
+		"defaultGuestName": "Ospite"
 	},
 	"ticketConfirmationDialog.selectMoreSeats": "Seleziona ancora {count} posto/i",
 	"ticketListCard": {

--- a/src/lib/components/tickets/TicketConfirmationDialog.svelte
+++ b/src/lib/components/tickets/TicketConfirmationDialog.svelte
@@ -338,8 +338,10 @@
 	// Default guest name for a hidden single-ticket input.
 	// Backend requires a non-empty guest_name (min_length 1); the buyer's profile
 	// name is used, mirroring getDefaultGuestName() on the non-dialog purchase path.
+	// Falls back to a localized placeholder so the payload is never empty when the
+	// buyer has no display name.
 	function getDefaultGuestName(): string {
-		return userName.trim();
+		return userName.trim() || m['ticketConfirmationDialog.defaultGuestName']();
 	}
 
 	// Set guest name error message based on validation state

--- a/src/lib/components/tokens/EventTokenCard.svelte
+++ b/src/lib/components/tokens/EventTokenCard.svelte
@@ -75,6 +75,7 @@
 				<div>
 					<span class="font-medium">{m['eventTokenCard.expires']()}</span>
 					<span title={expirationCountdown}>{expirationDate}</span>
+					<span class="sr-only">({expirationCountdown})</span>
 				</div>
 			</div>
 

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -376,10 +376,11 @@
 
 	/**
 	 * Get default guest name for single ticket purchase
-	 * Uses logged-in user's display name when available
+	 * Uses logged-in user's display name when available, falling back to a
+	 * localized placeholder so guest_name is never empty (backend min_length 1).
 	 */
 	function getDefaultGuestName(): string {
-		return userDisplayName;
+		return userDisplayName.trim() || m['ticketConfirmationDialog.defaultGuestName']();
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #435, addressing the CodeRabbit review findings that survived the merge. Each was verified against the current code on `main` before fixing.

## Confirmed & fixed

### 1. Empty `guest_name` in checkout payloads (Major)
`getDefaultGuestName()` in both `TicketConfirmationDialog.svelte` and the event page returned the buyer's display name verbatim, which can be empty (`authStore.user?.display_name ?? ''`, or an empty `userName` prop). For the hidden single-ticket flow, name validation is skipped, so `guest_name: ''` could be sent.

The backend's `TicketPurchaseItem.guest_name` has `minLength: 1` — an empty value 422s. Both paths now fall back to a **localized** placeholder (`Guest` / `Gast` / `Ospite`).

### 2. Inaccessible expiration countdown (WCAG 2.1 AA)
In `EventTokenCard.svelte` the relative countdown was exposed only via the `title` attribute on a non-focusable `<span>` — hover-only, invisible to keyboard and screen-reader users. Added visually-hidden text (`sr-only`) so the countdown is announced; the visible absolute date and the mouse-hover `title` are unchanged.

## Reviewed & intentionally skipped

| Finding | Why skipped |
|---------|-------------|
| `tokens.ts` `getExpirationDate` lacks date validation | `expires_at` is a typed backend ISO-datetime/null field; a malformed value isn't reachable in practice. |
| `admin/events` treats nullable `requires_ticket` as ticketed | This page uses `EventInListSchema`, where `requires_ticket` is a **non-nullable** boolean. The nullable contract CodeRabbit assumed doesn't apply here, so the existing truthy branch is correct. |

## Verification
- `make types` → 0 errors
- `make i18n-check` → 100% completion, all validations pass
- `prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)