### PR TITLE
refactor(i18n): route all dates through date.ts helpers + ESLint guardrail (#510)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,7 +641,9 @@ lib/components/
 - **Do not call `toLocaleDateString` / `toLocaleString` / `toLocaleTimeString` or
   `new Intl.DateTimeFormat(...).format()` directly** in components/routes — add a helper to
   `date.ts` instead. (`Intl.DateTimeFormat().resolvedOptions().timeZone` for timezone *detection*
-  is fine.) A repo-wide migration + ESLint guardrail enforcing this is tracked in #510.
+  is fine.) **ESLint actively bans `toLocaleDateString`, `toLocaleTimeString`, and `toLocaleString`
+  everywhere except `src/lib/utils/date.ts` and `src/lib/utils/calendar.ts`** (guardrail landed
+  in #510; `resolvedOptions()` for tz detection is not affected).
 - **Machine/ISO formats stay numeric** — `<input>` values, `datetime` attributes, API payloads,
   and structured data (schema.org) use ISO 8601, not localized strings.
 - For native `<input type="datetime-local">`, show `formatDateTimeReadback(value)` underneath as an

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,8 +50,21 @@ export default [
 			'no-useless-escape': 'warn',
 			'svelte/no-at-html-tags': 'warn',
 			'svelte/no-unused-svelte-ignore': 'warn',
-			'svelte/valid-compile': 'off' // Disable custom element warnings
+			'svelte/valid-compile': 'off', // Disable custom element warnings
+			'no-restricted-syntax': [
+				'error',
+				{
+					selector:
+						'CallExpression[callee.property.name=/^(toLocaleDateString|toLocaleTimeString|toLocaleString)$/]',
+					message:
+						'Do not format dates with toLocale* directly. Use a helper from $lib/utils/date.ts (or calendar.ts) so dates follow the UI language with textual months. See CLAUDE.md "Date & Time Formatting".'
+				}
+			]
 		}
+	},
+	{
+		files: ['src/lib/utils/date.ts', 'src/lib/utils/calendar.ts'],
+		rules: { 'no-restricted-syntax': 'off' }
 	},
 	{
 		ignores: [

--- a/src/lib/components/account/MembershipCard.svelte
+++ b/src/lib/components/account/MembershipCard.svelte
@@ -6,6 +6,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import StatusBadge from '$lib/components/members/StatusBadge.svelte';
 	import { formatPlanPrice, getDateLine } from '$lib/utils/subscriptions';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		membership: MyMembershipSchema;
@@ -16,7 +17,7 @@
 	const line = $derived(sub ? getDateLine(sub) : null);
 
 	function fmtDate(d: string | null | undefined): string {
-		return d ? new Date(d).toLocaleDateString() : '—';
+		return d ? formatDate(d) : '—';
 	}
 </script>
 

--- a/src/lib/components/account/OrgMembershipInline.svelte
+++ b/src/lib/components/account/OrgMembershipInline.svelte
@@ -7,6 +7,7 @@
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import StatusBadge from '$lib/components/members/StatusBadge.svelte';
 	import { formatPlanPrice, getDateLine } from '$lib/utils/subscriptions';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		orgId: string;
@@ -33,7 +34,7 @@
 	const sub = $derived(subQuery.data);
 
 	function fmtDate(d: string | null | undefined): string {
-		return d ? new Date(d).toLocaleDateString() : '—';
+		return d ? formatDate(d) : '—';
 	}
 </script>
 

--- a/src/lib/components/calendar/CalendarWeekView.svelte
+++ b/src/lib/components/calendar/CalendarWeekView.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
 	import type { EventInListSchema } from '$lib/api/generated/types.gen';
-	import { formatCalendarDate, getEventsForDay, isToday } from '$lib/utils/calendar';
+	import {
+		formatCalendarDate,
+		getEventsForDay,
+		isToday,
+		formatWeekdayShort
+	} from '$lib/utils/calendar';
+	import { formatTimeOfDay } from '$lib/utils/date';
 	import { Clock, MapPin, Loader2 } from 'lucide-svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -23,12 +29,7 @@
 	}
 
 	function formatEventTime(dateString: string): string {
-		const date = new Date(dateString);
-		return date.toLocaleTimeString(undefined, {
-			hour: 'numeric',
-			minute: '2-digit',
-			hour12: true
-		});
+		return formatTimeOfDay(dateString);
 	}
 </script>
 
@@ -48,7 +49,7 @@
 					<div class="week-day-header">
 						<div class="week-day-date">
 							<span class="week-day-weekday">
-								{day.toLocaleDateString(undefined, { weekday: 'short' })}
+								{formatWeekdayShort(day)}
 							</span>
 							<span class="week-day-number" class:week-day-number--today={isTodayDate}>
 								{formatCalendarDate(day, 'short')}

--- a/src/lib/components/calendar/EventModal.svelte
+++ b/src/lib/components/calendar/EventModal.svelte
@@ -4,7 +4,7 @@
 	import { Dialog, DialogContent, DialogHeader, DialogTitle } from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import { Calendar, Clock, MapPin, Building2, X } from 'lucide-svelte';
-	import { formatDate } from '$lib/utils/date';
+	import { formatDate, formatTimeOfDay } from '$lib/utils/date';
 	import { getImageUrl } from '$lib/utils/url';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -38,12 +38,7 @@
 	}
 
 	function formatTime(dateString: string): string {
-		const date = new Date(dateString);
-		return date.toLocaleTimeString(undefined, {
-			hour: 'numeric',
-			minute: '2-digit',
-			hour12: true
-		});
+		return formatTimeOfDay(dateString);
 	}
 </script>
 

--- a/src/lib/components/common/DemoBanner.svelte
+++ b/src/lib/components/common/DemoBanner.svelte
@@ -16,12 +16,15 @@
 		tomorrow.setDate(tomorrow.getDate() + 1);
 
 		// Create midnight CET time (00:00 in Europe/Paris)
+		// eslint-disable-next-line no-restricted-syntax -- timezone conversion, not display formatting
 		const midnightCET = new Date(tomorrow.toLocaleString('en-US', { timeZone: 'Europe/Paris' }));
 		midnightCET.setHours(0, 0, 0, 0);
 
 		// Convert to user's timezone
+		// eslint-disable-next-line no-restricted-syntax -- timezone conversion, not display formatting
 		const userTime = new Date(midnightCET.toLocaleString('en-US', { timeZone: userTimezone }));
 
