### PR TITLE
refactor(i18n): migrate relative time to `Intl.RelativeTimeFormat`

### DIFF
--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -226,10 +226,10 @@ export function formatRelativeTime(dateString: string): string {
 
 	for (const [unit, ms] of units) {
 		if (Math.abs(diffMs) >= ms) {
-			return rtf.format(Math.round(diffMs / ms), unit);
+			return rtf.format(Math.trunc(diffMs / ms), unit);
 		}
 	}
-	return rtf.format(Math.round(diffMs / 1000), 'second');
+	return rtf.format(Math.trunc(diffMs / 1000), 'second');
 }
 
 /**

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -7,98 +7,42 @@ import { formatDate } from './date';
 
 /**
  * Format a timestamp as relative time (e.g., "2 hours ago", "yesterday", "3 days ago")
+ *
+ * Falls back to an absolute date for deltas longer than ~30 days.
+ * Uses a "now" band for deltas under 30 seconds.
+ *
  * @param dateString ISO 8601 date-time string
  * @returns Relative time string
  */
 export function formatRelativeTime(dateString: string): string {
-	const date = new Date(dateString);
-	const now = new Date();
-	const diffMs = now.getTime() - date.getTime();
-	const diffSeconds = Math.floor(diffMs / 1000);
-	const diffMinutes = Math.floor(diffMs / (1000 * 60));
-	const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-	const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+	const diffMs = new Date(dateString).getTime() - Date.now();
+	const absDiffMs = Math.abs(diffMs);
 
-	const locale = getLocale();
+	// More than a month: fallback to absolute date
+	if (absDiffMs > 30 * 24 * 60 * 60 * 1000) {
+		return formatDate(dateString);
+	}
+
+	// Initialize standard formatter.
+	// `numeric: 'auto'` handles lexical conversions natively (e.g., "-1 day" -> "yesterday" / "gestern" / "ieri")
+	const rtf = new Intl.RelativeTimeFormat(getLocale(), { numeric: 'auto', style: 'long' });
 
 	// Just now (less than 30 seconds)
-	if (diffSeconds < 30) {
-		return locale === 'en' ? 'just now' : locale === 'de' ? 'gerade eben' : 'proprio ora';
+	if (absDiffMs < 30 * 1000) {
+		return rtf.format(0, 'second'); // "now" / "jetzt" / "ora"
 	}
 
-	// Less than a minute
-	if (diffMinutes < 1) {
-		return locale === 'en'
-			? `${diffSeconds} seconds ago`
-			: locale === 'de'
-				? `vor ${diffSeconds} Sekunden`
-				: `${diffSeconds} secondi fa`;
-	}
+	const units: [Intl.RelativeTimeFormatUnit, number][] = [
+		['week', 7 * 24 * 60 * 60 * 1000],
+		['day', 24 * 60 * 60 * 1000],
+		['hour', 60 * 60 * 1000],
+		['minute', 60 * 1000]
+	];
 
-	// Less than an hour
-	if (diffMinutes < 60) {
-		const unit = locale === 'en' ? 'minute' : locale === 'de' ? 'Minute' : 'minuto';
-		const units = locale === 'en' ? 'minutes' : locale === 'de' ? 'Minuten' : 'minuti';
-		const word = locale === 'en' ? 'ago' : locale === 'de' ? 'vor' : 'fa';
-
-		if (locale === 'de') {
-			return `vor ${diffMinutes} ${diffMinutes === 1 ? unit : units}`;
+	for (const [unit, ms] of units) {
+		if (absDiffMs >= ms) {
+			return rtf.format(Math.trunc(diffMs / ms), unit);
 		}
-
-		return locale === 'en'
-			? `${diffMinutes} ${diffMinutes === 1 ? unit : units} ago`
-			: `${diffMinutes} ${diffMinutes === 1 ? unit : units} fa`;
 	}
-
-	// Less than a day
-	if (diffHours < 24) {
-		const unit = locale === 'en' ? 'hour' : locale === 'de' ? 'Stunde' : 'ora';
-		const units = locale === 'en' ? 'hours' : locale === 'de' ? 'Stunden' : 'ore';
-		const word = locale === 'en' ? 'ago' : locale === 'de' ? 'vor' : 'fa';
-
-		if (locale === 'de') {
-			return `vor ${diffHours} ${diffHours === 1 ? unit : units}`;
-		}
-
-		return locale === 'en'
-			? `${diffHours} ${diffHours === 1 ? unit : units} ago`
-			: `${diffHours} ${diffHours === 1 ? unit : units} fa`;
-	}
-
-	// Yesterday
-	if (diffDays === 1) {
-		return locale === 'en' ? 'yesterday' : locale === 'de' ? 'gestern' : 'ieri';
-	}
-
-	// Less than a week
-	if (diffDays < 7) {
-		const unit = locale === 'en' ? 'day' : locale === 'de' ? 'Tag' : 'giorno';
-		const units = locale === 'en' ? 'days' : locale === 'de' ? 'Tagen' : 'giorni';
-		const word = locale === 'en' ? 'ago' : locale === 'de' ? 'vor' : 'fa';
-
-		if (locale === 'de') {
-			return `vor ${diffDays} ${units}`;
-		}
-
-		return locale === 'en' ? `${diffDays} ${units} ago` : `${diffDays} ${units} fa`;
-	}
-
-	// Less than a month
-	const diffWeeks = Math.floor(diffDays / 7);
-	if (diffWeeks < 4) {
-		const unit = locale === 'en' ? 'week' : locale === 'de' ? 'Woche' : 'settimana';
-		const units = locale === 'en' ? 'weeks' : locale === 'de' ? 'Wochen' : 'settimane';
-		const word = locale === 'en' ? 'ago' : locale === 'de' ? 'vor' : 'fa';
-
-		if (locale === 'de') {
-			return `vor ${diffWeeks} ${diffWeeks === 1 ? unit : units}`;
-		}
-
-		return locale === 'en'
-			? `${diffWeeks} ${diffWeeks === 1 ? unit : units} ago`
-			: `${diffWeeks} ${diffWeeks === 1 ? unit : units} fa`;
-	}
-
-	// More than a month: show absolute date
-	return formatDate(dateString);
+	return rtf.format(Math.trunc(diffMs / 1000), 'second');
 }


### PR DESCRIPTION
## Summary

Replaces the hand-rolled relative-time logic in `time.ts` — which maintained separate locale dictionaries for `en`, `de`, and `it` — with the native [`Intl.RelativeTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) API. Also fixes a rounding bug shared with `date.ts`.

## Motivation

The previous implementation had ~80 lines of per-locale string templates with manual pluralization (`Minute` vs. `Minuten`, `ora` vs. `ore`, etc.). Every new locale required editing this file, and several edge cases were wrong (e.g. German dative "Tagen" was hardcoded for all day counts). `Intl.RelativeTimeFormat` delegates all of this to the JS engine's CLDR data — zero maintenance for new locales.

## Changes

### `src/lib/utils/time.ts`

| Before | After |
|---|---|
| 100-line if-else ladder with 3 hardcoded locale dictionaries | 49-line function using `Intl.RelativeTimeFormat` |
| `Math.floor` on separate `diffMinutes`, `diffHours`, `diffDays` vars | Single `diffMs` with concise unit-loop (consistent with `date.ts`) |
| Mixed tabs + 4-space indentation | Consistent tabs (matches project convention) |
| Only handled past dates | Handles both past and future dates correctly |
| Limited to 3 hardcoded locales (`en`, `de`, `it`) | Supports all languages automatically via the engine's CLDR data |

Key design decisions preserved:
- **"Just now" band** (< 30 s) → `rtf.format(0, 'second')` → "now" / "jetzt" / "ora"
- **Month cutoff** → falls back to absolute date via `formatDate()` for deltas > 30 days
- **`getLocale()`** (Paraglide UI locale) — intentionally different from `date.ts`'s `getDateLocale()`

### `src/lib/utils/date.ts`

Surgical 2-line fix: `Math.round` → `Math.trunc` in `formatRelativeTime` (lines 229, 232).

`Math.round` could overshoot into the next bucket — e.g. 59 min 45 s would round to 60 minutes instead of promoting to the "hours" unit. `Math.trunc` rounds toward zero, keeping the value within the current unit's range.

## Testing

- TypeScript type-check passes (`npx tsc --noEmit`) — no new errors introduced.
- Existing call sites (`AnnouncementCard`, `AnnouncementPublicCard`, `NotificationItem`, admin announcements page) are unchanged — same function signature, same import path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative time displays to be more consistent and locale-aware.
  * Fixed rounding at time boundaries so values now count toward zero instead of snapping to the nearest unit.
  * Updated “just now” and short-range timestamps to show more natural wording.
  * Long time differences now fall back to standard date formatting more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->