### PR TITLE
fix(i18n): language-driven, unambiguous date display (#508)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -627,6 +627,27 @@ lib/components/
 - **Type all function parameters and return values**
 - **Use Zod** for runtime validation of external data (API responses, form inputs)
 
+#### Date & Time Formatting
+
+**Human-facing dates must follow the user's UI language and never be ambiguous.**
+
+- **Format only via `src/lib/utils/date.ts`** helpers (`formatDate`, `formatDateTime`,
+  `formatEventDate`, `formatTimeOfDay`, `formatDateTimeReadback`, …). These resolve the
+  locale from the active UI language via `getDateLocale()` — so switching language switches
+  month names. Calendar-specific display helpers live in `calendar.ts` and use the same locale.
+- **Never render a month as a number** in human-facing output (no `month: 'numeric'`/`'2-digit'`,
+  no bare `toLocaleDateString()`/`dateStyle: 'short'`). Always a textual month (`'short'`/`'long'`).
+  This removes DD/MM vs MM/DD ambiguity, so no per-user region/format preference is needed.
+- **Do not call `toLocaleDateString` / `toLocaleString` / `toLocaleTimeString` or
+  `new Intl.DateTimeFormat(...).format()` directly** in components/routes — add a helper to
+  `date.ts` instead. (`Intl.DateTimeFormat().resolvedOptions().timeZone` for timezone *detection*
+  is fine.) A repo-wide migration + ESLint guardrail enforcing this is tracked in #510.
+- **Machine/ISO formats stay numeric** — `<input>` values, `datetime` attributes, API payloads,
+  and structured data (schema.org) use ISO 8601, not localized strings.
+- For native `<input type="datetime-local">`, show `formatDateTimeReadback(value)` underneath as an
+  unambiguous confirmation (the native control's own display is browser-locale numeric and can't be
+  restyled).
+
 #### Svelte 5 Runes
 
 **IMPORTANT:** This project uses Svelte 5 Runes, not the legacy reactive syntax.

--- a/messages/de.json
+++ b/messages/de.json
@@ -6887,6 +6887,7 @@
 	"cityAutocomplete.clearSelection": "Stadtauswahl löschen",
 	"cityAutocomplete.searchPlaceholder": "Nach einer Stadt suchen...",
 	"dateTimePicker.required": "erforderlich",
+	"dateTimePicker.selectedDate": "Ausgewählt: {value}",
 	"markdownEditor.placeholderDefault": "Beschreibung eingeben…",
 	"markdownEditor.required": "erforderlich",
 	"markdownEditor.toolbarAriaLabel": "Textformatierung",

--- a/messages/en.json
+++ b/messages/en.json
@@ -6887,6 +6887,7 @@
 	"cityAutocomplete.clearSelection": "Clear city selection",
 	"cityAutocomplete.searchPlaceholder": "Search for a city...",
 	"dateTimePicker.required": "required",
+	"dateTimePicker.selectedDate": "Selected: {value}",
 	"markdownEditor.placeholderDefault": "Write a description…",
 	"markdownEditor.required": "required",
 	"markdownEditor.toolbarAriaLabel": "Text formatting",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -6858,6 +6858,7 @@
 	"cityAutocomplete.clearSelection": "Effacer la ville sélectionnée",
 	"cityAutocomplete.searchPlaceholder": "Rechercher une ville...",
 	"dateTimePicker.required": "obligatoire",
+	"dateTimePicker.selectedDate": "Sélectionné : {value}",
 	"markdownEditor.placeholderDefault": "Écris une description…",
 	"markdownEditor.required": "obligatoire",
 	"markdownEditor.toolbarAriaLabel": "Mise en forme du texte",

--- a/messages/it.json
+++ b/messages/it.json
@@ -6887,6 +6887,7 @@
 	"cityAutocomplete.clearSelection": "Cancella la città selezionata",
 	"cityAutocomplete.searchPlaceholder": "Cerca una città...",
 	"dateTimePicker.required": "obbligatorio",
+	"dateTimePicker.selectedDate": "Selezionato: {value}",
 	"markdownEditor.placeholderDefault": "Scrivi una descrizione…",
 	"markdownEditor.required": "obbligatorio",
 	"markdownEditor.toolbarAriaLabel": "Formattazione del testo",

--- a/src/lib/components/events/admin/DetailsStep.svelte
+++ b/src/lib/components/events/admin/DetailsStep.svelte
@@ -112,6 +112,12 @@
 		onUpdateImages
 	}: Props = $props();
 
