### PR TITLE
fix(docker): drop orphaned `COPY patches ./patches`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ RUN corepack enable
 
 WORKDIR /app
 
-# Copy dependency files and patches (needed for pnpm install).
-# pnpm-workspace.yaml holds overrides / patchedDependencies / allowBuilds (pnpm 11),
-# so the install needs it or it would resolve unpatched/unhardened deps.
+# Copy dependency files (needed for pnpm install).
+# pnpm-workspace.yaml holds overrides / allowBuilds (pnpm 11), so the install
+# needs it or it would resolve unpatched/unhardened deps.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY patches ./patches
 
 # Install dependencies with caching
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \


### PR DESCRIPTION
## Problem

The **v1.62.0 release failed** — both the `Build` and `Publish` jobs errored at the Docker build step:

```
#12 ERROR: failed to compute cache key: failed to calculate checksum of ref ...: "/patches": not found
```

## Root cause

PR #500 (unified image cropping) swapped the crop engine and its cleanup commit deleted `patches/svelte-crop-window@0.1.1.patch` — the **only** file in `patches/`. Git doesn't track empty directories, so `patches/` vanished from the repo. `Dockerfile` still ran `COPY patches ./patches` (added in #266), and `COPY` of a missing source is a hard error, so every image build on `main` since #500 merged has been broken.

There are now **zero** `patchedDependencies` references in `package.json`, `pnpm-workspace.yaml`, or `pnpm-lock.yaml` — the line is dead weight.

## Fix

Remove the orphaned `COPY patches ./patches` line and correct the now-inaccurate comment. Verified the builder stage builds clean locally.

## Why CI didn't catch it in the PR

- The Docker image build (`build.yaml`) has **no `pull_request` trigger** — it only runs on push to `main`. PR checks only run `ci.yml`'s native `pnpm build`, which never does `COPY patches`, so #500 stayed green.
- It *did* go red on `main` the moment #500 merged (the merge touched `patches/**`, matching `build.yaml`'s `paths:` filter), but the v1.62.0 release was tagged ~6 min later without gating on that red Build.

Follow-up worth considering (not in this PR): add a `pull_request` trigger to `build.yaml` so the Docker image is validated before merge.

## Release

The broken v1.62.0 release + tag have been yanked (no image was ever published). After this merges, re-cut **v1.62.0** at the new `main` HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)