### PR TITLE
feat(tickets): top-level org-admin Tickets tab (#450)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -3546,6 +3546,13 @@
 	"orgAdmin.nav.billing": "Abrechnung",
 	"orgAdmin.nav.discountCodes": "Rabattcodes",
 	"orgAdmin.nav.venues": "Veranstaltungsorte",
+	"orgAdmin.nav.tickets": "Tickets",
+	"orgAdmin.tickets.title": "Tickets",
+	"orgAdmin.tickets.subtitle": "Wähle ein Event aus, um dessen Tickets zu verwalten",
+	"orgAdmin.tickets.attendees": "{count} Teilnehmende",
+	"orgAdmin.tickets.empty.title": "Noch keine Events mit Tickets",
+	"orgAdmin.tickets.empty.description": "Sobald du ein Event erstellst, das ein Ticket erfordert, erscheint es hier zur Ticketverwaltung.",
+	"orgAdmin.tickets.empty.cta": "Zu den Events",
 	"orgAdmin.billing": {
 		"pageTitle": "Abrechnung & USt",
 		"pageDescription": "Verwalte deine Rechnungsdaten, USt-Einstellungen und sieh Rechnungen ein",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3546,6 +3546,13 @@
 	"orgAdmin.nav.billing": "Billing",
 	"orgAdmin.nav.discountCodes": "Discount Codes",
 	"orgAdmin.nav.venues": "Venues",
+	"orgAdmin.nav.tickets": "Tickets",
+	"orgAdmin.tickets.title": "Tickets",
+	"orgAdmin.tickets.subtitle": "Select an event to manage its tickets",
+	"orgAdmin.tickets.attendees": "{count} attendees",
+	"orgAdmin.tickets.empty.title": "No ticketed events yet",
+	"orgAdmin.tickets.empty.description": "Once you create an event that requires a ticket, it will show up here for ticket management.",
+	"orgAdmin.tickets.empty.cta": "Go to Events",
 	"orgAdmin.billing": {
 		"pageTitle": "Billing & VAT",
 		"pageDescription": "Manage your billing information, VAT settings, and view invoices",

--- a/messages/it.json
+++ b/messages/it.json
@@ -3546,6 +3546,13 @@
 	"orgAdmin.nav.billing": "Fatturazione",
 	"orgAdmin.nav.discountCodes": "Codici Sconto",
 	"orgAdmin.nav.venues": "Luoghi",
+	"orgAdmin.nav.tickets": "Biglietti",
+	"orgAdmin.tickets.title": "Biglietti",
+	"orgAdmin.tickets.subtitle": "Seleziona un evento per gestirne i biglietti",
+	"orgAdmin.tickets.attendees": "{count} partecipanti",
+	"orgAdmin.tickets.empty.title": "Nessun evento con biglietti",
+	"orgAdmin.tickets.empty.description": "Quando crei un evento che richiede un biglietto, comparirà qui per la gestione dei biglietti.",
+	"orgAdmin.tickets.empty.cta": "Vai agli Eventi",
 	"orgAdmin.billing": {
 		"pageTitle": "Fatturazione e IVA",
 		"pageDescription": "Gestisci le informazioni di fatturazione, le impostazioni IVA e visualizza le fatture",

--- a/src/lib/components/events/EventStatusBadge.svelte
+++ b/src/lib/components/events/EventStatusBadge.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { EventDetailSchema } from '$lib/api/generated/types.gen';
+	import type { EventDetailSchema, EventStatus } from '$lib/api/generated/types.gen';
 	import { cn } from '$lib/utils/cn';
 	import {
 		Calendar,
@@ -15,8 +15,17 @@
 
 	import * as m from '$lib/paraglide/messages.js';
 
+	/**
+	 * Only the fields the badge actually reads. Both EventDetailSchema and
+	 * EventInListSchema satisfy this, so the badge works in list contexts too.
+	 */
+	type EventStatusBadgeEvent = Pick<
+		EventDetailSchema,
+		'status' | 'start' | 'end' | 'max_attendees' | 'attendee_count'
+	> & { status: EventStatus };
+
 	interface Props {
-		event: EventDetailSchema;
+		event: EventStatusBadgeEvent;
 		class?: string;
 	}
 

--- a/src/lib/utils/ticket-event-picker.test.ts
+++ b/src/lib/utils/ticket-event-picker.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { EventInListSchema } from '$lib/api/generated/types.gen';
+import {
+	isTicketEventActive,
+	shouldRedirectToSingle,
+	sortTicketEventsForPicker
+} from './ticket-event-picker';
+
+// Fixed "now" so past/future are deterministic.
+const NOW = new Date('2026-06-21T12:00:00Z');
+const FUTURE = '2026-09-01T18:00:00Z';
+const PAST = '2026-01-01T18:00:00Z';
+
+function ev(overrides: Partial<EventInListSchema>): EventInListSchema {
+	return {
+		id: 'id',
+		name: 'Event',
+		slug: 'event',
+		start: FUTURE,
+		end: FUTURE,
+		status: 'open',
+		requires_ticket: true,
+		attendee_count: 0,
+		...overrides
+	} as EventInListSchema;
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe('isTicketEventActive', () => {
+	it('true for an upcoming, non-cancelled event', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+		expect(isTicketEventActive(ev({ end: FUTURE, status: 'open' }))).toBe(true);
+	});
+	it('false for a past event', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+		expect(isTicketEventActive(ev({ end: PAST, status: 'open' }))).toBe(false);
+	});
+	it('false for a cancelled event even if upcoming', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+		expect(isTicketEventActive(ev({ end: FUTURE, status: 'cancelled' }))).toBe(false);
+	});
+});
+
+describe('shouldRedirectToSingle', () => {
+	it('returns the event when exactly one active event', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+		const a = ev({ id: 'A', end: FUTURE });
+		expect(shouldRedirectToSingle([a])).toBe(a);
+	});
+	it('returns null when the single event is past', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+		expect(shouldRedirectToSingle([ev({ id: 'A', end: PAST })])).toBeNull();
+	});
+	it('returns null when the single event is cancelled', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+		expect(shouldRedirectToSingle([ev({ id: 'A', status: 'cancelled' })])).toBeNull();
+	});
+	it('returns null when more than one event (even if one is active)', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+		const a = ev({ id: 'A', end: FUTURE });
+		const b = ev({ id: 'B', end: PAST });
+		expect(shouldRedirectToSingle([a, b])).toBeNull();
+	});
+	it('returns null for an empty list', () => {
+		expect(shouldRedirectToSingle([])).toBeNull();
+	});
+});
+
+describe('sortTicketEventsForPicker', () => {
+	it('orders upcoming (asc) before past (desc)', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+		const upLater = ev({ id: 'up-later', start: '2026-10-01T10:00:00Z', end: '2026-10-01T12:00:00Z' });
+		const upSooner = ev({ id: 'up-sooner', start: '2026-07-01T10:00:00Z', end: '2026-07-01T12:00:00Z' });
+		const pastOld = ev({ id: 'past-old', start: '2026-01-01T10:00:00Z', end: '2026-01-01T12:00:00Z' });
+		const pastRecent = ev({ id: 'past-recent', start: '2026-05-01T10:00:00Z', end: '2026-05-01T12:00:00Z' });
+		const sorted = sortTicketEventsForPicker([pastOld, upLater, pastRecent, upSooner]);
+		expect(sorted.map((e) => e.id)).toEqual(['up-sooner', 'up-later', 'past-recent', 'past-old']);
+	});
+	it('does not mutate the input array', () => {
+		const input = [ev({ id: 'A' })];
+		const copy = [...input];
+		sortTicketEventsForPicker(input);
+		expect(input).toEqual(copy);
+	});
+});

