### PR TITLE
fix(theme): eliminate dark-mode flash (FOUC) on SSR loads (#440)

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -24,6 +24,29 @@
 		<meta property="og:image:type" content="image/png" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:image" content="%sveltekit.assets%/og-image.png" />
+		<!--
+			Anti-FOUC: apply the dark class before first paint so dark-mode users
+			never see a light flash on SSR loads (#440). mode-watcher injects an
+			equivalent <svelte:head> snippet, but it carries no nonce and is blocked
+			by our production CSP (script-src 'self'); this script is nonced via
+			%sveltekit.nonce% so it runs. Must stay synchronous (no defer/async) and
+			mirror mode-watcher's storage key ('mode-watcher-mode') and dark class.
+		-->
+		<script nonce="%sveltekit.nonce%">
+			(() => {
+				try {
+					const mode = localStorage.getItem('mode-watcher-mode') || 'system';
+					const dark =
+						mode === 'dark' ||
+						(mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+					const root = document.documentElement;
+					root.classList.toggle('dark', dark);
+					root.style.colorScheme = dark ? 'dark' : 'light';
+				} catch {
+					/* localStorage unavailable (e.g. private mode) — fall back to light */
+				}
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/tests/e2e/dark-mode-fouc.spec.ts
+++ b/tests/e2e/dark-mode-fouc.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+// Regression test for #440: dark-mode users saw a light flash (FOUC) on SSR
+// loads. The fix is a synchronous, nonced inline script in app.html that applies
+// the `dark` class before first paint. mode-watcher injects an equivalent
+// snippet, but it carries no nonce and is blocked by the production CSP
+// (script-src 'self'), so it never ran — hence the flash.
+//
+// These tests run against the production build+preview server (see
+// playwright.config.ts), where CSP is enforced — the only place the bug
+// reproduces. They would fail on `main` (no nonced anti-FOUC script).
+
+test.describe('dark-mode anti-FOUC (#440)', () => {
+	test('serves a nonced anti-FOUC script that the CSP allow-lists', async ({ request }) => {
+		const response = await request.get('/');
+		expect(response.ok()).toBeTruthy();
+
+		const html = await response.text();
+
+		// The synchronous anti-FOUC script must be present, must read the
+		// mode-watcher storage key, and must NOT be deferred/async.
+		const scriptMatch = html.match(
+			/<script nonce="([^"]+)">([\s\S]*?mode-watcher-mode[\s\S]*?)<\/script>/
+		);
+		if (!scriptMatch) {
+			throw new Error('anti-FOUC inline script with a nonce is not present in the served HTML');
+		}
+		const [scriptTag, nonce] = scriptMatch;
+		expect(scriptTag).not.toMatch(/\b(defer|async)\b/);
+		expect(nonce.length).toBeGreaterThan(0);
+
+		// The CSP must allow that exact nonce, or the browser blocks the script.
+		const csp = response.headers()['content-security-policy'];
+		expect(csp, 'a CSP header is present in production').toBeTruthy();
+		expect(csp).toContain(`'nonce-${nonce}'`);
+	});
+
+	test('applies the dark class before hydration for a dark-mode user', async ({ page }) => {
+		// Seed the mode-watcher preference before any document script runs, so the
+		// inline anti-FOUC script sees it on the very first paint.
+		await page.addInitScript(() => {
+			window.localStorage.setItem('mode-watcher-mode', 'dark');
+		});
+
+		await page.goto('/');
+
+		const root = page.locator('html');
+		await expect(root).toHaveClass(/\bdark\b/);
+		await expect(root).toHaveCSS('color-scheme', 'dark');
+	});
+
+	test('does not force dark on an explicit light-mode user', async ({ page }) => {
+		await page.addInitScript(() => {
+			window.localStorage.setItem('mode-watcher-mode', 'light');
+		});
+
+		await page.goto('/');
+
+		await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
+		await expect(page.locator('html')).toHaveCSS('color-scheme', 'light');
+	});
+});

--- a/tests/e2e/dark-mode-fouc.spec.ts
+++ b/tests/e2e/dark-mode-fouc.spec.ts
@@ -1,4 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+// Seed the mode-watcher preference before any document script runs, so the
+// inline anti-FOUC script sees it on the very first paint.
+async function seedModePreference(page: Page, mode: 'dark' | 'light'): Promise<void> {
+	await page.addInitScript((value: string) => {
+		window.localStorage.setItem('mode-watcher-mode', value);
+	}, mode);
+}
 
 // Regression test for #440: dark-mode users saw a light flash (FOUC) on SSR
 // loads. The fix is a synchronous, nonced inline script in app.html that applies
@@ -36,11 +44,7 @@ test.describe('dark-mode anti-FOUC (#440)', () => {
 	});
 
 	test('applies the dark class before hydration for a dark-mode user', async ({ page }) => {
-		// Seed the mode-watcher preference before any document script runs, so the
-		// inline anti-FOUC script sees it on the very first paint.
-		await page.addInitScript(() => {
-			window.localStorage.setItem('mode-watcher-mode', 'dark');
-		});
+		await seedModePreference(page, 'dark');
 
 		await page.goto('/');
 
@@ -50,9 +54,7 @@ test.describe('dark-mode anti-FOUC (#440)', () => {
 	});
 
 	test('does not force dark on an explicit light-mode user', async ({ page }) => {
-		await page.addInitScript(() => {
-			window.localStorage.setItem('mode-watcher-mode', 'light');
-		});
+		await seedModePreference(page, 'light');
 
 		await page.goto('/');
 


### PR DESCRIPTION
## Summary

Dark-mode users saw a **light flash (FOUC)** on initial load and navigation. Closes #440.

### Root cause (production-only)

`<ModeWatcher />` *does* inject an anti-FOUC snippet via `<svelte:head>` using `setInitialMode.toString()` — but it's emitted through `{@html}` **without a nonce**. Under our production CSP (`script-src 'self'`, and SvelteKit's `mode: 'auto'` resolves to **nonce-based** for SSR pages), SvelteKit only nonces the scripts *it* generates; an arbitrary `{@html}` script is not nonced and is therefore **blocked**. So the snippet never ran: the server painted light → the client flipped to dark after hydration → the visible flash.

This is why dev (CSP off) looked fine while demo/prod flashed.

### Fix

Add a **synchronous, nonced** inline script to `src/app.html` `<head>` (before `%sveltekit.head%`) that applies the `dark` class and `color-scheme` before first paint. It carries `nonce="%sveltekit.nonce%"`, which SvelteKit substitutes per-request so it passes CSP. It mirrors mode-watcher exactly:

- storage key `mode-watcher-mode`, values `dark` / `light` / `system` (defaulting to `system`)
- dark class `dark`
- `system` falls back to `prefers-color-scheme`

mode-watcher's `onMount` still drives runtime toggling and keeps everything in sync after hydration.

> Verified there is **no prerendering** in the app, so introducing `%sveltekit.nonce%` (which is incompatible with prerendering) is safe.

### Acceptance

- ✅ Dark-mode user sees no light flash on hard load or navigation.
- ✅ Light-mode and system-preference users are unaffected.

## Testing

New E2E spec `tests/e2e/dark-mode-fouc.spec.ts`, which runs against the **production build+preview** (the only place CSP is enforced):

1. The nonced anti-FOUC script is present, synchronous (no `defer`/`async`), and its nonce **is allow-listed** by the `content-security-policy` header.
2. A dark-mode user (seeded `localStorage`) lands with the `dark` class and `color-scheme: dark`.
3. An explicit light-mode user is **not** forced to dark.

Verified locally against a production preview — all 3 pass; manual `curl` confirms `script-src 'self' 'nonce-…'` matches the script's nonce. `make types` clean (0 errors); lint/format clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved flash of unstyled content when dark mode is active. Dark mode preference now applies smoothly during page load, respecting both user settings and system preferences.

* **Tests**
  * Added regression tests to verify dark mode functionality works correctly in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->