### PR TITLE
feat: guest sign-in prompt, check-in manual entry, questionnaire Next/Prev (#470, #473, #460, #443)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -4337,7 +4337,20 @@
 		"scanQr": "QR-Code scannen",
 		"initializing": "Kamera wird initialisiert...",
 		"error": "Fehler",
-		"cancel": "Abbrechen"
+		"cancel": "Abbrechen",
+		"instructions": "Positioniere den QR-Code im Rahmen, um den Gast einzuchecken.",
+		"scanSuccess": "QR-Code erfolgreich gescannt! Wird verarbeitet...",
+		"closeLabel": "Scanner schließen",
+		"manualEntryTitle": "Kamera funktioniert nicht?",
+		"manualEntryLabel": "Ticket-Code manuell eingeben",
+		"manualEntryPlaceholder": "Ticket-Code einfügen oder eingeben",
+		"manualEntrySubmit": "Einchecken",
+		"error_permissionDenied": "Kamerazugriff verweigert. Aktiviere die Kameraberechtigungen in deinen Browsereinstellungen oder gib den Ticket-Code unten manuell ein.",
+		"error_notFound": "Auf diesem Gerät wurde keine Kamera gefunden. Gib den Ticket-Code unten manuell ein.",
+		"error_notReadable": "Die Kamera wird bereits von einer anderen App verwendet. Schließe sie und versuche es erneut oder gib den Ticket-Code unten manuell ein.",
+		"error_insecureContext": "Der Kamerazugriff erfordert eine sichere (HTTPS-)Verbindung. Gib den Ticket-Code unten manuell ein.",
+		"error_generic": "Kein Zugriff auf die Kamera möglich. Gib den Ticket-Code unten manuell ein.",
+		"error_processFailed": "Das gescannte Ticket konnte nicht verarbeitet werden. Bitte versuche es erneut."
 	},
 	"questionAnswerDisplay": {
 		"noOptionSelected": "Keine Option ausgewählt",
@@ -4660,7 +4673,11 @@
 		"eventContextTitle": "Event-Kontext",
 		"eventNameLabel": "Event",
 		"viewEventLink": "Event ansehen",
-		"noEvaluationRequired": "Dieser Fragebogen erfordert keine Bewertung. Einreichungen werden automatisch akzeptiert."
+		"noEvaluationRequired": "Dieser Fragebogen erfordert keine Bewertung. Einreichungen werden automatisch akzeptiert.",
+		"previous": "Vorherige",
+		"next": "Nächste",
+		"positionLabel": "{current} von {total}",
+		"navLabel": "Navigation der Einreichungen"
 	},
 	"questionnaireSubmissionPage": {
 		"pageTitle": "{questionnaireName} - {eventName}",
@@ -6546,5 +6563,19 @@
 	"announcements.tabs.scheduled": "Geplant",
 	"announcements.empty.scheduled": "Keine geplanten Ankündigungen",
 	"announcements.empty.scheduledDescription": "Für später geplante Ankündigungen erscheinen hier.",
-	"announcements.schedule.kindLegend": "Planungsart"
+	"announcements.schedule.kindLegend": "Planungsart",
+	"eventGuestPrompt": {
+		"title": "Melde dich an, um mehr von dieser Veranstaltung zu sehen",
+		"subtitle": "Einige Details sind nur für angemeldete Gäste sichtbar.",
+		"cta": "Anmelden",
+		"expandLabel": "Das bekommst du nach der Anmeldung",
+		"item_potluck": "Potluck-Koordination",
+		"item_potluckDesc": "Sieh, was andere mitbringen, und füge deinen eigenen Beitrag hinzu",
+		"item_announcements": "Ankündigungen",
+		"item_announcementsDesc": "Die neuesten Updates der Veranstalter",
+		"item_attendees": "Wer kommt",
+		"item_attendeesDesc": "Die Gästeliste für diese Veranstaltung",
+		"item_dietary": "Ernährungspräferenzen",
+		"item_dietaryDesc": "Ernährungsbedürfnisse und -einschränkungen der Gäste"
+	}
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -4337,7 +4337,20 @@
 		"scanQr": "Scan QR Code",
 		"initializing": "Initializing camera...",
 		"error": "Error",
-		"cancel": "Cancel"
+		"cancel": "Cancel",
+		"instructions": "Position the QR code within the frame to check in the attendee.",
+		"scanSuccess": "QR code scanned successfully! Processing...",
+		"closeLabel": "Close scanner",
+		"manualEntryTitle": "Camera not working?",
+		"manualEntryLabel": "Enter ticket code manually",
+		"manualEntryPlaceholder": "Paste or type the ticket code",
+		"manualEntrySubmit": "Check in",
+		"error_permissionDenied": "Camera access was denied. Enable camera permissions in your browser settings, or enter the ticket code manually below.",
+		"error_notFound": "No camera was found on this device. Enter the ticket code manually below.",
+		"error_notReadable": "The camera is already in use by another app. Close it and try again, or enter the ticket code manually below.",
+		"error_insecureContext": "Camera access requires a secure (HTTPS) connection. Enter the ticket code manually below.",
+		"error_generic": "Couldn't access the camera. Enter the ticket code manually below.",
+		"error_processFailed": "Failed to process the scanned ticket. Please try again."
 	},
 	"questionAnswerDisplay": {
 		"noOptionSelected": "No option selected",
@@ -4660,7 +4673,11 @@
 		"eventContextTitle": "Event Context",
 		"eventNameLabel": "Event",
 		"viewEventLink": "View event",
-		"noEvaluationRequired": "This questionnaire does not require evaluation. Submissions are accepted automatically."
+		"noEvaluationRequired": "This questionnaire does not require evaluation. Submissions are accepted automatically.",
+		"previous": "Previous",
+		"next": "Next",
+		"positionLabel": "{current} of {total}",
+		"navLabel": "Submission navigation"
 	},
 	"questionnaireSubmissionPage": {
 		"pageTitle": "{questionnaireName} - {eventName}",
@@ -6546,5 +6563,19 @@
 	"announcements.tabs.scheduled": "Scheduled",
 	"announcements.empty.scheduled": "No scheduled announcements",
 	"announcements.empty.scheduledDescription": "Announcements scheduled to send later will appear here.",
-	"announcements.schedule.kindLegend": "Schedule type"
+	"announcements.schedule.kindLegend": "Schedule type",
+	"eventGuestPrompt": {
+		"title": "Sign in to see more of this event",
+		"subtitle": "Some details are only visible to signed-in guests.",
+		"cta": "Sign in",
+		"expandLabel": "What you'll get access to",
+		"item_potluck": "Potluck coordination",
+		"item_potluckDesc": "See what others are bringing and add your own",
+		"item_announcements": "Announcements",
+		"item_announcementsDesc": "The latest updates from the organizer",
+		"item_attendees": "Who's coming",
+		"item_attendeesDesc": "The guest list for this event",
+		"item_dietary": "Dietary preferences",
+		"item_dietaryDesc": "Attendees' dietary needs and restrictions"
+	}
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -4337,7 +4337,20 @@
 		"scanQr": "Scansiona Codice QR",
 		"initializing": "Inizializzazione fotocamera...",
 		"error": "Errore",
-		"cancel": "Annulla"
+		"cancel": "Annulla",
+		"instructions": "Posiziona il codice QR all'interno del riquadro per effettuare il check-in dell'ospite.",
+		"scanSuccess": "Codice QR scansionato correttamente! Elaborazione in corso...",
+		"closeLabel": "Chiudi scanner",
+		"manualEntryTitle": "La fotocamera non funziona?",
+		"manualEntryLabel": "Inserisci il codice del biglietto manualmente",
+		"manualEntryPlaceholder": "Incolla o digita il codice del biglietto",
+		"manualEntrySubmit": "Check-in",
+		"error_permissionDenied": "Accesso alla fotocamera negato. Abilita i permessi della fotocamera nelle impostazioni del browser oppure inserisci il codice del biglietto qui sotto.",
+		"error_notFound": "Nessuna fotocamera trovata su questo dispositivo. Inserisci il codice del biglietto qui sotto.",
+		"error_notReadable": "La fotocamera è già in uso da un'altra app. Chiudila e riprova oppure inserisci il codice del biglietto qui sotto.",
+		"error_insecureContext": "L'accesso alla fotocamera richiede una connessione sicura (HTTPS). Inserisci il codice del biglietto qui sotto.",
+		"error_generic": "Impossibile accedere alla fotocamera. Inserisci il codice del biglietto qui sotto.",
+		"error_processFailed": "Impossibile elaborare il biglietto scansionato. Riprova."
 	},
 	"questionAnswerDisplay": {
 		"noOptionSelected": "Nessuna opzione selezionata",
@@ -4660,7 +4673,11 @@
 		"eventContextTitle": "Contesto Evento",
 		"eventNameLabel": "Evento",
 		"viewEventLink": "Visualizza evento",
-		"noEvaluationRequired": "Questo questionario non richiede valutazione. Le risposte vengono accettate automaticamente."
+		"noEvaluationRequired": "Questo questionario non richiede valutazione. Le risposte vengono accettate automaticamente.",
+		"previous": "Precedente",
+		"next": "Successiva",
+		"positionLabel": "{current} di {total}",
+		"navLabel": "Navigazione delle risposte"
 	},
 	"questionnaireSubmissionPage": {
 		"pageTitle": "{questionnaireName} - {eventName}",
@@ -6546,5 +6563,19 @@
 	"announcements.tabs.scheduled": "Pianificati",
 	"announcements.empty.scheduled": "Nessun annuncio pianificato",
 	"announcements.empty.scheduledDescription": "Gli annunci pianificati per un invio successivo appariranno qui.",
-	"announcements.schedule.kindLegend": "Tipo di pianificazione"
+	"announcements.schedule.kindLegend": "Tipo di pianificazione",
+	"eventGuestPrompt": {
+		"title": "Accedi per vedere di più su questo evento",
+		"subtitle": "Alcuni dettagli sono visibili solo agli ospiti che hanno effettuato l'accesso.",
+		"cta": "Accedi",
+		"expandLabel": "Cosa potrai vedere",
+		"item_potluck": "Coordinamento potluck",
+		"item_potluckDesc": "Scopri cosa portano gli altri e aggiungi il tuo contributo",
+		"item_announcements": "Annunci",
+		"item_announcementsDesc": "Gli ultimi aggiornamenti degli organizzatori",
+		"item_attendees": "Chi partecipa",
+		"item_attendeesDesc": "L'elenco degli ospiti di questo evento",
+		"item_dietary": "Preferenze alimentari",
+		"item_dietaryDesc": "Esigenze e restrizioni alimentari degli ospiti"
+	}
 }