+	// Unambiguous textual readbacks for the native datetime inputs; '' when the
+	// value is empty or unparseable, so each hint is gated on the rendered text.
+	const rsvpReadback = $derived(formatDateTimeReadback(formData.rsvp_before));
+	const checkInStartReadback = $derived(formatDateTimeReadback(formData.check_in_starts_at));
+	const checkInEndReadback = $derived(formatDateTimeReadback(formData.check_in_ends_at));
+
 	// Modal state for questionnaire assignment
 	let isQuestionnaireModalOpen = $state(false);
 
@@ -437,11 +443,9 @@
 							oninput={(e) => onUpdate({ rsvp_before: e.currentTarget.value })}
 							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						/>
-						{#if formData.rsvp_before}
+						{#if rsvpReadback}
 							<p class="text-xs text-muted-foreground">
-								{m['dateTimePicker.selectedDate']({
-									value: formatDateTimeReadback(formData.rsvp_before)
-								})}
+								{m['dateTimePicker.selectedDate']({ value: rsvpReadback })}
 							</p>
 						{/if}
 						<p class="text-xs text-muted-foreground">
@@ -632,11 +636,9 @@
 							oninput={(e) => onUpdate({ check_in_starts_at: e.currentTarget.value })}
 							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						/>
-						{#if formData.check_in_starts_at}
+						{#if checkInStartReadback}
 							<p class="text-xs text-muted-foreground">
-								{m['dateTimePicker.selectedDate']({
-									value: formatDateTimeReadback(formData.check_in_starts_at)
-								})}
+								{m['dateTimePicker.selectedDate']({ value: checkInStartReadback })}
 							</p>
 						{/if}
 						<p class="text-xs text-muted-foreground">
@@ -658,11 +660,9 @@
 							oninput={(e) => onUpdate({ check_in_ends_at: e.currentTarget.value })}
 							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						/>
-						{#if formData.check_in_ends_at}
+						{#if checkInEndReadback}
 							<p class="text-xs text-muted-foreground">
-								{m['dateTimePicker.selectedDate']({
-									value: formatDateTimeReadback(formData.check_in_ends_at)
-								})}
+								{m['dateTimePicker.selectedDate']({ value: checkInEndReadback })}
 							</p>
 						{/if}
 						<p class="text-xs text-muted-foreground">

--- a/src/lib/components/events/admin/DetailsStep.svelte
+++ b/src/lib/components/events/admin/DetailsStep.svelte
@@ -8,6 +8,7 @@
 		VenueDetailSchema
 	} from '$lib/api/generated/types.gen';
 	import { getBackendUrl } from '$lib/config/api';
+	import { formatDateTimeReadback } from '$lib/utils/date';
 	import {
 		FileText,
 		Users,
@@ -436,6 +437,13 @@
 							oninput={(e) => onUpdate({ rsvp_before: e.currentTarget.value })}
 							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						/>
+						{#if formData.rsvp_before}
+							<p class="text-xs text-muted-foreground">
+								{m['dateTimePicker.selectedDate']({
+									value: formatDateTimeReadback(formData.rsvp_before)
+								})}
+							</p>
+						{/if}
 						<p class="text-xs text-muted-foreground">
 							{m['detailsStep.rsvpDeadlineHint']({
 								timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -624,6 +632,13 @@
 							oninput={(e) => onUpdate({ check_in_starts_at: e.currentTarget.value })}
 							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						/>
+						{#if formData.check_in_starts_at}
+							<p class="text-xs text-muted-foreground">
+								{m['dateTimePicker.selectedDate']({
+									value: formatDateTimeReadback(formData.check_in_starts_at)
+								})}
+							</p>
+						{/if}
 						<p class="text-xs text-muted-foreground">
 							{m['detailsStep.checkinOpensAtHint']({
 								timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -643,6 +658,13 @@
 							oninput={(e) => onUpdate({ check_in_ends_at: e.currentTarget.value })}
 							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						/>
+						{#if formData.check_in_ends_at}
+							<p class="text-xs text-muted-foreground">
+								{m['dateTimePicker.selectedDate']({
+									value: formatDateTimeReadback(formData.check_in_ends_at)
+								})}
+							</p>
+						{/if}
 						<p class="text-xs text-muted-foreground">
 							{m['detailsStep.checkinClosesAtHint']({
 								timezone: Intl.DateTimeFormat().resolvedOptions().timeZone

--- a/src/lib/components/events/admin/EssentialsStep.svelte
+++ b/src/lib/components/events/admin/EssentialsStep.svelte
@@ -42,6 +42,11 @@
 
 	const accessToken = $derived(authStore.accessToken);
 
+	// Unambiguous textual readbacks for the native datetime inputs; '' when the
+	// value is empty or unparseable, so the hint is gated on the rendered text.
+	const startReadback = $derived(formatDateTimeReadback(formData.start));
+	const endReadback = $derived(formatDateTimeReadback(formData.end));
+
 	// Slug editing state
 	let isEditingSlug = $state(false);
 	let editedSlug = $state('');
@@ -341,9 +346,9 @@
 				{validationErrors.start}
 			</p>
 		{/if}
-		{#if formData.start}
+		{#if startReadback}
 			<p class="text-xs text-muted-foreground">
-				{m['dateTimePicker.selectedDate']({ value: formatDateTimeReadback(formData.start) })}
+				{m['dateTimePicker.selectedDate']({ value: startReadback })}
 			</p>
 		{/if}
 		<p class="text-xs text-muted-foreground">
@@ -394,9 +399,9 @@
 					{validationErrors.end}
 				</p>
 			{/if}
-			{#if formData.end}
+			{#if endReadback}
 				<p class="text-xs text-muted-foreground">
-					{m['dateTimePicker.selectedDate']({ value: formatDateTimeReadback(formData.end) })}
+					{m['dateTimePicker.selectedDate']({ value: endReadback })}
 				</p>
 			{/if}
 		</div>

--- a/src/lib/components/events/admin/EssentialsStep.svelte
+++ b/src/lib/components/events/admin/EssentialsStep.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { EventCreateSchema } from '$lib/api/generated/types.gen';
 	import { cn } from '$lib/utils/cn';
+	import { formatDateTimeReadback } from '$lib/utils/date';
 	import { Calendar, Eye, Users, Ticket, Pencil, Check, X, Link, Loader2 } from 'lucide-svelte';
 	import { createMutation } from '@tanstack/svelte-query';
 	import { eventadmincoreEditSlug } from '$lib/api/generated/sdk.gen';
@@ -340,6 +341,11 @@
 				{validationErrors.start}
 			</p>
 		{/if}
+		{#if formData.start}
+			<p class="text-xs text-muted-foreground">
+				{m['dateTimePicker.selectedDate']({ value: formatDateTimeReadback(formData.start) })}
+			</p>
+		{/if}
 		<p class="text-xs text-muted-foreground">
 			{m['essentialsStep.localTimezoneHint']({
 				timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -386,6 +392,11 @@
 			{#if validationErrors.end}
 				<p id="event-end-error" class="text-sm text-destructive" role="alert">
 					{validationErrors.end}
+				</p>
+			{/if}
+			{#if formData.end}
+				<p class="text-xs text-muted-foreground">
+					{m['dateTimePicker.selectedDate']({ value: formatDateTimeReadback(formData.end) })}
 				</p>
 			{/if}
 		</div>

--- a/src/lib/components/events/admin/TierForm.svelte
+++ b/src/lib/components/events/admin/TierForm.svelte
@@ -28,6 +28,7 @@
 	import { extractErrorMessage, extractFieldErrors } from '$lib/utils/errors';
 	import { tierFieldLabel } from './tier-field-labels';
 	import { Building2, LayoutGrid, Armchair, Undo2 } from 'lucide-svelte';
+	import { formatDateTimeReadback } from '$lib/utils/date';
 
 	interface Props {
 		tier: TicketTierDetailSchema | null; // null = create new
@@ -721,6 +722,11 @@
 						bind:value={salesStartAt}
 						disabled={isPending}
 					/>
+					{#if salesStartAt}
+						<p class="mt-1 text-xs text-muted-foreground">
+							{m['dateTimePicker.selectedDate']({ value: formatDateTimeReadback(salesStartAt) })}
+						</p>
+					{/if}
 				</div>
 				<div>
 					<Label for="sales-end">{m['tierForm.salesEnd']()}</Label>
@@ -730,6 +736,11 @@
 						bind:value={salesEndAt}
 						disabled={isPending}
 					/>
+					{#if salesEndAt}
+						<p class="mt-1 text-xs text-muted-foreground">
+							{m['dateTimePicker.selectedDate']({ value: formatDateTimeReadback(salesEndAt) })}
+						</p>
+					{/if}
 				</div>
 			</div>
 

--- a/src/lib/components/events/admin/TierForm.svelte
+++ b/src/lib/components/events/admin/TierForm.svelte
@@ -161,6 +161,10 @@
 	);
 	let salesStartAt = $state(toDatetimeLocal(tier?.sales_start_at));
 	let salesEndAt = $state(toDatetimeLocal(tier?.sales_end_at));
+	// Unambiguous textual readbacks for the native datetime inputs; '' when the
+	// value is empty or unparseable, so each hint is gated on the rendered text.
+	const salesStartReadback = $derived(formatDateTimeReadback(salesStartAt));
+	const salesEndReadback = $derived(formatDateTimeReadback(salesEndAt));
 	let visibility = $state<'public' | 'private' | 'members-only' | 'staff-only'>(
 		(tier?.visibility as 'public' | 'private' | 'members-only' | 'staff-only') ?? 'public'
 	);
@@ -722,9 +726,9 @@
 						bind:value={salesStartAt}
 						disabled={isPending}
 					/>
-					{#if salesStartAt}
+					{#if salesStartReadback}
 						<p class="mt-1 text-xs text-muted-foreground">
-							{m['dateTimePicker.selectedDate']({ value: formatDateTimeReadback(salesStartAt) })}
+							{m['dateTimePicker.selectedDate']({ value: salesStartReadback })}
 						</p>
 					{/if}
 				</div>
@@ -736,9 +740,9 @@
 						bind:value={salesEndAt}
 						disabled={isPending}
 					/>
-					{#if salesEndAt}
+					{#if salesEndReadback}
 						<p class="mt-1 text-xs text-muted-foreground">
-							{m['dateTimePicker.selectedDate']({ value: formatDateTimeReadback(salesEndAt) })}
+							{m['dateTimePicker.selectedDate']({ value: salesEndReadback })}
 						</p>
 					{/if}
 				</div>

--- a/src/lib/components/forms/DateTimePicker.svelte
+++ b/src/lib/components/forms/DateTimePicker.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { cn } from '$lib/utils/cn';
 	import { toDateTimeLocal, toISOString } from '$lib/utils/datetime';
+	import { formatDateTimeReadback } from '$lib/utils/date';
 
 	/**
 	 * DateTimePicker Component
@@ -76,6 +77,10 @@
 		}
 	});
 
+	// Unambiguous textual confirmation of the picked value (the native control's
+	// own display is browser-locale numeric and can't be restyled).
+	const readback = $derived(formatDateTimeReadback(value));
+
 	function handleInput(event: Event): void {
 		const target = event.target as HTMLInputElement;
 		const newValue = target.value;
@@ -132,6 +137,12 @@
 				: 'border-gray-300 dark:border-gray-600'
 		)}
 	/>
+
+	{#if readback}
+		<p class="text-xs text-muted-foreground">
+			{m['dateTimePicker.selectedDate']({ value: readback })}
+		</p>
+	{/if}
 
 	{#if error}
 		<p id="{inputId}-error" class="text-sm text-destructive" role="alert">

--- a/src/lib/components/forms/DateTimePicker.test.ts
+++ b/src/lib/components/forms/DateTimePicker.test.ts
@@ -145,4 +145,18 @@ describe('DateTimePicker', () => {
 		expect(input).toBeInstanceOf(HTMLInputElement);
 		expect(input.getAttribute('type')).toBe('datetime-local');
 	});
+
+	it('shows an unambiguous textual readback of the selected value (#508)', () => {
+		render(DateTimePicker, {
+			props: { label: 'Start Time', value: '2025-10-20T14:30:00' }
+		});
+		const readback = screen.getByText(/Oct 20, 2025/);
+		expect(readback).toBeInTheDocument();
+		expect(readback.textContent).not.toMatch(/10\/20/); // never numeric month/day
+	});
+
+	it('renders no readback when no value is selected (#508)', () => {
+		render(DateTimePicker, { props: { label: 'Start Time' } });
+		expect(screen.queryByText(/Selected:/)).not.toBeInTheDocument();
+	});
 });

--- a/src/lib/utils/calendar.locale.test.ts
+++ b/src/lib/utils/calendar.locale.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { getLocale } = vi.hoisted(() => ({ getLocale: vi.fn(() => 'en') }));
+vi.mock('$lib/paraglide/runtime.js', () => ({ getLocale }));
+
+import { formatMonthYear, formatWeekRange, formatCalendarDate } from './calendar';
+
+describe('calendar formatting follows the app UI locale (#508)', () => {
+	it('formatMonthYear renders the month name in the active locale', () => {
+		getLocale.mockReturnValue('fr');
+		expect(formatMonthYear(2026, 1)).toContain('janvier');
+		getLocale.mockReturnValue('de');
+		expect(formatMonthYear(2026, 1)).toContain('Januar');
+	});
+
+	it('formatWeekRange uses a textual month (never a bare number)', () => {
+		getLocale.mockReturnValue('fr');
+		const out = formatWeekRange(2026, 10);
+		expect(out).toMatch(/[A-Za-zÀ-ÿ]{3,}/); // contains an alphabetic month, not "3/2"
+	});
+
+	it('formatCalendarDate long form renders a textual weekday + month', () => {
+		getLocale.mockReturnValue('it');
+		expect(formatCalendarDate(new Date(2026, 0, 15), 'long')).toMatch(/[A-Za-zÀ-ÿ]{3,}/);
+	});
+});

--- a/src/lib/utils/calendar.ts
+++ b/src/lib/utils/calendar.ts
@@ -3,6 +3,8 @@
  * Week system: Monday-Sunday (ISO 8601 standard)
  */
 
+import { getDateLocale } from './date';
+
 export type CalendarView = 'month' | 'week' | 'year';
 
 /**
@@ -232,10 +234,11 @@ export function isInMonth(date: Date, year: number, month: number): boolean {
  * Format date for display
  */
 export function formatCalendarDate(date: Date, format: 'short' | 'long' = 'short'): string {
+	const locale = getDateLocale();
 	if (format === 'short') {
-		return date.toLocaleDateString(undefined, { day: 'numeric' });
+		return date.toLocaleDateString(locale, { day: 'numeric' });
 	}
-	return date.toLocaleDateString(undefined, {
+	return date.toLocaleDateString(locale, {
 		weekday: 'short',
 		month: 'short',
 		day: 'numeric'
@@ -247,7 +250,7 @@ export function formatCalendarDate(date: Date, format: 'short' | 'long' = 'short
  */
 export function formatMonthYear(year: number, month: number): string {
 	const date = new Date(year, month - 1, 1);
-	return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+	return date.toLocaleDateString(getDateLocale(), { month: 'long', year: 'numeric' });
 }
 
 /**
@@ -256,9 +259,10 @@ export function formatMonthYear(year: number, month: number): string {
 export function formatWeekRange(year: number, week: number): string {
 	const start = getWeekStartDate(year, week);
 	const end = getWeekEndDate(year, week);
+	const locale = getDateLocale();
 
-	const startStr = start.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-	const endStr = end.toLocaleDateString(undefined, {
+	const startStr = start.toLocaleDateString(locale, { month: 'short', day: 'numeric' });
+	const endStr = end.toLocaleDateString(locale, {
 		month: 'short',
 		day: 'numeric',
 		year: 'numeric'

--- a/src/lib/utils/date.locale.test.ts
+++ b/src/lib/utils/date.locale.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Configurable locale mock (the module under test reads getLocale()).
+const { getLocale } = vi.hoisted(() => ({ getLocale: vi.fn(() => 'en') }));
+vi.mock('$lib/paraglide/runtime.js', () => ({ getLocale }));
+
+import { getDateLocale } from './date';
+
+describe('getDateLocale', () => {
+	it('maps fr → fr-FR (regression: French previously fell back to en-US)', () => {
+		getLocale.mockReturnValue('fr');
+		expect(getDateLocale()).toBe('fr-FR');
+	});
+	it('maps it → it-IT', () => {
+		getLocale.mockReturnValue('it');
+		expect(getDateLocale()).toBe('it-IT');
+	});
+	it('maps de → de-DE', () => {
+		getLocale.mockReturnValue('de');
+		expect(getDateLocale()).toBe('de-DE');
+	});
+	it('maps en → en-US', () => {
+		getLocale.mockReturnValue('en');
+		expect(getDateLocale()).toBe('en-US');
+	});
+	it('falls back to en-US for an unknown locale', () => {
+		getLocale.mockReturnValue('xx');
+		expect(getDateLocale()).toBe('en-US');
+	});
+});

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -11,6 +11,7 @@ import {
 	formatEventDateRange,
 	formatEventDateForScreenReader,
 	formatDateTime,
+	formatDateTimeReadback,
 	formatDate,
 	formatEventTimezoneLabel
 } from './date';
@@ -113,5 +114,28 @@ describe('formatDateTime and screen-reader format carry the timezone', () => {
 		expect(out).toContain('February');
 		expect(out).toContain('2:00 PM');
 		expect(out).toContain('EST');
+	});
+});
+
+describe('formatDateTimeReadback (#508 picker readback)', () => {
+	it('returns "" for empty/nullish input', () => {
+		expect(formatDateTimeReadback('')).toBe('');
+		expect(formatDateTimeReadback(null)).toBe('');
+		expect(formatDateTimeReadback(undefined)).toBe('');
+	});
+
+	it('returns "" for an invalid datetime string', () => {
+		expect(formatDateTimeReadback('not-a-date')).toBe('');
+	});
+
+	it('renders a textual month and year for a datetime-local value', () => {
+		const out = formatDateTimeReadback('2026-06-07T12:00');
+		expect(out).toContain('2026');
+		expect(out).toContain('Jun'); // en-US short month — textual, never "6"
+		expect(out).not.toMatch(/\b0?6\/0?7\b/); // not numeric m/d
+	});
+
+	it('also accepts a full ISO 8601 string', () => {
+		expect(formatDateTimeReadback('2026-06-07T12:00:00Z')).toContain('2026');
 	});
 });

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -5,14 +5,17 @@
 import { getLocale } from '$lib/paraglide/runtime.js';
 
 /**
- * Get the current locale in BCP 47 format (e.g., "en-US", "de-DE", "it-IT")
+ * Get the active UI language as a BCP 47 date locale (e.g. "en-US", "de-DE",
+ * "it-IT", "fr-FR"). Drives every human-facing date in the app, so switching
+ * the UI language switches month names. Exported so calendar.ts shares it.
  */
-function getCurrentLocale(): string {
+export function getDateLocale(): string {
 	const locale = getLocale();
 	const localeMap: Record<string, string> = {
 		en: 'en-US',
 		de: 'de-DE',
-		it: 'it-IT'
+		it: 'it-IT',
+		fr: 'fr-FR'
 	};
 	return localeMap[locale] || 'en-US';
 }
@@ -88,7 +91,7 @@ export function formatEventDate(
 	withAbbreviation = true
 ): string {
 	const date = new Date(dateString);
-	const locale = getCurrentLocale();
+	const locale = getDateLocale();
 
 	const dayOfWeek = date.toLocaleDateString(locale, { weekday: 'short', ...tzOpt(timeZone) });
 	const month = date.toLocaleDateString(locale, { month: 'short', ...tzOpt(timeZone) });
@@ -121,7 +124,7 @@ export function formatEventDateRange(
 ): string {
 	const start = new Date(startString);
 	const end = new Date(endString);
-	const locale = getCurrentLocale();
+	const locale = getDateLocale();
 
 	const dayOfWeek = start.toLocaleDateString(locale, { weekday: 'short', ...tzOpt(timeZone) });
 	const month = start.toLocaleDateString(locale, { month: 'short', ...tzOpt(timeZone) });
@@ -210,7 +213,7 @@ export function getRSVPDeadlineRelative(deadlineString: string): string {
  */
 export function formatRelativeTime(dateString: string): string {
 	const diffMs = new Date(dateString).getTime() - Date.now();
-	const rtf = new Intl.RelativeTimeFormat(getCurrentLocale(), { numeric: 'auto' });
+	const rtf = new Intl.RelativeTimeFormat(getDateLocale(), { numeric: 'auto' });
 
 	const units: [Intl.RelativeTimeFormatUnit, number][] = [
 		['year', 1000 * 60 * 60 * 24 * 365],
@@ -277,7 +280,7 @@ export function isRSVPClosingSoon(deadlineString: string | null): boolean {
  */
 export function formatEventDateForScreenReader(dateString: string, timeZone?: string): string {
 	const date = new Date(dateString);
-	const locale = getCurrentLocale();
+	const locale = getDateLocale();
 
 	const dayOfWeek = date.toLocaleDateString(locale, { weekday: 'long', ...tzOpt(timeZone) });
 	const month = date.toLocaleDateString(locale, { month: 'long', ...tzOpt(timeZone) });
@@ -333,7 +336,7 @@ function getOrdinalSuffix(day: number): string {
  */
 export function formatTimeOfDay(dateString: string, timeZone?: string): string {
 	const date = new Date(dateString);
-	const locale = getCurrentLocale();
+	const locale = getDateLocale();
 
 	return date.toLocaleTimeString(locale, {
 		hour: 'numeric',
@@ -351,7 +354,7 @@ export function formatTimeOfDay(dateString: string, timeZone?: string): string {
  */
 export function formatDateTime(dateString: string, timeZone?: string): string {
 	const date = new Date(dateString);
-	const locale = getCurrentLocale();
+	const locale = getDateLocale();
 
 	const formatted = date.toLocaleString(locale, {
 		year: 'numeric',
@@ -373,7 +376,7 @@ export function formatDateTime(dateString: string, timeZone?: string): string {
  */
 export function formatDate(dateString: string, timeZone?: string): string {
 	const date = new Date(dateString);
-	const locale = getCurrentLocale();
+	const locale = getDateLocale();
 
 	// Date-only: apply the timezone so the calendar day is correct, but don't
 	// append a tz abbreviation (it reads oddly next to a date with no time).
@@ -402,7 +405,7 @@ export function formatEventTimezoneLabel(
 	timeZone: string,
 	place?: string | null
 ): string {
-	const locale = getCurrentLocale();
+	const locale = getDateLocale();
 	const offset = getTimeZoneAbbreviation(new Date(referenceString), locale, timeZone);
 	const name = place?.trim() || timeZone.split('/').pop()?.replace(/_/g, ' ') || timeZone;
 	return offset ? `${name} (${offset})` : name;

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -4,20 +4,21 @@
 
 import { getLocale } from '$lib/paraglide/runtime.js';
 
+/** Maps the active Paraglide UI language to a BCP 47 date locale. */
+const LOCALE_MAP: Record<string, string> = {
+	en: 'en-US',
+	de: 'de-DE',
+	it: 'it-IT',
+	fr: 'fr-FR'
+};
+
 /**
  * Get the active UI language as a BCP 47 date locale (e.g. "en-US", "de-DE",
  * "it-IT", "fr-FR"). Drives every human-facing date in the app, so switching
  * the UI language switches month names. Exported so calendar.ts shares it.
  */
 export function getDateLocale(): string {
-	const locale = getLocale();
-	const localeMap: Record<string, string> = {
-		en: 'en-US',
-		de: 'de-DE',
-		it: 'it-IT',
-		fr: 'fr-FR'
-	};
-	return localeMap[locale] || 'en-US';
+	return LOCALE_MAP[getLocale()] || 'en-US';
 }
 
 /**

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -370,6 +370,25 @@ export function formatDateTime(dateString: string, timeZone?: string): string {
 }
 
 /**
+ * Unambiguous textual readback of a datetime input value, shown under a native
+ * <input type="datetime-local"> (whose own display is browser-locale numeric and
+ * cannot be restyled). Month is always textual, in the active UI language.
+ *
+ * Accepts a datetime-local string ("2026-06-07T19:00", parsed as local wall
+ * time) or a full ISO 8601 string. Returns "" for empty/invalid input so callers
+ * can render nothing before a value is picked.
+ *
+ * @param value datetime-local or ISO 8601 string (may be empty/null/undefined)
+ * @returns e.g. "Oct 20, 2025, 2:30 PM" (locale-dependent), or ""
+ */
+export function formatDateTimeReadback(value: string | null | undefined): string {
+	if (!value) return '';
+	const date = new Date(value);
+	if (isNaN(date.getTime())) return '';
+	return formatDateTime(value);
+}
+
+/**
  * Format a date without time for display
  * @param dateString ISO 8601 date-time string
  * @returns Formatted date string (e.g., "Oct 20, 2025" for en-US or "20. Okt. 2025" for de-DE)


### PR DESCRIPTION
Closes #508.

## Problem

Dates rendered according to the **browser locale**, not the user's chosen UI language. Switching the app language didn't change them — e.g. an app set to English/Italian on a French browser showed `Week of 1 Juin - 7 Juin 2026`.

## What this does

The app already mapped UI language → date locale (`getCurrentLocale()` in `date.ts`), but two bugs bypassed it. This PR makes the locale consistent and removes numeric-date ambiguity entirely by keeping months **textual**.

- **Fix the "1 Juin" bug** — `calendar.ts` (`formatWeekRange`/`formatMonthYear`/`formatCalendarDate`) used `toLocaleDateString(undefined, …)` (browser locale). Now routed through the shared app locale.
- **Fix French fallback** — `getCurrentLocale()` had no `fr` entry, so French UI silently got `en-US` dates. Exported as `getDateLocale()` with `fr→fr-FR` added; `calendar.ts` shares it.
- **Unambiguous datetime pickers** — new `formatDateTimeReadback()` helper renders a textual-month, UI-language confirmation line. Wired into the shared `DateTimePicker` wrapper (auto-applies to discount-codes, announcements, event-tokens) and added under the event-critical native inputs: event start/end (`EssentialsStep`), RSVP deadline + check-in (`DetailsStep`), ticket sales window (`TierForm`).
- **House rule documented** in `CLAUDE.md`: human-facing months always textual; format via `date.ts`; machine/ISO formats stay numeric.

## Design notes

- The event inputs get a **readback line, not a swap to the `DateTimePicker` wrapper** — `formData.start/end` etc. are `datetime-local` strings converted to ISO at submit by `EventEditor` and `RecurringEventWizard` (both reuse `EssentialsStep`); swapping would change that contract. Verified intact in review.
- New i18n key `dateTimePicker.selectedDate` added to all 4 locales (en/de/it/fr), placeholders consistent.

## Scope / follow-ups

- **#509** — migrate the long-tail `datetime-local` inputs onto the wrapper.
- **#510** — repo-wide migration of ~43 raw `toLocale*` call-sites onto `date.ts` helpers + an ESLint guardrail enforcing the rule.

## Testing

- Unit: `getDateLocale` mapping incl. `fr` regression + fallback; calendar formatters follow the active locale; `formatDateTimeReadback` empty/invalid/textual-month; `DateTimePicker` readback present/absent + never-numeric.
- i18n validation green across 4 locales.
- ⚠️ Manual language-switch smoke (event create/edit pickers + calendar header) recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear “selected date” readbacks beneath date/time inputs, making chosen values easier to confirm.
  * Improved date and calendar displays to follow the app’s language/locale more closely.

* **Bug Fixes**
  * Reduced ambiguity in date/time formatting by avoiding numeric-only month displays in human-facing UI.

* **Documentation**
  * Updated formatting guidance for consistent date/time display across the product.

* **Chores**
  * Added localized text for the new date/time picker message in supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->