### PR TITLE
docs(events): drop stale waitlist_cutoff_date caveat in DuplicateEventModal

### DIFF
--- a/src/lib/components/events/admin/DuplicateEventModal.svelte
+++ b/src/lib/components/events/admin/DuplicateEventModal.svelte
@@ -40,10 +40,9 @@
 	/**
 	 * Suggest the duplicate's start, prefilled from the source event.
 	 *
-	 * The backend shifts `end`, `rsvp_before`, `apply_before`, `check_in_starts_at`, and
-	 * `check_in_ends_at` by `newStart - sourceStart` (preserving the original durations), so
-	 * only the start needs to be chosen here. Exception: `waitlist_cutoff_date` is copied
-	 * verbatim (unshifted), so a duplicated event can inherit a stale waitlist cutoff.
+	 * The backend shifts `end`, `rsvp_before`, `apply_before`, `check_in_starts_at`,
+	 * `check_in_ends_at`, and `waitlist_cutoff_date` by `newStart - sourceStart` (preserving
+	 * the original durations), so only the start needs to be chosen here.
 	 * A source start still in the future is reused verbatim. A past start keeps its
 	 * (local) time-of-day and rolls forward to the next future occurrence of that time —
 	 * today if that time is still ahead, otherwise tomorrow — so the field always satisfies


### PR DESCRIPTION
## Summary

Comment-only change. `DuplicateEventModal.svelte` documented that the backend copies `waitlist_cutoff_date` verbatim (unshifted) when duplicating an event — that bug was fixed in letsrevel/revel-backend#646 (issue letsrevel/revel-backend#645), which the comment itself anticipated ("that comment should be removed once this lands").

The doc comment now lists `waitlist_cutoff_date` among the date fields the backend shifts by `newStart - sourceStart`, and the stale exception sentence is gone.

No behavior change; prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCmCKEjL7ftq8UGwiGt6UY