+		// eslint-disable-next-line no-restricted-syntax -- fixed-locale demo countdown
 		return userTime.toLocaleTimeString('en-US', {
 			hour: '2-digit',
 			minute: '2-digit',

--- a/src/lib/components/discount-codes/ScopeAssignment.svelte
+++ b/src/lib/components/discount-codes/ScopeAssignment.svelte
@@ -13,6 +13,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { Check, Search, ChevronDown } from 'lucide-svelte';
 	import { cn } from '$lib/utils/cn';
+	import { formatDate } from '$lib/utils/date';
 	import * as m from '$lib/paraglide/messages.js';
 
 	interface Props {
@@ -400,11 +401,7 @@
 											<p class="truncate">{event.name}</p>
 											{#if event.start}
 												<p class="text-xs text-muted-foreground">
-													{new Date(event.start).toLocaleDateString('en-US', {
-														year: 'numeric',
-														month: 'short',
-														day: 'numeric'
-													})}
+													{formatDate(event.start)}
 												</p>
 											{/if}
 										</div>

--- a/src/lib/components/events/EligibilityStatusDisplay.svelte
+++ b/src/lib/components/events/EligibilityStatusDisplay.svelte
@@ -23,6 +23,7 @@
 		UserCircle
 	} from 'lucide-svelte';
 	import { cn } from '$lib/utils/cn';
+	import { formatDateLongMonth } from '$lib/utils/date';
 	import IneligibilityActionButton from './IneligibilityActionButton.svelte';
 
 	interface Props {
@@ -90,12 +91,7 @@
 			return m['ineligibilityMessage.deadlineDaysLeft']?.({ days }) ?? `${days} days left to apply`;
 		}
 
-		return date.toLocaleDateString(undefined, {
-			month: 'long',
-			day: 'numeric',
-			year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-			...(timezone ? { timeZone: timezone } : {})
-		});
+		return formatDateLongMonth(deadline, timezone ?? undefined);
 	}
 
 	/**

--- a/src/lib/components/events/IneligibilityMessage.svelte
+++ b/src/lib/components/events/IneligibilityMessage.svelte
@@ -15,6 +15,7 @@
 		UserCircle
 	} from 'lucide-svelte';
 	import { getMissingProfileFieldLabel } from '$lib/utils/eligibility';
+	import { formatDateTime, formatDateLongMonth } from '$lib/utils/date';
 	import IneligibilityActionButton from './IneligibilityActionButton.svelte';
 	import RetryCountdown from './RetryCountdown.svelte';
 	import * as m from '$lib/paraglide/messages.js';
@@ -62,7 +63,7 @@
 	function formatTime(iso: string): string {
 		const date = new Date(iso);
 		if (isNaN(date.getTime())) return iso;
-		return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+		return formatDateTime(iso);
 	}
 
 	/**
@@ -96,11 +97,7 @@
 			return m['ineligibilityMessage.deadlineDaysLeft']?.({ days }) ?? `${days} days left to apply`;
 		}
 
-		return date.toLocaleDateString(undefined, {
-			month: 'long',
-			day: 'numeric',
-			year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
-		});
+		return formatDateLongMonth(deadline);
 	}
 
 	/**

--- a/src/lib/components/events/admin/TierCard.svelte
+++ b/src/lib/components/events/admin/TierCard.svelte
@@ -5,6 +5,7 @@
 	import { Card } from '$lib/components/ui/card';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import { Edit, Building2, LayoutGrid, Armchair, ChevronUp, ChevronDown } from 'lucide-svelte';
+	import { formatDateTime } from '$lib/utils/date';
 
 	interface Props {
 		tier: TicketTierDetailSchema;
@@ -56,14 +57,7 @@
 
 	function formatDate(dateString: string | null | undefined): string {
 		if (!dateString) return 'Not set';
-		const date = new Date(dateString);
-		return date.toLocaleString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-			hour: '2-digit',
-			minute: '2-digit'
-		});
+		return formatDateTime(dateString);
 	}
 
 	const priceDisplay = $derived(() => {

--- a/src/lib/components/events/waitlist/ActiveOfferBanner.svelte
+++ b/src/lib/components/events/waitlist/ActiveOfferBanner.svelte
@@ -4,6 +4,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils/cn';
 	import OfferExpiryCountdown from './OfferExpiryCountdown.svelte';
+	import { formatDateTime } from '$lib/utils/date';
 
 	interface Props {
 		expiresAt: string;
@@ -71,14 +72,7 @@
 	const livePoliteness = $derived<'assertive' | 'polite'>(isUrgent ? 'assertive' : 'polite');
 
 	const formattedExpiry = $derived(
-		Number.isFinite(targetMs)
-			? new Date(targetMs).toLocaleString(undefined, {
-					month: 'short',
-					day: 'numeric',
-					hour: 'numeric',
-					minute: '2-digit'
-				})
-			: ''
+		Number.isFinite(targetMs) ? formatDateTime(new Date(targetMs).toISOString()) : ''
 	);
 
 	function handleClaim() {

--- a/src/lib/components/invitations/InvitationCard.svelte
+++ b/src/lib/components/invitations/InvitationCard.svelte
@@ -4,7 +4,7 @@
 	import { Card } from '$lib/components/ui/card';
 	import { Calendar, MapPin, Ticket, CheckCircle2, ChevronDown, ChevronUp } from 'lucide-svelte';
 	import { getImageUrl } from '$lib/utils/url';
-	import { formatEventDateRange } from '$lib/utils/date';
+	import { formatEventDateRange, formatDate } from '$lib/utils/date';
 	import { getEventLogo, getEventLogoThumbnail } from '$lib/utils/event';
 
 	interface Props {
@@ -34,10 +34,7 @@
 	});
 
 	// Format created date
-	const createdDate = $derived.by(() => {
-		const date = new Date(invitation.created_at);
-		return date.toLocaleDateString();
-	});
+	const createdDate = $derived(formatDate(invitation.created_at));
 
 	// Get privileges granted by this invitation
 	const privileges = $derived.by(() => {

--- a/src/lib/components/invitations/InvitationRequestCard.svelte
+++ b/src/lib/components/invitations/InvitationRequestCard.svelte
@@ -4,7 +4,7 @@
 	import { Card } from '$lib/components/ui/card';
 	import { Calendar, MapPin, Ticket, Clock, CheckCircle2, XCircle, Loader2 } from 'lucide-svelte';
 	import { getImageUrl } from '$lib/utils/url';
-	import { formatEventDateRange } from '$lib/utils/date';
+	import { formatEventDateRange, formatDate } from '$lib/utils/date';
 	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
 	import { eventpublicdiscoveryDeleteInvitationRequest } from '$lib/api/generated/sdk.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -32,10 +32,7 @@
 	});
 
 	// Format created date
-	const createdDate = $derived.by(() => {
-		const date = new Date(request.created_at);
-		return date.toLocaleDateString();
-	});
+	const createdDate = $derived(formatDate(request.created_at));
 
 	// Status display
 	const statusDisplay = $derived.by(() => {

--- a/src/lib/components/members/CancelSubscriptionDialog.svelte
+++ b/src/lib/components/members/CancelSubscriptionDialog.svelte
@@ -7,6 +7,7 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Label } from '$lib/components/ui/label';
 	import { Loader2 } from 'lucide-svelte';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		subscription: SubscriptionSchema;
@@ -29,7 +30,7 @@
 	});
 
 	function fmtDate(d: string | null | undefined): string {
-		return d ? new Date(d).toLocaleDateString() : '—';
+		return d ? formatDate(d) : '—';
 	}
 
 	const canSubmit = $derived(mode === 'period_end' || immediateAck);

--- a/src/lib/components/members/PaymentsTable.svelte
+++ b/src/lib/components/members/PaymentsTable.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { PaymentSchema2 } from '$lib/api/generated/types.gen';
 	import { Button } from '$lib/components/ui/button';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		payments: PaymentSchema2[];
@@ -12,7 +13,7 @@
 
 	function fmtDate(d: string | null | undefined): string {
 		if (!d) return '—';
-		return new Date(d).toLocaleDateString();
+		return formatDate(d);
 	}
 </script>
 

--- a/src/lib/components/members/SubscriptionDrawer.svelte
+++ b/src/lib/components/members/SubscriptionDrawer.svelte
@@ -27,6 +27,7 @@
 	import CancelSubscriptionDialog from './CancelSubscriptionDialog.svelte';
 	import RefundPaymentDialog from './RefundPaymentDialog.svelte';
 	import { getAvailableActions, formatPlanPrice, getDateLine } from '$lib/utils/subscriptions';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -168,7 +169,7 @@
 	}));
 
 	function fmtDate(d: string | null | undefined): string {
-		return d ? new Date(d).toLocaleDateString() : '—';
+		return d ? formatDate(d) : '—';
 	}
 </script>
 

--- a/src/lib/components/members/SubscriptionListItem.svelte
+++ b/src/lib/components/members/SubscriptionListItem.svelte
@@ -3,6 +3,7 @@
 	import type { SubscriptionSchema } from '$lib/api/generated/types.gen';
 	import StatusBadge from './StatusBadge.svelte';
 	import { formatPlanPrice } from '$lib/utils/subscriptions';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		sub: SubscriptionSchema;
@@ -14,7 +15,7 @@
 
 	function fmtDate(d: string | null | undefined): string {
 		if (!d) return '—';
-		return new Date(d).toLocaleDateString();
+		return formatDate(d);
 	}
 </script>
 

--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -6,6 +6,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Circle, Check, X, Clock, Ticket } from 'lucide-svelte';
 	import { formatRelativeTime } from '$lib/utils/time';
+	import { formatDateTime } from '$lib/utils/date';
 	import { goto } from '$app/navigation';
 	import { createMutation } from '@tanstack/svelte-query';
 	import { toast } from 'svelte-sonner';
@@ -232,13 +233,7 @@
 		if (!timeText && expiresAt) {
 			const d = new Date(expiresAt);
 			if (!isNaN(d.getTime())) {
-				timeText = d.toLocaleString(undefined, {
-					month: 'short',
-					day: 'numeric',
-					year: 'numeric',
-					hour: 'numeric',
-					minute: '2-digit'
-				});
+				timeText = formatDateTime(expiresAt);
 			}
 		}
 

--- a/src/lib/components/polls/PollResultsView.svelte
+++ b/src/lib/components/polls/PollResultsView.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import McQuestionChart from '$lib/components/questionnaires/McQuestionChart.svelte';
 	import type { PollResultsSchema } from '$lib/api/generated/types.gen';
+	import { formatDateTime } from '$lib/utils/date';
 
 	interface Props {
 		results: PollResultsSchema;
@@ -78,7 +79,7 @@
 					<li class="rounded-md border bg-muted/30 p-3 text-sm">
 						<p class="whitespace-pre-wrap">{r.answer}</p>
 						<p class="mt-1 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
-							<span>{new Date(r.answered_at).toLocaleString()}</span>
+							<span>{formatDateTime(r.answered_at)}</span>
 							{#if !staffAnonymous && (r.user_display_name || r.user_email || r.user_id)}
 								{@render voterPill(r.user_display_name, r.user_email, r.user_id)}
 							{/if}

--- a/src/lib/components/polls/PollStatusBar.svelte
+++ b/src/lib/components/polls/PollStatusBar.svelte
@@ -13,6 +13,7 @@
 		pollReopenPollAction
 	} from '$lib/api/generated/sdk.gen';
 	import type { PollDetailSchema } from '$lib/api/generated/types.gen';
+	import { formatDateTime } from '$lib/utils/date';
 
 	interface Props {
 		poll: PollDetailSchema;
@@ -90,17 +91,17 @@
 			<PollStatusBadge status={poll.status} />
 			{#if poll.opened_at}
 				<span class="text-xs text-muted-foreground"
-					>{m['pollStatusBar.openedAt']({ at: new Date(poll.opened_at).toLocaleString() })}</span
+					>{m['pollStatusBar.openedAt']({ at: formatDateTime(poll.opened_at) })}</span
 				>
 			{/if}
 			{#if poll.closed_at}
 				<span class="text-xs text-muted-foreground"
-					>{m['pollStatusBar.closedAt']({ at: new Date(poll.closed_at).toLocaleString() })}</span
+					>{m['pollStatusBar.closedAt']({ at: formatDateTime(poll.closed_at) })}</span
 				>
 			{/if}
 			{#if poll.status === 'open' && poll.closes_at}
 				<span class="text-xs text-muted-foreground"
-					>{m['pollStatusBar.closesAt']({ at: new Date(poll.closes_at).toLocaleString() })}</span
+					>{m['pollStatusBar.closesAt']({ at: formatDateTime(poll.closes_at) })}</span
 				>
 			{/if}
 		</div>

--- a/src/lib/components/questionnaires/AutoEvalRecommendation.svelte
+++ b/src/lib/components/questionnaires/AutoEvalRecommendation.svelte
@@ -4,6 +4,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { AlertCircle, CheckCircle, XCircle, Sparkles } from 'lucide-svelte';
 	import { cn } from '$lib/utils/cn';
+	import { formatDateLongMonth } from '$lib/utils/date';
 	import type { EvaluationResponseSchema } from '$lib/api/generated';
 	import type { QuestionnaireEvaluationStatus } from '$lib/utils/questionnaire-types';
 
@@ -129,11 +130,7 @@
 					<p class="mt-1 text-sm text-muted-foreground">
 						{#if evaluation.created_at}
 							{m['autoEvalRecommendation.evaluatedManuallyOn']({
-								date: new Date(evaluation.created_at).toLocaleDateString('en-US', {
-									year: 'numeric',
-									month: 'long',
-									day: 'numeric'
-								})
+								date: formatDateLongMonth(evaluation.created_at)
 							})}
 						{:else}
 							{m['autoEvalRecommendation.evaluatedManually']()}

--- a/src/lib/components/resources/ResourceAssignment.svelte
+++ b/src/lib/components/resources/ResourceAssignment.svelte
@@ -6,6 +6,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { Check, Search } from 'lucide-svelte';
 	import { cn } from '$lib/utils/cn';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		organizationId: string;
@@ -173,11 +174,7 @@
 								</p>
 								{#if event.start}
 									<p class="text-xs text-muted-foreground">
-										{new Date(event.start).toLocaleDateString('en-US', {
-											year: 'numeric',
-											month: 'short',
-											day: 'numeric'
-										})}
+										{formatDate(event.start)}
 									</p>
 								{/if}
 							</div>

--- a/src/lib/components/rsvps/RSVPCard.svelte
+++ b/src/lib/components/rsvps/RSVPCard.svelte
@@ -4,7 +4,7 @@
 	import { Card } from '$lib/components/ui/card';
 	import { Calendar, MapPin, CheckCircle2, XCircle, HelpCircle } from 'lucide-svelte';
 	import { getImageUrl } from '$lib/utils/url';
-	import { formatEventDate, formatEventDateRange } from '$lib/utils/date';
+	import { formatDate, formatEventDate, formatEventDateRange } from '$lib/utils/date';
 	import {
 		getEventLogo,
 		getEventLogoThumbnail,
@@ -46,10 +46,7 @@
 	});
 
 	// Format created date
-	const createdDate = $derived.by(() => {
-		const date = new Date(rsvp.created_at);
-		return date.toLocaleDateString();
-	});
+	const createdDate = $derived(formatDate(rsvp.created_at));
 
 	// Get RSVP status info
 	const statusInfo = $derived.by(() => {

--- a/src/lib/components/tickets/CancelTicketDialog.svelte
+++ b/src/lib/components/tickets/CancelTicketDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+	import { formatDateTime } from '$lib/utils/date';
 	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import {
 		eventpublicticketsCancellationPreview,
@@ -152,15 +152,7 @@
 
 	function formatDeadline(iso: string | null | undefined): string {
 		if (!iso) return m['cancelTicket.deadlineNoDeadline']();
-		const date = new Date(iso);
-		return date.toLocaleString(getLocale(), {
-			weekday: 'short',
-			day: 'numeric',
-			month: 'short',
-			year: 'numeric',
-			hour: '2-digit',
-			minute: '2-digit'
-		});
+		return formatDateTime(iso);
 	}
 
 	function paymentMethodNote(method: PaymentMethod | undefined, hasRefund: boolean): string | null {

--- a/src/lib/components/tickets/MyTicket.svelte
+++ b/src/lib/components/tickets/MyTicket.svelte
@@ -6,6 +6,7 @@
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import DownloadPdfButton from './DownloadPdfButton.svelte';
 	import { Ticket, Calendar, MapPin, User, Armchair } from 'lucide-svelte';
+	import { formatDateTime } from '$lib/utils/date';
 	import QRCode from 'qrcode';
 	import { onMount } from 'svelte';
 
@@ -60,11 +61,9 @@
 	});
 
 	// Format checked in date
-	const checkedInDate = $derived(() => {
-		if (!ticket.checked_in_at) return null;
-		const date = new Date(ticket.checked_in_at);
-		return date.toLocaleString();
-	});
+	const checkedInDate = $derived(
+		ticket.checked_in_at ? formatDateTime(ticket.checked_in_at) : null
+	);
 
 	// Check if ticket is pending and payment method allows resume
 	const canResumePayment = $derived(() => {
@@ -280,9 +279,9 @@
 		{/if}
 
 		<!-- Checked In Info -->
-		{#if ticket.status === 'checked_in' && checkedInDate()}
+		{#if ticket.status === 'checked_in' && checkedInDate}
 			<div class="rounded-lg bg-blue-50 p-4 text-sm">
-				<p class="font-medium text-blue-900">{m['myTicket.checkedInAt']()} {checkedInDate()}</p>
+				<p class="font-medium text-blue-900">{m['myTicket.checkedInAt']()} {checkedInDate}</p>
 			</div>
 		{/if}
 

--- a/src/lib/components/tickets/MyTicketModal.svelte
+++ b/src/lib/components/tickets/MyTicketModal.svelte
@@ -19,6 +19,7 @@
 		X
 	} from 'lucide-svelte';
 	import QRCode from 'qrcode';
+	import { formatDateTime } from '$lib/utils/date';
 
 	interface Props {
 		open: boolean;
@@ -121,11 +122,9 @@
 	}
 
 	// Format checked in date
-	const checkedInDate = $derived.by(() => {
-		if (!ticket?.checked_in_at) return null;
-		const date = new Date(ticket.checked_in_at);
-		return date.toLocaleString();
-	});
+	const checkedInDate = $derived.by(() =>
+		ticket?.checked_in_at ? formatDateTime(ticket.checked_in_at) : null
+	);
 
 	// Check if ticket is pending and payment method allows resume
 	const canResumePayment = $derived.by(() => {

--- a/src/lib/components/tickets/TicketCardList.svelte
+++ b/src/lib/components/tickets/TicketCardList.svelte
@@ -4,6 +4,7 @@
 	import { getUserDisplayName } from '$lib/utils/user-display';
 	import { getTicketStatusColor, getTicketStatusLabel } from '$lib/utils/status-colors';
 	import { formatPrice } from '$lib/utils/format';
+	import { formatDate } from '$lib/utils/date';
 	import {
 		getGuestNameIfDifferent,
 		getSeatDisplay,
@@ -173,7 +174,7 @@
 				</div>
 				<div class="flex items-center justify-between">
 					<span class="text-muted-foreground">{m['eventTicketsAdmin.headerPurchased']()}:</span>
-					<span>{new Date(ticket.created_at).toLocaleDateString()}</span>
+					<span>{formatDate(ticket.created_at)}</span>
 				</div>
 				{#if ticket.payment?.vat_amount != null}
 					<div class="mt-2 space-y-1 border-t pt-2">

--- a/src/lib/components/tickets/TicketListCard.svelte
+++ b/src/lib/components/tickets/TicketListCard.svelte
@@ -8,9 +8,8 @@
 	import { Calendar, MapPin, Ticket, Download, CalendarDays } from 'lucide-svelte';
 	import { downloadRevelEventICalFile } from '$lib/utils/ical';
 	import { getImageUrl } from '$lib/utils/url';
-	import { formatEventDateRange } from '$lib/utils/date';
+	import { formatEventDateRange, formatDate } from '$lib/utils/date';
 	import { getEventLogo, getEventLogoThumbnail } from '$lib/utils/event';
-	import { getLocale } from '$lib/paraglide/runtime.js';
 	import { useQueryClient } from '@tanstack/svelte-query';
 
 	const queryClient = useQueryClient();
@@ -72,17 +71,8 @@
 			(ticket.status as string) === 'pending'
 	);
 
-	// Format created date to match event date format (e.g., "Tue, Jan 13, 2025")
-	const createdDate = $derived.by(() => {
-		const date = new Date(ticket.created_at);
-		const locale = getLocale();
-		return date.toLocaleDateString(locale, {
-			weekday: 'short',
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric'
-		});
-	});
+	// Format created date
+	const createdDate = $derived(formatDate(ticket.created_at));
 </script>
 
 <Card class="group overflow-hidden transition-shadow hover:shadow-lg">

--- a/src/lib/components/tickets/TicketTable.svelte
+++ b/src/lib/components/tickets/TicketTable.svelte
@@ -4,6 +4,7 @@
 	import { getUserDisplayName } from '$lib/utils/user-display';
 	import { getTicketStatusColor, getTicketStatusLabel } from '$lib/utils/status-colors';
 	import { formatPrice } from '$lib/utils/format';
+	import { formatDate } from '$lib/utils/date';
 	import {
 		getGuestNameIfDifferent,
 		getSeatDisplay,
@@ -237,7 +238,7 @@
 						</div>
 					</td>
 					<td class="px-4 py-3 text-sm text-muted-foreground">
-						{new Date(ticket.created_at).toLocaleDateString()}
+						{formatDate(ticket.created_at)}
 					</td>
 					<td class="px-4 py-3">
 						<div class="flex justify-end gap-2">

--- a/src/lib/utils/calendar.locale.test.ts
+++ b/src/lib/utils/calendar.locale.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it, vi } from 'vitest';
 const { getLocale } = vi.hoisted(() => ({ getLocale: vi.fn(() => 'en') }));
 vi.mock('$lib/paraglide/runtime.js', () => ({ getLocale }));
 
-import { formatMonthYear, formatWeekRange, formatCalendarDate } from './calendar';
+import {
+	formatMonthYear,
+	formatWeekRange,
+	formatCalendarDate,
+	formatWeekdayShort
+} from './calendar';
 
 describe('calendar formatting follows the app UI locale (#508)', () => {
 	it('formatMonthYear renders the month name in the active locale', () => {
@@ -22,5 +27,35 @@ describe('calendar formatting follows the app UI locale (#508)', () => {
 	it('formatCalendarDate long form renders a textual weekday + month', () => {
 		getLocale.mockReturnValue('it');
 		expect(formatCalendarDate(new Date(2026, 0, 15), 'long')).toMatch(/[A-Za-zÀ-ÿ]{3,}/);
+	});
+});
+
+describe('formatWeekdayShort (#510)', () => {
+	// 2026-01-05 is a Monday
+	const monday = new Date(2026, 0, 5);
+
+	it('returns an alphabetic abbreviation of at least 2 characters', () => {
+		getLocale.mockReturnValue('en');
+		const out = formatWeekdayShort(monday);
+		expect(out).toMatch(/[A-Za-zÀ-ÿ]{2,}/);
+	});
+
+	it('changes output when the locale changes (en vs fr)', () => {
+		getLocale.mockReturnValue('en');
+		const en = formatWeekdayShort(monday);
+		getLocale.mockReturnValue('fr');
+		const fr = formatWeekdayShort(monday);
+		expect(en).not.toBe(fr);
+	});
+
+	it('en locale produces "Mon" for a Monday', () => {
+		getLocale.mockReturnValue('en');
+		expect(formatWeekdayShort(monday)).toBe('Mon');
+	});
+
+	it('fr locale produces a French abbreviation for Monday', () => {
+		getLocale.mockReturnValue('fr');
+		// French Monday short form is "lun." in most ICU versions
+		expect(formatWeekdayShort(monday)).toMatch(/lun/i);
 	});
 });

--- a/src/lib/utils/calendar.ts
+++ b/src/lib/utils/calendar.ts
@@ -230,6 +230,11 @@ export function isInMonth(date: Date, year: number, month: number): boolean {
 	return date.getFullYear() === year && date.getMonth() === month - 1;
 }
 
+/** Short weekday name in the active locale, e.g. "Mon". */
+export function formatWeekdayShort(date: Date): string {
+	return date.toLocaleDateString(getDateLocale(), { weekday: 'short' });
+}
+
 /**
  * Format date for display
  */

--- a/src/lib/utils/date.format.locale.test.ts
+++ b/src/lib/utils/date.format.locale.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Use vi.hoisted so the mock factory runs before module imports, allowing
+// per-test locale switching via getLocale.mockReturnValue(). This is the
+// same pattern used in calendar.locale.test.ts.
+const { getLocale } = vi.hoisted(() => ({ getLocale: vi.fn(() => 'en') }));
+vi.mock('$lib/paraglide/runtime.js', () => ({ getLocale }));
+
+import { formatDateLongMonth, formatDateTimeVerbose, formatMonthYearLabel } from './date';
+
+// Fixed UTC noon on 2026-06-07 — well clear of any timezone's date boundary,
+// so the calendar day stays "June 7" regardless of the test machine's local zone.
+const JUNE_UTC = '2026-06-07T12:00:00Z';
+
+describe('formatDateLongMonth locale switching (#510)', () => {
+	it('en → contains "June"', () => {
+		getLocale.mockReturnValue('en');
+		expect(formatDateLongMonth(JUNE_UTC)).toContain('June');
+	});
+
+	it('fr → contains "juin"', () => {
+		getLocale.mockReturnValue('fr');
+		expect(formatDateLongMonth(JUNE_UTC)).toContain('juin');
+	});
+
+	it('de → contains "Juni"', () => {
+		getLocale.mockReturnValue('de');
+		expect(formatDateLongMonth(JUNE_UTC)).toContain('Juni');
+	});
+});
+
+describe('formatDateTimeVerbose locale switching (#510)', () => {
+	it('en → contains "June" and uses 12-hour AM/PM', () => {
+		getLocale.mockReturnValue('en');
+		const out = formatDateTimeVerbose(JUNE_UTC);
+		expect(out).toContain('June');
+		expect(out).toMatch(/AM|PM/);
+	});
+
+	it('fr → contains "juin" and does NOT use AM/PM (24-hour)', () => {
+		getLocale.mockReturnValue('fr');
+		const out = formatDateTimeVerbose(JUNE_UTC);
+		expect(out).toContain('juin');
+		expect(out).not.toMatch(/AM|PM/);
+	});
+
+	it('de → contains "Juni" and does NOT use AM/PM (24-hour)', () => {
+		getLocale.mockReturnValue('de');
+		const out = formatDateTimeVerbose(JUNE_UTC);
+		expect(out).toContain('Juni');
+		expect(out).not.toMatch(/AM|PM/);
+	});
+});
+
+describe('formatMonthYearLabel locale switching (#510)', () => {
+	it('en → contains "June 2026"', () => {
+		getLocale.mockReturnValue('en');
+		expect(formatMonthYearLabel(JUNE_UTC)).toContain('June 2026');
+	});
+
+	it('fr → contains "juin 2026"', () => {
+		getLocale.mockReturnValue('fr');
+		expect(formatMonthYearLabel(JUNE_UTC)).toContain('juin 2026');
+	});
+});

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -13,7 +13,10 @@ import {
 	formatDateTime,
 	formatDateTimeReadback,
 	formatDate,
-	formatEventTimezoneLabel
+	formatEventTimezoneLabel,
+	formatDateLongMonth,
+	formatDateTimeVerbose,
+	formatMonthYearLabel
 } from './date';
 
 // A fixed winter instant (no DST ambiguity):
@@ -137,5 +140,73 @@ describe('formatDateTimeReadback (#508 picker readback)', () => {
 
 	it('also accepts a full ISO 8601 string', () => {
 		expect(formatDateTimeReadback('2026-06-07T12:00:00Z')).toContain('2026');
+	});
+});
+
+describe('formatDateLongMonth (#510)', () => {
+	it('contains the full month name and year, no time', () => {
+		const out = formatDateLongMonth('2026-06-07T12:00:00Z');
+		expect(out).toContain('June');
+		expect(out).toContain('2026');
+	});
+
+	it('contains the day of month', () => {
+		const out = formatDateLongMonth('2026-06-07T12:00:00Z');
+		expect(out).toContain('7');
+	});
+
+	it('does not contain a time component (no colon)', () => {
+		const out = formatDateLongMonth('2026-06-07T12:00:00Z');
+		expect(out).not.toMatch(/\d+:\d+/);
+	});
+
+	it('respects timezone when supplied (date may shift a day)', () => {
+		// 2026-02-06T23:00:00Z is Feb 6 in New York and Feb 7 in Vienna
+		const ny = formatDateLongMonth('2026-02-06T23:00:00Z', 'America/New_York');
+		const vienna = formatDateLongMonth('2026-02-06T23:00:00Z', 'Europe/Vienna');
+		expect(ny).toContain('February');
+		expect(ny).toContain('6');
+		expect(vienna).toContain('February');
+		expect(vienna).toContain('7');
+	});
+});
+
+describe('formatDateTimeVerbose (#510)', () => {
+	it('contains the full month name, year, and a time component', () => {
+		const out = formatDateTimeVerbose('2026-06-07T12:00:00Z');
+		expect(out).toContain('June');
+		expect(out).toContain('2026');
+		expect(out).toMatch(/\d+:\d+/);
+	});
+
+	it('includes AM/PM for en-US locale', () => {
+		const out = formatDateTimeVerbose('2026-06-07T12:00:00Z');
+		expect(out).toMatch(/AM|PM/);
+	});
+
+	it('respects a supplied timezone', () => {
+		// 2026-02-06T19:00:00Z → 2:00 PM EST in New York
+		const out = formatDateTimeVerbose('2026-02-06T19:00:00Z', 'America/New_York');
+		expect(out).toContain('2:00 PM');
+		expect(out).toContain('February');
+	});
+});
+
+describe('formatMonthYearLabel (#510)', () => {
+	it('contains the full month name and year', () => {
+		const out = formatMonthYearLabel('2026-06-07T12:00:00Z');
+		expect(out).toContain('June');
+		expect(out).toContain('2026');
+	});
+
+	it('does not contain a day number', () => {
+		// The string should not contain " 7" or "7," etc. (isolated day digit)
+		const out = formatMonthYearLabel('2026-06-07T12:00:00Z');
+		expect(out).not.toMatch(/\b7\b/);
+	});
+
+	it('does not contain a time component', () => {
+		const out = formatMonthYearLabel('2026-06-07T12:00:00Z');
+		expect(out).not.toMatch(/\d+:\d+/);
 	});
 });

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -408,6 +408,39 @@ export function formatDate(dateString: string, timeZone?: string): string {
 	});
 }
 
