### PR TITLE
fix(i18n): align server/client locale & de-{@html} welcome heading (#505)

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -4,7 +4,7 @@
  * This file provides utilities for language detection and management.
  */
 
-import { setLocale, getLocale, locales, baseLocale } from '$lib/paraglide/runtime.js';
+import { setLocale, getLocale, locales, baseLocale, cookieName } from '$lib/paraglide/runtime.js';
 import type { Handle } from '@sveltejs/kit';
 
 /**
@@ -28,13 +28,22 @@ function detectLanguage(event: Parameters<Handle>[0]['event']): string {
 		return urlLang;
 	}
 
-	// 2. Check cookie
+	// 2. Check Paraglide's canonical locale cookie.
+	// This is the cookie the client-side Paraglide runtime resolves from
+	// (written by setLocale() on the client), so honouring it here keeps the
+	// server and client on the same locale.
+	const paraglideCookie = event.cookies.get(cookieName);
+	if (paraglideCookie && SUPPORTED_LANGUAGES.includes(paraglideCookie as any)) {
+		return paraglideCookie;
+	}
+
+	// 3. Check legacy user_language cookie
 	const cookieLang = event.cookies.get('user_language');
 	if (cookieLang && SUPPORTED_LANGUAGES.includes(cookieLang as any)) {
 		return cookieLang;
 	}
 
-	// 3. Check Accept-Language header
+	// 4. Check Accept-Language header
 	const acceptLanguage = event.request.headers.get('accept-language');
 	if (acceptLanguage) {
 		const lang = acceptLanguage.split(',')[0]?.split('-')[0];
@@ -43,7 +52,7 @@ function detectLanguage(event: Parameters<Handle>[0]['event']): string {
 		}
 	}
 
-	// 4. Default
+	// 5. Default
 	return DEFAULT_LANGUAGE;
 }
 
@@ -57,13 +66,21 @@ export function i18nHandle(): Handle {
 		// Set the locale for this request
 		setLocale(lang as any);
 
-		// Store language in cookie for persistence
-		event.cookies.set('user_language', lang, {
+		const cookieOptions = {
 			path: '/',
 			maxAge: 60 * 60 * 24 * 365, // 1 year
 			sameSite: 'lax',
 			httpOnly: false // Allow client-side access
-		});
+		} as const;
+
+		// Write Paraglide's canonical locale cookie so the client-side runtime
+		// resolves the SAME locale during hydration. Without this the client falls
+		// back to baseLocale and the whole UI flashes to English on first visit
+		// (the server's own setLocale() does not write this cookie). See #505.
+		event.cookies.set(cookieName, lang, cookieOptions);
+
+		// Keep the legacy cookie for backwards compatibility / explicit reads.
+		event.cookies.set('user_language', lang, cookieOptions);
 
 		// Resolve with lang attribute replacement
 		return resolve(event, {

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -114,10 +114,10 @@
 					</span>
 					su <span class="revel-shine">Revel</span>
 				{:else}
-					<!-- Other languages using i18n -->
-					{@html m['home.welcomeToRevel']({
-						revel: `<span class="revel-shine">Revel</span>`
-					})}
+					<!-- Other languages using i18n.
+					     Rendered as real markup (not {@html}) so it re-renders on
+					     hydration and follows the active locale. See #505. -->
+					{m['home.welcomeTo']()} <span class="revel-shine">Revel</span>
 				{/if}
 			</h1>
 			<p


### PR DESCRIPTION
Fixes #505.

## Problem

On a **fresh visit** (best reproduced in a private/incognito window) with a browser whose `Accept-Language` is **not** English (e.g. French), the landing page was server-rendered in that language, then the whole UI **flipped to English** on hydration — **except the "Welcome to Revel" `<h1>`**, which stayed stuck in the `Accept-Language` language (e.g. "Bienvenue sur Revel") on every refresh.

That was two stacked bugs.

## Root cause & fix

### 1. Server-detected locale was never propagated to the client (the flash)
`i18nHandle` detected the locale and wrote a **`user_language`** cookie, but Paraglide's client runtime resolves from the **`PARAGLIDE_LOCALE`** cookie (its configured `cookieName`). The server's own `setLocale()` deliberately **skips the cookie strategy on the server** (`if (isServer) continue`), so `PARAGLIDE_LOCALE` was never written. On first load the client therefore fell back to `baseLocale` (`en`) → an SSR(detected)→CSR(`en`) **hydration mismatch** every time.

**Fix:** write `PARAGLIDE_LOCALE` server-side (and check it first during detection) so SSR and hydration resolve the *same* locale. The legacy `user_language` cookie is kept for backwards compatibility.

### 2. `{@html}` heading wasn't re-rendered on hydration (the stuck heading)
The heading used `{@html m['home.welcomeToRevel']()}`. Per the Svelte docs, `{@html}` content is **"invisible to Svelte"** — it is not re-rendered or diffed during hydration, so it kept the stale SSR markup while every other (reactive) string on the page updated to the client locale. That's why it was the *single* element that stayed in the `Accept-Language` language.

**Fix:** render it as real, reactive markup:
```svelte
{m['home.welcomeTo']()} <span class="revel-shine">Revel</span>
```
(`home.welcomeTo` already exists in all four locales; `.revel-shine` is a `:global` style, so it's styled identically.)

### Italian quirk — preserved
The Italian heading has its own special branch: a client-only animated flip of the final vowel (`a` → `o` → `ə`) in "Benvenut_ su Revel". That branch is **untouched** — only the shared `{:else}` branch changed. Italian still SSR-renders "Benvenuti su Revel" and transitions to the animated version client-side exactly as before.

## Verification
- `make types` — **0 errors** (358 pre-existing `state_referenced_locally` warnings unchanged).
- `make i18n-check` — all 4 locales 100%.
- `make format-check` — clean.
- `svelte-autofixer` on the changed heading — no issues.

**Manual smoke test recommended before merge:** private window, browser language set to French/German/Italian, load `/` — the page should render in a single consistent language with no flash, and the heading should match the rest of the UI.

## Notes / out of scope
The issue also flagged that the server hook mutates the **module-level `_locale`** in the generated runtime (a latent SSR concurrency hazard, since there's no Paraglide server middleware / `AsyncLocalStorage`). That's intentionally **not** addressed here to keep the PR focused on the user-reported bug; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved locale handling so the app now recognizes the primary language setting more reliably and keeps it consistent across visits.
  * Updated the homepage welcome message to use structured text for cleaner rendering.

* **Bug Fixes**
  * Fixed language selection priority so saved locale preferences are applied before fallback detection.
  * Improved display of the non-Italian welcome heading to avoid HTML-based rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->