--- a/src/lib/components/announcements/EventAnnouncements.svelte
+++ b/src/lib/components/announcements/EventAnnouncements.svelte
@@ -19,7 +19,10 @@
 	// Derived
 	const accessToken = $derived(authStore.accessToken);
 
-	// Fetch announcements
+	// Fetch announcements (only signed-in guests can see them; the backend hides
+	// them from anonymous requests to reduce scraping surface). This component is
+	// only rendered for authenticated users; anonymous guests get the consolidated
+	// EventGuestSignInPrompt instead.
 	const announcementsQuery = createQuery(() => ({
 		queryKey: ['event-announcements', eventId],
 		queryFn: async () => {

--- a/src/lib/components/events/EventGuestSignInPrompt.svelte
+++ b/src/lib/components/events/EventGuestSignInPrompt.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import { page } from '$app/stores';
+	import type { EventDetailSchema } from '$lib/api/generated/types.gen';
+	import {
+		LogIn,
+		ChevronDown,
+		ChevronUp,
+		UtensilsCrossed,
+		Megaphone,
+		Users,
+		Salad
+	} from 'lucide-svelte';
+
+	interface Props {
+		event: EventDetailSchema;
+	}
+
+	const { event }: Props = $props();
+
+	// Collapsed by default — keep the card light; the value-prop list expands on click
+	let isExpanded = $state(false);
+
+	// Login link that returns the guest to this event page after signing in
+	const loginHref = $derived(
+		`/login?returnUrl=${encodeURIComponent($page.url.pathname + $page.url.search)}`
+	);
+
+	interface PerkItem {
+		icon: typeof Megaphone;
+		label: string;
+		description: string;
+	}
+
+	// Sections that are gated behind authentication on this page. Potluck is only
+	// listed when the event actually has it enabled, so the list stays accurate.
+	const perks = $derived.by((): PerkItem[] => {
+		const items: PerkItem[] = [];
+		if (event.potluck_open) {
+			items.push({
+				icon: UtensilsCrossed,
+				label: m['eventGuestPrompt.item_potluck'](),
+				description: m['eventGuestPrompt.item_potluckDesc']()
+			});
+		}
+		items.push(
+			{
+				icon: Megaphone,
+				label: m['eventGuestPrompt.item_announcements'](),
+				description: m['eventGuestPrompt.item_announcementsDesc']()
+			},
+			{
+				icon: Users,
+				label: m['eventGuestPrompt.item_attendees'](),
+				description: m['eventGuestPrompt.item_attendeesDesc']()
+			},
+			{
+				icon: Salad,
+				label: m['eventGuestPrompt.item_dietary'](),
+				description: m['eventGuestPrompt.item_dietaryDesc']()
+			}
+		);
+		return items;
+	});
+</script>
+
+<section
+	class="rounded-lg border border-primary/30 bg-primary/5 p-4 sm:p-5"
+	aria-labelledby="guest-signin-heading"
+>
+	<div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+		<div class="flex items-start gap-3">
+			<LogIn class="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+			<div>
+				<h2 id="guest-signin-heading" class="font-semibold">
+					{m['eventGuestPrompt.title']()}
+				</h2>
+				<p class="mt-1 text-sm text-muted-foreground">{m['eventGuestPrompt.subtitle']()}</p>
+			</div>
+		</div>
+		<a
+			href={loginHref}
+			class="inline-flex shrink-0 items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+		>
+			{m['eventGuestPrompt.cta']()}
+		</a>
+	</div>
+
+	<!-- Collapsible list of what signing in unlocks -->
+	<button
+		type="button"
+		onclick={() => (isExpanded = !isExpanded)}
+		aria-expanded={isExpanded}
+		aria-controls="guest-signin-perks"
+		class="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+	>
+		{#if isExpanded}
+			<ChevronUp class="h-4 w-4" aria-hidden="true" />
+		{:else}
+			<ChevronDown class="h-4 w-4" aria-hidden="true" />
+		{/if}
+		{m['eventGuestPrompt.expandLabel']()}
+	</button>
+
+	{#if isExpanded}
+		<ul id="guest-signin-perks" class="mt-3 space-y-3">
+			{#each perks as perk (perk.label)}
+				{@const Icon = perk.icon}
+				<li class="flex items-start gap-3">
+					<Icon class="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+					<div class="text-sm">
+						<p class="font-medium">{perk.label}</p>
+						<p class="text-muted-foreground">{perk.description}</p>
+					</div>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</section>

--- a/src/lib/components/questionnaires/EvaluationForm.svelte
+++ b/src/lib/components/questionnaires/EvaluationForm.svelte
@@ -12,10 +12,18 @@
 		submissionId: string;
 		currentStatus?: 'approved' | 'rejected' | 'pending review' | null;
 		isSubmitting?: boolean;
+		/** Filter/sort query string (no leading `?`) to preserve after evaluating */
+		returnQuery?: string;
 		onCancel?: () => void;
 	}
 
-	const { submissionId, currentStatus = null, isSubmitting = false, onCancel }: Props = $props();
+	const {
+		submissionId,
+		currentStatus = null,
+		isSubmitting = false,
+		returnQuery = '',
+		onCancel
+	}: Props = $props();
 
 	// Form state
 	let showAdvancedOptions = $state(false);
@@ -39,6 +47,7 @@
 -->
 <form method="POST" action="?/evaluate">
 	<input type="hidden" name="submission_id" value={submissionId} />
+	<input type="hidden" name="return_query" value={returnQuery} />
 
 	<Card class="p-6">
 		<h3 class="mb-4 text-lg font-semibold">{m['evaluationForm.yourEvaluation']()}</h3>

--- a/src/lib/components/tickets/QRScannerModal.svelte
+++ b/src/lib/components/tickets/QRScannerModal.svelte
@@ -3,7 +3,7 @@
 	import { onDestroy } from 'svelte';
 	import { Html5Qrcode } from 'html5-qrcode';
 	import { Button } from '$lib/components/ui/button';
-	import { X, Camera, AlertCircle } from 'lucide-svelte';
+	import { X, Camera, AlertCircle, KeyRound } from 'lucide-svelte';
 
 	interface Props {
 		isOpen: boolean;
@@ -17,11 +17,47 @@
 	let isScanning = $state(false);
 	let error = $state<string | null>(null);
 	let scanSuccess = $state(false);
+	let manualCode = $state('');
+	let isSubmittingManual = $state(false);
 
 	/**
-	 * Start the QR scanner
+	 * Returns true if the error matches a given getUserMedia error name, whether it
+	 * arrives as a DOMException or as a wrapped string/Error (html5-qrcode does both).
 	 */
-	async function startScanner() {
+	function errIncludes(err: unknown, name: string): boolean {
+		if (err instanceof DOMException && err.name === name) return true;
+		const text = typeof err === 'string' ? err : err instanceof Error ? err.message : '';
+		return text.includes(name);
+	}
+
+	/**
+	 * Map a camera failure to a localized, actionable message. The manual-entry
+	 * field below is always available, so every message points the organizer there.
+	 */
+	function resolveCameraError(err: unknown): string {
+		if (errIncludes(err, 'NotAllowedError') || errIncludes(err, 'PermissionDeniedError')) {
+			return m['qrScannerModal.error_permissionDenied']();
+		}
+		if (errIncludes(err, 'NotFoundError') || errIncludes(err, 'DevicesNotFoundError')) {
+			return m['qrScannerModal.error_notFound']();
+		}
+		if (errIncludes(err, 'NotReadableError') || errIncludes(err, 'TrackStartError')) {
+			return m['qrScannerModal.error_notReadable']();
+		}
+		return m['qrScannerModal.error_generic']();
+	}
+
+	/**
+	 * Start the QR scanner. Falls back to the front camera once if the requested
+	 * facing mode can't be satisfied, and surfaces actionable per-error messages.
+	 */
+	async function startScanner(facingMode: 'environment' | 'user' = 'environment', isRetry = false) {
+		// Camera access requires a secure context (HTTPS or localhost).
+		if (typeof window !== 'undefined' && !window.isSecureContext) {
+			error = m['qrScannerModal.error_insecureContext']();
+			return;
+		}
+
 		try {
 			error = null;
 			const scannerId = 'qr-reader';
@@ -33,7 +69,7 @@
 
 			// Request camera permission and start scanning
 			await scanner.start(
-				{ facingMode: 'environment' }, // Use back camera on mobile
+				{ facingMode }, // Back camera by default, front camera as fallback
 				{
 					fps: 10, // Frames per second to scan
 					qrbox: { width: 250, height: 250 } // Scanning box size
@@ -45,7 +81,37 @@
 			isScanning = true;
 		} catch (err) {
 			console.error('Failed to start scanner:', err);
-			error = 'Failed to access camera. Please ensure camera permissions are granted.';
+
+			// The back camera can't satisfy the constraint — try the front camera once.
+			if (errIncludes(err, 'OverconstrainedError') && !isRetry) {
+				await startScanner('user', true);
+				return;
+			}
+
+			error = resolveCameraError(err);
+		}
+	}
+
+	/**
+	 * Submit a manually-entered ticket code — a guaranteed fallback when the camera
+	 * can't start. Routes through the same onScan path as a successful scan.
+	 */
+	async function submitManualCode(event?: SubmitEvent) {
+		event?.preventDefault();
+		const code = manualCode.trim();
+		if (!code || isSubmittingManual) return;
+
+		isSubmittingManual = true;
+		error = null;
+		try {
+			await stopScanner();
+			await onScan(code);
+			manualCode = '';
+		} catch (err) {
+			console.error('Manual check-in failed:', err);
+			error = m['qrScannerModal.error_processFailed']();
+		} finally {
+			isSubmittingManual = false;
 		}
 	}
 
@@ -75,7 +141,7 @@
 			await onScan(decodedText);
 		} catch (err) {
 			console.error('Scan processing error:', err);
-			error = 'Failed to process scanned ticket. Please try again.';
+			error = m['qrScannerModal.error_processFailed']();
 			scanSuccess = false;
 			// Restart scanner after error
 			setTimeout(() => {
@@ -104,6 +170,7 @@
 		await stopScanner();
 		error = null;
 		scanSuccess = false;
+		manualCode = '';
 		onClose();
 	}
 
@@ -147,7 +214,7 @@
 					type="button"
 					onclick={handleClose}
 					class="rounded-full p-1 hover:bg-accent"
-					aria-label="Close scanner"
+					aria-label={m['qrScannerModal.closeLabel']()}
 				>
 					<X class="h-5 w-5" />
 				</button>
@@ -155,7 +222,7 @@
 
 			<!-- Instructions -->
 			<p class="mb-4 text-sm text-muted-foreground">
-				Position the QR code within the frame to check in the attendee.
+				{m['qrScannerModal.instructions']()}
 			</p>
 
 			<!-- Scanner Container -->
@@ -196,9 +263,35 @@
 					class="mb-4 rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
 					role="status"
 				>
-					✓ QR code scanned successfully! Processing...
+					✓ {m['qrScannerModal.scanSuccess']()}
 				</div>
 			{/if}
+
+			<!-- Manual entry fallback (always available when the camera won't start) -->
+			<form
+				onsubmit={submitManualCode}
+				class="mb-4 rounded-lg border border-border bg-muted/30 p-3"
+			>
+				<label for="manual-ticket-code" class="mb-2 flex items-center gap-2 text-sm font-medium">
+					<KeyRound class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+					{m['qrScannerModal.manualEntryLabel']()}
+				</label>
+				<div class="flex gap-2">
+					<input
+						id="manual-ticket-code"
+						type="text"
+						bind:value={manualCode}
+						placeholder={m['qrScannerModal.manualEntryPlaceholder']()}
+						autocomplete="off"
+						autocapitalize="off"
+						spellcheck="false"
+						class="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					/>
+					<Button type="submit" disabled={!manualCode.trim() || isSubmittingManual}>
+						{m['qrScannerModal.manualEntrySubmit']()}
+					</Button>
+				</div>
+			</form>
 
 			<!-- Actions -->
 			<div class="flex justify-end gap-2">

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/+page.svelte
@@ -256,7 +256,8 @@
 								{/if}
 								<td class="px-6 py-4 text-right">
 									<Button
-										href="/org/{data.organizationSlug}/admin/questionnaires/{data.questionnaireId}/submissions/{submission.id}"
+										href="/org/{data.organizationSlug}/admin/questionnaires/{data.questionnaireId}/submissions/{submission.id}{$page
+											.url.search}"
 										variant="outline"
 										size="sm"
 									>
@@ -303,7 +304,8 @@
 					</div>
 
 					<Button
-						href="/org/{data.organizationSlug}/admin/questionnaires/{data.questionnaireId}/submissions/{submission.id}"
+						href="/org/{data.organizationSlug}/admin/questionnaires/{data.questionnaireId}/submissions/{submission.id}{$page
+							.url.search}"
 						variant="outline"
 						size="sm"
 						class="mt-4 w-full"

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.server.ts
@@ -3,11 +3,17 @@ import { error, fail, redirect } from '@sveltejs/kit';
 import {
 	questionnaireGetSubmissionDetail,
 	questionnaireEvaluateSubmission,
-	questionnaireGetOrgQuestionnaire
+	questionnaireGetOrgQuestionnaire,
+	questionnaireListSubmissions
 } from '$lib/api/client';
 import { log } from '$lib/server/logger';
 
-export const load: PageServerLoad = async ({ params, locals, fetch }) => {
+// How many siblings to load for Next/Previous navigation. Covers the vast
+// majority of questionnaires; submissions beyond this window simply don't get
+// neighbor links (the buttons disable at the edges of the loaded set).
+const SIBLING_NAV_LIMIT = 100;
+
+export const load: PageServerLoad = async ({ params, url, locals, fetch }) => {
 	const { slug, id, submission_id } = params;
 
 	// Ensure user is authenticated
@@ -21,8 +27,16 @@ export const load: PageServerLoad = async ({ params, locals, fetch }) => {
 		Authorization: `Bearer ${user.accessToken}`
 	};
 
-	// Fetch submission detail and org questionnaire in parallel
-	const [submissionResult, questionnaireResult] = await Promise.all([
+	// Carry the list's filter/sort context so Next/Previous walks the same
+	// ordered, filtered set the reviewer was looking at.
+	const search = url.searchParams.get('search') || undefined;
+	const evaluationStatus = url.searchParams.get('evaluation_status') || undefined;
+	const orderBy = (url.searchParams.get('order_by') || '-submitted_at') as
+		| 'submitted_at'
+		| '-submitted_at';
+
+	// Fetch submission detail, org questionnaire, and the sibling list in parallel
+	const [submissionResult, questionnaireResult, siblingsResult] = await Promise.all([
 		questionnaireGetSubmissionDetail({
 			fetch,
 			path: { org_questionnaire_id: id, submission_id },
@@ -31,6 +45,18 @@ export const load: PageServerLoad = async ({ params, locals, fetch }) => {
 		questionnaireGetOrgQuestionnaire({
 			fetch,
 			path: { org_questionnaire_id: id },
+			headers
+		}),
+		questionnaireListSubmissions({
+			fetch,
+			path: { org_questionnaire_id: id },
+			query: {
+				page: 1,
+				page_size: SIBLING_NAV_LIMIT,
+				search,
+				evaluation_status: evaluationStatus,
+				order_by: orderBy
+			},
 			headers
 		})
 	]);
@@ -44,11 +70,30 @@ export const load: PageServerLoad = async ({ params, locals, fetch }) => {
 		throw error(404, 'Submission not found');
 	}
 
+	// Compute Previous/Next neighbors within the loaded, filtered, ordered set.
+	const siblings = siblingsResult.data?.results ?? [];
+	const totalSiblings = siblingsResult.data?.count ?? siblings.length;
+	const currentIndex = siblings.findIndex((s) => s.id === submission_id);
+	const previousId = currentIndex > 0 ? siblings[currentIndex - 1].id : null;
+	const nextId =
+		currentIndex >= 0 && currentIndex < siblings.length - 1 ? siblings[currentIndex + 1].id : null;
+
+	// Preserve the filter/sort query string on neighbor and back links.
+	const contextQuery = url.searchParams.toString();
+
 	return {
 		submission: submissionResult.data,
 		organizationSlug: slug,
 		questionnaireId: id,
-		requiresEvaluation: questionnaireResult.data?.requires_evaluation ?? true
+		requiresEvaluation: questionnaireResult.data?.requires_evaluation ?? true,
+		navigation: {
+			previousId,
+			nextId,
+			// 1-based position; null when the submission falls outside the loaded window
+			position: currentIndex >= 0 ? currentIndex + 1 : null,
+			total: totalSiblings,
+			contextQuery
+		}
 	};
 };
 

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.server.ts
@@ -71,9 +71,27 @@ export const load: PageServerLoad = async ({ params, url, locals, fetch }) => {
 	}
 
 	// Compute Previous/Next neighbors within the loaded, filtered, ordered set.
-	const siblings = siblingsResult.data?.results ?? [];
-	const totalSiblings = siblingsResult.data?.count ?? siblings.length;
-	const currentIndex = siblings.findIndex((s) => s.id === submission_id);
+	let siblings = siblingsResult.data?.results ?? [];
+	let totalSiblings = siblingsResult.data?.count ?? siblings.length;
+	let currentIndex = siblings.findIndex((s) => s.id === submission_id);
+
+	// Edge case: after evaluating, this submission's status may no longer match the
+	// active evaluation_status filter, dropping it out of the filtered set. Fall back
+	// to an unfiltered (search + order_by) list so Next/Previous keeps working.
+	if (currentIndex === -1 && evaluationStatus) {
+		const fallback = await questionnaireListSubmissions({
+			fetch,
+			path: { org_questionnaire_id: id },
+			query: { page: 1, page_size: SIBLING_NAV_LIMIT, search, order_by: orderBy },
+			headers
+		});
+		if (fallback.data?.results) {
+			siblings = fallback.data.results;
+			totalSiblings = fallback.data.count ?? siblings.length;
+			currentIndex = siblings.findIndex((s) => s.id === submission_id);
+		}
+	}
+
 	const previousId = currentIndex > 0 ? siblings[currentIndex - 1].id : null;
 	const nextId =
 		currentIndex >= 0 && currentIndex < siblings.length - 1 ? siblings[currentIndex + 1].id : null;
@@ -116,6 +134,7 @@ export const actions: Actions = {
 		const status = formData.get('status') as string;
 		const score = formData.get('score') as string | null;
 		const comments = formData.get('comments') as string | null;
+		const returnQuery = (formData.get('return_query') as string | null) ?? '';
 
 		// Validate status
 		if (!status || !['approved', 'rejected', 'pending review'].includes(status)) {
@@ -159,7 +178,12 @@ export const actions: Actions = {
 			return fail(500, { error: 'Failed to submit evaluation. Please try again.' });
 		}
 
-		// Redirect back to submissions list
-		throw redirect(303, `/org/${params.slug}/admin/questionnaires/${id}/submissions`);
+		// Stay on this submission (preserving the list's filter/sort context) so the
+		// reviewer can use the Next/Previous nav to move on after approving/rejecting.
+		const suffix = returnQuery ? `?${returnQuery}` : '';
+		throw redirect(
+			303,
+			`/org/${params.slug}/admin/questionnaires/${id}/submissions/${submission_id}${suffix}`
+		);
 	}
 };

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
@@ -7,7 +7,16 @@
 	import AutoEvalRecommendation from '$lib/components/questionnaires/AutoEvalRecommendation.svelte';
 	import EvaluationForm from '$lib/components/questionnaires/EvaluationForm.svelte';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
-	import { ArrowLeft, Mail, Calendar, CalendarDays, ExternalLink, Info } from 'lucide-svelte';
+	import {
+		ArrowLeft,
+		ChevronLeft,
+		ChevronRight,
+		Mail,
+		Calendar,
+		CalendarDays,
+		ExternalLink,
+		Info
+	} from 'lucide-svelte';
 	import {
 		isPendingReview,
 		type QuestionnaireEvaluationStatus
@@ -22,6 +31,24 @@
 
 	// Form submission state
 	const isSubmitting = $state(false);
+
+	// Submission list navigation (Next/Previous), preserving filter/sort context
+	const submissionsBasePath = $derived(
+		`/org/${data.organizationSlug}/admin/questionnaires/${data.questionnaireId}/submissions`
+	);
+	const contextQuery = $derived(
+		data.navigation?.contextQuery ? `?${data.navigation.contextQuery}` : ''
+	);
+	const previousHref = $derived(
+		data.navigation?.previousId
+			? `${submissionsBasePath}/${data.navigation.previousId}${contextQuery}`
+			: null
+	);
+	const nextHref = $derived(
+		data.navigation?.nextId
+			? `${submissionsBasePath}/${data.navigation.nextId}${contextQuery}`
+			: null
+	);
 
 	function formatDate(dateString: string | null | undefined): string {
 		if (!dateString) return m['questionnaireSubmissionDetailPage.notSubmitted']();
@@ -85,13 +112,68 @@
 <div class="container mx-auto max-w-5xl px-4 py-8">
 	<!-- Header -->
 	<div class="mb-8">
-		<a
-			href="/org/{data.organizationSlug}/admin/questionnaires/{data.questionnaireId}/submissions"
-			class="mb-4 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-		>
-			<ArrowLeft class="h-4 w-4" />
-			{m['questionnaireSubmissionDetailPage.backToSubmissions']()}
-		</a>
+		<div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+			<a
+				href="{submissionsBasePath}{contextQuery}"
+				class="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+			>
+				<ArrowLeft class="h-4 w-4" />
+				{m['questionnaireSubmissionDetailPage.backToSubmissions']()}
+			</a>
+
+			<!-- Next/Previous navigation through the (filtered) submission list -->
+			{#if previousHref || nextHref}
+				<nav
+					class="flex items-center gap-1"
+					aria-label={m['questionnaireSubmissionDetailPage.navLabel']()}
+				>
+					{#if previousHref}
+						<a
+							href={previousHref}
+							class="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						>
+							<ChevronLeft class="h-4 w-4" aria-hidden="true" />
+							{m['questionnaireSubmissionDetailPage.previous']()}
+						</a>
+					{:else}
+						<span
+							class="inline-flex cursor-not-allowed items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground opacity-50"
+							aria-disabled="true"
+						>
+							<ChevronLeft class="h-4 w-4" aria-hidden="true" />
+							{m['questionnaireSubmissionDetailPage.previous']()}
+						</span>
+					{/if}
+
+					{#if data.navigation?.position}
+						<span class="px-2 text-sm text-muted-foreground" aria-live="polite">
+							{m['questionnaireSubmissionDetailPage.positionLabel']({
+								current: data.navigation.position,
+								total: data.navigation.total
+							})}
+						</span>
+					{/if}
+
+					{#if nextHref}
+						<a
+							href={nextHref}
+							class="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						>
+							{m['questionnaireSubmissionDetailPage.next']()}
+							<ChevronRight class="h-4 w-4" aria-hidden="true" />
+						</a>
+					{:else}
+						<span
+							class="inline-flex cursor-not-allowed items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground opacity-50"
+							aria-disabled="true"
+						>
+							{m['questionnaireSubmissionDetailPage.next']()}
+							<ChevronRight class="h-4 w-4" aria-hidden="true" />
+						</span>
+					{/if}
+				</nav>
+			{/if}
+		</div>
 		<div class="flex items-start justify-between gap-4">
 			<div class="flex-1">
 				<h1 class="text-3xl font-bold">{m['questionnaireSubmissionDetailPage.title']()}</h1>

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
@@ -109,6 +109,63 @@
 	>
 </svelte:head>
 
+<!-- Next/Previous navigation through the (filtered) submission list; rendered at
+	 the top and again below the evaluation form so reviewers can advance without
+	 scrolling back up after approving/rejecting. -->
+{#snippet submissionNav()}
+	{#if previousHref || nextHref}
+		<nav
+			class="flex items-center gap-1"
+			aria-label={m['questionnaireSubmissionDetailPage.navLabel']()}
+		>
+			{#if previousHref}
+				<a
+					href={previousHref}
+					class="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				>
+					<ChevronLeft class="h-4 w-4" aria-hidden="true" />
+					{m['questionnaireSubmissionDetailPage.previous']()}
+				</a>
+			{:else}
+				<span
+					class="inline-flex cursor-not-allowed items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground opacity-50"
+					aria-disabled="true"
+				>
+					<ChevronLeft class="h-4 w-4" aria-hidden="true" />
+					{m['questionnaireSubmissionDetailPage.previous']()}
+				</span>
+			{/if}
+
+			{#if data.navigation?.position}
+				<span class="px-2 text-sm text-muted-foreground">
+					{m['questionnaireSubmissionDetailPage.positionLabel']({
+						current: data.navigation.position,
+						total: data.navigation.total
+					})}
+				</span>
+			{/if}
+
+			{#if nextHref}
+				<a
+					href={nextHref}
+					class="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				>
+					{m['questionnaireSubmissionDetailPage.next']()}
+					<ChevronRight class="h-4 w-4" aria-hidden="true" />
+				</a>
+			{:else}
+				<span
+					class="inline-flex cursor-not-allowed items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground opacity-50"
+					aria-disabled="true"
+				>
+					{m['questionnaireSubmissionDetailPage.next']()}
+					<ChevronRight class="h-4 w-4" aria-hidden="true" />
+				</span>
+			{/if}
+		</nav>
+	{/if}
+{/snippet}
+
 <div class="container mx-auto max-w-5xl px-4 py-8">
 	<!-- Header -->
 	<div class="mb-8">
@@ -121,58 +178,7 @@
 				{m['questionnaireSubmissionDetailPage.backToSubmissions']()}
 			</a>
 
-			<!-- Next/Previous navigation through the (filtered) submission list -->
-			{#if previousHref || nextHref}
-				<nav
-					class="flex items-center gap-1"
-					aria-label={m['questionnaireSubmissionDetailPage.navLabel']()}
-				>
-					{#if previousHref}
-						<a
-							href={previousHref}
-							class="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-						>
-							<ChevronLeft class="h-4 w-4" aria-hidden="true" />
-							{m['questionnaireSubmissionDetailPage.previous']()}
-						</a>
-					{:else}
-						<span
-							class="inline-flex cursor-not-allowed items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground opacity-50"
-							aria-disabled="true"
-						>
-							<ChevronLeft class="h-4 w-4" aria-hidden="true" />
-							{m['questionnaireSubmissionDetailPage.previous']()}
-						</span>
-					{/if}
-
-					{#if data.navigation?.position}
-						<span class="px-2 text-sm text-muted-foreground" aria-live="polite">
-							{m['questionnaireSubmissionDetailPage.positionLabel']({
-								current: data.navigation.position,
-								total: data.navigation.total
-							})}
-						</span>
-					{/if}
-
-					{#if nextHref}
-						<a
-							href={nextHref}
-							class="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-						>
-							{m['questionnaireSubmissionDetailPage.next']()}
-							<ChevronRight class="h-4 w-4" aria-hidden="true" />
-						</a>
-					{:else}
-						<span
-							class="inline-flex cursor-not-allowed items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground opacity-50"
-							aria-disabled="true"
-						>
-							{m['questionnaireSubmissionDetailPage.next']()}
-							<ChevronRight class="h-4 w-4" aria-hidden="true" />
-						</span>
-					{/if}
-				</nav>
-			{/if}
+			{@render submissionNav()}
 		</div>
 		<div class="flex items-start justify-between gap-4">
 			<div class="flex-1">
@@ -234,8 +240,17 @@
 							| 'rejected'
 							| 'pending review'
 							| null) || null}
+						returnQuery={data.navigation?.contextQuery ?? ''}
 						{isSubmitting}
 					/>
+				</div>
+			{/if}
+
+			<!-- Repeat the Next/Previous nav at the bottom so reviewers can advance
+				 straight after approving/rejecting, without scrolling back up. -->
+			{#if previousHref || nextHref}
+				<div class="flex justify-end border-t pt-6">
+					{@render submissionNav()}
 				</div>
 			{/if}
 		</div>

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -19,6 +19,7 @@
 	import DietarySummary from '$lib/components/events/DietarySummary.svelte';
 	import EventResources from '$lib/components/events/EventResources.svelte';
 	import EventAnnouncements from '$lib/components/announcements/EventAnnouncements.svelte';
+	import EventGuestSignInPrompt from '$lib/components/events/EventGuestSignInPrompt.svelte';
 	import AttendeeList from '$lib/components/events/AttendeeList.svelte';
 	import TicketTierList from '$lib/components/tickets/TicketTierList.svelte';
 	import MyTicket from '$lib/components/tickets/MyTicket.svelte';
@@ -748,29 +749,34 @@
 			<div class="space-y-8 lg:col-span-2">
 				<EventDetails {event} />
 
-				<!-- Announcements Section (high visibility, directly under details) -->
-				<EventAnnouncements eventId={event.id} />
+				{#if data.isAuthenticated}
+					<!-- Announcements Section (high visibility, directly under details) -->
+					<EventAnnouncements eventId={event.id} />
 
-				<!-- Potluck Coordination Section -->
-				<!-- Show if potluck is open OR if there are existing items -->
-				{#if event.potluck_open || data.potluckItems.length > 0}
-					<div class="space-y-6">
-						<!-- Dietary Summary -->
-						<DietarySummary
-							eventId={event.id}
-							authToken={authStore.accessToken}
-							isAuthenticated={data.isAuthenticated}
-						/>
+					<!-- Potluck Coordination Section -->
+					<!-- Show if potluck is open OR if there are existing items -->
+					{#if event.potluck_open || data.potluckItems.length > 0}
+						<div class="space-y-6">
+							<!-- Dietary Summary -->
+							<DietarySummary
+								eventId={event.id}
+								authToken={authStore.accessToken}
+								isAuthenticated={data.isAuthenticated}
+							/>
 
-						<!-- Potluck Items -->
-						<PotluckSection
-							{event}
-							permissions={potluckPermissions}
-							isAuthenticated={data.isAuthenticated}
-							{hasRSVPd}
-							initialItems={data.potluckItems}
-						/>
-					</div>
+							<!-- Potluck Items -->
+							<PotluckSection
+								{event}
+								permissions={potluckPermissions}
+								isAuthenticated={data.isAuthenticated}
+								{hasRSVPd}
+								initialItems={data.potluckItems}
+							/>
+						</div>
+					{/if}
+				{:else}
+					<!-- Consolidated sign-in prompt covering all auth-gated sections -->
+					<EventGuestSignInPrompt {event} />
 				{/if}
 
 				<!-- My Ticket (if user has a ticket) -->


### PR DESCRIPTION
FE-only quick-wins bundle picked from issues #443+, none blocked by the backend.

## What's in it

### #470 + #473 — consolidated guest sign-in prompt
Logged-out visitors couldn't see potluck coordination or announcements (intentional, anti-scraping) and got a misleading empty/zero state. Rather than two scattered banners, this adds a single **`EventGuestSignInPrompt`** in the high-visibility slot under the event details:
- Headline + **Sign in** button (returns to the event via `returnUrl`).
- Collapsed-by-default "what you'll unlock" list: **Potluck coordination** (only when `potluck_open`), **Announcements**, **Who's coming**, **Dietary preferences**.

The event page now gates the announcements + potluck/dietary sections behind auth and shows the prompt otherwise. While mapping what's gated, I found the **dietary summary** and **attendee list** previously gave logged-out visitors *no* sign-in cue at all (silent empty/non-render) — the consolidated prompt now covers them too.

> Note: an anonymous client can't detect whether announcements/attendees actually exist (backend requires auth), so the prompt shows for all logged-out visitors on every event. It's a single tasteful card, so this is a deliberate trade-off.

### #460 — check-in camera failures (priority:high)
`QRScannerModal` previously funneled every camera failure into one generic English message with no recovery path. Now:
- **Manual ticket-code entry** field (routes through the existing `onScan`) — a guaranteed fallback when the camera won't start.
- Per-`err.name` messages (NotAllowed / NotFound / NotReadable).
- Secure-context (HTTPS) guard.
- Front-camera retry on `OverconstrainedError`.
- i18n'd the previously-hardcoded English strings.

### #443 (Q7 only) — questionnaire submission Next/Previous
Reviewing submissions one-at-a-time required returning to the list each time. Adds **Next/Previous** + "n of m" position to the submission detail header, respecting the list's current filter/sort (Review links carry the query string; the server load computes neighbors from the filtered, ordered set). The larger tabular/CSV review (Q6) is deferred as a bigger build.

## Excluded (and why)
- **#469** phantom end-date — ambiguous FE-save-vs-BE-persist, needs investigation
- **#459** tier discoverability — medium-sized UX work
- **#471** (BE #559), **#472** (BE moderation epic #544), **#464** (BE #530) — backend-blocked

## Quality gate
0 type errors, i18n 100% (en/de/it), prettier clean, Svelte autofixer clean. New i18n groups: `eventGuestPrompt.*`, `qrScannerModal.*`, `questionnaireSubmissionDetailPage.{previous,next,positionLabel,navLabel}`.

Closes #470
Closes #473
Closes #460
Partially addresses #443 (Q7 only; Q6 tabular/CSV review remains open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
