### PR TITLE
feat(dashboard): URL-driven multi-status RSVP filter (#517)

### DIFF
--- a/src/routes/(auth)/dashboard/+page.svelte
+++ b/src/routes/(auth)/dashboard/+page.svelte
@@ -580,7 +580,7 @@
 			<!-- Upcoming RSVPs -->
 			{#if upcomingRsvpsCount > 0}
 				<a
-					href="/dashboard/rsvps"
+					href="/dashboard/rsvps?status=yes,maybe"
 					class="group rounded-lg border bg-card p-6 transition-all hover:border-primary hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 				>
 					<div class="flex items-start justify-between">

--- a/src/routes/(auth)/dashboard/rsvps/+page.svelte
+++ b/src/routes/(auth)/dashboard/rsvps/+page.svelte
@@ -5,15 +5,7 @@
 	import { dashboardDashboardRsvps } from '$lib/api/generated/sdk.gen';
 	import type { RsvpStatus } from '$lib/api/generated/types.gen';
 	import RSVPCard from '$lib/components/rsvps/RSVPCard.svelte';
-	import {
-		CheckCircle2,
-		XCircle,
-		HelpCircle,
-		Filter,
-		ChevronLeft,
-		ChevronRight,
-		Loader2
-	} from 'lucide-svelte';
+	import { CheckCircle2, Filter, ChevronLeft, ChevronRight, Loader2 } from 'lucide-svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 
@@ -22,15 +14,28 @@
 	// Get current page from URL params
 	const currentPage = $derived(Number(page.url.searchParams.get('page') || '1'));
 
-	const statusFilters: Array<{ label: string; value: RsvpStatus | null }> = [
-		{ label: m['dashboard.rsvps.status_all'](), value: null },
+	// Canonical status order — keeps the URL (?status=yes,maybe) and the query key
+	// stable regardless of the order chips were toggled in.
+	const STATUS_ORDER: RsvpStatus[] = ['yes', 'maybe', 'no'];
+
+	const statusToggles: Array<{ label: string; value: RsvpStatus }> = [
 		{ label: m['dashboard.rsvps.status_going'](), value: 'yes' },
 		{ label: m['dashboard.rsvps.status_maybe'](), value: 'maybe' },
 		{ label: m['dashboard.rsvps.status_notGoing'](), value: 'no' }
 	];
 
+	// Status is URL-driven (?status=yes,maybe) so the filter is linkable and
+	// restorable — e.g. the dashboard "Upcoming RSVPs" card links straight to
+	// the Going + Maybe scope it counts. An empty selection means "all".
+	function parseStatuses(param: string | null): RsvpStatus[] {
+		if (!param) return [];
+		const tokens = new Set(param.split(','));
+		return STATUS_ORDER.filter((status) => tokens.has(status));
+	}
+
+	const selectedStatuses = $derived(parseStatuses(page.url.searchParams.get('status')));
+
 	// Active filters
-	let statusFilter = $state<RsvpStatus | null>(null);
 	let searchQuery = $state('');
 	let includePast = $state(false);
 
@@ -48,14 +53,20 @@
 
 	// Fetch RSVPs with filters
 	const rsvpsQuery = createQuery(() => ({
-		queryKey: ['dashboard-rsvps', statusFilter, debouncedSearch, includePast, currentPage] as const,
+		queryKey: [
+			'dashboard-rsvps',
+			selectedStatuses,
+			debouncedSearch,
+			includePast,
+			currentPage
+		] as const,
 		queryFn: async () => {
 			if (!accessToken) return { results: [], count: 0 };
 
 			const response = await dashboardDashboardRsvps({
 				headers: { Authorization: `Bearer ${accessToken}` },
 				query: {
-					status: statusFilter ? [statusFilter] : undefined,
+					status: selectedStatuses.length ? selectedStatuses : undefined,
 					search: debouncedSearch || undefined,
 					include_past: includePast,
 					page: currentPage,
@@ -74,10 +85,27 @@
 	const hasNextPage = $derived(currentPage < totalPages);
 	const hasPrevPage = $derived(currentPage > 1);
 
-	// Apply filter
-	function applyStatusFilter(status: RsvpStatus | null) {
-		statusFilter = status;
-		navigateToPage(1); // Reset to first page when filter changes
+	// Write the selected statuses to the URL (canonical order) and reset to the
+	// first page. An empty selection drops the param entirely ("all").
+	function setStatuses(statuses: RsvpStatus[]) {
+		const url = new URL(page.url);
+		const ordered = STATUS_ORDER.filter((status) => statuses.includes(status));
+		if (ordered.length) {
+			url.searchParams.set('status', ordered.join(','));
+		} else {
+			url.searchParams.delete('status');
+		}
+		url.searchParams.delete('page'); // Reset to first page when filter changes
+		goto(url.toString(), { replaceState: true, noScroll: true });
+	}
+
+	// Toggle a single status in/out of the current selection.
+	function toggleStatus(status: RsvpStatus) {
+		setStatuses(
+			selectedStatuses.includes(status)
+				? selectedStatuses.filter((s) => s !== status)
+				: [...selectedStatuses, status]
+		);
 	}
 
 	// Navigate to page
@@ -89,11 +117,6 @@
 			url.searchParams.set('page', pageNum.toString());
 		}
 		goto(url.toString(), { replaceState: true, noScroll: true });
-	}
-
-	// Check if filter is active
-	function isStatusFilterActive(status: RsvpStatus | null): boolean {
-		return statusFilter === status;
 	}
 </script>
 
@@ -148,17 +171,28 @@
 				<span class="text-sm font-medium">{m['dashboard.rsvps.status']()}</span>
 			</div>
 			<div class="flex flex-wrap gap-2">
-				{#each statusFilters as filter}
+				<button
+					type="button"
+					aria-pressed={selectedStatuses.length === 0}
+					onclick={() => setStatuses([])}
+					class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {selectedStatuses.length ===
+					0
+						? 'bg-primary text-primary-foreground hover:bg-primary/90'
+						: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
+				>
+					{m['dashboard.rsvps.status_all']()}
+				</button>
+				{#each statusToggles as toggle}
+					{@const active = selectedStatuses.includes(toggle.value)}
 					<button
 						type="button"
-						onclick={() => applyStatusFilter(filter.value)}
-						class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isStatusFilterActive(
-							filter.value
-						)
+						aria-pressed={active}
+						onclick={() => toggleStatus(toggle.value)}
+						class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {active
 							? 'bg-primary text-primary-foreground hover:bg-primary/90'
 							: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
 					>
-						{filter.label}
+						{toggle.label}
 					</button>
 				{/each}
 			</div>
@@ -197,16 +231,15 @@
 				<CheckCircle2 class="h-8 w-8 text-primary" aria-hidden="true" />
 			</div>
 			<h2 class="mb-2 text-xl font-semibold">{m['dashboardRsvpsPage.noResults']()}</h2>
-			{#if statusFilter || debouncedSearch}
+			{#if selectedStatuses.length || debouncedSearch}
 				<p class="mb-4 text-muted-foreground">
 					{m['dashboardRsvpsPage.noResultsFiltered']()}
 				</p>
 				<button
 					type="button"
 					onclick={() => {
-						statusFilter = null;
 						searchQuery = '';
-						navigateToPage(1);
+						setStatuses([]);
 					}}
 					class="rounded-lg border bg-background px-6 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 				>


### PR DESCRIPTION
## Summary

Follow-up to #511 / #516. The dashboard **Upcoming RSVPs** card counts **Going + Maybe**, but the linked `/dashboard/rsvps` list defaulted to *all* statuses — so clicking the card landed on a list that also included **No** RSVPs. This makes the detail-page filter **URL-driven multi-select** and points the card at it, so the count and the list agree.

Closes #517.

## What changed

- **Status is URL-driven** (`?status=yes,maybe`): parsed, validated against `yes|maybe|no`, deduped, and canonically ordered — now linkable and restorable (same pattern the page already uses for the current page). Empty selection = show all.
- **Filter row → toggle chips:** `[ All ] [ Going ] [ Maybe ] [ Not going ]`. Going/Maybe/Not-going toggle independently; **All** clears the selection. Chips are proper `aria-pressed` toggle buttons (accessibility win over the old color-only state).
- Each change rewrites the URL and resets to page 1; pagination preserves the filter.
- **Dashboard card** links to `/dashboard/rsvps?status=yes,maybe`.
- Removed two genuinely-dead imports (`XCircle`, `HelpCircle`).

No backend or client-type changes — the `status` param is already `Array<RsvpStatus>` after #516.

## Verification

Drove the running app (dev server + local backend) via Playwright, logged in as demo accounts, and read the real network requests:

- Card (count 2) → `?status=yes,maybe`; chips restore Going+Maybe; API sends `status=yes&status=maybe` (correct repeated-param serialization for the backend `status__in`); list "Showing 2 of 2".
- Toggle Maybe off → `?status=yes`; add Not-going (out of order) → `?status=yes,no` (canonical); **All** → param removed, no `status` sent.
- Garbage `?status=bogus,yes` → sanitized to `status=yes` at the parse layer.
- 0 console errors throughout.

**Known minor (deferred):** landing on a URL with an invalid token leaves the address bar dirty until the first chip interaction — parsed chips and the API query are always correct; only the URL looks untidy. Flagged, not blocking.

## Quality gate
- `make types` → 0 errors
- Prettier clean; ESLint 0 new warnings on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)