+/** Long-month date, no time, e.g. "October 20, 2025". */
+export function formatDateLongMonth(dateString: string, timeZone?: string): string {
+	return new Date(dateString).toLocaleDateString(getDateLocale(), {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+		...tzOpt(timeZone)
+	});
+}
+
+/** Long-month date + time, e.g. "October 20, 2025, 8:00 PM". */
+export function formatDateTimeVerbose(dateString: string, timeZone?: string): string {
+	const locale = getDateLocale();
+	return new Date(dateString).toLocaleString(locale, {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit',
+		hour12: locale === 'en-US',
+		...tzOpt(timeZone)
+	});
+}
+
+/** Month + year only, e.g. "October 2025". */
+export function formatMonthYearLabel(dateString: string, timeZone?: string): string {
+	return new Date(dateString).toLocaleDateString(getDateLocale(), {
+		year: 'numeric',
+		month: 'long',
+		...tzOpt(timeZone)
+	});
+}
+
 /**
  * Human label naming the timezone an event's times are shown in, e.g.
  * "London (GMT+1)". Pair it with abbreviation-free times (pass

--- a/src/lib/utils/eligibility.ts
+++ b/src/lib/utils/eligibility.ts
@@ -7,6 +7,7 @@ import type {
 	RsvpStatus as ApiRsvpStatus,
 	TicketStatus as ApiTicketStatus
 } from '$lib/api/generated/types.gen';
+import { formatDateTime } from './date';
 
 /**
  * RSVP Status - Correctly typed from backend
@@ -229,13 +230,7 @@ export function formatRetryDate(retryOn: string | null | undefined): string | nu
 	if (!retryOn) return null;
 	const date = new Date(retryOn);
 	if (isNaN(date.getTime())) return null;
-	return date.toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		year: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit'
-	});
+	return formatDateTime(retryOn);
 }
 
 /**

--- a/src/lib/utils/recurrence.test.ts
+++ b/src/lib/utils/recurrence.test.ts
@@ -209,10 +209,11 @@ describe('formatRecurrence — boundary suffix', () => {
 	it('appends until boundary with locale-formatted date', () => {
 		const out = formatRecurrence(
 			base({ weekdays: [0], until: '2026-12-31T00:00:00Z' }),
-			// Pinning locale keeps the Intl output deterministic across CI runners.
-			{ locale: 'en-GB' }
+			// locale is no longer used for date formatting (getDateLocale() drives the
+			// output); the boundary now routes through formatDateLongMonth from date.ts.
+			{ locale: 'en' }
 		);
-		expect(out).toBe('Every Monday until 31 December 2026');
+		expect(out).toBe('Every Monday until December 31, 2026');
 	});
 
 	it('omits boundary when includeBoundary=false', () => {

--- a/src/lib/utils/recurrence.ts
+++ b/src/lib/utils/recurrence.ts
@@ -68,12 +68,15 @@ export interface FormatRecurrenceOptions {
 //   "The second Tuesday of every month"
 //   "Every day"
 //   "Every 3 days"
-//   "… until 31 December 2026"
+//   "… until December 31, 2026"
 //   "… for 12 occurrences"
 //
-// Locale parameter is plumbed through for future paraglide-backed i18n; the
-// current implementation is English-only. The boundary suffix is appended when
-// `includeBoundary` (default true) and the rule has one.
+// The cadence text ("Every Monday", etc.) is currently English-only; the
+// `locale` option is reserved for future paraglide-backed cadence translations
+// and does not affect output today. The boundary DATE, by contrast, already
+// follows the active UI language via `formatDateLongMonth`/`getDateLocale`. The
+// boundary suffix is appended when `includeBoundary` (default true) and the rule
+// has one.
 export function formatRecurrence(
 	rule: RecurrenceDescriptor,
 	options: FormatRecurrenceOptions = {}
@@ -81,7 +84,7 @@ export function formatRecurrence(
 	const { locale = 'en', includeBoundary = true } = options;
 	const head = formatCadence(rule, locale);
 	if (!includeBoundary) return head;
-	const boundary = formatBoundary(rule, locale);
+	const boundary = formatBoundary(rule);
 	return boundary ? `${head} ${boundary}` : head;
 }
 
@@ -137,14 +140,14 @@ function formatMonthly(rule: RecurrenceDescriptor, interval: number, _locale: st
 	return `Every ${interval} months on the ${nthLabel} ${wdLabel}`;
 }
 
-function formatBoundary(rule: RecurrenceDescriptor, _locale: string): string {
+function formatBoundary(rule: RecurrenceDescriptor): string {
 	if (rule.count != null && rule.count > 0) {
 		return rule.count === 1 ? 'for 1 occurrence' : `for ${rule.count} occurrences`;
 	}
 	if (rule.until) {
 		const d = new Date(rule.until);
 		if (!Number.isNaN(d.getTime())) {
-			return `until ${formatDateLongMonth(rule.until!)}`;
+			return `until ${formatDateLongMonth(rule.until)}`;
 		}
 	}
 	return '';

--- a/src/lib/utils/recurrence.ts
+++ b/src/lib/utils/recurrence.ts
@@ -4,6 +4,7 @@ import type {
 	Weekday,
 	WeekdayOrdinal
 } from '$lib/types/recurrence';
+import { formatDateLongMonth } from './date';
 
 // --- weekday / ordinal labels ----------------------------------------------
 
@@ -136,18 +137,14 @@ function formatMonthly(rule: RecurrenceDescriptor, interval: number, _locale: st
 	return `Every ${interval} months on the ${nthLabel} ${wdLabel}`;
 }
 
-function formatBoundary(rule: RecurrenceDescriptor, locale: string): string {
+function formatBoundary(rule: RecurrenceDescriptor, _locale: string): string {
 	if (rule.count != null && rule.count > 0) {
 		return rule.count === 1 ? 'for 1 occurrence' : `for ${rule.count} occurrences`;
 	}
 	if (rule.until) {
 		const d = new Date(rule.until);
 		if (!Number.isNaN(d.getTime())) {
-			return `until ${new Intl.DateTimeFormat(locale, {
-				day: 'numeric',
-				month: 'long',
-				year: 'numeric'
-			}).format(d)}`;
+			return `until ${formatDateLongMonth(rule.until!)}`;
 		}
 	}
 	return '';

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -3,6 +3,7 @@
  */
 
 import { getLocale } from '$lib/paraglide/runtime.js';
