### PR TITLE
chore(release): 1.62.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.62.1] - 2026-06-28
+
+### Fixed
+- First-time visitors whose browser language is not English no longer see the landing page briefly render in that language and then flip to English; the page now stays in the detected language consistently.
+- The "Welcome to Revel" heading no longer stays stuck in the browser's language while the rest of the page is shown in another language.
+
 ## [1.62.0] - 2026-06-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.62.0",
+	"version": "1.62.1",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Patch release **1.62.1**.

Bumps `package.json` 1.62.0 → 1.62.1 and adds the CHANGELOG section for the one user-facing change merged since the 1.62.0 tag (#506; the #504 docker fix was already included in 1.62.0).

## Changelog

### Fixed
- First-time visitors whose browser language is not English no longer see the landing page briefly render in that language and then flip to English; the page now stays in the detected language consistently.
- The "Welcome to Revel" heading no longer stays stuck in the browser's language while the rest of the page is shown in another language.

## After merge
Tag + release via `make release` (not done here — left to the maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
