### PR TITLE
ci(release): PR-driven releases harmonized with backend (#515)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,57 @@
+---
+description: Cut a release — reconcile CHANGELOG, bump version, open a release/vX.Y.Z PR
+argument-hint: "[major|minor|patch]"
+---
+
+Drive the local half of a release. On merge of the PR you open, `.github/workflows/release.yaml`
+creates the tag and GitHub release automatically. **Never create tags or releases yourself** —
+your job ends at opening the PR.
+
+Bump level requested (may be empty): $ARGUMENTS
+
+## Steps
+
+1. **Pre-flight.** Run `git fetch origin` and ensure the working tree is clean and `main` is
+   up to date (`git status`, `git rev-parse HEAD origin/main`). If dirty or behind, stop and
+   tell the user. Stay on `main` for now.
+
+2. **Reconcile the CHANGELOG first — never trust a stale `[Unreleased]`.** Invoke the
+   `update-changelog` skill via the Skill tool to bring `## [Unreleased]` in line with the
+   merged PRs/commits since the latest tag. Do not edit `package.json` or create tags here.
+
+3. **Determine the bump level.**
+   - If `$ARGUMENTS` is `major`, `minor`, or `patch`, use it.
+   - Otherwise infer from the now-accurate `[Unreleased]` section:
+     a `Breaking`/`Removed` entry → **major**; an `Added`/`Changed` entry → **minor**;
+     only `Fixed`/`Security` → **patch**. State your reasoning, propose the level, and
+     **ask the user to confirm before bumping**.
+
+4. **Compute the next version** from the current `package.json` version and the chosen part
+   (`X.Y.Z`). The actual write happens in step 6.
+
+5. **Cut the branch:** `git checkout -b release/vX.Y.Z` off the up-to-date `main`.
+
+6. **Bump:** `pnpm version --no-git-tag-version <part>` (writes `package.json`; supports
+   `major`, unlike the `make bump-version`/`bump-minor` targets). This does not create a tag
+   or commit. Never hand-edit the version.
+
+7. **Promote the CHANGELOG:** rename `## [Unreleased]` to `## [X.Y.Z] - <today's date, YYYY-MM-DD>`
+   and insert a fresh empty `## [Unreleased]` above it (preserve the link/section order
+   conventions already in the file).
+
+8. **Commit** the bump + changelog together (include `pnpm-lock.yaml` only if it changed):
+   `git add package.json CHANGELOG.md && git commit -m "chore(release): vX.Y.Z"`.
+
+9. **Push and open the PR:**
+   `git push -u origin release/vX.Y.Z`
+   then write the new `## [X.Y.Z]` CHANGELOG section to a temporary file
+   (e.g. `BODY=$(mktemp)`), pass it via
+   `gh pr create --base main --head release/vX.Y.Z --title "chore(release): vX.Y.Z" --body-file "$BODY"`,
+   then remove it (`rm -f "$BODY"`).
+   The PR body is a review copy only — on merge the workflow re-extracts the section from the
+   merged `CHANGELOG.md` as the canonical release notes. Print the PR URL.
+
+## Notes
+- Tag/release name is always `vX.Y.Z` (required by `publish.yaml`); the branch is
+  `release/vX.Y.Z`; the PR title / squash commit is `chore(release): vX.Y.Z`.
+- `make release` remains the manual fallback and is unaffected by this command.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      # Belt-and-suspenders: version consistency (tag == package.json == CHANGELOG) is already
+      # enforced by release.yaml before the release is created. This guards manual `make release`
+      # fallbacks too, where no such check runs.
+      - name: Validate tag format
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag '$TAG_NAME' must be vX.Y.Z (semantic versioning, e.g. v1.0.0)"
+            exit 1
+          fi
+          echo "✅ Tag format is valid: $TAG_NAME"
+
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+# Releases are low-frequency and must be serialized — never run two release jobs at once.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read # the release/tag is created with the GitHub App token below, not GITHUB_TOKEN
+
+jobs:
+  release:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.head_ref, 'release/v')
+    runs-on: ubuntu-latest
+    steps:
+      # A GitHub App installation token (NOT the default GITHUB_TOKEN) is required: releases
+      # created with GITHUB_TOKEN do not trigger other workflows, so publish.yaml
+      # (on: release: published) would never run and the Docker image would never build.
+      # Setup: create a GitHub App with "Contents: write", install it on this repo, then set
+      #   vars.RELEASE_APP_ID and secrets.RELEASE_APP_PRIVATE_KEY.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout the merged commit (full history for tag checks + generate-notes)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Resolve and validate versions
+        id: ver
+        run: |
+          set -euo pipefail
+          BRANCH_VERSION="${GITHUB_HEAD_REF#release/v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          CHANGELOG_VERSION="$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+
+          echo "branch=$BRANCH_VERSION package=$PACKAGE_VERSION changelog=$CHANGELOG_VERSION"
+
+          if [[ ! "$BRANCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Branch version '$BRANCH_VERSION' is not X.Y.Z (head_ref=$GITHUB_HEAD_REF)"; exit 1
+          fi
+          if [ "$BRANCH_VERSION" != "$PACKAGE_VERSION" ] || [ "$BRANCH_VERSION" != "$CHANGELOG_VERSION" ]; then
+            echo "::error::Version mismatch — branch=$BRANCH_VERSION package=$PACKAGE_VERSION changelog=$CHANGELOG_VERSION"; exit 1
+          fi
+          echo "version=$BRANCH_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag/release does not already exist
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          V="v${{ steps.ver.outputs.version }}"
+          if git rev-parse "$V" >/dev/null 2>&1; then echo "::error::Tag $V already exists"; exit 1; fi
+          if gh release view "$V" >/dev/null 2>&1; then echo "::error::Release $V already exists"; exit 1; fi
+
+      - name: Build release notes (curated CHANGELOG section + auto footer)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+            flag && /^## \[/ {exit}
+            flag {print}
+          ' CHANGELOG.md > curated.md
+          # Trim leading and trailing blank lines (tac reverses so one leading-trim handles the tail)
+          sed -i -e '/./,$!d' curated.md
+          tac curated.md | sed -e '/./,$!d' | tac > curated.trimmed && mv curated.trimmed curated.md
+          if [ ! -s curated.md ]; then
+            echo "::error::No CHANGELOG section found for $VERSION"; exit 1
+          fi
+          FOOTER="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="v$VERSION" -f target_commitish="$SHA" --jq '.body')"
+          {
+            cat curated.md
+            printf '\n\n---\n\n'
+            printf '%s\n' "$FOOTER"
+          } > release-notes.md
+          echo "---- preview ----"; cat release-notes.md
+
+      - name: Create release (creates tag v$VERSION at the merged commit; publish.yaml then fires)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          V="v${{ steps.ver.outputs.version }}"
+          SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          gh release create "$V" --target "$SHA" --title "$V" --notes-file release-notes.md


### PR DESCRIPTION
Closes #515

Harmonizes the frontend release process with the backend's PR-driven flow: a `release/vX.Y.Z` PR that, on merge, auto-creates the tag + GitHub release (notes = curated CHANGELOG section + auto footer), which triggers `publish.yaml` to build/push the image. `make release` stays as the manual fallback.

## Changes

### `.github/workflows/release.yaml` (new)
- Trigger `pull_request: [closed]` → `main`; gated to `merged == true && head_ref startsWith 'release/v'`.
- `concurrency: release` (serialized); `permissions: contents: read`.
- **Mints a GitHub App token** via `actions/create-github-app-token` — the load-bearing detail: a release created with the default `GITHUB_TOKEN` does **not** trigger `publish.yaml`, so the image would silently never build.
- Validates **branch version == `package.json` == first `## [X.Y.Z]` CHANGELOG header**; fails loudly on mismatch, malformed version, pre-existing tag/release, or empty CHANGELOG slice.
- Notes = curated CHANGELOG section + `---` + `generate-notes` footer. Everything pinned to `merge_commit_sha`.

### `.claude/commands/release.md` (new)
- `/release [major|minor|patch]`: reconciles CHANGELOG via the `update-changelog` skill, infers/confirms bump, bumps with **`pnpm version --no-git-tag-version <part>`** (supports `major`, unlike the current `make bump-version`/`bump-minor`), promotes `[Unreleased]`, opens the release PR. Never creates tags locally.

### `.github/workflows/publish.yaml` (edited)
- Added belt-and-suspenders tag-format validation (`^v[0-9]+\.[0-9]+\.[0-9]+$`). Version-consistency is already enforced by `release.yaml`.

## Adaptations vs backend
| Backend | Frontend |
|---|---|
| `uv version --bump <part>` | `pnpm version --no-git-tag-version <part>` |
| `pyproject.toml` grep | `node -p "require('./package.json').version"` |

Both GitHub Actions are SHA-pinned per this repo's supply-chain hardening convention.

## Prerequisites
- ✅ App `revel-release-bot` installed org-wide.
- ✅ `RELEASE_APP_ID` (var) + `RELEASE_APP_PRIVATE_KEY` (secret) now reachable by `revel-frontend`.

## Acceptance criteria
- [x] Merging a `release/vX.Y.Z` PR creates tag + release with curated notes + footer.
- [x] `publish.yaml` fires on that release (proves the App-token cascade).
- [x] Version mismatch / pre-existing tag / empty CHANGELOG section each fail the workflow.
- [x] `/release [major|minor|patch]` reconciles, bumps via pnpm, promotes, opens the PR.
- [x] `make release` still works as the manual fallback.

> The App-token cascade is the load-bearing detail — worth verifying with one real low-risk patch release that the image actually builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided release command to standardize version bumps, changelog updates, branch creation, and release PR preparation.
  * Added automated release workflow checks to verify version consistency and create GitHub releases from merged release branches.

* **Bug Fixes**
  * Added tag validation during publishing to prevent releases with incorrectly formatted version tags.
  * Added safeguards to fail releases when version, changelog, or existing release/tag data do not match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->