+import { formatDate } from './date';
 
 /**
  * Format a timestamp as relative time (e.g., "2 hours ago", "yesterday", "3 days ago")
@@ -99,9 +100,5 @@ export function formatRelativeTime(dateString: string): string {
 	}
 
 	// More than a month: show absolute date
-	return date.toLocaleDateString(locale === 'en' ? 'en-US' : locale === 'de' ? 'de-DE' : 'it-IT', {
-		month: 'short',
-		day: 'numeric',
-		year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
-	});
+	return formatDate(dateString);
 }

--- a/src/routes/(auth)/account/invoices/+page.svelte
+++ b/src/routes/(auth)/account/invoices/+page.svelte
@@ -22,6 +22,7 @@
 		dashboardDashboardInvoiceDownload
 	} from '$lib/api/generated/sdk.gen';
 	import type { AttendeeInvoiceSchema } from '$lib/api/generated/types.gen';
+	import { formatDate } from '$lib/utils/date';
 
 	const accessToken = $derived(authStore.accessToken);
 
@@ -115,14 +116,6 @@
 		} catch {
 			return `${amount} ${currency.toUpperCase()}`;
 		}
-	}
-
-	function formatDate(dateStr: string): string {
-		return new Date(dateStr).toLocaleDateString(undefined, {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric'
-		});
 	}
 
 	function statusColor(status: string): string {

--- a/src/routes/(auth)/account/referral/payouts/+page.svelte
+++ b/src/routes/(auth)/account/referral/payouts/+page.svelte
@@ -16,6 +16,7 @@
 		ReferralPayoutSchema,
 		ReferralPayoutStatementSchema
 	} from '$lib/api/generated/types.gen';
+	import { formatDate } from '$lib/utils/date';
 
 	const user = $derived(authStore.user);
 	const accessToken = $derived(authStore.accessToken);
@@ -96,14 +97,6 @@
 		dialogOpen = false;
 		selectedPayout = null;
 		statement = null;
-	}
-
-	function formatDate(dateStr: string): string {
-		return new Date(dateStr).toLocaleDateString(undefined, {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric'
-		});
 	}
 
 	function formatPeriod(start: string, end: string): string {

--- a/src/routes/(auth)/org/[slug]/admin/billing/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/+page.svelte
@@ -31,6 +31,7 @@
 		organizationadminvatSetInvoicingMode
 	} from '$lib/api/generated/sdk.gen';
 	import type { LayoutData } from '../$types';
+	import { formatDate } from '$lib/utils/date';
 	import {
 		Dialog,
 		DialogContent,
@@ -584,7 +585,7 @@
 					{#if billingQuery?.data?.vat_id_validated_at}
 						<span class="text-xs text-muted-foreground">
 							{m['orgAdmin.billing.vatId.validatedAt']({
-								date: new Date(billingQuery.data.vat_id_validated_at).toLocaleDateString()
+								date: formatDate(billingQuery.data.vat_id_validated_at)
 							})}
 						</span>
 					{/if}

--- a/src/routes/(auth)/org/[slug]/admin/billing/attendee-credit-notes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/attendee-credit-notes/+page.svelte
@@ -17,6 +17,7 @@
 	import { extractErrorMessage } from '$lib/utils/errors';
 	import { organizationadminvatListAttendeeCreditNotes } from '$lib/api/generated/sdk.gen';
 	import type { LayoutData } from '../../$types';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		data: LayoutData;
@@ -76,14 +77,6 @@
 		} catch {
 			return amount;
 		}
-	}
-
-	function formatDate(dateStr: string): string {
-		return new Date(dateStr).toLocaleDateString(undefined, {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric'
-		});
 	}
 </script>
 

--- a/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
@@ -41,6 +41,7 @@
 	} from '$lib/api/generated/sdk.gen';
 	import type { AttendeeInvoiceDetailSchema } from '$lib/api/generated/types.gen';
 	import type { LayoutData } from '../../$types';
+	import { formatDate } from '$lib/utils/date';
 
 	interface Props {
 		data: LayoutData;
@@ -247,13 +248,6 @@
 		editBuyerCountry = inv.buyer_vat_country || '';
 		editBuyerAddress = inv.buyer_address || '';
 		isEditing = true;
-	}
-	function formatDate(d: string) {
-		return new Date(d).toLocaleDateString(undefined, {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric'
-		});
 	}
 	function openAction(invoiceId: string, type: 'issue' | 'delete') {
 		actionInvoiceId = invoiceId;

--- a/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
@@ -24,6 +24,7 @@
 	} from '$lib/api/generated/sdk.gen';
 	import type { PlatformFeeInvoiceSchema } from '$lib/api/generated';
 	import type { LayoutData } from '../../$types';
+	import { formatMonthYearLabel } from '$lib/utils/date';
 
 	interface Props {
 		data: LayoutData;
@@ -105,9 +106,8 @@
 		: null;
 
 	// ─── Helpers ────────────────────────────────────────────────────
-	function formatPeriod(start: string, end: string): string {
-		const startDate = new Date(start);
-		return startDate.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+	function formatPeriod(start: string, _end: string): string {
+		return formatMonthYearLabel(start);
 	}
 
 	function formatCurrency(amount: string, currency: string): string {

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
@@ -37,6 +37,7 @@
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
 	import type { RsvpDetailSchema, MembershipTierSchema } from '$lib/api/generated/types.gen';
 	import * as m from '$lib/paraglide/messages.js';
+	import { formatDateTime } from '$lib/utils/date';
 
 	const { data }: { data: PageData } = $props();
 
@@ -370,13 +371,7 @@
 	 * Format date
 	 */
 	function formatDate(date: string): string {
-		return new Date(date).toLocaleDateString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
-		});
+		return formatDateTime(date);
 	}
 
 	async function handleExportAttendees(): Promise<string> {

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/waitlist/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/waitlist/+page.svelte
@@ -21,6 +21,7 @@
 	} from '$lib/api/queries/waitlist-offers';
 	import type { WaitlistEntrySchema, WaitlistOfferStatus } from '$lib/api/generated/types.gen';
 	import { toast } from 'svelte-sonner';
