### PR TITLE
chore(release): v1.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Brand identity evaluation (demo/staging only)**: a new opt-in brand switcher, visible on the demo/staging environment and in local development, lets testers preview four candidate 2026 rebrands against the current **Legacy** look — **Gradient** (full-page purple→crimson wash), **Midnight** (near-black with neon accents), **Crimson** (hot, crimson-led), and **Mono** (stark black & white) — each with full light and dark modes. The default stays Legacy, so normal visitors see no change. Foundation only: the new palette (Hearty Purple / Light Crimson / Amber highlight, purple→crimson gradient) and the Nata Sans typeface are wired through the existing design tokens, with the final visual design to follow.
 
+### Changed
+- **New Revel logo & favicon**: the browser tab icon, app icons (apple-touch), and theme color now use the 2026 gradient "R" mark for everyone. On the candidate brand themes the header home button becomes the "let's revel." lockup; Legacy keeps the current "Revel" wordmark.
+
 ## [1.63.0] - 2026-06-29
 
 ### Changed


### PR DESCRIPTION
### Added
- **Brand identity evaluation (demo/staging only)**: a new opt-in brand switcher, visible on the demo/staging environment and in local development, lets testers preview four candidate 2026 rebrands against the current **Legacy** look — **Gradient** (full-page purple→crimson wash), **Midnight** (near-black with neon accents), **Crimson** (hot, crimson-led), and **Mono** (stark black & white) — each with full light and dark modes. The default stays Legacy, so normal visitors see no change. Foundation only: the new palette (Hearty Purple / Light Crimson / Amber highlight, purple→crimson gradient) and the Nata Sans typeface are wired through the existing design tokens, with the final visual design to follow.

### Changed
- **New Revel logo & favicon**: the browser tab icon, app icons (apple-touch), and theme color now use the 2026 gradient "R" mark for everyone. On the candidate brand themes the header home button becomes the "let's revel." lockup; Legacy keeps the current "Revel" wordmark.

