### PR TITLE
fix(i18n): write paraglide canonical cookie and fix transient 500 error on language switch

### DIFF
--- a/src/lib/components/common/LanguageSwitcher.svelte
+++ b/src/lib/components/common/LanguageSwitcher.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { getLocale, setLocale } from '$lib/paraglide/runtime.js';
+	import { getLocale, setLocale, cookieName } from '$lib/paraglide/runtime.js';
 	import { invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -66,6 +66,7 @@
 
 		// Update cookie (for non-logged-in users and SSR)
 		document.cookie = `user_language=${lang}; path=/; max-age=31536000; SameSite=Lax`;
+		document.cookie = `${cookieName}=${lang}; path=/; max-age=31536000; SameSite=Lax`;
 
 		// If user is logged in, persist to backend
 		// IMPORTANT: We must await this call before invalidateAll() to prevent a race condition.
@@ -92,7 +93,6 @@
 
 		// For regular pages, use Paraglide's locale switching
 		setLocale(typedLang);
-		await invalidateAll();
 	}
 
 	// Get current language details

--- a/src/lib/components/common/LanguageSwitcher.svelte
+++ b/src/lib/components/common/LanguageSwitcher.svelte
@@ -65,8 +65,9 @@
 		isOpen = false;
 
 		// Update cookie (for non-logged-in users and SSR)
-		document.cookie = `user_language=${lang}; path=/; max-age=31536000; SameSite=Lax`;
-		document.cookie = `${cookieName}=${lang}; path=/; max-age=31536000; SameSite=Lax`;
+		const cookieAttrs = 'path=/; max-age=31536000; SameSite=Lax';
+		document.cookie = `user_language=${lang}; ${cookieAttrs}`;
+		document.cookie = `${cookieName}=${lang}; ${cookieAttrs}`;
 
 		// If user is logged in, persist to backend
 		// IMPORTANT: We must await this call before invalidateAll() to prevent a race condition.


### PR DESCRIPTION
## Summary

This PR resolves issues with the client-side language switcher dropdown:
1. **Locale Reversion**: Clicking on a language in the dropdown previously had no permanent effect because the client-side runtime did not update Paraglide's canonical `PARAGLIDE_LOCALE` cookie. Since the server-side language detector prioritizes the canonical cookie, subsequent SvelteKit invalidations/reloads reverted the language to the previous setting. This is resolved by writing `cookieName` (`PARAGLIDE_LOCALE`) on the client alongside the legacy `user_language` cookie.
2. **Transient 500 Error Flash**: On language switch, the user briefly saw a "500 Server Error" page. This happened because `setLocale()` triggers a browser reload by default to re-evaluate static translations. A concurrent SvelteKit client-side data reload via `invalidateAll()` was being initiated and immediately aborted by the browser, causing SvelteKit to catch the abort error and display the 500 error page. This is resolved by removing the redundant `invalidateAll()` call since a full page reload refreshes all data anyway.

## Changes

- **`src/lib/components/common/LanguageSwitcher.svelte`**:
  - Imported `cookieName` from `$lib/paraglide/runtime.js`.
  - Updated `switchLanguage()` to write the canonical `PARAGLIDE_LOCALE` cookie value.
  - Consolidated the duplicated cookie options string (`path=/; max-age=31536000; SameSite=Lax`) into a shared `cookieAttrs` constant to simplify future updates.
  - Removed the redundant `await invalidateAll()` call to prevent aborted fetch requests.

## Design Review & Verification Decisions

- **Full Page Reload vs. Client Transition**: We reviewed whether we could use a client-side-only transition (`setLocale(..., { reload: false })` + `invalidateAll()`). However, because Paraglide's static translations (e.g. `m.hello()`) are not reactively wrapped in Svelte 5 runes, static layout elements (like the Header, Sidebar, and button labels) remain untranslated until a manual refresh. Re-enabling the default browser reload of `setLocale()` ensures the entire UI is correctly localized.
- **Resolving the Transient 500 Error**: Removing the redundant `invalidateAll()` call stops the concurrent SvelteKit data fetch. This prevents the browser from aborting the fetch during the page reload, which SvelteKit caught as a routing error and rendered as a transient "500 Server Error" page.
- **Locale Persistence & Consolidations**: Verified that both cookies (`user_language` and `PARAGLIDE_LOCALE`) are updated successfully on the client before the reload using the consolidated attributes, allowing SvelteKit's server-side layout hook to resolve and serve the correct language.

## Pre-existing Edge Case Note

- **Language-prefixed SEO routes on first load**: If a user directly visits a language-prefixed SEO landing page (e.g. `/fr/eventbrite-alternative`) for the first time without having any pre-existing language cookies, SvelteKit's `detectLanguage()` hook will default the global layout components (Header/Footer) to English while the page template renders the French content. This is a pre-existing layout routing design behavior (since the `detectLanguage` hook does not parse the pathname prefix) and is not affected or introduced by this PR. Once the user interacts with the language switcher, both the layout and page sync up correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language switching to store the selected language more reliably.
  * Reduced unnecessary full-page refresh behavior when changing languages, helping switches feel smoother.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->