### PR TITLE
feat: quick-wins bundle — edit past events, notif cleanup, discount/TierCard i18n, membership-grants disclosure (#447, #439, #481, #458)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -537,7 +537,7 @@
 	},
 	"discountCodesAdmin": {
 		"heading": "Rabattcodes",
-		"description": "Erstellen und verwalten Sie Rabattcodes für den Ticketkauf.",
+		"description": "Erstelle und verwalte Rabattcodes für den Ticketkauf.",
 		"newCode": "Neuer Rabattcode",
 		"search": {
 			"placeholder": "Nach Code suchen...",
@@ -553,12 +553,12 @@
 			"percentage": "Prozentual",
 			"fixedAmount": "Fester Betrag"
 		},
-		"loadError": "Rabattcodes konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+		"loadError": "Rabattcodes konnten nicht geladen werden. Bitte versuche es erneut.",
 		"loadingAria": "Rabattcodes werden geladen",
 		"empty": {
 			"title": "Keine Rabattcodes gefunden",
-			"adjustFilters": "Passen Sie Ihre Filter an",
-			"getStarted": "Erstellen Sie Ihren ersten Rabattcode"
+			"adjustFilters": "Passe deine Filter an",
+			"getStarted": "Erstelle deinen ersten Rabattcode"
 		},
 		"table": {
 			"code": "Code",
@@ -584,6 +584,7 @@
 		},
 		"scope": {
 			"orgWide": "Organisationsweit",
+			"serie": "{count} Serie",
 			"series": "{count} Serien",
 			"event": "{count} Event",
 			"events": "{count} Events",
@@ -3354,11 +3355,11 @@
 			},
 			"grantsInfo": {
 				"title": "Was gewährt eine Mitgliedschaft?",
-				"intro": "Je nach Konfiguration können Mitglieder Ihrer Organisation Folgendes erhalten:",
+				"intro": "Je nach Konfiguration können Mitglieder deiner Organisation Folgendes erhalten:",
 				"coOrganizer": "Mitorganisator-Zugriff (Staff) zum Verwalten von Events, Mitgliedern und Einstellungen",
-				"screening": "Die Möglichkeit, Prüfungs-Fragebögen bei Ihren Events zu überspringen",
+				"screening": "Die Möglichkeit, Prüfungs-Fragebögen bei deinen Events zu überspringen",
 				"exclusive": "Zugang zu Events und Ticket-Stufen nur für Mitglieder",
-				"fees": "Mitgliedschaftsgebühren und Rabatte, die Sie einrichten"
+				"fees": "Mitgliedschaftsgebühren und Rabatte, die du einrichtest"
 			}
 		},
 		"eventSeries": {
@@ -4782,7 +4783,7 @@
 		"messagePlaceholder": "Erzähle den Organisierenden, warum du beitreten möchtest...",
 		"characters": "Zeichen",
 		"requestSubmittedDesc": "Deine Mitgliedschaftsanfrage wurde an {organizationName} gesendet. Du wirst benachrichtigt, wenn sie geprüft wurde.",
-		"requestDesc": "Stellen Sie eine Anfrage, um Mitglied von {organizationName} zu werden. Eine Mitgliedschaft kann Zugang zu Events und Ticket-Stufen nur für Mitglieder gewähren, das Überspringen von Prüfungs-Fragebögen ermöglichen sowie Mitgliedschaftsvorteile oder Rabatte bieten, die die Organisatoren anbieten.",
+		"requestDesc": "Stelle eine Anfrage, um Mitglied von {organizationName} zu werden. Eine Mitgliedschaft kann Zugang zu Events und Ticket-Stufen nur für Mitglieder gewähren, das Überspringen von Prüfungs-Fragebögen ermöglichen sowie Mitgliedschaftsvorteile oder Rabatte bieten, die die Organisierenden anbieten.",
 		"cancel": "Abbrechen",
 		"submitting": "Wird gesendet...",
 		"submitRequest": "Anfrage senden",
@@ -5382,12 +5383,12 @@
 		"reserveTicket": "Ticket reservieren",
 		"getTicket": "Ticket holen",
 		"configError": "Konfigurationsfehler",
-		"youHaveTicket": "Sie haben ein Ticket",
+		"youHaveTicket": "Du hast ein Ticket",
 		"limitReached": "Limit erreicht",
-		"limitReachedDetail": "Sie haben Ihr Ticketlimit für diese Stufe erreicht",
+		"limitReachedDetail": "Du hast dein Ticketlimit für diese Stufe erreicht",
 		"soldOutDetail": "Keine Tickets mehr verfügbar",
 		"free": "Kostenlos",
-		"pwyc": "Zahlen Sie, was Sie können ({range})",
+		"pwyc": "Zahle, was du kannst ({range})",
 		"pwycAny": "beliebig",
 		"requiresMembership": "Mitgliedschaft erforderlich: {tiers}",
 		"signInToCheck": "Anmelden, um die Berechtigung zu prüfen"

--- a/messages/de.json
+++ b/messages/de.json
@@ -536,6 +536,77 @@
 		"tiersHelp": "Leer lassen, um auf alle Kategorien der ausgewählten Veranstaltung(en) anzuwenden."
 	},
 	"discountCodesAdmin": {
+		"heading": "Rabattcodes",
+		"description": "Erstellen und verwalten Sie Rabattcodes für den Ticketkauf.",
+		"newCode": "Neuer Rabattcode",
+		"search": {
+			"placeholder": "Nach Code suchen...",
+			"ariaLabel": "Rabattcodes durchsuchen"
+		},
+		"filters": {
+			"statusAria": "Nach Status filtern",
+			"typeAria": "Nach Typ filtern",
+			"allStatus": "Alle Status",
+			"allTypes": "Alle Typen"
+		},
+		"discountType": {
+			"percentage": "Prozentual",
+			"fixedAmount": "Fester Betrag"
+		},
+		"loadError": "Rabattcodes konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+		"loadingAria": "Rabattcodes werden geladen",
+		"empty": {
+			"title": "Keine Rabattcodes gefunden",
+			"adjustFilters": "Passen Sie Ihre Filter an",
+			"getStarted": "Erstellen Sie Ihren ersten Rabattcode"
+		},
+		"table": {
+			"code": "Code",
+			"discount": "Rabatt",
+			"status": "Status",
+			"usage": "Nutzung",
+			"validPeriod": "Gültigkeitszeitraum",
+			"scope": "Geltungsbereich",
+			"actions": "Aktionen"
+		},
+		"status": {
+			"active": "Aktiv",
+			"inactive": "Inaktiv"
+		},
+		"actions": {
+			"copyAria": "Code {code} kopieren",
+			"activate": "Aktivieren",
+			"deactivate": "Deaktivieren",
+			"activateAria": "Code aktivieren",
+			"deactivateAria": "Code deaktivieren",
+			"edit": "Bearbeiten",
+			"editAria": "Rabattcode bearbeiten"
+		},
+		"scope": {
+			"orgWide": "Organisationsweit",
+			"series": "{count} Serien",
+			"event": "{count} Event",
+			"events": "{count} Events",
+			"tier": "{count} Stufe",
+			"tiers": "{count} Stufen"
+		},
+		"dateRange": {
+			"always": "Immer",
+			"now": "Jetzt",
+			"noExpiry": "Kein Ablauf"
+		},
+		"card": {
+			"usage": "Nutzung",
+			"scope": "Geltungsbereich",
+			"valid": "Gültig"
+		},
+		"pagination": {
+			"total": "{count} Codes insgesamt",
+			"totalOne": "{count} Code insgesamt",
+			"page": "Seite {current} von {total}",
+			"prevAria": "Vorherige Seite",
+			"nextAria": "Nächste Seite"
+		},
 		"delete": {
 			"confirmHardDelete": "Rabattcode \"{code}\" löschen? Unbenutzte Codes werden dauerhaft entfernt (der Code wird wieder verfügbar); ist er mit Tickets verknüpft, wird er stattdessen deaktiviert.",
 			"confirmDeactivate": "Rabattcode \"{code}\" deaktivieren? Er wurde bereits verwendet und kann daher nicht gelöscht werden — sein Einlöseverlauf bleibt erhalten.",
@@ -3280,6 +3351,14 @@
 				},
 				"emptyFiltered": "No matching subscriptions on this page.",
 				"openDrawer": "Open subscription details"
+			},
+			"grantsInfo": {
+				"title": "Was gewährt eine Mitgliedschaft?",
+				"intro": "Je nach Konfiguration können Mitglieder Ihrer Organisation Folgendes erhalten:",
+				"coOrganizer": "Mitorganisator-Zugriff (Staff) zum Verwalten von Events, Mitgliedern und Einstellungen",
+				"screening": "Die Möglichkeit, Prüfungs-Fragebögen bei Ihren Events zu überspringen",
+				"exclusive": "Zugang zu Events und Ticket-Stufen nur für Mitglieder",
+				"fees": "Mitgliedschaftsgebühren und Rabatte, die Sie einrichten"
 			}
 		},
 		"eventSeries": {
@@ -4703,7 +4782,7 @@
 		"messagePlaceholder": "Erzähle den Organisierenden, warum du beitreten möchtest...",
 		"characters": "Zeichen",
 		"requestSubmittedDesc": "Deine Mitgliedschaftsanfrage wurde an {organizationName} gesendet. Du wirst benachrichtigt, wenn sie geprüft wurde.",
-		"requestDesc": "Sende eine Anfrage, um Mitglied von {organizationName} zu werden. Mitglieder haben möglicherweise Zugang zu exklusiven Events und Inhalten.",
+		"requestDesc": "Stellen Sie eine Anfrage, um Mitglied von {organizationName} zu werden. Eine Mitgliedschaft kann Zugang zu Events und Ticket-Stufen nur für Mitglieder gewähren, das Überspringen von Prüfungs-Fragebögen ermöglichen sowie Mitgliedschaftsvorteile oder Rabatte bieten, die die Organisatoren anbieten.",
 		"cancel": "Abbrechen",
 		"submitting": "Wird gesendet...",
 		"submitRequest": "Anfrage senden",
@@ -5301,7 +5380,17 @@
 		"claimFreeTicket": "Gratis-Ticket sichern",
 		"buyTicket": "Ticket kaufen",
 		"reserveTicket": "Ticket reservieren",
-		"getTicket": "Ticket holen"
+		"getTicket": "Ticket holen",
+		"configError": "Konfigurationsfehler",
+		"youHaveTicket": "Sie haben ein Ticket",
+		"limitReached": "Limit erreicht",
+		"limitReachedDetail": "Sie haben Ihr Ticketlimit für diese Stufe erreicht",
+		"soldOutDetail": "Keine Tickets mehr verfügbar",
+		"free": "Kostenlos",
+		"pwyc": "Zahlen Sie, was Sie können ({range})",
+		"pwycAny": "beliebig",
+		"requiresMembership": "Mitgliedschaft erforderlich: {tiers}",
+		"signInToCheck": "Anmelden, um die Berechtigung zu prüfen"
 	},
 	"tierDelete": {
 		"title": "Mitgliedschaftsstufe löschen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -536,6 +536,77 @@
 		"tiersHelp": "Leave empty to apply to all tiers of the selected event(s)."
 	},
 	"discountCodesAdmin": {
+		"heading": "Discount Codes",
+		"description": "Create and manage discount codes for ticket checkout.",
+		"newCode": "New Discount Code",
+		"search": {
+			"placeholder": "Search by code...",
+			"ariaLabel": "Search discount codes"
+		},
+		"filters": {
+			"statusAria": "Filter by status",
+			"typeAria": "Filter by type",
+			"allStatus": "All Status",
+			"allTypes": "All Types"
+		},
+		"discountType": {
+			"percentage": "Percentage",
+			"fixedAmount": "Fixed Amount"
+		},
+		"loadError": "Failed to load discount codes. Please try again.",
+		"loadingAria": "Loading discount codes",
+		"empty": {
+			"title": "No discount codes found",
+			"adjustFilters": "Try adjusting your filters",
+			"getStarted": "Get started by creating your first discount code"
+		},
+		"table": {
+			"code": "Code",
+			"discount": "Discount",
+			"status": "Status",
+			"usage": "Usage",
+			"validPeriod": "Valid Period",
+			"scope": "Scope",
+			"actions": "Actions"
+		},
+		"status": {
+			"active": "Active",
+			"inactive": "Inactive"
+		},
+		"actions": {
+			"copyAria": "Copy code {code}",
+			"activate": "Activate",
+			"deactivate": "Deactivate",
+			"activateAria": "Activate code",
+			"deactivateAria": "Deactivate code",
+			"edit": "Edit",
+			"editAria": "Edit discount code"
+		},
+		"scope": {
+			"orgWide": "Org-wide",
+			"series": "{count} series",
+			"event": "{count} event",
+			"events": "{count} events",
+			"tier": "{count} tier",
+			"tiers": "{count} tiers"
+		},
+		"dateRange": {
+			"always": "Always",
+			"now": "Now",
+			"noExpiry": "No expiry"
+		},
+		"card": {
+			"usage": "Usage",
+			"scope": "Scope",
+			"valid": "Valid"
+		},
+		"pagination": {
+			"total": "{count} codes total",
+			"totalOne": "{count} code total",
+			"page": "Page {current} of {total}",
+			"prevAria": "Previous page",
+			"nextAria": "Next page"
+		},
 		"delete": {
 			"confirmHardDelete": "Delete discount code \"{code}\"? Unused codes are permanently removed (freeing the code for reuse); if it's linked to any tickets it will be deactivated instead.",
 			"confirmDeactivate": "Deactivate discount code \"{code}\"? It has been used, so it can't be deleted — its redemption history will be kept.",
@@ -3280,6 +3351,14 @@
 				},
 				"emptyFiltered": "No matching subscriptions on this page.",
 				"openDrawer": "Open subscription details"
+			},
+			"grantsInfo": {
+				"title": "What does membership grant?",
+				"intro": "Depending on how you configure them, members of your organization can get:",
+				"coOrganizer": "Co-organizer (staff) access to manage events, members, and settings",
+				"screening": "The ability to skip screening questionnaires on your events",
+				"exclusive": "Access to members-only events and ticket tiers",
+				"fees": "Membership-tier fees and discounts you set up"
 			}
 		},
 		"eventSeries": {
@@ -4703,7 +4782,7 @@
 		"messagePlaceholder": "Tell the organizers why you'd like to join...",
 		"characters": "characters",
 		"requestSubmittedDesc": "Your membership request has been sent to {organizationName}. You'll be notified when it's reviewed.",
-		"requestDesc": "Submit a request to become a member of {organizationName}. Members may have access to exclusive events and content.",
+		"requestDesc": "Submit a request to become a member of {organizationName}. Membership can grant access to members-only events and ticket tiers, the ability to skip screening questionnaires, and any membership perks or discounts the organizers offer.",
 		"cancel": "Cancel",
 		"submitting": "Submitting...",
 		"submitRequest": "Submit Request",
@@ -5301,7 +5380,17 @@
 		"claimFreeTicket": "Claim Free Ticket",
 		"buyTicket": "Buy Ticket",
 		"reserveTicket": "Reserve Ticket",
-		"getTicket": "Get Ticket"
+		"getTicket": "Get Ticket",
+		"configError": "Configuration Error",
+		"youHaveTicket": "You have a ticket",
+		"limitReached": "Limit Reached",
+		"limitReachedDetail": "You've reached your ticket limit for this tier",
+		"soldOutDetail": "No more tickets available",
+		"free": "Free",
+		"pwyc": "Pay What You Can ({range})",
+		"pwycAny": "any",
+		"requiresMembership": "Requires membership: {tiers}",
+		"signInToCheck": "Sign in to check eligibility"
 	},
 	"tierDelete": {
 		"title": "Delete Membership Tier",

--- a/messages/en.json
+++ b/messages/en.json
@@ -584,6 +584,7 @@
 		},
 		"scope": {
 			"orgWide": "Org-wide",
+			"serie": "{count} series",
 			"series": "{count} series",
 			"event": "{count} event",
 			"events": "{count} events",

--- a/messages/it.json
+++ b/messages/it.json
@@ -584,6 +584,7 @@
 		},
 		"scope": {
 			"orgWide": "Tutta l'organizzazione",
+			"serie": "{count} serie",
 			"series": "{count} serie",
 			"event": "{count} evento",
 			"events": "{count} eventi",

--- a/messages/it.json
+++ b/messages/it.json
@@ -536,6 +536,77 @@
 		"tiersHelp": "Lascia vuoto per applicare a tutti i tipi di biglietto dell'evento/i selezionato/i."
 	},
 	"discountCodesAdmin": {
+		"heading": "Codici sconto",
+		"description": "Crea e gestisci i codici sconto per l'acquisto dei biglietti.",
+		"newCode": "Nuovo codice sconto",
+		"search": {
+			"placeholder": "Cerca per codice...",
+			"ariaLabel": "Cerca codici sconto"
+		},
+		"filters": {
+			"statusAria": "Filtra per stato",
+			"typeAria": "Filtra per tipo",
+			"allStatus": "Tutti gli stati",
+			"allTypes": "Tutti i tipi"
+		},
+		"discountType": {
+			"percentage": "Percentuale",
+			"fixedAmount": "Importo fisso"
+		},
+		"loadError": "Impossibile caricare i codici sconto. Riprova.",
+		"loadingAria": "Caricamento codici sconto",
+		"empty": {
+			"title": "Nessun codice sconto trovato",
+			"adjustFilters": "Prova a modificare i filtri",
+			"getStarted": "Inizia creando il tuo primo codice sconto"
+		},
+		"table": {
+			"code": "Codice",
+			"discount": "Sconto",
+			"status": "Stato",
+			"usage": "Utilizzo",
+			"validPeriod": "Periodo di validità",
+			"scope": "Ambito",
+			"actions": "Azioni"
+		},
+		"status": {
+			"active": "Attivo",
+			"inactive": "Inattivo"
+		},
+		"actions": {
+			"copyAria": "Copia codice {code}",
+			"activate": "Attiva",
+			"deactivate": "Disattiva",
+			"activateAria": "Attiva codice",
+			"deactivateAria": "Disattiva codice",
+			"edit": "Modifica",
+			"editAria": "Modifica codice sconto"
+		},
+		"scope": {
+			"orgWide": "Tutta l'organizzazione",
+			"series": "{count} serie",
+			"event": "{count} evento",
+			"events": "{count} eventi",
+			"tier": "{count} livello",
+			"tiers": "{count} livelli"
+		},
+		"dateRange": {
+			"always": "Sempre",
+			"now": "Ora",
+			"noExpiry": "Senza scadenza"
+		},
+		"card": {
+			"usage": "Utilizzo",
+			"scope": "Ambito",
+			"valid": "Valido"
+		},
+		"pagination": {
+			"total": "{count} codici in totale",
+			"totalOne": "{count} codice in totale",
+			"page": "Pagina {current} di {total}",
+			"prevAria": "Pagina precedente",
+			"nextAria": "Pagina successiva"
+		},
 		"delete": {
 			"confirmHardDelete": "Eliminare il codice sconto \"{code}\"? I codici inutilizzati vengono rimossi definitivamente (il codice torna disponibile); se è collegato a dei biglietti verrà invece disattivato.",
 			"confirmDeactivate": "Disattivare il codice sconto \"{code}\"? È già stato utilizzato, quindi non può essere eliminato — la cronologia di utilizzo verrà mantenuta.",
@@ -3280,6 +3351,14 @@
 				},
 				"emptyFiltered": "No matching subscriptions on this page.",
 				"openDrawer": "Open subscription details"
+			},
+			"grantsInfo": {
+				"title": "Cosa offre l'iscrizione?",
+				"intro": "A seconda di come li configuri, i membri della tua organizzazione possono ottenere:",
+				"coOrganizer": "Accesso da co-organizzatore (staff) per gestire eventi, membri e impostazioni",
+				"screening": "La possibilità di saltare i questionari di selezione sui tuoi eventi",
+				"exclusive": "Accesso a eventi e livelli di biglietto riservati ai membri",
+				"fees": "Quote di iscrizione e sconti che configuri"
 			}
 		},
 		"eventSeries": {
@@ -4703,7 +4782,7 @@
 		"messagePlaceholder": "Racconta agli organizzatori perché vorresti unirti...",
 		"characters": "caratteri",
 		"requestSubmittedDesc": "La tua richiesta di iscrizione è stata inviata a {organizationName}. Sarai avvisato quando verrà esaminata.",
-		"requestDesc": "Invia una richiesta per diventare membro di {organizationName}. I membri potrebbero avere accesso a eventi e contenuti esclusivi.",
+		"requestDesc": "Invia una richiesta per diventare membro di {organizationName}. L'iscrizione può dare accesso a eventi e livelli di biglietto riservati ai membri, la possibilità di saltare i questionari di selezione e gli eventuali vantaggi o sconti offerti dagli organizzatori.",
 		"cancel": "Annulla",
 		"submitting": "Invio in corso...",
 		"submitRequest": "Invia richiesta",
@@ -5301,7 +5380,17 @@
 		"claimFreeTicket": "Riscuoti Biglietto Gratuito",
 		"buyTicket": "Acquista Biglietto",
 		"reserveTicket": "Prenota Biglietto",
-		"getTicket": "Ottieni Biglietto"
+		"getTicket": "Ottieni Biglietto",
+		"configError": "Errore di configurazione",
+		"youHaveTicket": "Hai un biglietto",
+		"limitReached": "Limite raggiunto",
+		"limitReachedDetail": "Hai raggiunto il limite di biglietti per questo livello",
+		"soldOutDetail": "Nessun biglietto disponibile",
+		"free": "Gratuito",
+		"pwyc": "Paga quanto puoi ({range})",
+		"pwycAny": "qualsiasi",
+		"requiresMembership": "Iscrizione richiesta: {tiers}",
+		"signInToCheck": "Accedi per verificare l'idoneità"
 	},
 	"tierDelete": {
 		"title": "Elimina livello di iscrizione",

--- a/src/lib/components/events/admin/AdminEventCard.svelte
+++ b/src/lib/components/events/admin/AdminEventCard.svelte
@@ -68,7 +68,11 @@
 
 	const showAttendeeCount = $derived(variant !== 'draft' && event.attendee_count !== undefined);
 
-	const showEdit = $derived(variant === 'draft' || variant === 'open');
+	// Editing is valid for any status (the edit route has no date/status guard),
+	// so organizers can fix details on closed/cancelled events too — see #447.
+	const showEdit = $derived(
+		variant === 'draft' || variant === 'open' || variant === 'closed' || variant === 'cancelled'
+	);
 	const showManagement = $derived(variant !== 'draft');
 
 	function viewEvent(): void {

--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -4,7 +4,6 @@
 	import { notificationMarkRead, notificationMarkUnread } from '$lib/api/generated';
 	import { Card } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { Badge } from '$lib/components/ui/badge';
 	import { Circle, Check, X, Clock, Ticket } from 'lucide-svelte';
 	import { formatRelativeTime } from '$lib/utils/time';
 	import { goto } from '$app/navigation';
@@ -189,15 +188,6 @@
 		return null;
 	}
 
-	// Compute notification type badge variant
-	const notificationTypeVariant = $derived.by(() => {
-		const type = notification.notification_type.toLowerCase();
-		if (type.includes('invitation')) return 'default' as const;
-		if (type.includes('event')) return 'secondary' as const;
-		if (type.includes('rsvp')) return 'outline' as const;
-		return 'secondary' as const;
-	});
-
 	// ===== Waitlist spot available =====
 	const isWaitlistSpot = $derived(notification.notification_type === 'waitlist_spot_available');
 
@@ -315,9 +305,6 @@
 					<h3 class={cn('text-base font-semibold leading-tight', !isRead && 'font-bold')}>
 						{isWaitlistSpot ? m['notifications.waitlistSpot.title']() : notification.title}
 					</h3>
-					<Badge variant={notificationTypeVariant} class="mt-1 text-xs">
-						{notification.notification_type}
-					</Badge>
 				</div>
 
 				<!-- Timestamp -->
@@ -330,7 +317,7 @@
 			<!-- Body content -->
 			{#if isWaitlistSpot && waitlistSpotData}
 				<div class="space-y-3">
-					<p class={cn('text-sm', compact && 'line-clamp-2')}>
+					<p class={cn('text-sm', compact && 'line-clamp-4')}>
 						{m['notifications.waitlistSpot.body']({
 							event: waitlistSpotData.eventName,
 							time: waitlistSpotData.timeText
@@ -366,7 +353,7 @@
 				<div class="notification-body">
 					<MarkdownContent
 						content={notification.body}
-						class={cn('text-sm text-muted-foreground', compact && 'line-clamp-2')}
+						class={cn('text-sm text-muted-foreground', compact && 'line-clamp-4')}
 					/>
 				</div>
 			{/if}
@@ -412,11 +399,11 @@
 		line-height: inherit;
 	}
 
-	/* Line clamp for compact mode */
-	.line-clamp-2 {
+	/* Line clamp for compact (dropdown) mode — 4 lines so messages aren't cut mid-sentence */
+	.line-clamp-4 {
 		display: -webkit-box;
-		-webkit-line-clamp: 2;
-		line-clamp: 2;
+		-webkit-line-clamp: 4;
+		line-clamp: 4;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 	}

--- a/src/lib/components/notifications/NotificationItem.test.ts
+++ b/src/lib/components/notifications/NotificationItem.test.ts
@@ -154,8 +154,8 @@ describe('NotificationItem', () => {
 			}
 		});
 
-		// Check if line-clamp-2 class is applied
-		const bodyElement = container.querySelector('.line-clamp-2');
+		// Check if the compact-mode line-clamp class is applied
+		const bodyElement = container.querySelector('.line-clamp-4');
 		expect(bodyElement).toBeInTheDocument();
 	});
 

--- a/src/lib/components/tickets/TierCard.svelte
+++ b/src/lib/components/tickets/TierCard.svelte
@@ -82,7 +82,7 @@
 
 	// Format price display
 	const priceDisplay = $derived(() => {
-		if (tier.payment_method === 'free') return 'Free';
+		if (tier.payment_method === 'free') return m['tierCardAdmin.free']();
 
 		if (tier.price_type === 'pwyc') {
 			const price = typeof tier.price === 'string' ? parseFloat(tier.price) : tier.price;
@@ -97,8 +97,10 @@
 					: tier.pwyc_max
 				: null;
 
-			const maxDisplay = max ? `${tier.currency} ${max.toFixed(2)}` : 'any';
-			return `Pay What You Can (${tier.currency} ${min.toFixed(2)} - ${maxDisplay})`;
+			const maxDisplay = max ? `${tier.currency} ${max.toFixed(2)}` : m['tierCardAdmin.pwycAny']();
+			return m['tierCardAdmin.pwyc']({
+				range: `${tier.currency} ${min.toFixed(2)} - ${maxDisplay}`
+			});
 		}
 
 		const price = typeof tier.price === 'string' ? parseFloat(tier.price) : tier.price;
@@ -192,13 +194,16 @@
 
 		// If tier is restricted but user is not authenticated
 		if (!isAuthenticated) {
-			return { allowed: false, reason: 'Sign in to check eligibility' };
+			return { allowed: false, reason: m['tierCardAdmin.signInToCheck']() };
 		}
 
 		// If user doesn't have a membership tier
 		if (!membershipTier || !membershipTier.id) {
 			const tierNames = restrictedTiers.map((t: MembershipTierSchema) => t.name).join(', ');
-			return { allowed: false, reason: `Requires membership: ${tierNames}` };
+			return {
+				allowed: false,
+				reason: m['tierCardAdmin.requiresMembership']({ tiers: tierNames })
+			};
 		}
 
 		// Check if user's membership tier is in the allowed list
@@ -206,7 +211,10 @@
 
 		if (!isAllowed) {
 			const tierNames = restrictedTiers.map((t: MembershipTierSchema) => t.name).join(', ');
-			return { allowed: false, reason: `Requires membership: ${tierNames}` };
+			return {
+				allowed: false,
+				reason: m['tierCardAdmin.requiresMembership']({ tiers: tierNames })
+			};
 		}
 
 		return { allowed: true };
@@ -255,13 +263,13 @@
 		<div class="flex shrink-0 flex-col items-end gap-2">
 			{#if !hasId}
 				<div class="rounded-md bg-destructive/10 px-4 py-2 text-sm text-destructive">
-					Configuration Error
+					{m['tierCardAdmin.configError']()}
 				</div>
 			{:else if hasTicket}
 				<div
 					class="rounded-md bg-green-100 px-4 py-2 text-sm font-medium text-green-800 dark:bg-green-950 dark:text-green-100"
 				>
-					✓ You have a ticket
+					✓ {m['tierCardAdmin.youHaveTicket']()}
 				</div>
 			{:else if !salesStatus.active}
 				<Button disabled class="w-full sm:w-auto">{m['tierCardAdmin.notAvailable']()}</Button>
@@ -271,7 +279,7 @@
 				<!-- User doesn't have required membership tier -->
 				<Button disabled class="w-full sm:w-auto">
 					<AlertCircle class="mr-2 h-4 w-4" />
-					Not Eligible
+					{m['tierCardAdmin.notEligible']()}
 				</Button>
 				{#if membershipRestriction.reason}
 					<p class="max-w-[250px] text-right text-xs text-muted-foreground">
@@ -292,7 +300,7 @@
 					{#if tierPurchaseStatus.reason === 'Sold out'}
 						{m['tierCardAdmin.soldOut']()}
 					{:else if tierPurchaseStatus.reason === 'Limit reached'}
-						Limit Reached
+						{m['tierCardAdmin.limitReached']()}
 					{:else}
 						{m['tierCardAdmin.notEligible']()}
 					{/if}
@@ -300,10 +308,10 @@
 				{#if tierPurchaseStatus.reason && tierPurchaseStatus.reason !== 'Not eligible'}
 					<p class="max-w-[250px] text-right text-xs text-muted-foreground">
 						{tierPurchaseStatus.reason === 'Limit reached'
-							? "You've reached your ticket limit for this tier"
+							? m['tierCardAdmin.limitReachedDetail']()
 							: tierPurchaseStatus.reason === 'Sold out'
-								? 'No more tickets available'
-								: tierPurchaseStatus.reason}
+								? m['tierCardAdmin.soldOutDetail']()
+								: m['tierCardAdmin.notAvailable']()}
 					</p>
 				{/if}
 			{:else if canClaim}

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
@@ -27,6 +27,7 @@
 		Check
 	} from 'lucide-svelte';
 	import { toast } from 'svelte-sonner';
+	import { formatDate } from '$lib/utils/date';
 	import * as m from '$lib/paraglide/messages.js';
 
 	const organization = $derived($page.data.organization);
@@ -163,33 +164,35 @@
 	function formatScope(code: DiscountCodeSchema): string {
 		const parts: string[] = [];
 		if (code.series_ids && code.series_ids.length > 0) {
-			parts.push(`${code.series_ids.length} series`);
+			parts.push(m['discountCodesAdmin.scope.series']({ count: code.series_ids.length }));
 		}
 		if (code.event_ids && code.event_ids.length > 0) {
-			parts.push(`${code.event_ids.length} event${code.event_ids.length > 1 ? 's' : ''}`);
+			const n = code.event_ids.length;
+			parts.push(
+				n === 1
+					? m['discountCodesAdmin.scope.event']({ count: n })
+					: m['discountCodesAdmin.scope.events']({ count: n })
+			);
 		}
 		if (code.tier_ids && code.tier_ids.length > 0) {
-			parts.push(`${code.tier_ids.length} tier${code.tier_ids.length > 1 ? 's' : ''}`);
+			const n = code.tier_ids.length;
+			parts.push(
+				n === 1
+					? m['discountCodesAdmin.scope.tier']({ count: n })
+					: m['discountCodesAdmin.scope.tiers']({ count: n })
+			);
 		}
-		return parts.length > 0 ? parts.join(', ') : 'Org-wide';
+		return parts.length > 0 ? parts.join(', ') : m['discountCodesAdmin.scope.orgWide']();
 	}
 
 	function formatDateRange(code: DiscountCodeSchema): string {
-		if (!code.valid_from && !code.valid_until) return 'Always';
+		if (!code.valid_from && !code.valid_until) return m['discountCodesAdmin.dateRange.always']();
 		const from = code.valid_from
-			? new Date(code.valid_from).toLocaleDateString('en-US', {
-					month: 'short',
-					day: 'numeric',
-					year: 'numeric'
-				})
-			: 'Now';
+			? formatDate(code.valid_from)
+			: m['discountCodesAdmin.dateRange.now']();
 		const until = code.valid_until
-			? new Date(code.valid_until).toLocaleDateString('en-US', {
-					month: 'short',
-					day: 'numeric',
-					year: 'numeric'
-				})
-			: 'No expiry';
+			? formatDate(code.valid_until)
+			: m['discountCodesAdmin.dateRange.noExpiry']();
 		return `${from} → ${until}`;
 	}
 </script>
@@ -198,13 +201,15 @@
 	<!-- Header -->
 	<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
 		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">Discount Codes</h1>
-			<p class="text-muted-foreground">Create and manage discount codes for ticket checkout.</p>
+			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
+				{m['discountCodesAdmin.heading']()}
+			</h1>
+			<p class="text-muted-foreground">{m['discountCodesAdmin.description']()}</p>
 		</div>
 
 		<Button onclick={() => goto(`/org/${organization.slug}/admin/discount-codes/new`)}>
 			<Plus class="mr-2 h-4 w-4" aria-hidden="true" />
-			New Discount Code
+			{m['discountCodesAdmin.newCode']()}
 		</Button>
 	</div>
 
@@ -219,9 +224,9 @@
 				type="search"
 				bind:value={searchQuery}
 				oninput={() => (currentPage = 1)}
-				placeholder="Search by code..."
+				placeholder={m['discountCodesAdmin.search.placeholder']()}
 				class="w-full rounded-md border border-input bg-background py-2 pl-10 pr-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				aria-label="Search discount codes"
+				aria-label={m['discountCodesAdmin.search.ariaLabel']()}
 			/>
 		</div>
 
@@ -229,22 +234,22 @@
 			bind:value={activeFilter}
 			onchange={() => (currentPage = 1)}
 			class="rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			aria-label="Filter by status"
+			aria-label={m['discountCodesAdmin.filters.statusAria']()}
 		>
-			<option value="all">All Status</option>
-			<option value="active">Active</option>
-			<option value="inactive">Inactive</option>
+			<option value="all">{m['discountCodesAdmin.filters.allStatus']()}</option>
+			<option value="active">{m['discountCodesAdmin.status.active']()}</option>
+			<option value="inactive">{m['discountCodesAdmin.status.inactive']()}</option>
 		</select>
 
 		<select
 			bind:value={typeFilter}
 			onchange={() => (currentPage = 1)}
 			class="rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			aria-label="Filter by type"
+			aria-label={m['discountCodesAdmin.filters.typeAria']()}
 		>
-			<option value="all">All Types</option>
-			<option value="percentage">Percentage</option>
-			<option value="fixed_amount">Fixed Amount</option>
+			<option value="all">{m['discountCodesAdmin.filters.allTypes']()}</option>
+			<option value="percentage">{m['discountCodesAdmin.discountType.percentage']()}</option>
+			<option value="fixed_amount">{m['discountCodesAdmin.discountType.fixedAmount']()}</option>
 		</select>
 	</div>
 
@@ -252,13 +257,13 @@
 	{#if error}
 		<Alert variant="destructive">
 			<AlertCircle class="h-4 w-4" />
-			<AlertDescription>Failed to load discount codes. Please try again.</AlertDescription>
+			<AlertDescription>{m['discountCodesAdmin.loadError']()}</AlertDescription>
 		</Alert>
 	{:else if isLoading}
 		<div class="flex items-center justify-center py-12">
 			<div
 				class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"
-				aria-label="Loading discount codes"
+				aria-label={m['discountCodesAdmin.loadingAria']()}
 			></div>
 		</div>
 	{:else if codes.length === 0}
@@ -266,11 +271,11 @@
 			class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600"
 		>
 			<Tag class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-4 text-lg font-semibold">No discount codes found</h3>
+			<h3 class="mt-4 text-lg font-semibold">{m['discountCodesAdmin.empty.title']()}</h3>
 			<p class="mt-2 text-sm text-muted-foreground">
 				{searchQuery || activeFilter !== 'all' || typeFilter !== 'all'
-					? 'Try adjusting your filters'
-					: 'Get started by creating your first discount code'}
+					? m['discountCodesAdmin.empty.adjustFilters']()
+					: m['discountCodesAdmin.empty.getStarted']()}
 			</p>
 			{#if !searchQuery && activeFilter === 'all' && typeFilter === 'all'}
 				<Button
@@ -278,7 +283,7 @@
 					onclick={() => goto(`/org/${organization.slug}/admin/discount-codes/new`)}
 				>
 					<Plus class="mr-2 h-4 w-4" aria-hidden="true" />
-					New Discount Code
+					{m['discountCodesAdmin.newCode']()}
 				</Button>
 			{/if}
 		</div>
@@ -289,13 +294,26 @@
 				<table class="w-full text-sm">
 					<thead class="bg-muted/50">
 						<tr>
-							<th class="px-4 py-3 text-left font-medium">Code</th>
-							<th class="px-4 py-3 text-left font-medium">Discount</th>
-							<th class="px-4 py-3 text-left font-medium">Status</th>
-							<th class="px-4 py-3 text-left font-medium">Usage</th>
-							<th class="px-4 py-3 text-left font-medium">Valid Period</th>
-							<th class="px-4 py-3 text-left font-medium">Scope</th>
-							<th class="px-4 py-3 text-right font-medium">Actions</th>
+							<th class="px-4 py-3 text-left font-medium">{m['discountCodesAdmin.table.code']()}</th
+							>
+							<th class="px-4 py-3 text-left font-medium"
+								>{m['discountCodesAdmin.table.discount']()}</th
+							>
+							<th class="px-4 py-3 text-left font-medium"
+								>{m['discountCodesAdmin.table.status']()}</th
+							>
+							<th class="px-4 py-3 text-left font-medium"
+								>{m['discountCodesAdmin.table.usage']()}</th
+							>
+							<th class="px-4 py-3 text-left font-medium"
+								>{m['discountCodesAdmin.table.validPeriod']()}</th
+							>
+							<th class="px-4 py-3 text-left font-medium"
+								>{m['discountCodesAdmin.table.scope']()}</th
+							>
+							<th class="px-4 py-3 text-right font-medium"
+								>{m['discountCodesAdmin.table.actions']()}</th
+							>
 						</tr>
 					</thead>
 					<tbody class="divide-y">
@@ -308,7 +326,7 @@
 											type="button"
 											onclick={() => copyCode(code.id, code.code)}
 											class="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-											aria-label="Copy code {code.code}"
+											aria-label={m['discountCodesAdmin.actions.copyAria']({ code: code.code })}
 										>
 											{#if copiedCodeId === code.id}
 												<Check class="h-3.5 w-3.5 text-emerald-600" aria-hidden="true" />
@@ -334,7 +352,9 @@
 											? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
 											: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'}"
 									>
-										{code.is_active ? 'Active' : 'Inactive'}
+										{code.is_active
+											? m['discountCodesAdmin.status.active']()
+											: m['discountCodesAdmin.status.inactive']()}
 									</span>
 								</td>
 								<td class="px-4 py-3 text-muted-foreground">
@@ -352,8 +372,12 @@
 											type="button"
 											onclick={() => handleToggleActive(code)}
 											class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-											title={code.is_active ? 'Deactivate' : 'Activate'}
-											aria-label={code.is_active ? 'Deactivate code' : 'Activate code'}
+											title={code.is_active
+												? m['discountCodesAdmin.actions.deactivate']()
+												: m['discountCodesAdmin.actions.activate']()}
+											aria-label={code.is_active
+												? m['discountCodesAdmin.actions.deactivateAria']()
+												: m['discountCodesAdmin.actions.activateAria']()}
 										>
 											{#if code.is_active}
 												<ToggleRight class="h-4 w-4 text-emerald-600" />
@@ -366,8 +390,8 @@
 											onclick={() =>
 												goto(`/org/${organization.slug}/admin/discount-codes/${code.id}/edit`)}
 											class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-											title="Edit"
-											aria-label="Edit discount code"
+											title={m['discountCodesAdmin.actions.edit']()}
+											aria-label={m['discountCodesAdmin.actions.editAria']()}
 										>
 											<Pencil class="h-4 w-4" />
 										</button>
@@ -409,7 +433,7 @@
 									type="button"
 									onclick={() => copyCode(code.id, code.code)}
 									class="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-									aria-label="Copy code {code.code}"
+									aria-label={m['discountCodesAdmin.actions.copyAria']({ code: code.code })}
 								>
 									{#if copiedCodeId === code.id}
 										<Check class="h-4 w-4 text-emerald-600" aria-hidden="true" />
@@ -432,21 +456,29 @@
 								? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
 								: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'}"
 						>
-							{code.is_active ? 'Active' : 'Inactive'}
+							{code.is_active
+								? m['discountCodesAdmin.status.active']()
+								: m['discountCodesAdmin.status.inactive']()}
 						</span>
 					</div>
 
 					<div class="mt-3 grid grid-cols-2 gap-2 text-sm text-muted-foreground">
 						<div>
-							<span class="font-medium text-foreground">Usage:</span>
+							<span class="font-medium text-foreground"
+								>{m['discountCodesAdmin.card.usage']()}:</span
+							>
 							{formatUsage(code)}
 						</div>
 						<div>
-							<span class="font-medium text-foreground">Scope:</span>
+							<span class="font-medium text-foreground"
+								>{m['discountCodesAdmin.card.scope']()}:</span
+							>
 							{formatScope(code)}
 						</div>
 						<div class="col-span-2">
-							<span class="font-medium text-foreground">Valid:</span>
+							<span class="font-medium text-foreground"
+								>{m['discountCodesAdmin.card.valid']()}:</span
+							>
 							{formatDateRange(code)}
 						</div>
 					</div>
@@ -460,10 +492,10 @@
 						>
 							{#if code.is_active}
 								<ToggleRight class="mr-1 h-4 w-4 text-emerald-600" />
-								Deactivate
+								{m['discountCodesAdmin.actions.deactivate']()}
 							{:else}
 								<ToggleLeft class="mr-1 h-4 w-4" />
-								Activate
+								{m['discountCodesAdmin.actions.activate']()}
 							{/if}
 						</Button>
 						<Button
@@ -473,7 +505,7 @@
 							class="flex-1"
 						>
 							<Pencil class="mr-1 h-4 w-4" />
-							Edit
+							{m['discountCodesAdmin.actions.edit']()}
 						</Button>
 						<Button
 							variant="outline"
@@ -499,7 +531,9 @@
 		{#if totalPages > 1}
 			<div class="flex items-center justify-between border-t pt-4">
 				<p class="text-sm text-muted-foreground">
-					{totalCount} code{totalCount === 1 ? '' : 's'} total
+					{totalCount === 1
+						? m['discountCodesAdmin.pagination.totalOne']({ count: totalCount })
+						: m['discountCodesAdmin.pagination.total']({ count: totalCount })}
 				</p>
 				<div class="flex items-center gap-2">
 					<Button
@@ -507,19 +541,19 @@
 						size="sm"
 						onclick={() => (currentPage = Math.max(1, currentPage - 1))}
 						disabled={currentPage <= 1}
-						aria-label="Previous page"
+						aria-label={m['discountCodesAdmin.pagination.prevAria']()}
 					>
 						<ChevronLeft class="h-4 w-4" />
 					</Button>
 					<span class="text-sm">
-						Page {currentPage} of {totalPages}
+						{m['discountCodesAdmin.pagination.page']({ current: currentPage, total: totalPages })}
 					</span>
 					<Button
 						variant="outline"
 						size="sm"
 						onclick={() => (currentPage = Math.min(totalPages, currentPage + 1))}
 						disabled={currentPage >= totalPages}
-						aria-label="Next page"
+						aria-label={m['discountCodesAdmin.pagination.nextAria']()}
 					>
 						<ChevronRight class="h-4 w-4" />
 					</Button>

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
@@ -27,12 +27,19 @@
 		Check
 	} from 'lucide-svelte';
 	import { toast } from 'svelte-sonner';
-	import { formatDate } from '$lib/utils/date';
+	import { formatDateTime } from '$lib/utils/date';
 	import * as m from '$lib/paraglide/messages.js';
 
 	const organization = $derived($page.data.organization);
 	const accessToken = $derived(authStore.accessToken);
 	const queryClient = useQueryClient();
+
+	// Discount validity (valid_from/valid_until) are UTC datetime instants with no
+	// associated timezone (orgs, unlike events, have none). Render them in the
+	// viewer's own zone with an explicit tz label so the same instant isn't shown
+	// as a different calendar day to admins in different zones — and so the time
+	// isn't silently dropped (the picker stores a precise moment, not a bare day).
+	const viewerTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 	// Copy-to-clipboard state (tracks which code ID was just copied)
 	let copiedCodeId = $state<string | null>(null);
@@ -193,10 +200,10 @@
 	function formatDateRange(code: DiscountCodeSchema): string {
 		if (!code.valid_from && !code.valid_until) return m['discountCodesAdmin.dateRange.always']();
 		const from = code.valid_from
-			? formatDate(code.valid_from)
+			? formatDateTime(code.valid_from, viewerTimeZone)
 			: m['discountCodesAdmin.dateRange.now']();
 		const until = code.valid_until
-			? formatDate(code.valid_until)
+			? formatDateTime(code.valid_until, viewerTimeZone)
 			: m['discountCodesAdmin.dateRange.noExpiry']();
 		return `${from} → ${until}`;
 	}

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
@@ -171,6 +171,10 @@
 	function formatScope(code: DiscountCodeSchema): string {
 		const parts: string[] = [];
 		if (code.series_ids && code.series_ids.length > 0) {
+			// Singular/plural split is only grammatically distinct in German
+			// (Serie/Serien). en ("series") and it ("serie") are invariant, so their
+			// scope.serie and scope.series values intentionally match — i18n parity
+			// requires the key in every locale; the duplication is not a copy-paste slip.
 			const n = code.series_ids.length;
 			parts.push(
 				n === 1

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
@@ -164,7 +164,12 @@
 	function formatScope(code: DiscountCodeSchema): string {
 		const parts: string[] = [];
 		if (code.series_ids && code.series_ids.length > 0) {
-			parts.push(m['discountCodesAdmin.scope.series']({ count: code.series_ids.length }));
+			const n = code.series_ids.length;
+			parts.push(
+				n === 1
+					? m['discountCodesAdmin.scope.serie']({ count: n })
+					: m['discountCodesAdmin.scope.series']({ count: n })
+			);
 		}
 		if (code.event_ids && code.event_ids.length > 0) {
 			const n = code.event_ids.length;
@@ -527,14 +532,14 @@
 			{/each}
 		</div>
 
-		<!-- Pagination -->
-		{#if totalPages > 1}
-			<div class="flex items-center justify-between border-t pt-4">
-				<p class="text-sm text-muted-foreground">
-					{totalCount === 1
-						? m['discountCodesAdmin.pagination.totalOne']({ count: totalCount })
-						: m['discountCodesAdmin.pagination.total']({ count: totalCount })}
-				</p>
+		<!-- Pagination: total count always shows; prev/next only when multi-page -->
+		<div class="flex items-center justify-between border-t pt-4">
+			<p class="text-sm text-muted-foreground">
+				{totalCount === 1
+					? m['discountCodesAdmin.pagination.totalOne']({ count: totalCount })
+					: m['discountCodesAdmin.pagination.total']({ count: totalCount })}
+			</p>
+			{#if totalPages > 1}
 				<div class="flex items-center gap-2">
 					<Button
 						variant="outline"
@@ -558,7 +563,7 @@
 						<ChevronRight class="h-4 w-4" />
 					</Button>
 				</div>
-			</div>
-		{/if}
+			{/if}
+		</div>
 	{/if}
 </div>

--- a/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
@@ -26,7 +26,8 @@
 		Trash2,
 		Mail,
 		MoreVertical,
-		Copy
+		Copy,
+		Edit
 	} from 'lucide-svelte';
 
 	const { data }: { data: PageData } = $props();
@@ -432,6 +433,13 @@
 									>
 										<Eye class="h-4 w-4" aria-hidden="true" />
 										{m['orgAdmin.events.actions.view']()}
+									</a>
+									<a
+										href="/org/{data.organization.slug}/admin/events/{event.id}/edit"
+										class="inline-flex items-center gap-1 rounded-md bg-secondary px-3 py-1 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80"
+									>
+										<Edit class="h-4 w-4" aria-hidden="true" />
+										{m['orgAdmin.events.actions.edit']()}
 									</a>
 									{#if event.requires_ticket}
 										<a

--- a/src/routes/(auth)/org/[slug]/admin/members/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/members/+page.svelte
@@ -11,7 +11,17 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { Tabs, TabsList, TabsTrigger, TabsContent } from '$lib/components/ui/tabs';
 	import { Button } from '$lib/components/ui/button';
-	import { Users, UserCog, UserPlus, Shield, Link, Plus, CreditCard } from 'lucide-svelte';
+	import {
+		Users,
+		UserCog,
+		UserPlus,
+		Shield,
+		Link,
+		Plus,
+		CreditCard,
+		Info,
+		ChevronDown
+	} from 'lucide-svelte';
 	import MembersTab from '$lib/components/members/MembersTab.svelte';
 	import StaffTab from '$lib/components/members/StaffTab.svelte';
 	import MembershipRequestsTab from '$lib/components/members/MembershipRequestsTab.svelte';
@@ -128,6 +138,29 @@
 			Invite members
 		</Button>
 	</div>
+
+	<!-- What membership grants (discreet inline disclosure, collapsed by default) -->
+	<details class="group">
+		<summary
+			class="inline-flex cursor-pointer list-none items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground [&::-webkit-details-marker]:hidden"
+		>
+			<Info class="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+			<span>{m['orgAdmin.members.grantsInfo.title']()}</span>
+			<ChevronDown
+				class="h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
+				aria-hidden="true"
+			/>
+		</summary>
+		<div class="mt-2 space-y-2 rounded-lg bg-muted/40 p-3 text-sm text-muted-foreground">
+			<p>{m['orgAdmin.members.grantsInfo.intro']()}</p>
+			<ul class="ml-4 list-disc space-y-1">
+				<li>{m['orgAdmin.members.grantsInfo.coOrganizer']()}</li>
+				<li>{m['orgAdmin.members.grantsInfo.screening']()}</li>
+				<li>{m['orgAdmin.members.grantsInfo.exclusive']()}</li>
+				<li>{m['orgAdmin.members.grantsInfo.fees']()}</li>
+			</ul>
+		</div>
+	</details>
 
 	<!-- Tabs -->
 	<Tabs bind:value={activeTab} class="w-full">


### PR DESCRIPTION
Second Oskar quick-wins bundle — all **FE-only, no backend dependency**. Each issue is small; shipped together.

## What's in here

### #447 — edit past/closed/cancelled events from the org-admin list
- Added an **Edit** anchor to the bespoke past-event card in `org/[slug]/admin/events/+page.svelte`.
- Extended `AdminEventCard.svelte`'s `showEdit` to include `closed`/`cancelled` (the edit route has no date/status guard, so editing is always valid).

### #439 — notifications cleanup (parts a + c only)
- Removed the redundant snake_case **type chip** (plus its `notificationTypeVariant` derived and the now-unused `Badge` import) — it just restated the already-localized title/body.
- Relaxed the dropdown body clamp `line-clamp-2` → `line-clamp-4` so longer messages aren't cut mid-sentence.
- Part **(b)** importance-colored left accent is intentionally **out of scope** — it waits on backend #505.

### #481 — i18n the discount-codes admin page + TierCard audit
- Fully localized `discount-codes/+page.svelte` (new `discountCodesAdmin.*` keys: heading, filters, table headers, scope, date range, pagination, action labels; reuses the locale-aware `formatDate` instead of hardcoded `en-US`).
- Audited `TierCard.svelte` and localized the remaining hardcoded strings (configuration error, "you have a ticket", limit-reached / sold-out detail, price `Free` / PWYC, membership-restriction reasons) under `tierCardAdmin.*`.
- **en/de/it all at 100%.**

### #458 — explain what organization membership grants
- Added a **discreet, default-collapsed inline disclosure** ("What does membership grant?") above the members tabs, using the native `<details>/<summary>` house pattern (Info icon + chevron that rotates via `group-open:rotate-180`).
- Lists the concrete grants: co-organizer (staff) access, screening-questionnaire bypass, members-only events & tiers, membership-tier fees/discounts.
- Expanded `requestMembershipButton.requestDesc` on the public org page with the same concrete benefits.

## Quality gate
- `make types` — **0 errors**
- `make format-check` — clean
- `make i18n-check` — **100%** across en/de/it
- `make lint` — 0 errors (pre-existing warning baseline only)
- `make file-length` — no new offenders

> Tests not run in-session (per repo convention — reviewer/CI runs them).

## Notes
- Sync was verified before starting: all FE `[ready]`/`[blocked]` labels are accurate. FE #461 (schedule/timeline) is genuinely unblocked now (BE #524 merged via PR #539; schema already in the committed client). FE #464 stays blocked on BE #530. The check-in camera issue (#460) was explicitly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added discount code management admin page with search, filtering, and actions.
  * Added membership grants information display explaining membership benefits.
  * Added Edit button for event cards, including past events.

* **Improvements**
  * Notification items now display expanded text (4 lines instead of 2).
  * Enhanced tier card labels with full localization support.
  * Expanded membership request descriptions with detailed benefits information.

* **Bug Fixes**
  * Removed notification type badges from notification display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->