+	import { formatDateTime } from '$lib/utils/date';
 
 	const { data }: { data: PageData } = $props();
 
@@ -265,16 +266,6 @@
 				toast.success(m['orgAdmin.waitlist.offer.revoke']());
 			},
 			onError: (err) => handleMutationError(err, 'Failed to revoke offer')
-		});
-	}
-
-	function formatDateTime(iso: string): string {
-		return new Date(iso).toLocaleString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
 		});
 	}
 

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
@@ -28,6 +28,7 @@
 	import SectionEditor from '$lib/components/questionnaires/SectionEditor.svelte';
 	import { questionnaireUpdateQuestionnaireStatus } from '$lib/api/generated/sdk.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { formatDate } from '$lib/utils/date';
 	import type { PageData } from './$types';
 	import type {
 		QuestionnaireEvaluationMode,
@@ -552,11 +553,7 @@
 												<p class="font-medium">{event.name}</p>
 												{#if event.start}
 													<p class="text-sm text-muted-foreground">
-														{new Date(event.start).toLocaleDateString('en-US', {
-															month: 'short',
-															day: 'numeric',
-															year: 'numeric'
-														})}
+														{formatDate(event.start)}
 													</p>
 												{/if}
 											</div>

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/+page.svelte
@@ -16,6 +16,7 @@
 		ArrowUpDown
 	} from 'lucide-svelte';
 	import { resolveSubmissionBadgeStatus } from '$lib/utils/resolve-submission-badge-status';
+	import { formatDateTime } from '$lib/utils/date';
 
 	interface Props {
 		data: PageData;
@@ -61,13 +62,7 @@
 
 	function formatDate(dateString: string | null | undefined): string {
 		if (!dateString) return m['questionnaireSubmissionsPage.notSubmitted']();
-		return new Date(dateString).toLocaleDateString('en-US', {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric',
-			hour: '2-digit',
-			minute: '2-digit'
-		});
+		return formatDateTime(dateString);
 	}
 
 	function formatScore(score: string | number | null | undefined): string {

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
@@ -22,6 +22,7 @@
 		type QuestionnaireEvaluationStatus
 	} from '$lib/utils/questionnaire-types';
 	import { resolveSubmissionBadgeStatus } from '$lib/utils/resolve-submission-badge-status';
+	import { formatDateTimeVerbose } from '$lib/utils/date';
 
 	interface Props {
 		data: PageData;
@@ -52,13 +53,7 @@
 
 	function formatDate(dateString: string | null | undefined): string {
 		if (!dateString) return m['questionnaireSubmissionDetailPage.notSubmitted']();
-		return new Date(dateString).toLocaleString('en-US', {
-			year: 'numeric',
-			month: 'long',
-			day: 'numeric',
-			hour: '2-digit',
-			minute: '2-digit'
-		});
+		return formatDateTimeVerbose(dateString);
 	}
 
 	// Check if submission is already evaluated
@@ -90,13 +85,7 @@
 	function formatEventDate(dateString: string | undefined): string {
 		if (!dateString) return '';
 		try {
-			return new Date(dateString).toLocaleString('en-US', {
-				year: 'numeric',
-				month: 'long',
-				day: 'numeric',
-				hour: '2-digit',
-				minute: '2-digit'
-			});
+			return formatDateTimeVerbose(dateString);
 		} catch {
 			return dateString;
 		}

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -50,6 +50,7 @@
 	} from '$lib/api/generated/types.gen';
 	import { getPotluckPermissions } from '$lib/utils/permissions';
 	import { formatEventLocation } from '$lib/utils/event';
+	import { formatDateTime } from '$lib/utils/date';
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
 	import * as m from '$lib/paraglide/messages.js';
@@ -785,7 +786,7 @@
 					<MyTicket
 						ticket={userTicket}
 						eventName={event.name}
-						eventDate={event.start ? new Date(event.start).toLocaleString() : undefined}
+						eventDate={event.start ? formatDateTime(event.start) : undefined}
 						eventLocation={formatEventLocation(event)}
 						onResumePayment={handleResumePaymentFromSidebar}
 						isResumingPayment={resumePaymentMutation.isPending}
@@ -990,7 +991,7 @@
 		bind:open={showMyTicketModal}
 		tickets={userTickets}
 		eventName={event.name}
-		eventDate={event.start ? new Date(event.start).toLocaleString() : undefined}
+		eventDate={event.start ? formatDateTime(event.start) : undefined}
 		eventLocation={formatEventLocation(event)}
 		onResumePayment={handleResumePayment}
 		isResumingPayment={resumePaymentMutation.isPending}

--- a/src/routes/feed.xml/+server.ts
+++ b/src/routes/feed.xml/+server.ts
@@ -98,7 +98,7 @@ ${events
 		const eventDate = new Date(event.start);
 		const locationParts = [event.city?.name, event.city?.country].filter(Boolean);
 		const location = locationParts.join(', ');
-		// eslint-disable-next-line no-restricted-syntax -- RSS server endpoint, no request locale; fixed en-US by design
+		/* eslint-disable no-restricted-syntax -- RSS server endpoint, no request locale; fixed en-US by design */
 		const eventDateFormatted = event.start
 			? eventDate.toLocaleDateString('en-US', {
 					weekday: 'long',
@@ -107,6 +107,7 @@ ${events
 					day: 'numeric'
 				})
 			: '';
+		/* eslint-enable no-restricted-syntax */
 
 		return `    <item>
       <title>${escapeXml(event.name)}</title>

--- a/src/routes/feed.xml/+server.ts
+++ b/src/routes/feed.xml/+server.ts
@@ -98,12 +98,21 @@ ${events
 		const eventDate = new Date(event.start);
 		const locationParts = [event.city?.name, event.city?.country].filter(Boolean);
 		const location = locationParts.join(', ');
+		// eslint-disable-next-line no-restricted-syntax -- RSS server endpoint, no request locale; fixed en-US by design
+		const eventDateFormatted = event.start
+			? eventDate.toLocaleDateString('en-US', {
+					weekday: 'long',
+					year: 'numeric',
+					month: 'long',
+					day: 'numeric'
+				})
+			: '';
 
 		return `    <item>
       <title>${escapeXml(event.name)}</title>
       <link>${escapeXml(eventUrl)}</link>
       <guid isPermaLink="true">${escapeXml(eventUrl)}</guid>
-      <description><![CDATA[${truncatedDescription}${location ? `\n\nLocation: ${location}` : ''}${event.start ? `\nDate: ${eventDate.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}` : ''}]]></description>
+      <description><![CDATA[${truncatedDescription}${location ? `\n\nLocation: ${location}` : ''}${eventDateFormatted ? `\nDate: ${eventDateFormatted}` : ''}]]></description>
       <pubDate>${formatRfc822Date(event.created_at || event.start)}</pubDate>
       <dc:creator>${escapeXml(event.organization.name)}</dc:creator>
       <category>${escapeXml(event.organization.name)}</category>${


### PR DESCRIPTION
Closes #510.

The enforcement follow-up to #508/#509. Routes **every** human-facing date through `src/lib/utils/date.ts` (textual months, UI-language) and adds an ESLint guardrail so raw `toLocale*` date formatting can't creep back in.

## What changed
- **Migrated ~43 raw `toLocale*` call-sites** across components, routes, and utils onto `date.ts` helpers. Dates now follow the chosen UI language with textual months everywhere (no more browser-locale numeric `6/7/2026` or hardcoded `en-US`).
- **4 new helpers:** `formatDateLongMonth` ("October 20, 2025"), `formatDateTimeVerbose` ("October 20, 2025, 8:00 PM"), `formatMonthYearLabel` ("October 2025") in `date.ts`; `formatWeekdayShort` ("Mon") in `calendar.ts`.
- **ESLint guardrail:** `no-restricted-syntax` bans `toLocaleDateString`/`toLocaleTimeString`/`toLocaleString` everywhere except the allow-listed `date.ts`/`calendar.ts`. `Intl.DateTimeFormat().resolvedOptions()` (timezone detection) stays allowed. Verified: 0 violations; a raw `toLocaleDateString()` is correctly flagged; `resolvedOptions()` is not.
- **CLAUDE.md** updated — the "Date & Time Formatting" rule is now mechanically enforced.

## Exceptions (2, intentionally kept + `eslint-disable`d with rationale)
- `DemoBanner.svelte` — two lines are **timezone arithmetic** (`new Date(x.toLocaleString('en-US',{timeZone}))`), not display; one is a **fixed-locale demo countdown**.
- `feed.xml/+server.ts` — RSS server endpoint with no request locale; fixed `en-US` long-form by design (month already textual).

## Intentional behavior changes (consistent with the issue's goal)
- Long-month helpers always show the year (a few eligibility deadlines previously omitted same-year).
- Recurrence "until" dates now follow the UI language (e.g. en-US "December 31, 2026") instead of a caller-pinned `en-GB`; test updated.
- `time.ts` relative-time absolute fallback always shows the year.

## Testing
- `svelte-check` **0 errors**; prettier clean; i18n all-pass; **+22 new passing tests** (new helpers get en/fr/de locale-switch coverage); test suite otherwise at the pre-existing svelte-query baseline (no new failures).
- ESLint guardrail independently verified (0 violations + positive control).
- Built via subagent-driven development: per-task spec+quality review + an Opus whole-branch review (verdict: ready to merge).
- ⚠️ Display-only changes (no data-contract impact). A light visual smoke of a few date surfaces (tickets, billing periods, eligibility deadlines, calendar week view, MyTicket check-in) is worthwhile but low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more consistent, localized date and time display across the app, including richer long-date and month-year labels.
  * Improved calendar weekday and event-time formatting in views and event details.

* **Bug Fixes**
  * Standardized many date labels in memberships, tickets, invitations, polls, billing, and questionnaires for clearer, locale-aware display.
  * Updated recurring event summaries and feed content to show dates in a more readable format.
  * Reduced inconsistent formatting between pages and dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->