### PR TITLE
chore(deps-dev): bump prettier-plugin-svelte to 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"jsdom": "^29.1.1",
 		"postcss": "^8.5.10",
 		"prettier": "~3.6.2",
-		"prettier-plugin-svelte": "^3.3.2",
+		"prettier-plugin-svelte": "^4.1.1",
 		"prettier-plugin-tailwindcss": "^0.6.9",
 		"svelte": "^5.55.7",
 		"svelte-check": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,11 +194,11 @@ importers:
         specifier: ~3.6.2
         version: 3.6.2
       prettier-plugin-svelte:
-        specifier: ^3.3.2
-        version: 3.5.2(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0))
+        specifier: ^4.1.1
+        version: 4.1.1(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       prettier-plugin-tailwindcss:
         specifier: ^0.6.9
-        version: 0.6.14(prettier-plugin-svelte@3.5.2(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(prettier@3.6.2)
+        version: 0.6.14(prettier-plugin-svelte@4.1.1(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(prettier@3.6.2)
       svelte:
         specifier: ^5.55.7
         version: 5.56.3(@typescript-eslint/types@8.61.0)
@@ -2482,11 +2482,12 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-svelte@3.5.2:
-    resolution: {integrity: sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==}
+  prettier-plugin-svelte@4.1.1:
+    resolution: {integrity: sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==}
+    engines: {node: '>=20'}
     peerDependencies:
       prettier: ^3.0.0
-      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+      svelte: ^5.0.0
 
   prettier-plugin-tailwindcss@0.6.14:
     resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
@@ -5270,16 +5271,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.5.2(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0)):
+  prettier-plugin-svelte@4.1.1(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0)):
     dependencies:
       prettier: 3.6.2
       svelte: 5.56.3(@typescript-eslint/types@8.61.0)
 
-  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.5.2(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(prettier@3.6.2):
+  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@4.1.1(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(prettier@3.6.2):
     dependencies:
       prettier: 3.6.2
     optionalDependencies:
-      prettier-plugin-svelte: 3.5.2(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0))
+      prettier-plugin-svelte: 4.1.1(prettier@3.6.2)(svelte@5.56.3(@typescript-eslint/types@8.61.0))
 
   prettier@3.6.2: {}
 

--- a/src/lib/components/forms/MarkdownEditor.svelte
+++ b/src/lib/components/forms/MarkdownEditor.svelte
@@ -224,8 +224,7 @@
 				'focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
 				'disabled:cursor-not-allowed disabled:opacity-50',
 				error ? 'border-destructive' : 'border-gray-300 dark:border-gray-600'
-			)}
-		></textarea>
+			)}></textarea>
 		{#if sourceMode && editor}
 			<button
 				type="button"

--- a/src/lib/components/ui/textarea/textarea.svelte
+++ b/src/lib/components/ui/textarea/textarea.svelte
@@ -18,5 +18,4 @@
 		className
 	)}
 	bind:value
-	{...restProps}
-></textarea>
+	{...restProps}></textarea>


### PR DESCRIPTION
Supersedes #412 (Dependabot), adding the reformat that v4 requires so CI stays green.

## What
- Bumps `prettier-plugin-svelte` `^3.3.2` → `^4.1.1`.
- Applies the v4 formatting change to the only two affected files: `MarkdownEditor.svelte` and `textarea.svelte` (self-closing `<textarea>` closing tag collapses onto the previous line — cosmetic, no behavior change).

## Why a fresh branch instead of #412
Dependabot's #412 bumped the dependency but not the reformat, so `pnpm prettier --check .` failed. This branch includes both.

## Verification
- `pnpm prettier --check .` → all files pass
- `pnpm check` (svelte-check) → 0 errors
- No peer conflict (v4 requires prettier ≥3; repo is on 3.6.2)

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)