### PR TITLE
fix(dashboard): count Going + Maybe in Upcoming RSVPs (#511)

### DIFF
--- a/src/lib/api/generated/types.gen.ts
+++ b/src/lib/api/generated/types.gen.ts
@@ -2414,7 +2414,10 @@ export type PaginatedResponseSchemaEventInvitationRequestSchema = {
  * Filter schema for event RSVPs.
  */
 export type RsvpFilterSchema = {
-    status?: RsvpStatus | null;
+    /**
+     * Status
+     */
+    status?: Array<RsvpStatus> | null;
     /**
      * User Id
      */
@@ -5786,7 +5789,7 @@ export type RecurrenceRuleCreateSchema = {
     /**
      * Timezone
      *
-     * IANA timezone name for the recurrence anchor. NOTE: this field is currently advisory metadata only — occurrences are anchored to the UTC `dtstart` and do not observe DST in the named zone. A weekly rule for 'Mondays at 10:00 Europe/Vienna' starting before the spring DST transition will materialize at 11:00 Vienna time after the transition (because it stays anchored to 09:00 UTC). Phase 3 will localize the anchor; until then, set `dtstart` to the exact UTC instant you want and treat `timezone` as informational.
+     * IANA timezone name the recurrence anchor is localized to. Occurrences preserve their wall-clock time-of-day in this zone across DST transitions: a weekly rule for 'Mondays at 10:00 Europe/Vienna' materializes at 10:00 Vienna time both before and after the spring/autumn switch (the underlying UTC instant shifts by the DST offset). `dtstart` is the UTC instant of the first occurrence; its wall-clock time in this zone defines the anchor. The default 'UTC' has no DST, so occurrences stay fixed to the stored UTC instant.
      */
     timezone?: string;
 };
@@ -14025,7 +14028,10 @@ export type DashboardDashboardRsvps8D4D3BeeData = {
     body?: never;
     path?: never;
     query?: {
-        status?: RsvpStatus | null;
+        /**
+         * Status
+         */
+        status?: Array<RsvpStatus> | null;
         /**
          * User Id
          */
@@ -19940,7 +19946,10 @@ export type EventadminrsvpsListRsvpsBfffe54fData = {
         event_id: string;
     };
     query?: {
-        status?: RsvpStatus | null;
+        /**
+         * Status
+         */
+        status?: Array<RsvpStatus> | null;
         /**
          * User Id
          */

--- a/src/routes/(auth)/dashboard/+page.svelte
+++ b/src/routes/(auth)/dashboard/+page.svelte
@@ -286,7 +286,8 @@
 		enabled: !!accessToken
 	}));
 
-	// Fetch upcoming RSVPs count (status = "yes")
+	// Fetch upcoming RSVPs count (Going + Maybe — a tentative RSVP is the one
+	// users are most likely to forget, so it must be surfaced too).
 	const upcomingRsvpsQuery = createQuery(() => ({
 		queryKey: ['dashboard-upcoming-rsvps-count'],
 		queryFn: async () => {
@@ -295,7 +296,7 @@
 			const response = await dashboardDashboardRsvps({
 				headers: { Authorization: `Bearer ${accessToken}` },
 				query: {
-					status: 'yes' as const,
+					status: ['yes', 'maybe'],
 					include_past: false,
 					page_size: 1
 				}

--- a/src/routes/(auth)/dashboard/rsvps/+page.svelte
+++ b/src/routes/(auth)/dashboard/rsvps/+page.svelte
@@ -55,7 +55,7 @@
 			const response = await dashboardDashboardRsvps({
 				headers: { Authorization: `Bearer ${accessToken}` },
 				query: {
-					status: statusFilter as any,
+					status: statusFilter ? [statusFilter] : undefined,
 					search: debouncedSearch || undefined,
 					include_past: includePast,
 					page: currentPage,

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.server.ts
@@ -1,7 +1,7 @@
 import { error, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
 import type { PageServerLoad } from './$types';
 import { eventpublicdetailsGetEvent, eventadminrsvpsListRsvps } from '$lib/api';
-import type { RsvpStatus } from '$lib/api/generated/types.gen';
 import { log } from '$lib/server/logger';
 
 export const load: PageServerLoad = async ({ parent, params, locals, fetch, url }) => {
@@ -64,8 +64,15 @@ export const load: PageServerLoad = async ({ parent, params, locals, fetch, url 
 		redirect(302, `/org/${params.slug}/admin/events/${params.event_id}/tickets`);
 	}
 
-	// Get query parameters for filtering
-	const status = url.searchParams.get('status') || undefined;
+	// Get query parameters for filtering. `status` is untrusted external input,
+	// so validate it against the allowed RSVP statuses; anything else (incl. a
+	// crafted value that would 422 the API and silently empty the list) falls
+	// back to undefined = "all statuses".
+	const status = z
+		.enum(['yes', 'no', 'maybe'])
+		.optional()
+		.catch(undefined)
+		.parse(url.searchParams.get('status') || undefined);
 	const search = url.searchParams.get('search') || undefined;
 	const page = parseInt(url.searchParams.get('page') || '1');
 	const pageSize = 100; // Fixed page size
@@ -81,7 +88,7 @@ export const load: PageServerLoad = async ({ parent, params, locals, fetch, url 
 			fetch,
 			path: { event_id: params.event_id },
 			query: {
-				status: status ? [status as RsvpStatus] : undefined,
+				status: status ? [status] : undefined,
 				search,
 				page,
 				page_size: pageSize,

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { eventpublicdetailsGetEvent, eventadminrsvpsListRsvps } from '$lib/api';
+import type { RsvpStatus } from '$lib/api/generated/types.gen';
 import { log } from '$lib/server/logger';
 
 export const load: PageServerLoad = async ({ parent, params, locals, fetch, url }) => {
@@ -80,7 +81,7 @@ export const load: PageServerLoad = async ({ parent, params, locals, fetch, url 
 			fetch,
 			path: { event_id: params.event_id },
 			query: {
-				status: status as any,
+				status: status ? [status as RsvpStatus] : undefined,
 				search,
 				page,
 				page_size: pageSize,


### PR DESCRIPTION
## Summary

The dashboard **Upcoming RSVPs** count only included **Going** RSVPs. A **Maybe** is exactly the RSVP a user is most likely to forget (and then not attend), so it was being hidden when it mattered most. This widens the count to **Going + Maybe** (still excludes **No** — a declined RSVP).

Reported by an organizer. Closes #511.

## What changed

- **Dashboard count card** (`dashboard/+page.svelte`) — queries `status: ['yes', 'maybe']` instead of `'yes'`.
- **Generated API client** — adopts backend multi-status filtering (letsrevel/revel-backend#628): the dashboard/admin RSVP `status` query param is now `Array<RsvpStatus> | null` (was a single value). Also refreshes the recurrence `timezone` doc-string to match the shipped Phase-3 localization.
- **RSVPs detail page** (`dashboard/rsvps/+page.svelte`) — wraps the single filter value in a list (`status ? [status] : undefined`); drops the `as any`. Filter UI/behaviour unchanged.
- **Admin attendees** (`.../attendees/+page.server.ts`) — same one-element-list adaptation for the shared, now-array endpoint; drops the `as any`.

## Note on the client regen

A full `pnpm generate:api` produces ~2,000 lines of diff, but **the only real semantic changes are the three `status` fields → array and the one `timezone` doc-string** — everything else is hey-api hash-suffix churn on untouched endpoints. To keep this PR reviewable I applied only the real changes by hand and **verified they are byte-for-byte identical to a true regen once hash suffixes are normalized away**. The next full regen will produce zero semantic diff on these fields.

## Verification

- `make types` → **0 errors** (pre-existing baseline warnings only)
- Prettier clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upcoming RSVP counts now include both confirmed (“yes”) and tentative (“maybe”) responses.
  * RSVP status filters on the dashboard now apply the selected status correctly and clear to “all statuses” when not set.
  * Attendee RSVP listings now validate and consistently apply the selected status (yes/no/maybe), defaulting to all when an invalid value is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->