### PR TITLE
refactor(datetime): migrate long-tail datetime inputs to DateTimePicker (#509)

### DIFF
--- a/src/lib/components/event-series/admin/GenerateNowButton.svelte
+++ b/src/lib/components/event-series/admin/GenerateNowButton.svelte
@@ -137,7 +137,7 @@
 
 		<div class="mt-4 space-y-2">
 			<DateTimePicker
-				id="generate-now-until"
+				id={`generate-now-until-${series.id}`}
 				bind:value={untilLocal}
 				label={m['recurringEvents.generateNow.untilLabel']()}
 				disabled={generateMutation.isPending}

--- a/src/lib/components/event-series/admin/GenerateNowButton.svelte
+++ b/src/lib/components/event-series/admin/GenerateNowButton.svelte
@@ -3,9 +3,8 @@
 	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
 	import { Dialog, DialogContent, DialogHeader, DialogTitle } from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
-	import { Label } from '$lib/components/ui/label';
 	import { Loader2, RefreshCw } from 'lucide-svelte';
+	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
 	import { toast } from 'svelte-sonner';
 	import { organizationadminrecurringeventsGenerateEvents } from '$lib/api/generated/sdk.gen';
 	import type {
@@ -29,10 +28,9 @@
 
 	const queryClient = useQueryClient();
 
-	// `<input type="datetime-local">` stores a naive "YYYY-MM-DDTHH:mm" string.
-	// We convert to a full ISO stamp (browser tz → UTC) at submit time; an empty
-	// string means "use the series' default generation window" and is sent as
-	// no body (the SDK treats `body: null | undefined` as a no-op override).
+	// `DateTimePicker` stores and emits ISO 8601; an empty string means "use the
+	// series' default generation window" and is sent as no body (the SDK treats
+	// `body: null | undefined` as a no-op override).
 	let untilLocal = $state<string>('');
 	let errorBanner = $state<string | null>(null);
 
@@ -62,7 +60,7 @@
 	const generateMutation = createMutation(() => ({
 		mutationFn: async (): Promise<EventDetailSchema[]> => {
 			if (!accessToken) throw new Error('Not authenticated');
-			const body = untilLocal.trim() ? { until: new Date(untilLocal).toISOString() } : null;
+			const body = untilLocal.trim() ? { until: untilLocal } : null;
 			const response = await organizationadminrecurringeventsGenerateEvents({
 				path: { slug: organizationSlug, series_id: series.id },
 				body,
@@ -138,15 +136,11 @@
 		</p>
 
 		<div class="mt-4 space-y-2">
-			<Label for="generate-now-until">
-				{m['recurringEvents.generateNow.untilLabel']()}
-			</Label>
-			<Input
+			<DateTimePicker
 				id="generate-now-until"
-				type="datetime-local"
 				bind:value={untilLocal}
+				label={m['recurringEvents.generateNow.untilLabel']()}
 				disabled={generateMutation.isPending}
-				data-testid="generate-now-until"
 			/>
 			<p class="text-xs text-muted-foreground">
 				{m['recurringEvents.generateNow.untilHelper']({

--- a/src/lib/components/event-series/admin/RecurrencePicker.svelte
+++ b/src/lib/components/event-series/admin/RecurrencePicker.svelte
@@ -4,6 +4,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group';
 	import { cn } from '$lib/utils/cn';
+	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
 	import {
 		FREQUENCIES,
 		WEEKDAYS,
@@ -182,25 +183,21 @@
 
 	const MONTHLY_TYPES = ['day', 'weekday'] as const satisfies readonly MonthlyType[];
 
-	function handleUntilInput(event: Event): void {
-		const raw = (event.target as HTMLInputElement).value;
-		patch({ until: raw ? new Date(raw).toISOString() : null });
+	// ISO state for the until DateTimePicker. Kept in sync with rule.until so
+	// editing an existing rule pre-populates the field.
+	let untilValue = $state('');
+
+	$effect(() => {
+		untilValue = rule.until ?? '';
+	});
+
+	function handleUntilChange(value: string): void {
+		patch({ until: value || null });
 	}
 
 	function handleCountInput(event: Event): void {
 		const raw = (event.target as HTMLInputElement).value;
 		patch({ count: raw ? Math.max(1, Math.floor(Number(raw))) : null });
-	}
-
-	const untilForInput = $derived(rule.until ? toDatetimeLocalValue(rule.until) : '');
-
-	function toDatetimeLocalValue(iso: string): string {
-		const d = new Date(iso);
-		if (Number.isNaN(d.getTime())) return '';
-		const pad = (n: number) => n.toString().padStart(2, '0');
-		return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
-			d.getHours()
-		)}:${pad(d.getMinutes())}`;
 	}
 
 	function frequencyLabel(f: Frequency): string {
@@ -500,12 +497,11 @@
 					<Label for="boundary-until">{m['recurringEvents.picker.boundary.until']()}</Label>
 				</div>
 				{#if selectedBoundary === 'until'}
-					<Input
-						type="datetime-local"
-						value={untilForInput}
-						oninput={handleUntilInput}
+					<DateTimePicker
+						bind:value={untilValue}
+						label={m['recurringEvents.picker.untilLabel']()}
+						onValueChange={handleUntilChange}
 						class="sm:w-72"
-						aria-label={m['recurringEvents.picker.untilLabel']()}
 					/>
 				{/if}
 			</div>

--- a/src/lib/components/events/admin/AdmissionScreeningSection.svelte
+++ b/src/lib/components/events/admin/AdmissionScreeningSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import { formatDateTimeReadback } from '$lib/utils/date';
 	import { ShieldCheck, ChevronDown, ChevronRight } from 'lucide-svelte';
 	import EventQuestionnaires from './EventQuestionnaires.svelte';
 	import type { EventCreateSchema } from '$lib/api/generated/types.gen';
@@ -34,6 +35,8 @@
 		questionnaires = [],
 		onAssignQuestionnaire
 	}: Props = $props();
+
+	const applyBeforeReadback = $derived(formatDateTimeReadback(formData.apply_before));
 </script>
 
 <!-- Admission & Screening Section -->
@@ -131,6 +134,11 @@
 					}) ??
 						`Deadline for submitting invitation requests or questionnaires. Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`}
 				</p>
+				{#if applyBeforeReadback}
+					<p class="text-xs text-muted-foreground">
+						{m['dateTimePicker.selectedDate']({ value: applyBeforeReadback })}
+					</p>
+				{/if}
 			</div>
 		</div>
 	{/if}

--- a/src/lib/components/events/admin/DuplicateEventModal.svelte
+++ b/src/lib/components/events/admin/DuplicateEventModal.svelte
@@ -8,6 +8,7 @@
 	import { goto } from '$app/navigation';
 	import { Copy, Loader2 } from 'lucide-svelte';
 	import { cn } from '$lib/utils/cn';
+	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
 
 	interface Props {
 		open: boolean;
@@ -39,10 +40,10 @@
 		if (open) {
 			// Suggest name with "Copy of" prefix
 			newName = m['duplicateEventModal.copyOf']({ name: eventName });
-			// Default to current date/time in local format
+			// Default to current date/time + 1 hour as ISO
 			const now = new Date();
 			now.setMinutes(now.getMinutes() + 60); // Add 1 hour
-			newStart = now.toISOString().slice(0, 16);
+			newStart = now.toISOString();
 			errorMessage = null;
 		}
 	});
@@ -56,7 +57,7 @@
 				path: { event_id: eventId },
 				body: {
 					name: newName.trim(),
-					start: new Date(newStart).toISOString()
+					start: newStart
 				},
 				headers: {
 					Authorization: `Bearer ${accessToken}`
@@ -154,18 +155,11 @@
 
 			<!-- New Start Date -->
 			<div class="space-y-2">
-				<label for="duplicate-start" class="block text-sm font-medium">
-					{m['duplicateEventModal.newStart']()} <span class="text-destructive">*</span>
-				</label>
-				<input
-					id="duplicate-start"
-					type="datetime-local"
+				<DateTimePicker
 					bind:value={newStart}
+					label={m['duplicateEventModal.newStart']()}
 					required
 					disabled={duplicateMutation.isPending}
-					class={cn(
-						'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
-					)}
 				/>
 				<p class="text-xs text-muted-foreground">
 					{m['duplicateEventModal.startHint']()}

--- a/src/lib/components/events/admin/ScheduleEditor.svelte
+++ b/src/lib/components/events/admin/ScheduleEditor.svelte
@@ -7,6 +7,7 @@
 	import MarkdownEditor from '$lib/components/forms/MarkdownEditor.svelte';
 	import { CalendarClock, Plus, Trash2, AlertTriangle } from 'lucide-svelte';
 	import { emptyRow, rowCompleteness, startsBeforeAnchor, type ScheduleRow } from './schedule-rows';
+	import { formatDateTimeReadback } from '$lib/utils/date';
 
 	interface Props {
 		/** Editor rows, owned by the parent (bindable). */
@@ -55,6 +56,7 @@
 				{@const titleInvalid = completeness === 'invalid' && !row.title.trim()}
 				{@const startMissing = completeness === 'invalid' && !row.startLocal}
 				{@const startBefore = startsBeforeAnchor(row, eventStart)}
+				{@const startReadback = formatDateTimeReadback(row.startLocal)}
 				<li class="space-y-3 rounded-lg border bg-muted/30 p-4">
 					<div class="flex items-center justify-between">
 						<span class="text-xs font-medium text-muted-foreground">
@@ -131,6 +133,11 @@
 								>
 									<AlertTriangle class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
 									{m['eventScheduleAdmin.beforeStartWarning']()}
+								</p>
+							{/if}
+							{#if startReadback && !startMissing}
+								<p class="mt-1 text-xs text-muted-foreground">
+									{m['dateTimePicker.selectedDate']({ value: startReadback })}
 								</p>
 							{/if}
 						</div>

--- a/src/lib/components/events/waitlist/WaitlistSettingsModal.svelte
+++ b/src/lib/components/events/waitlist/WaitlistSettingsModal.svelte
@@ -233,7 +233,9 @@
 
 			<div class="space-y-1.5">
 				<div class="flex items-center gap-2">
-					<span class="text-sm font-medium">{m['waitlistSettings.cutoffDate.label']()}</span>
+					<label for="waitlist-cutoff-date" class="text-sm font-medium"
+						>{m['waitlistSettings.cutoffDate.label']()}</label
+					>
 					<button
 						type="button"
 						aria-pressed={!cutoffLocal}
@@ -245,7 +247,11 @@
 						{m['waitlistSettings.notSet']()}
 					</button>
 				</div>
-				<DateTimePicker bind:value={cutoffLocal} error={fieldErrors.waitlist_cutoff_date} />
+				<DateTimePicker
+					id="waitlist-cutoff-date"
+					bind:value={cutoffLocal}
+					error={fieldErrors.waitlist_cutoff_date}
+				/>
 				<p class="text-xs text-muted-foreground">{m['waitlistSettings.cutoffDate.helper']()}</p>
 			</div>
 

--- a/src/lib/components/events/waitlist/WaitlistSettingsModal.svelte
+++ b/src/lib/components/events/waitlist/WaitlistSettingsModal.svelte
@@ -14,6 +14,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import DurationInput from '$lib/components/forms/DurationInput.svelte';
+	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
 	import type {
 		WaitlistSettingsSchema,
 		WaitlistSettingsUpdateSchema
@@ -69,27 +70,11 @@
 		return out === 'P' ? null : out;
 	}
 
-	// datetime-local <input> consumes/produces "YYYY-MM-DDTHH:mm" strings; we
-	// round-trip with the backend's ISO timestamp.
-	function isoDateTimeToLocalInput(iso: string | null | undefined): string {
-		if (!iso) return '';
-		const d = new Date(iso);
-		if (isNaN(d.getTime())) return '';
-		const pad = (n: number) => n.toString().padStart(2, '0');
-		return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-	}
-
-	function localInputToIso(local: string): string | null {
-		if (!local) return null;
-		const d = new Date(local);
-		return isNaN(d.getTime()) ? null : d.toISOString();
-	}
-
 	let timeWindowMinutes = $state<number | null>(
 		isoToMinutes(initialValues?.waitlist_time_window ?? null)
 	);
 	let batchSize = $state<number>(initialValues?.waitlist_batch_size ?? 0);
-	let cutoffLocal = $state<string>(isoDateTimeToLocalInput(initialValues?.waitlist_cutoff_date));
+	let cutoffLocal = $state<string>(initialValues?.waitlist_cutoff_date ?? '');
 	let lotteryMode = $state<boolean>(initialValues?.waitlist_lottery_mode ?? false);
 
 	let fieldErrors = $state<Record<string, string>>({});
@@ -128,7 +113,7 @@
 		if (!data) return;
 		timeWindowMinutes = isoToMinutes(data.waitlist_time_window ?? null);
 		batchSize = data.waitlist_batch_size ?? 0;
-		cutoffLocal = isoDateTimeToLocalInput(data.waitlist_cutoff_date);
+		cutoffLocal = data.waitlist_cutoff_date ?? '';
 		lotteryMode = data.waitlist_lottery_mode ?? false;
 		hasHydrated = true;
 	});
@@ -137,7 +122,7 @@
 		return {
 			waitlist_time_window: minutesToIso(timeWindowMinutes),
 			waitlist_batch_size: Number.isFinite(batchSize) ? Math.max(0, Math.floor(batchSize)) : 0,
-			waitlist_cutoff_date: localInputToIso(cutoffLocal),
+			waitlist_cutoff_date: cutoffLocal || null,
 			waitlist_lottery_mode: lotteryMode
 		};
 	}
@@ -248,7 +233,7 @@
 
 			<div class="space-y-1.5">
 				<div class="flex items-center gap-2">
-					<Label for="waitlist-cutoff-date">{m['waitlistSettings.cutoffDate.label']()}</Label>
+					<span class="text-sm font-medium">{m['waitlistSettings.cutoffDate.label']()}</span>
 					<button
 						type="button"
 						aria-pressed={!cutoffLocal}
@@ -260,11 +245,8 @@
 						{m['waitlistSettings.notSet']()}
 					</button>
 				</div>
-				<Input id="waitlist-cutoff-date" type="datetime-local" bind:value={cutoffLocal} />
+				<DateTimePicker bind:value={cutoffLocal} error={fieldErrors.waitlist_cutoff_date} />
 				<p class="text-xs text-muted-foreground">{m['waitlistSettings.cutoffDate.helper']()}</p>
-				{#if fieldErrors.waitlist_cutoff_date}
-					<p class="text-xs text-destructive">{fieldErrors.waitlist_cutoff_date}</p>
-				{/if}
 			</div>
 
 			<div class="space-y-1.5">

--- a/src/lib/components/members/RecordPaymentModal.svelte
+++ b/src/lib/components/members/RecordPaymentModal.svelte
@@ -8,6 +8,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Loader2 } from 'lucide-svelte';
 	import { CURRENCY_OPTIONS } from '$lib/utils/currencies';
+	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
 
 	interface Props {
 		subscription: SubscriptionSchema;
@@ -46,8 +47,7 @@
 			notes
 		};
 		if (occurredAt) {
-			// datetime-local gives us "YYYY-MM-DDTHH:mm"; backend expects ISO8601
-			payload.occurred_at = new Date(occurredAt).toISOString();
+			payload.occurred_at = occurredAt;
 		}
 		onSubmit(payload);
 	}
@@ -108,10 +108,11 @@
 			</div>
 
 			<div class="space-y-1">
-				<Label for="rp-occurred">
-					{m['orgAdmin.members.subscriptions.recordPayment.occurredAt']()}
-				</Label>
-				<Input id="rp-occurred" type="datetime-local" bind:value={occurredAt} />
+				<DateTimePicker
+					id="rp-occurred"
+					bind:value={occurredAt}
+					label={m['orgAdmin.members.subscriptions.recordPayment.occurredAt']()}
+				/>
 				<p class="text-xs text-muted-foreground">
 					{m['orgAdmin.members.subscriptions.recordPayment.occurredAtHint']()}
 				</p>

--- a/src/lib/components/polls/PollReopenDialog.svelte
+++ b/src/lib/components/polls/PollReopenDialog.svelte
@@ -9,8 +9,7 @@
 		DialogTitle
 	} from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
-	import { Label } from '$lib/components/ui/label';
+	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
 
 	interface Props {
 		open: boolean;
@@ -47,11 +46,10 @@
 		</DialogHeader>
 		<div class="space-y-3">
 			<div class="space-y-2">
-				<Label for="reopen-closes-at">{m['pollReopenDialog.closesAtLabel']()}</Label>
-				<Input
+				<DateTimePicker
 					id="reopen-closes-at"
-					type="datetime-local"
 					bind:value={closesAt}
+					label={m['pollReopenDialog.closesAtLabel']()}
 					disabled={clearClosesAt}
 				/>
 			</div>
@@ -63,11 +61,7 @@
 		<DialogFooter>
 			<Button variant="outline" onclick={onCancel}>{m['pollReopenDialog.cancel']()}</Button>
 			<Button
-				onclick={() =>
-					onConfirm(
-						clearClosesAt ? null : closesAt ? new Date(closesAt).toISOString() : null,
-						clearClosesAt
-					)}
+				onclick={() => onConfirm(clearClosesAt ? null : closesAt || null, clearClosesAt)}
 				disabled={submitting || !canSubmit}
 			>
 				{m['pollReopenDialog.confirm']()}

--- a/src/lib/components/polls/PollScheduleCard.svelte
+++ b/src/lib/components/polls/PollScheduleCard.svelte
@@ -16,21 +16,9 @@
 
 	let { closesAt = $bindable(), error = null }: Props = $props();
 
-	// Bridge: DateTimePicker stores '' for empty; this component's public API uses null.
-	// We keep a local string state and sync bidirectionally with the parent's nullable value.
-	let pickerValue = $state(closesAt ?? '');
-
-	// Picker → parent: propagate user's selection up as ISO or null.
-	$effect(() => {
-		const next = pickerValue === '' ? null : pickerValue;
-		if (closesAt !== next) closesAt = next;
-	});
-
-	// Parent → picker: propagate external resets (e.g. post-save re-sync) down.
-	$effect(() => {
-		const expected = closesAt ?? '';
-		if (pickerValue !== expected) pickerValue = expected;
-	});
+	// DateTimePicker stores '' for empty; this component's public API uses null.
+	// Controlled-input pattern: closesAt is the single source of truth — read it
+	// into the picker, map the picker's '' back to null on change.
 </script>
 
 <Card>
@@ -40,9 +28,10 @@
 	</CardHeader>
 	<CardContent class="space-y-2">
 		<DateTimePicker
-			bind:value={pickerValue}
+			value={closesAt ?? ''}
 			label={m['pollNewPage.closesAtLabel']()}
 			error={error ?? undefined}
+			onValueChange={(v) => (closesAt = v === '' ? null : v)}
 		/>
 	</CardContent>
 </Card>

--- a/src/lib/components/polls/PollScheduleCard.svelte
+++ b/src/lib/components/polls/PollScheduleCard.svelte
@@ -7,8 +7,7 @@
 		CardHeader,
 		CardTitle
 	} from '$lib/components/ui/card';
-	import { Label } from '$lib/components/ui/label';
-	import { Input } from '$lib/components/ui/input';
+	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
 
 	interface Props {
 		closesAt: string | null;
@@ -16,6 +15,22 @@
 	}
 
 	let { closesAt = $bindable(), error = null }: Props = $props();
+
+	// Bridge: DateTimePicker stores '' for empty; this component's public API uses null.
+	// We keep a local string state and sync bidirectionally with the parent's nullable value.
+	let pickerValue = $state(closesAt ?? '');
+
+	// Picker → parent: propagate user's selection up as ISO or null.
+	$effect(() => {
+		const next = pickerValue === '' ? null : pickerValue;
+		if (closesAt !== next) closesAt = next;
+	});
+
+	// Parent → picker: propagate external resets (e.g. post-save re-sync) down.
+	$effect(() => {
+		const expected = closesAt ?? '';
+		if (pickerValue !== expected) pickerValue = expected;
+	});
 </script>
 
 <Card>
@@ -24,21 +39,10 @@
 		<CardDescription>{m['pollNewPage.scheduleDescription']()}</CardDescription>
 	</CardHeader>
 	<CardContent class="space-y-2">
-		<Label for="closes-at">{m['pollNewPage.closesAtLabel']()}</Label>
-		<Input
-			id="closes-at"
-			type="datetime-local"
-			value={closesAt ?? ''}
-			oninput={(e) => {
-				const v = (e.currentTarget as HTMLInputElement).value;
-				closesAt = v === '' ? null : v;
-			}}
-			class={error ? 'border-destructive' : ''}
-			aria-invalid={error ? true : undefined}
-			aria-describedby={error ? 'closes-at-error' : undefined}
+		<DateTimePicker
+			bind:value={pickerValue}
+			label={m['pollNewPage.closesAtLabel']()}
+			error={error ?? undefined}
 		/>
-		{#if error}
-			<p id="closes-at-error" class="text-sm text-destructive">{error}</p>
-		{/if}
 	</CardContent>
 </Card>

--- a/src/lib/components/tokens/OrganizationTokenModal.svelte
+++ b/src/lib/components/tokens/OrganizationTokenModal.svelte
@@ -21,7 +21,7 @@
 	import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group';
 	import { AlertCircle, Loader2 } from 'lucide-svelte';
 	import { durationOptions } from '$lib/utils/tokens';
-	import { toDateTimeLocal, toISOString } from '$lib/utils/datetime';
+	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
 
 	interface Props {
 		open: boolean;
@@ -65,7 +65,7 @@
 				grantsMembership = token.grants_membership ?? false;
 				grantsStaffStatus = token.grants_staff_status ?? false;
 				membershipTierId = token.membership_tier || '';
-				expiresAt = toDateTimeLocal(token.expires_at);
+				expiresAt = token.expires_at ?? '';
 				duration = '1440'; // Not used in edit mode
 			} else {
 				// Reset to defaults for create
@@ -87,7 +87,7 @@
 			const updateData: OrganizationTokenUpdateSchema = {
 				name: name || null,
 				max_uses: maxUses,
-				expires_at: toISOString(expiresAt),
+				expires_at: expiresAt || null,
 				grants_membership: grantsMembership,
 				grants_staff_status: grantsStaffStatus,
 				membership_tier_id: grantsMembership && membershipTierId ? membershipTierId : null
@@ -175,8 +175,10 @@
 			{:else}
 				<!-- Expires At (edit only) -->
 				<div class="space-y-2">
-					<Label for="expires-at">{m['organizationTokenModal.expirationDate']()}</Label>
-					<Input id="expires-at" type="datetime-local" bind:value={expiresAt} />
+					<DateTimePicker
+						bind:value={expiresAt}
+						label={m['organizationTokenModal.expirationDate']()}
+					/>
 					<p class="text-xs text-muted-foreground">{m['organizationTokenModal.noExpiration']()}</p>
 				</div>
 			{/if}

--- a/src/lib/components/tokens/OrganizationTokenModal.svelte
+++ b/src/lib/components/tokens/OrganizationTokenModal.svelte
@@ -176,6 +176,7 @@
 				<!-- Expires At (edit only) -->
 				<div class="space-y-2">
 					<DateTimePicker
+						id="org-token-expires-at"
 						bind:value={expiresAt}
 						label={m['organizationTokenModal.expirationDate']()}
 					/>

--- a/src/routes/(auth)/org/[slug]/admin/polls/[id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/polls/[id]/+page.svelte
@@ -27,7 +27,6 @@
 	import SectionEditor from '$lib/components/questionnaires/SectionEditor.svelte';
 	import { pollPatchPoll, pollDeletePollAction } from '$lib/api/generated/sdk.gen';
 	import { buildPollVoterUrl, isPollDraft, validateClosesAt } from '$lib/utils/polls';
-	import { toDateTimeLocal, toISOString } from '$lib/utils/datetime';
 	import { initializeFromApiData } from '$lib/utils/questionnaire-api-converters';
 	import {
 		addTopLevelQuestion as _addTopLevelQuestion,
@@ -69,10 +68,8 @@
 	let staffAnonymous = $state(poll.staff_anonymous);
 	let publicAnonymous = $state(poll.public_anonymous);
 	let allowVoteChanges = $state(poll.allow_vote_changes);
-	// Seed the datetime-local input in the user's local timezone (not UTC) so the
-	// field shows the same wall-clock time the backend stored. `toDateTimeLocal`
-	// pairs with `toISOString` on save to round-trip without timezone drift.
-	let closesAt = $state<string | null>(poll.closes_at ? toDateTimeLocal(poll.closes_at) : null);
+	// DateTimePicker stores ISO; pass the backend value directly (no conversion needed).
+	let closesAt = $state<string | null>(poll.closes_at ?? null);
 	let closesAtError = $state<string | null>(null);
 	let saving = $state(false);
 	let deleting = $state(false);
@@ -186,7 +183,7 @@
 					result_membership_tier_ids: resultTierIds,
 					result_timing: resultTiming,
 					allow_vote_changes: allowVoteChanges,
-					closes_at: toISOString(closesAt)
+					closes_at: closesAt || null
 				}
 			});
 			if (res.error) throw new Error('patch');
@@ -224,7 +221,7 @@
 			staffAnonymous = poll.staff_anonymous;
 			publicAnonymous = poll.public_anonymous;
 			allowVoteChanges = poll.allow_vote_changes;
-			closesAt = poll.closes_at ? toDateTimeLocal(poll.closes_at) : null;
+			closesAt = poll.closes_at ?? null;
 
 			// Re-derive editor state from the freshly loaded poll so newly-created
 			// question/option IDs are tracked for the next incremental save.

--- a/src/routes/(auth)/org/[slug]/admin/polls/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/polls/new/+page.svelte
@@ -50,7 +50,6 @@
 		parseValidationErrors
 	} from '$lib/utils/questionnaire-form-helpers';
 	import { validateClosesAt } from '$lib/utils/polls';
-	import { toISOString } from '$lib/utils/datetime';
 
 	interface Props {
 		data: PageData;
@@ -191,7 +190,7 @@
 					staff_anonymous: staffAnonymous,
 					public_anonymous: publicAnonymous,
 					allow_vote_changes: allowVoteChanges,
-					closes_at: toISOString(closesAt),
+					closes_at: closesAt || null,
 					sections: buildCreateApiSections(sections) as SectionCreateSchema[],
 					multiplechoicequestion_questions: topLevelQuestions
 						.filter((q) => q.type === 'multiple_choice')


### PR DESCRIPTION
Closes #509.

Follow-up to #508. Makes the long-tail native `datetime-local` inputs unambiguous by migrating them onto the shared `DateTimePicker` wrapper (stores/emits **ISO 8601**, renders the textual readback added in #508). Where an input's datetime-local value is structurally entangled with a parent/serializer, a **readback-line** (the #508 pattern) is used instead — same UX benefit, zero data-contract risk.

## Migrated to the wrapper (state now ISO; conversion dropped; nullable `'' → null`)
- **Self-contained modals:** `DuplicateEventModal`, `GenerateNowButton`, `PollReopenDialog`, `RecordPaymentModal`.
- **Helper-conversion modals:** `WaitlistSettingsModal`, `OrganizationTokenModal` (dead converters removed).
- **`RecurrencePicker`** `until` field (re-seeds from the rule; verified loop-free).
- **`PollScheduleCard`** close-time + its two route consumers (`polls/new`, `polls/[id]`) updated to pass ISO; card uses a controlled-input pattern.

## Readback-line instead of swap (data contract kept)
- **`ScheduleEditor`** — `schedule-rows.ts` computes millisecond offsets requiring the row + anchor to share the datetime-local wall-clock frame; swapping would corrupt the schedule round-trip. Serializer untouched; per-row readback added.
- **`AdmissionScreeningSection`** — `apply_before` lives in the parent `EventEditor` `formData` (same contract as the #508 event-critical inputs).

## Intentional UX deltas (please note in review)
- `RecurrencePicker` `until` now shows a **visible "End date" label** (was `aria-label` only) — an a11y improvement.
- `GenerateNowButton` dropped a `data-testid` the wrapper doesn't forward — confirmed **no test references it** (the `id` remains for label association).

## Out of scope (intentional)
- `NotificationPreferencesForm` `<input type="time">` (`HH:mm`) — time has no DD/MM ambiguity.
- Display-date `toLocale*` calls — tracked in #510.

## Testing
- `svelte-check` **0 errors**; prettier clean; **0 new lint warnings**; test suite at the pre-existing svelte-query baseline (no new failures).
- Built via subagent-driven development: per-task spec+quality review + an Opus whole-branch review (verdict: ready to merge).
- ⚠️ **These components lack unit tests — please manually smoke each migrated flow** before merge: duplicate event, generate-now, poll reopen, poll new + edit (close time), record payment, waitlist cutoff (incl. the "Not set" pill), org-token expiry edit, recurrence `until`, and the two readback surfaces (schedule editor row, admission-screening deadline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced multiple native `datetime-local` inputs with a consistent DateTimePicker across admin flows.
  * Added clearer date/time readbacks in scheduling editors and displays selected application deadlines in a formatted way.
* **Bug Fixes**
  * Improved date/time submission and persistence by passing picker values directly (ISO-compatible) instead of manual timezone conversions.
  * Better preserved cleared/empty date fields by sending `null` (or omitting overrides) rather than forcing conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->