--- a/src/lib/utils/ticket-event-picker.test.ts
+++ b/src/lib/utils/ticket-event-picker.test.ts
@@ -78,10 +78,26 @@ describe('sortTicketEventsForPicker', () => {
 	it('orders upcoming (asc) before past (desc)', () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(NOW);
-		const upLater = ev({ id: 'up-later', start: '2026-10-01T10:00:00Z', end: '2026-10-01T12:00:00Z' });
-		const upSooner = ev({ id: 'up-sooner', start: '2026-07-01T10:00:00Z', end: '2026-07-01T12:00:00Z' });
-		const pastOld = ev({ id: 'past-old', start: '2026-01-01T10:00:00Z', end: '2026-01-01T12:00:00Z' });
-		const pastRecent = ev({ id: 'past-recent', start: '2026-05-01T10:00:00Z', end: '2026-05-01T12:00:00Z' });
+		const upLater = ev({
+			id: 'up-later',
+			start: '2026-10-01T10:00:00Z',
+			end: '2026-10-01T12:00:00Z'
+		});
+		const upSooner = ev({
+			id: 'up-sooner',
+			start: '2026-07-01T10:00:00Z',
+			end: '2026-07-01T12:00:00Z'
+		});
+		const pastOld = ev({
+			id: 'past-old',
+			start: '2026-01-01T10:00:00Z',
+			end: '2026-01-01T12:00:00Z'
+		});
+		const pastRecent = ev({
+			id: 'past-recent',
+			start: '2026-05-01T10:00:00Z',
+			end: '2026-05-01T12:00:00Z'
+		});
 		const sorted = sortTicketEventsForPicker([pastOld, upLater, pastRecent, upSooner]);
 		expect(sorted.map((e) => e.id)).toEqual(['up-sooner', 'up-later', 'past-recent', 'past-old']);
 	});

--- a/src/lib/utils/ticket-event-picker.ts
+++ b/src/lib/utils/ticket-event-picker.ts
@@ -1,0 +1,44 @@
+import type { EventInListSchema } from '$lib/api/generated/types.gen';
+import { isEventPast } from '$lib/utils/date';
+
+/**
+ * An event is "active" for ticket-picker purposes when it has not ended and is
+ * not cancelled. `end` is a required string on EventInListSchema (the backend
+ * always returns one), so no null handling is needed.
+ */
+export function isTicketEventActive(
+	event: Pick<EventInListSchema, 'end' | 'status'>
+): boolean {
+	return !isEventPast(event.end) && event.status !== 'cancelled';
+}
+
+/**
+ * When the org has exactly one ticketed event and it is active, return it so the
+ * Tickets tab can deep-link straight to its management page. Otherwise null
+ * (render the picker) — this keeps past/cancelled events reachable.
+ */
+export function shouldRedirectToSingle(
+	events: EventInListSchema[]
+): EventInListSchema | null {
+	if (events.length === 1 && isTicketEventActive(events[0])) {
+		return events[0];
+	}
+	return null;
+}
+
+/**
+ * Upcoming events first (soonest start first), then past events (most recent
+ * first). Pure — returns a new array.
+ */
+export function sortTicketEventsForPicker(
+	events: EventInListSchema[]
+): EventInListSchema[] {
+	return [...events].sort((a, b) => {
+		const aPast = isEventPast(a.end);
+		const bPast = isEventPast(b.end);
+		if (aPast !== bPast) return aPast ? 1 : -1;
+		const aStart = new Date(a.start).getTime();
+		const bStart = new Date(b.start).getTime();
+		return aPast ? bStart - aStart : aStart - bStart;
+	});
+}

--- a/src/lib/utils/ticket-event-picker.ts
+++ b/src/lib/utils/ticket-event-picker.ts
@@ -6,9 +6,7 @@ import { isEventPast } from '$lib/utils/date';
  * not cancelled. `end` is a required string on EventInListSchema (the backend
  * always returns one), so no null handling is needed.
  */
-export function isTicketEventActive(
-	event: Pick<EventInListSchema, 'end' | 'status'>
-): boolean {
+export function isTicketEventActive(event: Pick<EventInListSchema, 'end' | 'status'>): boolean {
 	return !isEventPast(event.end) && event.status !== 'cancelled';
 }
 
@@ -17,9 +15,7 @@ export function isTicketEventActive(
  * Tickets tab can deep-link straight to its management page. Otherwise null
  * (render the picker) — this keeps past/cancelled events reachable.
  */
-export function shouldRedirectToSingle(
-	events: EventInListSchema[]
-): EventInListSchema | null {
+export function shouldRedirectToSingle(events: EventInListSchema[]): EventInListSchema | null {
 	if (events.length === 1 && isTicketEventActive(events[0])) {
 		return events[0];
 	}
@@ -30,9 +26,7 @@ export function shouldRedirectToSingle(
  * Upcoming events first (soonest start first), then past events (most recent
  * first). Pure — returns a new array.
  */
-export function sortTicketEventsForPicker(
-	events: EventInListSchema[]
-): EventInListSchema[] {
+export function sortTicketEventsForPicker(events: EventInListSchema[]): EventInListSchema[] {
 	return [...events].sort((a, b) => {
 		const aPast = isEventPast(a.end);
 		const bPast = isEventPast(b.end);

--- a/src/routes/(auth)/org/[slug]/admin/+layout.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/+layout.svelte
@@ -22,6 +22,10 @@
 		{ href: `/org/${data.organization.slug}/admin`, label: m['orgAdmin.nav.dashboard']() },
 		{ href: `/org/${data.organization.slug}/admin/events`, label: m['orgAdmin.nav.events']() },
 		{
+			href: `/org/${data.organization.slug}/admin/tickets`,
+			label: m['orgAdmin.nav.tickets']()
+		},
+		{
 			href: `/org/${data.organization.slug}/admin/discount-codes`,
 			label: m['orgAdmin.nav.discountCodes']()
 		},

--- a/src/routes/(auth)/org/[slug]/admin/tickets/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/tickets/+page.server.ts
@@ -3,10 +3,7 @@ import type { PageServerLoad } from './$types';
 import { error, redirect } from '@sveltejs/kit';
 import { extractErrorMessage } from '$lib/utils/errors';
 import { log } from '$lib/server/logger';
-import {
-	shouldRedirectToSingle,
-	sortTicketEventsForPicker
-} from '$lib/utils/ticket-event-picker';
+import { shouldRedirectToSingle, sortTicketEventsForPicker } from '$lib/utils/ticket-event-picker';
 
 export const load: PageServerLoad = async ({ parent, params, locals, fetch }) => {
 	const { organization } = await parent();

--- a/src/routes/(auth)/org/[slug]/admin/tickets/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/tickets/+page.server.ts
@@ -1,0 +1,58 @@
+import { eventpublicdiscoveryListEvents } from '$lib/api/generated/sdk.gen';
+import type { PageServerLoad } from './$types';
+import { error, redirect } from '@sveltejs/kit';
+import { extractErrorMessage } from '$lib/utils/errors';
+import { log } from '$lib/server/logger';
+import {
+	shouldRedirectToSingle,
+	sortTicketEventsForPicker
+} from '$lib/utils/ticket-event-picker';
+
+export const load: PageServerLoad = async ({ parent, params, locals, fetch }) => {
+	const { organization } = await parent();
+	const user = locals.user;
+
+	if (!user) {
+		throw error(401, 'You must be logged in to manage tickets');
+	}
+
+	const headers: HeadersInit = {
+		Authorization: `Bearer ${user.accessToken}`
+	};
+
+	const eventsResponse = await eventpublicdiscoveryListEvents({
+		fetch,
+		headers,
+		query: {
+			organization: organization.id,
+			requires_ticket: true,
+			include_past: true,
+			next_events: false,
+			page_size: 100
+		}
+	});
+
+	if (eventsResponse.error) {
+		log.error('admin_tickets_events_load_failed', {
+			error: eventsResponse.error,
+			orgId: organization.id
+		});
+		const errorMessage = extractErrorMessage(
+			eventsResponse.error,
+			'Failed to load ticketed events. Please try again later.'
+		);
+		throw error(500, errorMessage);
+	}
+
+	const events = eventsResponse.data?.results ?? [];
+
+	// Convenience: jump straight to the only ticketed event when it's active.
+	const single = shouldRedirectToSingle(events);
+	if (single) {
+		throw redirect(303, `/org/${params.slug}/admin/events/${single.id}/tickets`);
+	}
+
+	return {
+		events: sortTicketEventsForPicker(events)
+	};
+};

--- a/src/routes/(auth)/org/[slug]/admin/tickets/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/tickets/+page.svelte
@@ -64,7 +64,9 @@
 								<span class="truncate font-semibold">{event.name}</span>
 								<EventStatusBadge {event} />
 							</div>
-							<div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+							<div
+								class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground"
+							>
 								<span>{formatEventDate(event.start, event.timezone)}</span>
 								<span class="inline-flex items-center gap-1">
 									<Users class="h-3.5 w-3.5" aria-hidden="true" />

--- a/src/routes/(auth)/org/[slug]/admin/tickets/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/tickets/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import * as m from '$lib/paraglide/messages.js';
+	import { formatEventDate } from '$lib/utils/date';
+	import EventStatusBadge from '$lib/components/events/EventStatusBadge.svelte';
+	import { Ticket, ChevronRight, Users } from 'lucide-svelte';
+
+	const { data }: { data: PageData } = $props();
+
+	const slug = $derived(data.organization.slug);
+	const events = $derived(data.events);
+</script>
+
+<svelte:head>
+	<title>{m['orgAdmin.tickets.title']()} · {data.organization.name}</title>
+	<meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<section class="space-y-6">
+	<header>
+		<h1 class="text-2xl font-bold tracking-tight">{m['orgAdmin.tickets.title']()}</h1>
+		<p class="mt-1 text-sm text-muted-foreground">{m['orgAdmin.tickets.subtitle']()}</p>
+	</header>
+
+	{#if events.length === 0}
+		<div class="rounded-lg border border-border bg-card p-12 text-center">
+			<Ticket class="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
+			<h2 class="mt-4 text-lg font-semibold">{m['orgAdmin.tickets.empty.title']()}</h2>
+			<p class="mt-2 text-sm text-muted-foreground">
+				{m['orgAdmin.tickets.empty.description']()}
+			</p>
+			<a
+				href="/org/{slug}/admin/events"
+				class="mt-4 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+			>
+				{m['orgAdmin.tickets.empty.cta']()}
+			</a>
+		</div>
+	{:else}
+		<ul class="space-y-3">
+			{#each events as event (event.id)}
+				<li>
+					<a
+						href="/org/{slug}/admin/events/{event.id}/tickets"
+						class="flex items-center gap-4 rounded-lg border border-border bg-card p-4 transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					>
+						{#if event.logo_thumbnail_url}
+							<img
+								src={event.logo_thumbnail_url}
+								alt=""
+								class="h-12 w-12 shrink-0 rounded-md object-cover"
+							/>
+						{:else}
+							<div
+								class="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-muted"
+								aria-hidden="true"
+							>
+								<Ticket class="h-6 w-6 text-muted-foreground" />
+							</div>
+						{/if}
+
+						<div class="min-w-0 flex-1">
+							<div class="flex flex-wrap items-center gap-2">
+								<span class="truncate font-semibold">{event.name}</span>
+								<EventStatusBadge {event} />
+							</div>
+							<div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+								<span>{formatEventDate(event.start, event.timezone)}</span>
+								<span class="inline-flex items-center gap-1">
+									<Users class="h-3.5 w-3.5" aria-hidden="true" />
+									{m['orgAdmin.tickets.attendees']({ count: event.attendee_count })}
+								</span>
+							</div>
+						</div>
+
+						<ChevronRight class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</section>

--- a/src/routes/(auth)/org/[slug]/admin/tickets/page.test.ts
+++ b/src/routes/(auth)/org/[slug]/admin/tickets/page.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { EventInListSchema } from '$lib/api/generated/types.gen';
+import Page from './+page.svelte';
+
+const organization = { slug: 'acme', name: 'Acme' };
+
+function ev(overrides: Partial<EventInListSchema>): EventInListSchema {
+	return {
+		id: 'e1',
+		name: 'Summer Gala',
+		slug: 'summer-gala',
+		start: '2026-09-01T18:00:00Z',
+		end: '2026-09-01T22:00:00Z',
+		status: 'open',
+		requires_ticket: true,
+		attendee_count: 12,
+		timezone: 'UTC',
+		...overrides
+	} as EventInListSchema;
+}
+
+describe('Tickets tab page', () => {
+	it('renders the empty state with a link to events when no events', () => {
+		render(Page, { props: { data: { organization, events: [] } as never } });
+		expect(screen.getByText('No ticketed events yet')).toBeInTheDocument();
+		const cta = screen.getByRole('link', { name: 'Go to Events' });
+		expect(cta).toHaveAttribute('href', '/org/acme/admin/events');
+	});
+
+	it('renders one card per event linking to the per-event tickets page', () => {
+		const events = [
+			ev({ id: 'A', name: 'Summer Gala' }),
+			ev({ id: 'B', name: 'Workshop Night' })
+		];
+		render(Page, { props: { data: { organization, events } as never } });
+
+		const galaLink = screen.getByRole('link', { name: /Summer Gala/ });
+		expect(galaLink).toHaveAttribute('href', '/org/acme/admin/events/A/tickets');
+		const workshopLink = screen.getByRole('link', { name: /Workshop Night/ });
+		expect(workshopLink).toHaveAttribute('href', '/org/acme/admin/events/B/tickets');
+	});
+});

--- a/src/routes/(auth)/org/[slug]/admin/tickets/page.test.ts
+++ b/src/routes/(auth)/org/[slug]/admin/tickets/page.test.ts
@@ -29,10 +29,7 @@ describe('Tickets tab page', () => {
 	});
 
 	it('renders one card per event linking to the per-event tickets page', () => {
-		const events = [
-			ev({ id: 'A', name: 'Summer Gala' }),
-			ev({ id: 'B', name: 'Workshop Night' })
-		];
+		const events = [ev({ id: 'A', name: 'Summer Gala' }), ev({ id: 'B', name: 'Workshop Night' })];
 		render(Page, { props: { data: { organization, events } as never } });
 
 		const galaLink = screen.getByRole('link', { name: /Summer Gala/ });


### PR DESCRIPTION
## Summary

Adds a top-level **Tickets** tab to org-admin so ticket management is discoverable without drilling into a specific event (Oskar feedback). Closes #450.

- New tab (after **Events**) → a picker listing the org's ticketed events; each card links into the **existing** per-event tickets page. No ticket-management logic (confirm/cancel/check-in/QR) is duplicated.
- **Convenience redirect:** when the org has exactly **one** ticketed event **and it's active** (not past, not cancelled), the route server-redirects straight to that event's tickets page. Past/cancelled events stay reachable via the picker.
- **Empty state** when the org has no ticketed events (tab still always visible).
- Picker cards show logo/name, start date, attendee count, and an `EventStatusBadge` (upcoming-first, then past).

### Notable changes
- `src/lib/utils/ticket-event-picker.ts` — pure, unit-tested helpers (`isTicketEventActive`, `shouldRedirectToSingle`, `sortTicketEventsForPicker`).
- `EventStatusBadge.svelte` — prop widened to a structural subset so it accepts `EventInListSchema` (was `EventDetailSchema`-only).
- Route `…/admin/tickets/` (`+page.server.ts` load + redirect, `+page.svelte` picker).
- i18n: new `orgAdmin.nav.tickets` + `orgAdmin.tickets.*` keys (en/it/de).

### Scope notes
- Sibling issue **#459** (team/helper tier discoverability) was investigated and **closed as not-a-defect** — the link-invite tier picker exists but is gated behind the "Grant invitation" toggle.
- FE-only; no backend dependency. Reuses the same `eventpublicdiscoveryListEvents` endpoint the Events tab already uses (with `requires_ticket: true`).

## Test plan
- [x] Unit tests for picker helpers (redirect truth table + sorting) — 10/10
- [x] Component test for the picker page (empty state + per-event card hrefs) — 2/2
- [x] `pnpm check` (types) 0 errors; `make format-check` / `make i18n-check` green; new files add 0 lint warnings
- [ ] Manual: verify 0 / 1-active / 1-past / ≥2 ticketed-event branches as an org admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)