### PR TITLE
feat(events): event schedule/timeline display + editor (#461)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1,5 +1,33 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"eventSchedule": {
+		"title": "Programm",
+		"description": "Was wann passiert",
+		"requiredBadge": "Pflicht"
+	},
+	"eventScheduleAdmin": {
+		"title": "Programm",
+		"description": "Füge eine Zeitleiste mit Programmpunkten für diese Veranstaltung hinzu. Die Zeiten sind relativ zum Veranstaltungsbeginn, sodass das Programm auch beim Duplizieren der Veranstaltung korrekt bleibt.",
+		"empty": "Noch keine Programmpunkte. Füge den ersten hinzu, um deine Zeitleiste zu erstellen.",
+		"sessionNumber": "Programmpunkt {number}",
+		"removeSession": "Programmpunkt entfernen",
+		"sessionTitle": "Titel des Programmpunkts",
+		"sessionTitlePlaceholder": "z. B. Einlass, Keynote, Abendessen",
+		"titleRequired": "Ein Titel ist erforderlich",
+		"startsAt": "Beginnt um",
+		"beforeStartWarning": "Das liegt vor dem Veranstaltungsbeginn und wird daher auf die Startzeit gesetzt.",
+		"duration": "Dauer",
+		"noDuration": "Keine Dauer",
+		"location": "Ort",
+		"locationPlaceholder": "z. B. Haupthalle, Raum 2",
+		"descriptionLabel": "Beschreibung",
+		"descriptionPlaceholder": "Optionale Details zu diesem Programmpunkt",
+		"required": "Pflicht-Programmpunkt",
+		"requiredHelp": "Hebe diesen Punkt als wichtig für die Teilnehmenden hervor.",
+		"addSession": "Programmpunkt hinzufügen",
+		"saveError": "Das Programm konnte nicht gespeichert werden",
+		"incompleteError": "Jeder Programmpunkt benötigt einen Titel und eine Startzeit."
+	},
 	"SFwESEssentialsStep": {
 		"clearDescriptiveName": "Wähle einen klaren, beschreibenden Namen für deine Veranstaltung",
 		"optionalOpenEnded": "Optional - leer lassen für offene Veranstaltungen",

--- a/messages/de.json
+++ b/messages/de.json
@@ -14,6 +14,7 @@
 		"sessionTitle": "Titel des Programmpunkts",
 		"sessionTitlePlaceholder": "z. B. Einlass, Keynote, Abendessen",
 		"titleRequired": "Ein Titel ist erforderlich",
+		"startRequired": "Eine Startzeit ist erforderlich",
 		"startsAt": "Beginnt um",
 		"beforeStartWarning": "Das liegt vor dem Veranstaltungsbeginn und wird daher auf die Startzeit gesetzt.",
 		"duration": "Dauer",

--- a/messages/en.json
+++ b/messages/en.json
@@ -14,6 +14,7 @@
 		"sessionTitle": "Session title",
 		"sessionTitlePlaceholder": "e.g. Doors open, Keynote, Dinner",
 		"titleRequired": "A session title is required",
+		"startRequired": "A start time is required",
 		"startsAt": "Starts at",
 		"beforeStartWarning": "This is before the event start, so it will be pinned to the start time.",
 		"duration": "Duration",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,33 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"eventSchedule": {
+		"title": "Schedule",
+		"description": "What's happening and when",
+		"requiredBadge": "Required"
+	},
+	"eventScheduleAdmin": {
+		"title": "Schedule",
+		"description": "Add a timeline of sessions for this event. Times are relative to the event start, so the schedule stays correct if you duplicate the event.",
+		"empty": "No sessions yet. Add the first one to build your event timeline.",
+		"sessionNumber": "Session {number}",
+		"removeSession": "Remove session",
+		"sessionTitle": "Session title",
+		"sessionTitlePlaceholder": "e.g. Doors open, Keynote, Dinner",
+		"titleRequired": "A session title is required",
+		"startsAt": "Starts at",
+		"beforeStartWarning": "This is before the event start, so it will be pinned to the start time.",
+		"duration": "Duration",
+		"noDuration": "No duration",
+		"location": "Location",
+		"locationPlaceholder": "e.g. Main hall, Room 2",
+		"descriptionLabel": "Description",
+		"descriptionPlaceholder": "Optional details about this session",
+		"required": "Required session",
+		"requiredHelp": "Highlight this as a session attendees shouldn't miss.",
+		"addSession": "Add session",
+		"saveError": "Failed to save the schedule",
+		"incompleteError": "Each schedule session needs a title and a start time."
+	},
 	"SFwESEssentialsStep": {
 		"clearDescriptiveName": "Choose a clear, descriptive name for your event",
 		"optionalOpenEnded": "Optional - leave blank for open-ended events",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,5 +1,33 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"eventSchedule": {
+		"title": "Programma",
+		"description": "Cosa succede e quando",
+		"requiredBadge": "Obbligatorio"
+	},
+	"eventScheduleAdmin": {
+		"title": "Programma",
+		"description": "Aggiungi una scaletta di sessioni per questo evento. Gli orari sono relativi all'inizio dell'evento, così il programma resta corretto se duplichi l'evento.",
+		"empty": "Ancora nessuna sessione. Aggiungi la prima per creare la scaletta dell'evento.",
+		"sessionNumber": "Sessione {number}",
+		"removeSession": "Rimuovi sessione",
+		"sessionTitle": "Titolo della sessione",
+		"sessionTitlePlaceholder": "es. Apertura porte, Keynote, Cena",
+		"titleRequired": "Il titolo della sessione è obbligatorio",
+		"startsAt": "Inizia alle",
+		"beforeStartWarning": "È prima dell'inizio dell'evento, quindi verrà fissata all'orario di inizio.",
+		"duration": "Durata",
+		"noDuration": "Nessuna durata",
+		"location": "Luogo",
+		"locationPlaceholder": "es. Sala principale, Stanza 2",
+		"descriptionLabel": "Descrizione",
+		"descriptionPlaceholder": "Dettagli facoltativi su questa sessione",
+		"required": "Sessione obbligatoria",
+		"requiredHelp": "Evidenzia questa come una sessione da non perdere.",
+		"addSession": "Aggiungi sessione",
+		"saveError": "Impossibile salvare il programma",
+		"incompleteError": "Ogni sessione del programma necessita di un titolo e di un orario di inizio."
+	},
 	"SFwESEssentialsStep": {
 		"clearDescriptiveName": "Scegli un nome chiaro e descrittivo per il tuo evento",
 		"optionalOpenEnded": "Facoltativo - lascia vuoto per eventi senza fine",

--- a/messages/it.json
+++ b/messages/it.json
@@ -14,6 +14,7 @@
 		"sessionTitle": "Titolo della sessione",
 		"sessionTitlePlaceholder": "es. Apertura porte, Keynote, Cena",
 		"titleRequired": "Il titolo della sessione è obbligatorio",
+		"startRequired": "È richiesto un orario di inizio",
 		"startsAt": "Inizia alle",
 		"beforeStartWarning": "È prima dell'inizio dell'evento, quindi verrà fissata all'orario di inizio.",
 		"duration": "Durata",

--- a/src/lib/components/events/EventSchedule.svelte
+++ b/src/lib/components/events/EventSchedule.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import type { EventScheduleSession } from '$lib/api/generated/types.gen';
+	import { formatTimeOfDay, formatDate } from '$lib/utils/date';
+	import { AlertCircle, MapPin } from 'lucide-svelte';
+	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+
+	interface Props {
+		/** Display-only timeline entries; times are relative to the event start. */
+		schedule?: EventScheduleSession[];
+		/** ISO 8601 event start — the anchor every session offset is measured from. */
+		eventStart: string;
+		/** IANA timezone the event runs in; sessions render in it, not the viewer's. */
+		timezone?: string | null;
+	}
+
+	const { schedule = [], eventStart, timezone = null }: Props = $props();
+
+	const tz = $derived(timezone ?? undefined);
+	const startMs = $derived(new Date(eventStart).getTime());
+
+	// Backend already orders by offset, but sort defensively so display never
+	// depends on payload order.
+	const sessions = $derived([...schedule].sort((a, b) => a.offset_minutes - b.offset_minutes));
+	const hasSchedule = $derived(sessions.length > 0);
+
+	// The event's own calendar day (in the event timezone) — sessions that fall
+	// on it show time only; multi-day sessions get a date chip.
+	const eventStartDay = $derived(formatDate(eventStart, tz));
+
+	function instantOf(offsetMinutes: number): string {
+		return new Date(startMs + offsetMinutes * 60_000).toISOString();
+	}
+
+	function timeLabel(session: EventScheduleSession): string {
+		const start = instantOf(session.offset_minutes);
+		const startTime = formatTimeOfDay(start, tz);
+		if (!session.duration_minutes) return startTime;
+		const end = new Date(
+			startMs + (session.offset_minutes + session.duration_minutes) * 60_000
+		).toISOString();
+		return `${startTime} – ${formatTimeOfDay(end, tz)}`;
+	}
+
+	function dayLabel(session: EventScheduleSession): string | null {
+		const day = formatDate(instantOf(session.offset_minutes), tz);
+		return day === eventStartDay ? null : day;
+	}
+</script>
+
+{#if hasSchedule}
+	<section class="rounded-lg border bg-card p-6" aria-labelledby="schedule-heading">
+		<h2 id="schedule-heading" class="mb-4 text-xl font-bold">{m['eventSchedule.title']()}</h2>
+		<p class="mb-6 text-sm text-muted-foreground">{m['eventSchedule.description']()}</p>
+
+		<ol class="space-y-3">
+			{#each sessions as session, index (index)}
+				<li class="flex items-start gap-4 rounded-md border p-4">
+					<!-- Time column -->
+					<div class="w-24 shrink-0 sm:w-28">
+						<p class="text-sm font-semibold tabular-nums leading-tight">{timeLabel(session)}</p>
+						{#if dayLabel(session)}
+							<p class="mt-0.5 text-xs text-muted-foreground">{dayLabel(session)}</p>
+						{/if}
+					</div>
+
+					<!-- Details -->
+					<div class="min-w-0 flex-1">
+						<div class="flex flex-wrap items-center gap-2">
+							<h3 class="font-semibold leading-tight">{session.title}</h3>
+							{#if session.is_required}
+								<span
+									class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+								>
+									<AlertCircle class="h-3 w-3" aria-hidden="true" />
+									{m['eventSchedule.requiredBadge']()}
+								</span>
+							{/if}
+						</div>
+
+						{#if session.location}
+							<p class="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
+								<MapPin class="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+								<span class="min-w-0 truncate">{session.location}</span>
+							</p>
+						{/if}
+
+						{#if session.description}
+							<MarkdownContent
+								content={session.description}
+								inline
+								class="!prose-sm mt-1 text-muted-foreground [&>*]:m-0"
+							/>
+						{/if}
+					</div>
+				</li>
+			{/each}
+		</ol>
+	</section>
+{/if}

--- a/src/lib/components/events/EventSchedule.svelte
+++ b/src/lib/components/events/EventSchedule.svelte
@@ -4,6 +4,7 @@
 	import { formatTimeOfDay, formatDate } from '$lib/utils/date';
 	import { AlertCircle, MapPin } from 'lucide-svelte';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import EventTimezoneNote from './EventTimezoneNote.svelte';
 
 	interface Props {
 		/** Display-only timeline entries; times are relative to the event start. */
@@ -12,9 +13,11 @@
 		eventStart: string;
 		/** IANA timezone the event runs in; sessions render in it, not the viewer's. */
 		timezone?: string | null;
+		/** Human place name (e.g. the event's city) for the timezone note. */
+		place?: string | null;
 	}
 
-	const { schedule = [], eventStart, timezone = null }: Props = $props();
+	const { schedule = [], eventStart, timezone = null, place = null }: Props = $props();
 
 	const tz = $derived(timezone ?? undefined);
 	const startMs = $derived(new Date(eventStart).getTime());
@@ -51,16 +54,20 @@
 {#if hasSchedule}
 	<section class="rounded-lg border bg-card p-6" aria-labelledby="schedule-heading">
 		<h2 id="schedule-heading" class="mb-4 text-xl font-bold">{m['eventSchedule.title']()}</h2>
-		<p class="mb-6 text-sm text-muted-foreground">{m['eventSchedule.description']()}</p>
+		<p class="mb-2 text-sm text-muted-foreground">{m['eventSchedule.description']()}</p>
+
+		<!-- Times below are in the event timezone, not the viewer's — shown once here. -->
+		<EventTimezoneNote start={eventStart} timeZone={timezone} {place} class="mb-6" />
 
 		<ol class="space-y-3">
 			{#each sessions as session, index (index)}
+				{@const day = dayLabel(session)}
 				<li class="flex items-start gap-4 rounded-md border p-4">
 					<!-- Time column -->
 					<div class="w-24 shrink-0 sm:w-28">
 						<p class="text-sm font-semibold tabular-nums leading-tight">{timeLabel(session)}</p>
-						{#if dayLabel(session)}
-							<p class="mt-0.5 text-xs text-muted-foreground">{dayLabel(session)}</p>
+						{#if day}
+							<p class="mt-0.5 text-xs text-muted-foreground">{day}</p>
 						{/if}
 					</div>
 

--- a/src/lib/components/events/admin/EventEditor.svelte
+++ b/src/lib/components/events/admin/EventEditor.svelte
@@ -13,7 +13,8 @@
 		organizationadminresourcesUpdateResource,
 		questionnaireListOrgQuestionnaires,
 		eventadmincoreAddTags,
-		eventadmincoreRemoveTags
+		eventadmincoreRemoveTags,
+		eventadmincoreUpdateEventSchedule
 	} from '$lib/api/generated/sdk.gen';
 	import { toDateTimeLocal, toISOString } from '$lib/utils/datetime';
 	import type {
@@ -31,6 +32,13 @@
 	import EssentialsStep from './EssentialsStep.svelte';
 	import DetailsStep from './DetailsStep.svelte';
 	import EventResources from './EventResources.svelte';
+	import ScheduleEditor from './ScheduleEditor.svelte';
+	import {
+		sessionsToRows,
+		rowsToSessions,
+		scheduleRowsValid,
+		type ScheduleRow
+	} from './schedule-rows';
 	import TicketingStep from './TicketingStep.svelte';
 	import SaveBar from './SaveBar.svelte';
 	import * as Tabs from '$lib/components/ui/tabs';
@@ -134,6 +142,17 @@
 		location_maps_url: existingEvent?.location_maps_url || null,
 		location_maps_embed: existingEvent?.location_maps_embed || null
 	});
+
+	// Schedule/timeline state. Rows are seeded once from the saved schedule,
+	// anchored to the (initial) event start, and edited as absolute clock times.
+	// `scheduleSessions` re-derives the offset-encoded payload against the
+	// CURRENT start, so moving the event start re-times sessions sensibly.
+	// handleSave persists it through the dedicated schedule endpoint.
+	let scheduleRows = $state<ScheduleRow[]>(
+		sessionsToRows(existingEvent?.schedule ?? [], formData.start || '')
+	);
+	const scheduleSessions = $derived(rowsToSessions(scheduleRows, formData.start || ''));
+	const scheduleValid = $derived(scheduleRowsValid(scheduleRows));
 
 	// Editor state (after formData so derived can reference it)
 	let eventCreated = $state(false);
@@ -377,6 +396,16 @@
 		initialTags = [...currentTags];
 	}
 
+	async function saveSchedule(currentEventId: string): Promise<void> {
+		const response = await eventadmincoreUpdateEventSchedule({
+			path: { event_id: currentEventId },
+			body: { sessions: scheduleSessions }
+		});
+		if (response.error) {
+			throw new Error(m['eventScheduleAdmin.saveError']());
+		}
+	}
+
 	// --- Validation ---
 
 	function validateEssentials(): boolean {
@@ -456,6 +485,13 @@
 			return;
 		}
 
+		if (!scheduleValid) {
+			errorMessage = m['eventScheduleAdmin.incompleteError']();
+			toast.error(m['eventScheduleAdmin.incompleteError']());
+			scrollToFirstInvalid();
+			return;
+		}
+
 		if (!eventId) {
 			errorMessage = m['eventWizard.error_eventIdNotFound']();
 			return;
@@ -506,6 +542,7 @@
 			// Save associations
 			await saveResourceAssociations(eventId);
 			await saveTagAssociations(eventId);
+			await saveSchedule(eventId);
 
 			// Invalidate queries
 			queryClient.invalidateQueries({ queryKey: ['events'] });
@@ -626,6 +663,41 @@
 			organizationSlug={organization.slug}
 		/>
 
+		{#snippet detailsSection()}
+			<DetailsStep
+				{formData}
+				eventSeries={eventSeries as any}
+				questionnaires={assignedQuestionnaires}
+				{eventId}
+				organizationId={organization.id}
+				organizationSlug={organization.slug}
+				accessToken={authStore.accessToken ?? undefined}
+				{selectedCity}
+				{selectedVenue}
+				{validationErrors}
+				{isEditMode}
+				onCitySelect={handleCitySelect}
+				onVenueSelect={handleVenueSelect}
+				onUpdate={updateFormData}
+				onUpdateImages={updateImages}
+			/>
+
+			{#if eventId}
+				<EventResources
+					organizationSlug={organization.slug}
+					{eventId}
+					{selectedResourceIds}
+					onSelectionChange={(ids) => (selectedResourceIds = ids)}
+				/>
+
+				<ScheduleEditor
+					bind:rows={scheduleRows}
+					eventStart={formData.start ?? ''}
+					disabled={isSaving}
+				/>
+			{/if}
+		{/snippet}
+
 		<!-- Tabs (only for ticketed events in edit mode) -->
 		{#if showTabs}
 			<div bind:this={tabsEl}></div>
@@ -640,32 +712,7 @@
 				</Tabs.List>
 
 				<Tabs.Content value="details" class="mt-6 space-y-6">
-					<DetailsStep
-						{formData}
-						eventSeries={eventSeries as any}
-						questionnaires={assignedQuestionnaires}
-						{eventId}
-						organizationId={organization.id}
-						organizationSlug={organization.slug}
-						accessToken={authStore.accessToken ?? undefined}
-						{selectedCity}
-						{selectedVenue}
-						{validationErrors}
-						{isEditMode}
-						onCitySelect={handleCitySelect}
-						onVenueSelect={handleVenueSelect}
-						onUpdate={updateFormData}
-						onUpdateImages={updateImages}
-					/>
-
-					{#if eventId}
-						<EventResources
-							organizationSlug={organization.slug}
-							{eventId}
-							{selectedResourceIds}
-							onSelectionChange={(ids) => (selectedResourceIds = ids)}
-						/>
-					{/if}
+					{@render detailsSection()}
 				</Tabs.Content>
 
 				<Tabs.Content value="ticketing" class="mt-6">
@@ -686,32 +733,7 @@
 		{:else}
 			<!-- Non-ticketed: Details + Resources directly -->
 			<div class="space-y-6">
-				<DetailsStep
-					{formData}
-					eventSeries={eventSeries as any}
-					questionnaires={assignedQuestionnaires}
-					{eventId}
-					organizationId={organization.id}
-					organizationSlug={organization.slug}
-					accessToken={authStore.accessToken ?? undefined}
-					{selectedCity}
-					{selectedVenue}
-					{validationErrors}
-					{isEditMode}
-					onCitySelect={handleCitySelect}
-					onVenueSelect={handleVenueSelect}
-					onUpdate={updateFormData}
-					onUpdateImages={updateImages}
-				/>
-
-				{#if eventId}
-					<EventResources
-						organizationSlug={organization.slug}
-						{eventId}
-						{selectedResourceIds}
-						onSelectionChange={(ids) => (selectedResourceIds = ids)}
-					/>
-				{/if}
+				{@render detailsSection()}
 			</div>
 		{/if}
 

--- a/src/lib/components/events/admin/EventEditor.svelte
+++ b/src/lib/components/events/admin/EventEditor.svelte
@@ -486,6 +486,8 @@
 		}
 
 		if (!scheduleValid) {
+			// ScheduleEditor lives in the Details tab — surface it before scrolling.
+			if (showTabs) handleTabChange('details');
 			errorMessage = m['eventScheduleAdmin.incompleteError']();
 			toast.error(m['eventScheduleAdmin.incompleteError']());
 			scrollToFirstInvalid();

--- a/src/lib/components/events/admin/ScheduleEditor.svelte
+++ b/src/lib/components/events/admin/ScheduleEditor.svelte
@@ -52,6 +52,9 @@
 		<ul class="space-y-4">
 			{#each rows as row, index (row.id)}
 				{@const completeness = rowCompleteness(row)}
+				{@const titleInvalid = completeness === 'invalid' && !row.title.trim()}
+				{@const startMissing = completeness === 'invalid' && !row.startLocal}
+				{@const startBefore = startsBeforeAnchor(row, eventStart)}
 				<li class="space-y-3 rounded-lg border bg-muted/30 p-4">
 					<div class="flex items-center justify-between">
 						<span class="text-xs font-medium text-muted-foreground">
@@ -81,10 +84,15 @@
 							maxlength={150}
 							placeholder={m['eventScheduleAdmin.sessionTitlePlaceholder']()}
 							{disabled}
-							aria-invalid={completeness === 'invalid' && !row.title.trim()}
+							aria-invalid={titleInvalid}
+							aria-describedby={titleInvalid ? `schedule-title-error-${row.id}` : undefined}
 						/>
-						{#if completeness === 'invalid' && !row.title.trim()}
-							<p class="mt-1 text-xs text-destructive">
+						{#if titleInvalid}
+							<p
+								id="schedule-title-error-{row.id}"
+								class="mt-1 text-xs text-destructive"
+								role="alert"
+							>
 								{m['eventScheduleAdmin.titleRequired']()}
 							</p>
 						{/if}
@@ -101,10 +109,26 @@
 								type="datetime-local"
 								bind:value={row.startLocal}
 								{disabled}
-								aria-invalid={completeness === 'invalid' && !row.startLocal}
+								aria-invalid={startMissing}
+								aria-describedby={startMissing
+									? `schedule-start-error-${row.id}`
+									: startBefore
+										? `schedule-start-warning-${row.id}`
+										: undefined}
 							/>
-							{#if startsBeforeAnchor(row, eventStart)}
-								<p class="mt-1 flex items-start gap-1 text-xs text-amber-600 dark:text-amber-500">
+							{#if startMissing}
+								<p
+									id="schedule-start-error-{row.id}"
+									class="mt-1 text-xs text-destructive"
+									role="alert"
+								>
+									{m['eventScheduleAdmin.startRequired']()}
+								</p>
+							{:else if startBefore}
+								<p
+									id="schedule-start-warning-{row.id}"
+									class="mt-1 flex items-start gap-1 text-xs text-amber-600 dark:text-amber-500"
+								>
 									<AlertTriangle class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
 									{m['eventScheduleAdmin.beforeStartWarning']()}
 								</p>

--- a/src/lib/components/events/admin/ScheduleEditor.svelte
+++ b/src/lib/components/events/admin/ScheduleEditor.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Button } from '$lib/components/ui/button';
+	import { DurationInput } from '$lib/components/forms';
+	import MarkdownEditor from '$lib/components/forms/MarkdownEditor.svelte';
+	import { CalendarClock, Plus, Trash2, AlertTriangle } from 'lucide-svelte';
+	import { emptyRow, rowCompleteness, startsBeforeAnchor, type ScheduleRow } from './schedule-rows';
+
+	interface Props {
+		/** Editor rows, owned by the parent (bindable). */
+		rows: ScheduleRow[];
+		/** `datetime-local` string for the event start — the offset anchor. */
+		eventStart: string;
+		disabled?: boolean;
+	}
+
+	let { rows = $bindable([]), eventStart, disabled = false }: Props = $props();
+
+	function addRow(): void {
+		rows = [...rows, emptyRow(eventStart)];
+	}
+
+	function removeRow(id: number): void {
+		rows = rows.filter((r) => r.id !== id);
+	}
+</script>
+
+<div class="space-y-4">
+	<!-- Header -->
+	<div class="flex items-start gap-2">
+		<CalendarClock class="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+		<div>
+			<h3 class="text-sm font-medium text-gray-900 dark:text-gray-100">
+				{m['eventScheduleAdmin.title']()}
+			</h3>
+			<p class="mt-1 text-xs text-muted-foreground">
+				{m['eventScheduleAdmin.description']()}
+			</p>
+		</div>
+	</div>
+
+	{#if rows.length === 0}
+		<div
+			class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center dark:border-gray-600"
+		>
+			<CalendarClock class="mx-auto h-8 w-8 text-muted-foreground" aria-hidden="true" />
+			<p class="mt-2 text-sm text-muted-foreground">{m['eventScheduleAdmin.empty']()}</p>
+		</div>
+	{:else}
+		<ul class="space-y-4">
+			{#each rows as row, index (row.id)}
+				{@const completeness = rowCompleteness(row)}
+				<li class="space-y-3 rounded-lg border bg-muted/30 p-4">
+					<div class="flex items-center justify-between">
+						<span class="text-xs font-medium text-muted-foreground">
+							{m['eventScheduleAdmin.sessionNumber']({ number: index + 1 })}
+						</span>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onclick={() => removeRow(row.id)}
+							{disabled}
+							aria-label={m['eventScheduleAdmin.removeSession']()}
+							class="h-8 px-2 text-destructive hover:text-destructive"
+						>
+							<Trash2 class="h-4 w-4" aria-hidden="true" />
+						</Button>
+					</div>
+
+					<!-- Title -->
+					<div>
+						<Label for="schedule-title-{row.id}">
+							{m['eventScheduleAdmin.sessionTitle']()} <span class="text-destructive">*</span>
+						</Label>
+						<Input
+							id="schedule-title-{row.id}"
+							bind:value={row.title}
+							maxlength={150}
+							placeholder={m['eventScheduleAdmin.sessionTitlePlaceholder']()}
+							{disabled}
+							aria-invalid={completeness === 'invalid' && !row.title.trim()}
+						/>
+						{#if completeness === 'invalid' && !row.title.trim()}
+							<p class="mt-1 text-xs text-destructive">
+								{m['eventScheduleAdmin.titleRequired']()}
+							</p>
+						{/if}
+					</div>
+
+					<!-- Start + Duration -->
+					<div class="grid gap-3 sm:grid-cols-2">
+						<div>
+							<Label for="schedule-start-{row.id}">
+								{m['eventScheduleAdmin.startsAt']()} <span class="text-destructive">*</span>
+							</Label>
+							<Input
+								id="schedule-start-{row.id}"
+								type="datetime-local"
+								bind:value={row.startLocal}
+								{disabled}
+								aria-invalid={completeness === 'invalid' && !row.startLocal}
+							/>
+							{#if startsBeforeAnchor(row, eventStart)}
+								<p class="mt-1 flex items-start gap-1 text-xs text-amber-600 dark:text-amber-500">
+									<AlertTriangle class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+									{m['eventScheduleAdmin.beforeStartWarning']()}
+								</p>
+							{/if}
+						</div>
+						<DurationInput
+							id="schedule-duration-{row.id}"
+							label={m['eventScheduleAdmin.duration']()}
+							bind:value={row.durationMinutes}
+							storageUnit="minutes"
+							defaultUnit="minutes"
+							emptyValue={null}
+							emptyLabel={m['eventScheduleAdmin.noDuration']()}
+							{disabled}
+						/>
+					</div>
+
+					<!-- Location -->
+					<div>
+						<Label for="schedule-location-{row.id}">
+							{m['eventScheduleAdmin.location']()}
+						</Label>
+						<Input
+							id="schedule-location-{row.id}"
+							bind:value={row.location}
+							maxlength={150}
+							placeholder={m['eventScheduleAdmin.locationPlaceholder']()}
+							{disabled}
+						/>
+					</div>
+
+					<!-- Description -->
+					<MarkdownEditor
+						id="schedule-description-{row.id}"
+						label={m['eventScheduleAdmin.descriptionLabel']()}
+						bind:value={row.description}
+						rows={2}
+						placeholder={m['eventScheduleAdmin.descriptionPlaceholder']()}
+						{disabled}
+					/>
+
+					<!-- Required -->
+					<label class="flex cursor-pointer items-start gap-2">
+						<input
+							type="checkbox"
+							bind:checked={row.isRequired}
+							{disabled}
+							class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+						/>
+						<div>
+							<span class="text-sm font-medium">{m['eventScheduleAdmin.required']()}</span>
+							<p class="text-xs text-muted-foreground">{m['eventScheduleAdmin.requiredHelp']()}</p>
+						</div>
+					</label>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+
+	<Button type="button" variant="outline" size="sm" onclick={addRow} {disabled}>
+		<Plus class="mr-1 h-4 w-4" aria-hidden="true" />
+		{m['eventScheduleAdmin.addSession']()}
+	</Button>
+</div>

--- a/src/lib/components/events/admin/schedule-rows.test.ts
+++ b/src/lib/components/events/admin/schedule-rows.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+	sessionsToRows,
+	rowsToSessions,
+	rowCompleteness,
+	scheduleRowsValid,
+	startsBeforeAnchor,
+	emptyRow,
+	type ScheduleRow
+} from './schedule-rows';
+import type { EventScheduleSession } from '$lib/api/generated/types.gen';
+
+// A fixed local anchor. The editor works in `datetime-local` (no zone), so the
+// helpers treat both anchor and row starts as the same wall-clock frame —
+// offsets are pure elapsed minutes and stay timezone-independent.
+const ANCHOR = '2026-07-01T19:00';
+
+function row(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
+	return { ...emptyRow(ANCHOR), ...overrides };
+}
+
+describe('schedule-rows round-trip', () => {
+	it('seeds rows from sessions and re-encodes the same offsets', () => {
+		const sessions: EventScheduleSession[] = [
+			{ title: 'Doors', offset_minutes: 0, is_required: false },
+			{
+				title: 'Keynote',
+				offset_minutes: 90,
+				duration_minutes: 60,
+				location: 'Main hall',
+				description: 'Opening talk',
+				is_required: true
+			}
+		];
+
+		const rows = sessionsToRows(sessions, ANCHOR);
+		expect(rows.map((r) => r.startLocal)).toEqual(['2026-07-01T19:00', '2026-07-01T20:30']);
+
+		const encoded = rowsToSessions(rows, ANCHOR);
+		expect(encoded).toEqual([
+			{
+				title: 'Doors',
+				description: null,
+				offset_minutes: 0,
+				duration_minutes: null,
+				location: null,
+				is_required: false
+			},
+			{
+				title: 'Keynote',
+				description: 'Opening talk',
+				offset_minutes: 90,
+				duration_minutes: 60,
+				location: 'Main hall',
+				is_required: true
+			}
+		]);
+	});
+
+	it('sorts encoded sessions by offset regardless of row order', () => {
+		const rows = [
+			row({ title: 'Late', startLocal: '2026-07-01T21:00' }),
+			row({ title: 'Early', startLocal: '2026-07-01T19:30' })
+		];
+		expect(rowsToSessions(rows, ANCHOR).map((s) => s.title)).toEqual(['Early', 'Late']);
+	});
+
+	it('clamps starts before the event to offset 0', () => {
+		const rows = [row({ title: 'Pre-show', startLocal: '2026-07-01T18:00' })];
+		expect(rowsToSessions(rows, ANCHOR)[0].offset_minutes).toBe(0);
+		expect(startsBeforeAnchor(rows[0], ANCHOR)).toBe(true);
+	});
+});
+
+describe('row completeness & validity', () => {
+	it('classifies complete, blank, and invalid rows', () => {
+		expect(rowCompleteness(row({ title: 'X', startLocal: ANCHOR }))).toBe('complete');
+		expect(rowCompleteness(emptyRow(''))).toBe('blank');
+		expect(rowCompleteness(row({ title: 'X', startLocal: '' }))).toBe('invalid');
+		expect(rowCompleteness(row({ title: '', startLocal: ANCHOR }))).toBe('invalid');
+	});
+
+	it('drops fully-blank rows but keeps complete ones when encoding', () => {
+		const rows = [row({ title: 'Real', startLocal: ANCHOR }), emptyRow('')];
+		expect(rowsToSessions(rows, ANCHOR)).toHaveLength(1);
+	});
+
+	it('is valid alongside an untouched blank row, but not a half-filled one', () => {
+		expect(scheduleRowsValid([row({ title: 'X', startLocal: ANCHOR }), emptyRow('')])).toBe(true);
+		// A started-but-untitled row is invalid — it blocks save rather than
+		// being silently dropped (no accidental data loss).
+		expect(scheduleRowsValid([row({ title: '', startLocal: ANCHOR })])).toBe(false);
+		expect(scheduleRowsValid([row({ title: 'X', startLocal: '' })])).toBe(false);
+	});
+});

--- a/src/lib/components/events/admin/schedule-rows.ts
+++ b/src/lib/components/events/admin/schedule-rows.ts
@@ -1,0 +1,120 @@
+/**
+ * Helpers for the event schedule editor.
+ *
+ * The backend stores each session as `offset_minutes` relative to the event
+ * start (so a schedule survives event duplication/recurrence verbatim). The
+ * editor, however, works in absolute wall-clock times — `datetime-local`
+ * strings in the viewer's timezone, consistent with the rest of EventEditor.
+ * These helpers translate between the two representations, anchored to the
+ * event start. Both seeding and encoding use the SAME anchor so a round-trip
+ * reproduces the original offsets.
+ */
+import type { EventScheduleSession } from '$lib/api/generated/types.gen';
+import { toDateTimeLocal } from '$lib/utils/datetime';
+
+export interface ScheduleRow {
+	/** Stable key for `{#each}` — local to the session, never persisted. */
+	id: number;
+	title: string;
+	/** `datetime-local` string in the viewer's timezone. */
+	startLocal: string;
+	durationMinutes: number | null;
+	location: string;
+	description: string;
+	isRequired: boolean;
+}
+
+let counter = 0;
+
+/** Monotonic local id for keying editor rows (uniqueness within a session). */
+export function nextRowId(): number {
+	return counter++;
+}
+
+/**
+ * Seed editor rows from saved sessions, projecting each offset back to an
+ * absolute `datetime-local` against `anchorLocal` (the event start).
+ */
+export function sessionsToRows(
+	sessions: EventScheduleSession[],
+	anchorLocal: string
+): ScheduleRow[] {
+	const anchorMs = new Date(anchorLocal).getTime();
+	return [...sessions]
+		.sort((a, b) => a.offset_minutes - b.offset_minutes)
+		.map((s) => ({
+			id: nextRowId(),
+			title: s.title,
+			startLocal: Number.isNaN(anchorMs)
+				? ''
+				: toDateTimeLocal(new Date(anchorMs + s.offset_minutes * 60_000).toISOString()),
+			durationMinutes: s.duration_minutes ?? null,
+			location: s.location ?? '',
+			description: s.description ?? '',
+			isRequired: s.is_required ?? false
+		}));
+}
+
+/**
+ * A row is `complete` (persisted) when it has a title and a start; `blank`
+ * (ignored) when fully empty; otherwise `invalid` (blocks save).
+ */
+export function rowCompleteness(row: ScheduleRow): 'complete' | 'blank' | 'invalid' {
+	const hasTitle = !!row.title.trim();
+	const hasStart = !!row.startLocal;
+	if (hasTitle && hasStart) return 'complete';
+	const isBlank =
+		!hasTitle &&
+		!hasStart &&
+		!row.location.trim() &&
+		!row.description.trim() &&
+		row.durationMinutes == null &&
+		!row.isRequired;
+	return isBlank ? 'blank' : 'invalid';
+}
+
+/** Offset of a row from the anchor, clamped to ≥0 (backend rejects negatives). */
+export function offsetMinutes(row: ScheduleRow, anchorLocal: string): number {
+	return Math.max(
+		0,
+		Math.round((new Date(row.startLocal).getTime() - new Date(anchorLocal).getTime()) / 60_000)
+	);
+}
+
+/** True when a row's start falls before the event start (it gets pinned to 0). */
+export function startsBeforeAnchor(row: ScheduleRow, anchorLocal: string): boolean {
+	return !!row.startLocal && new Date(row.startLocal).getTime() < new Date(anchorLocal).getTime();
+}
+
+/** Encode complete rows into the offset-based payload, ordered by start. */
+export function rowsToSessions(rows: ScheduleRow[], anchorLocal: string): EventScheduleSession[] {
+	return rows
+		.filter((r) => rowCompleteness(r) === 'complete')
+		.map((r) => ({
+			title: r.title.trim(),
+			description: r.description.trim() || null,
+			offset_minutes: offsetMinutes(r, anchorLocal),
+			duration_minutes: r.durationMinutes ?? null,
+			location: r.location.trim() || null,
+			is_required: r.isRequired
+		}))
+		.sort((a, b) => a.offset_minutes - b.offset_minutes);
+}
+
+/** No half-filled rows. */
+export function scheduleRowsValid(rows: ScheduleRow[]): boolean {
+	return rows.every((r) => rowCompleteness(r) !== 'invalid');
+}
+
+/** A fresh, empty row starting at the event start. */
+export function emptyRow(startLocal: string): ScheduleRow {
+	return {
+		id: nextRowId(),
+		title: '',
+		startLocal,
+		durationMinutes: null,
+		location: '',
+		description: '',
+		isRequired: false
+	};
+}

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -321,6 +321,29 @@ function getOrdinalSuffix(day: number): string {
 }
 
 /**
+ * Format only the time-of-day for an instant, in an optional timezone.
+ *
+ * Used by the event schedule/timeline where the calendar day is implied by the
+ * event itself, so only the clock time needs rendering. No tz abbreviation is
+ * appended — the schedule shows the event's timezone once, in a shared label.
+ *
+ * @param dateString ISO 8601 date-time string
+ * @param timeZone Optional IANA timezone to render in (e.g. the event's timezone)
+ * @returns Formatted time string (e.g., "8:00 PM" for en-US or "20:00" for de-DE)
+ */
+export function formatTimeOfDay(dateString: string, timeZone?: string): string {
+	const date = new Date(dateString);
+	const locale = getCurrentLocale();
+
+	return date.toLocaleTimeString(locale, {
+		hour: 'numeric',
+		minute: '2-digit',
+		hour12: locale === 'en-US',
+		...tzOpt(timeZone)
+	});
+}
+
+/**
  * Format a date for display in admin pages and lists
  * Uses locale-aware formatting with medium date and short time
  * @param dateString ISO 8601 date-time string

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -18,6 +18,7 @@
 	import PotluckSection from '$lib/components/events/PotluckSection.svelte';
 	import DietarySummary from '$lib/components/events/DietarySummary.svelte';
 	import EventResources from '$lib/components/events/EventResources.svelte';
+	import EventSchedule from '$lib/components/events/EventSchedule.svelte';
 	import EventAnnouncements from '$lib/components/announcements/EventAnnouncements.svelte';
 	import EventGuestSignInPrompt from '$lib/components/events/EventGuestSignInPrompt.svelte';
 	import AttendeeList from '$lib/components/events/AttendeeList.svelte';
@@ -812,6 +813,13 @@
 						onGuestTierClick={openGuestTicketDialog}
 					/>
 				{/if}
+
+				<!-- Schedule / Timeline Section -->
+				<EventSchedule
+					schedule={event.schedule}
+					eventStart={event.start}
+					timezone={event.timezone}
+				/>
 
 				<!-- Resources Section -->
 				<EventResources resources={data.resources} />

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -819,6 +819,7 @@
 					schedule={event.schedule}
 					eventStart={event.start}
 					timezone={event.timezone}
+					place={event.city?.name}
 				/>
 
 				<!-- Resources Section -->


### PR DESCRIPTION
Closes #461.

Adds a session **schedule/timeline** to events (à la Wix), per the Oskar feedback session. Backed by the existing backend `Event.schedule` JSON blob (BE #524/#539) — sessions store a **relative `offset_minutes` from event start**, so a schedule survives event duplication/recurrence with no date-shifting.

## What's included

**Display** — `EventSchedule.svelte`, slotted into the public event page just before `EventResources`:
- Session list with start (and end, when `duration_minutes` is set) computed from the offset and **rendered in the event's timezone**.
- Optional location, markdown description, and an `AlertCircle` **Required** badge for `is_required` sessions.

**Editor** — `ScheduleEditor.svelte` + `schedule-rows.ts`, in `EventEditor`'s details section (both the ticketed-tab and non-ticketed branches, gated on an existing event):
- Inline repeatable rows: title, start (`datetime-local`), duration, location, description, required.
- Organizers enter **clock times**; on save the rows are encoded to `offset_minutes` against the event start (clamped ≥0, sorted) and persisted via `PUT /event-admin/{id}/schedule` through the existing single Save bar.
- Untitled rows block save (surfaces incomplete rows rather than silently dropping them).

## Design notes
- Clock-time entry over the relative-offset model keeps tz handling consistent with the rest of the editor (instant arithmetic — no tz library needed); display re-projects `eventStart + offset` into the event timezone.
- `ScheduleEditor` is a controlled `bind:rows` component; payload + validity are parent `$derived` (no `$effect`-writes-parent-state).
- Deduped `EventEditor`'s two identical details branches into a `{#snippet}` — also brings the file back under the 750-line limit.
- New `formatTimeOfDay` helper in `date.ts`; `eventSchedule.*` / `eventScheduleAdmin.*` strings in en/de/it.
- Out of scope (YAGNI): JSON-LD `subEvent`, drag-reorder (order is purely time-derived).

## Verification
- `pnpm check` (types): **0 errors**. `pnpm build`: clean. i18n validate: 100% across 3 locales. `svelte-autofixer`: clean on all new components.
- New unit tests `schedule-rows.test.ts`: **6/6** (offset round-trip, sort, clamp, completeness/validity).
- **Live smoke test** against the running backend: attached a 2-session schedule to a public event and confirmed the public page renders `11:54 AM  Doors open` and `1:24 PM – 2:24 PM  Keynote  Required` — offsets correctly computed in `Europe/Berlin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)