### PR TITLE
fix(ci): make svelte-check green on clean checkout and CI-blocking (#493)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,8 @@ jobs:
           # Load into the local Docker daemon so the scan step can read it.
           load: true
           # PUBLIC_API_URL and ORIGIN are set at RUNTIME (see #396), not baked at
-          # build time. Only PUBLIC_VERSION is embedded into the bundle.
+          # build time. PUBLIC_VERSION is passed as a build arg and baked into the
+          # image's runtime ENV, read via $env/dynamic/public at runtime (#493).
           build-args: |
             PUBLIC_VERSION=${{ env.VERSION }}
           tags: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,13 @@ jobs:
       - name: Run ESLint
         run: pnpm lint
 
+      # svelte-check resolves $lib/paraglide/messages, which is gitignored and
+      # generated — compile it first or every message reference is a type error.
+      - name: Compile translations
+        run: pnpm paraglide:compile
+
       - name: Run SvelteKit type check
         run: pnpm check
-        continue-on-error: true
 
   # Test translations
   i18n:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,8 +29,10 @@ jobs:
 
       # One image for all deployments. PUBLIC_API_URL and ORIGIN are set at
       # RUNTIME (#396), so they are not build args; demo/prod differ only by the
-      # runtime env in their respective compose files. Only PUBLIC_VERSION (shown
-      # in the footer) is embedded at build time.
+      # runtime env in their respective compose files. PUBLIC_VERSION (shown in
+      # the footer) is known only at release time, so it is passed as a build arg
+      # and baked into the image's runtime ENV — read at runtime via
+      # $env/dynamic/public (#493), not inlined into the JS bundle.
       - name: Build and push Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,11 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
 # Copy source code
 COPY . .
 
-# Accept build arguments for values that MUST be embedded at build time (Vite
-# inlines $env/static/public values into the bundle). Only PUBLIC_VERSION
-# qualifies. PUBLIC_API_URL and ORIGIN are read at RUNTIME (PUBLIC_API_URL via
-# $env/dynamic/public, ORIGIN by adapter-node), so one prebuilt image can target
-# any backend (see #396).
-ARG PUBLIC_VERSION
-
-# Set as environment variables for the build process
-ENV PUBLIC_VERSION=${PUBLIC_VERSION}
+# All PUBLIC_* values are read at RUNTIME, so nothing needs embedding here and a
+# single prebuilt image can target any deployment (see #396):
+#   - PUBLIC_API_URL via $env/dynamic/public
+#   - PUBLIC_VERSION via $env/dynamic/public (set on the runtime stage below)
+#   - ORIGIN by adapter-node
 
 # Compile Paraglide i18n translations
 # Generates runtime files from messages/*.json (en, de, it)
@@ -62,6 +58,12 @@ COPY --from=builder --chown=appuser:appuser /app/package.json ./package.json
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOST=0.0.0.0
+
+# PUBLIC_VERSION is known at build time (git tag) but read at runtime via
+# $env/dynamic/public, so bake the build arg into the runtime env. Falls back to
+# 'dev' in the footer if unset.
+ARG PUBLIC_VERSION
+ENV PUBLIC_VERSION=${PUBLIC_VERSION}
 
 # RUNTIME configuration (set these when running the container, e.g. via
 # `docker run -e` or compose). PUBLIC_API_URL points the frontend at your

--- a/src/lib/components/common/Footer.svelte
+++ b/src/lib/components/common/Footer.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
-	import { PUBLIC_VERSION } from '$env/static/public';
+	import { env } from '$env/dynamic/public';
 	import { appStore } from '$lib/stores/app.svelte';
 	import { Github, Bug, Info } from 'lucide-svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import { getLocale } from '$lib/paraglide/runtime.js';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 
-	// Frontend version from build-time environment variable (set in Dockerfile)
-	// Falls back to 'dev' for local development
-	// Remove leading 'v' if present since we add it in the template
-	const FRONTEND_VERSION = PUBLIC_VERSION ? PUBLIC_VERSION.replace(/^v/, '') : 'dev';
+	// Frontend version from environment variable (set in Dockerfile).
+	// Read via $env/dynamic/public so it has no compile-time requirement —
+	// a checkout without a populated .env still type-checks and falls back to 'dev'.
+	// Remove leading 'v' if present since we add it in the template.
+	const FRONTEND_VERSION = env.PUBLIC_VERSION ? env.PUBLIC_VERSION.replace(/^v/, '') : 'dev';
 	const FRONTEND_REPO = 'https://github.com/letsrevel/revel-frontend';
 	const BACKEND_REPO = 'https://github.com/letsrevel/revel-backend';
 


### PR DESCRIPTION
## Summary

`make types` / `pnpm check` (svelte-check) was red on `main`, and CI ran it with `continue-on-error: true`, so type regressions could land silently. This makes the type check pass on a clean checkout and become a blocking CI gate.

## Changes

**Part 1 — `EventRevenueSchema`:** already resolved upstream. The financials work renamed it to `EventFinancialsSchema`; no dangling refs remain in `src/`. No change needed.

**Part 2 — Footer `PUBLIC_VERSION`** (`src/lib/components/common/Footer.svelte`): switched `$env/static/public` → `$env/dynamic/public`. It was the only `$env/static` import in the codebase; the static import required the var at compile time, so a fresh worktree without a populated `.env` failed svelte-check. The code already guards `undefined → 'dev'`.

**Companion Dockerfile change** (prevents a self-hosting regression): moved `ARG PUBLIC_VERSION` + `ENV PUBLIC_VERSION` from the **builder** stage to the **runtime** stage. With the dynamic import the value is read from `process.env` at runtime; `publish.yaml`/`build.yaml` still pass it as a build arg, so the prebuilt image carries it as a runtime ENV and the footer keeps showing the correct version. Infra runs the prebuilt `ghcr.io/letsrevel/revel-frontend:latest` and sets no `PUBLIC_VERSION`, so **no infra change is required** — same runtime-env mechanism as `PUBLIC_API_URL`/`ORIGIN` (#396). Stale "inlined into the bundle" comments in both workflows updated.

**Part 3 — CI** (`.github/workflows/ci.yml`): added `pnpm paraglide:compile` before `pnpm check` (the paraglide messages module is gitignored/generated — without compiling it, every `m[...]` reference is a type error, which was the real reason check was always red), then dropped `continue-on-error: true`.

## Verification

- `make types` → **0 errors** (after `pnpm paraglide:compile`; the prior 359 "errors" were all stale paraglide messages)
- `pnpm build` → **✓ built** (run without `PUBLIC_VERSION` set, confirming nothing is needed at build time)
- `prettier --check` on changed files → clean
- No `prerender = true` routes, so `$env/dynamic/public` in the layout footer is safe

## Acceptance (from #493)
- [x] `EventRevenueSchema` resolved (already done — renamed to `EventFinancialsSchema`)
- [x] `Footer` `PUBLIC_VERSION` no longer errors svelte-check on a clean checkout
- [x] `make types` green
- [x] CI `pnpm check` made blocking (dropped `continue-on-error`)

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)