### PR TITLE
fix: dashboard org show-all toggle (#560) + a11y pass on filters, selection, dialogs (#564)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1080,6 +1080,7 @@
 			"nextPage": "Nächste Seite"
 		},
 		"seeAllOrganizations": "Alle {count} Organisationen ansehen",
+		"showFewerOrganizations": "Weniger anzeigen",
 		"followingButton": "Folge ich",
 		"following": {
 			"title": "Folge ich",
@@ -1619,6 +1620,8 @@
 		"registeredUsersTitle": "Registered Users ({count})",
 		"pendingUsersTitle": "Pending (Unregistered) ({count})",
 		"selected": "{count} selected",
+		"selectAll": "Alle Einladungen auswählen",
+		"selectInvitation": "Einladung für {name} auswählen",
 		"noTier": "No tier",
 		"linksDescription": "Create shareable invitation links that anyone can use to register for this event. Perfect for social media, emails, or QR codes.",
 		"createLink": "Create Link",
@@ -2599,7 +2602,6 @@
 		"ticketingFeature4": "QR-Code-Check-in und Ticket-Validierung",
 		"feeCalculator": {
 			"title": "Gebührenrechner",
-			"close": "Schließen",
 			"ticketPrice": "Ticketpreis",
 			"creditCardFees": "Kreditkartengebühren",
 			"creditCardFeesDescription": "1,5% + 0,25€ pro Transaktion. Diese gehen an Stripe - wir haben keinen Einfluss darauf.",
@@ -7712,7 +7714,6 @@
 	"eventTicketsAdmin.blacklistSuccess": "{name} wurde auf die Sperrliste gesetzt",
 	"eventTicketsAdmin.userIdNotAvailable": "Nutzer-ID nicht verfügbar",
 	"eventTicketsAdmin.paginationShowing": "Seite {page} von {totalPages} ({total} Tickets insgesamt)",
-	"eventTicketsAdmin.closeDialog": "Dialog schließen",
 	"eventTicketsAdmin.amountPaidLabel": "Gezahlter Betrag ({currency})",
 	"eventTicketsAdmin.confirmingPayment": "Wird bestätigt...",
 	"eventTicketsAdmin.blacklistDialogTitle": "Nutzer sperren",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1080,6 +1080,7 @@
 			"nextPage": "Next page"
 		},
 		"seeAllOrganizations": "See all {count} organizations",
+		"showFewerOrganizations": "Show fewer",
 		"followingButton": "Following",
 		"following": {
 			"title": "Following",
@@ -1619,6 +1620,8 @@
 		"registeredUsersTitle": "Registered Users ({count})",
 		"pendingUsersTitle": "Pending (Unregistered) ({count})",
 		"selected": "{count} selected",
+		"selectAll": "Select all invitations",
+		"selectInvitation": "Select invitation for {name}",
 		"noTier": "No tier",
 		"linksDescription": "Create shareable invitation links that anyone can use to register for this event. Perfect for social media, emails, or QR codes.",
 		"createLink": "Create Link",
@@ -2599,7 +2602,6 @@
 		"ticketingFeature4": "QR code check-in and ticket validation",
 		"feeCalculator": {
 			"title": "Fee Calculator",
-			"close": "Close",
 			"ticketPrice": "Ticket Price",
 			"creditCardFees": "Credit Card Fees",
 			"creditCardFeesDescription": "1.5% + €0.25 per transaction. These go to Stripe - we have no control over them.",
@@ -7712,7 +7714,6 @@
 	"eventTicketsAdmin.blacklistSuccess": "{name} has been blacklisted",
 	"eventTicketsAdmin.userIdNotAvailable": "User ID not available",
 	"eventTicketsAdmin.paginationShowing": "Showing page {page} of {totalPages} ({total} total tickets)",
-	"eventTicketsAdmin.closeDialog": "Close dialog",
 	"eventTicketsAdmin.amountPaidLabel": "Amount paid ({currency})",
 	"eventTicketsAdmin.confirmingPayment": "Confirming...",
 	"eventTicketsAdmin.blacklistDialogTitle": "Blacklist User",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -967,6 +967,7 @@
 			"nextPage": "Page suivante"
 		},
 		"seeAllOrganizations": "Voir toutes les {count} organisations",
+		"showFewerOrganizations": "Afficher moins",
 		"followingButton": "Abonnements",
 		"following": {
 			"title": "Abonnements",
@@ -1506,6 +1507,8 @@
 		"registeredUsersTitle": "Utilisateurs inscrits ({count})",
 		"pendingUsersTitle": "En attente (non inscrits) ({count})",
 		"selected": "{count} sélectionnées",
+		"selectAll": "Sélectionner toutes les invitations",
+		"selectInvitation": "Sélectionner l'invitation de {name}",
 		"noTier": "Aucune catégorie",
 		"linksDescription": "Crée des liens d'invitation partageables que n'importe qui peut utiliser pour s'inscrire à cet événement. Parfaits pour les réseaux sociaux, les e-mails ou les QR codes.",
 		"createLink": "Créer un lien",
@@ -2486,7 +2489,6 @@
 		"ticketingFeature4": "Enregistrement par code QR et validation des billets",
 		"feeCalculator": {
 			"title": "Calculateur de frais",
-			"close": "Fermer",
 			"ticketPrice": "Prix du billet",
 			"creditCardFees": "Frais de carte bancaire",
 			"creditCardFeesDescription": "1,5 % + 0,25 € par transaction. Ils reviennent à Stripe - nous n'avons aucun contrôle dessus.",
@@ -7683,7 +7685,6 @@
 	"eventTicketsAdmin.blacklistSuccess": "{name} a été ajouté à la liste noire",
 	"eventTicketsAdmin.userIdNotAvailable": "Identifiant utilisateur non disponible",
 	"eventTicketsAdmin.paginationShowing": "Page {page} sur {totalPages} ({total} billets au total)",
-	"eventTicketsAdmin.closeDialog": "Fermer la boîte de dialogue",
 	"eventTicketsAdmin.amountPaidLabel": "Montant payé ({currency})",
 	"eventTicketsAdmin.confirmingPayment": "Confirmation...",
 	"eventTicketsAdmin.blacklistDialogTitle": "Ajouter l'utilisateur à la liste noire",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1080,6 +1080,7 @@
 			"nextPage": "Pagina successiva"
 		},
 		"seeAllOrganizations": "Vedi tutte le {count} organizzazioni",
+		"showFewerOrganizations": "Mostra meno",
 		"followingButton": "Seguiti",
 		"following": {
 			"title": "Seguiti",
@@ -1619,6 +1620,8 @@
 		"registeredUsersTitle": "Registered Users ({count})",
 		"pendingUsersTitle": "Pending (Unregistered) ({count})",
 		"selected": "{count} selected",
+		"selectAll": "Seleziona tutti gli inviti",
+		"selectInvitation": "Seleziona l'invito per {name}",
 		"noTier": "No tier",
 		"linksDescription": "Create shareable invitation links that anyone can use to register for this event. Perfect for social media, emails, or QR codes.",
 		"createLink": "Create Link",
@@ -2599,7 +2602,6 @@
 		"ticketingFeature4": "Check-in con codice QR e convalida biglietti",
 		"feeCalculator": {
 			"title": "Calcolatore Commissioni",
-			"close": "Chiudi",
 			"ticketPrice": "Prezzo Biglietto",
 			"creditCardFees": "Commissioni Carta di Credito",
 			"creditCardFeesDescription": "1,5% + €0,25 per transazione. Queste vanno a Stripe - non abbiamo controllo su di esse.",
@@ -7712,7 +7714,6 @@
 	"eventTicketsAdmin.blacklistSuccess": "{name} è stato inserito nella lista nera",
 	"eventTicketsAdmin.userIdNotAvailable": "ID utente non disponibile",
 	"eventTicketsAdmin.paginationShowing": "Pagina {page} di {totalPages} ({total} biglietti in totale)",
-	"eventTicketsAdmin.closeDialog": "Chiudi la finestra",
 	"eventTicketsAdmin.amountPaidLabel": "Importo pagato ({currency})",
 	"eventTicketsAdmin.confirmingPayment": "Conferma in corso...",
 	"eventTicketsAdmin.blacklistDialogTitle": "Inserisci utente nella lista nera",

--- a/src/lib/components/attendees/AttendeeFilters.svelte
+++ b/src/lib/components/attendees/AttendeeFilters.svelte
@@ -28,6 +28,7 @@
 		<button
 			type="button"
 			onclick={() => onStatusFilter(null)}
+			aria-pressed={!activeStatusFilter}
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
 				!activeStatusFilter
@@ -40,6 +41,7 @@
 		<button
 			type="button"
 			onclick={() => onStatusFilter('yes')}
+			aria-pressed={activeStatusFilter === 'yes'}
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
 				activeStatusFilter === 'yes'
@@ -52,6 +54,7 @@
 		<button
 			type="button"
 			onclick={() => onStatusFilter('maybe')}
+			aria-pressed={activeStatusFilter === 'maybe'}
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
 				activeStatusFilter === 'maybe'
@@ -64,6 +67,7 @@
 		<button
 			type="button"
 			onclick={() => onStatusFilter('no')}
+			aria-pressed={activeStatusFilter === 'no'}
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
 				activeStatusFilter === 'no'

--- a/src/lib/components/dashboard/DashboardOrganizationsSection.svelte
+++ b/src/lib/components/dashboard/DashboardOrganizationsSection.svelte
@@ -24,6 +24,12 @@
 		permissions: OrganizationPermissionsSchema | null;
 	}
 	let { organizations, isLoading, permissions }: Props = $props();
+
+	const COLLAPSED_COUNT = 3;
+	let showAll = $state(false);
+	const visibleOrganizations = $derived(
+		showAll ? organizations : organizations.slice(0, COLLAPSED_COUNT)
+	);
 </script>
 
 <!-- My Organizations Section -->
@@ -61,8 +67,8 @@
 		</div>
 	{:else}
 		<!-- Organization Cards -->
-		<div class="space-y-3">
-			{#each organizations.slice(0, 3) as org (org.id)}
+		<div id="dashboard-organizations-list" class="space-y-3">
+			{#each visibleOrganizations as org (org.id)}
 				{@const descriptionText = org.description ? stripMarkdown(org.description) : ''}
 				<div
 					class="flex items-center gap-4 rounded-lg border bg-card p-4 transition-shadow hover:shadow-md"
@@ -165,5 +171,19 @@
 				</div>
 			{/each}
 		</div>
+
+		{#if organizations.length > COLLAPSED_COUNT}
+			<button
+				type="button"
+				onclick={() => (showAll = !showAll)}
+				aria-expanded={showAll}
+				aria-controls="dashboard-organizations-list"
+				class="mt-3 w-full rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+			>
+				{showAll
+					? m['dashboard.showFewerOrganizations']()
+					: m['dashboard.seeAllOrganizations']({ count: organizations.length })}
+			</button>
+		{/if}
 	{/if}
 </section>

--- a/src/lib/components/invitations/InvitationTable.svelte
+++ b/src/lib/components/invitations/InvitationTable.svelte
@@ -10,6 +10,7 @@
 	import { Trash2, Edit, CheckSquare, Square } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import { Button } from '$lib/components/ui/button';
+	import { getUserDisplayName } from '$lib/utils/user-display';
 
 	interface Props {
 		title: string;
@@ -54,6 +55,12 @@
 		}
 	}
 
+	function invitationLabel(
+		invitation: EventInvitationListSchema | PendingEventInvitationListSchema
+	): string {
+		return 'user' in invitation ? getUserDisplayName(invitation.user) : invitation.email;
+	}
+
 	function toggleSelectAll() {
 		const allSelected = selectedIds.size === invitations.length;
 		selectedIds.clear();
@@ -94,6 +101,8 @@
 								<button
 									type="button"
 									onclick={toggleSelectAll}
+									aria-label={m['eventInvitationsAdmin.selectAll']()}
+									aria-pressed={selectedIds.size === invitations.length && invitations.length > 0}
 									class="flex items-center justify-center text-muted-foreground hover:text-foreground"
 								>
 									{#if selectedIds.size === invitations.length && invitations.length > 0}
@@ -129,6 +138,10 @@
 									<button
 										type="button"
 										onclick={() => toggleSelection(invitation.id)}
+										aria-label={m['eventInvitationsAdmin.selectInvitation']({
+											name: invitationLabel(invitation)
+										})}
+										aria-pressed={selectedIds.has(invitation.id)}
 										class="flex items-center justify-center text-muted-foreground hover:text-foreground"
 									>
 										{#if selectedIds.has(invitation.id)}

--- a/src/lib/components/landing/FeeCalculatorModal.svelte
+++ b/src/lib/components/landing/FeeCalculatorModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { X } from '@lucide/svelte';
+	import { Dialog, DialogContent, DialogHeader, DialogTitle } from '$lib/components/ui/dialog';
 
 	interface Props {
 		open: boolean;
@@ -48,133 +48,110 @@
 	}
 </script>
 
-{#if open}
-	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-		onclick={(e) => e.target === e.currentTarget && (open = false)}
-		onkeydown={(e) => e.key === 'Escape' && (open = false)}
-		role="dialog"
-		aria-modal="true"
-		aria-labelledby="fee-calculator-title"
-		tabindex="-1"
-	>
-		<div class="w-full max-w-md rounded-lg border bg-background shadow-xl">
-			<!-- Header -->
-			<div class="flex items-center justify-between border-b px-6 py-4">
-				<h2 id="fee-calculator-title" class="text-xl font-bold">
-					{m['learnMore.feeCalculator.title']()}
-				</h2>
-				<button
-					type="button"
-					onclick={() => (open = false)}
-					class="rounded-full p-1 hover:bg-accent"
-					aria-label={m['learnMore.feeCalculator.close']()}
+<Dialog bind:open>
+	<DialogContent class="max-h-[90vh] max-w-md overflow-y-auto">
+		<DialogHeader>
+			<DialogTitle>{m['learnMore.feeCalculator.title']()}</DialogTitle>
+		</DialogHeader>
+
+		<!-- Content -->
+		<div class="space-y-6">
+			<!-- Ticket Price Input -->
+			<div>
+				<label for="ticket-price" class="mb-2 block text-sm font-medium"
+					>{m['learnMore.feeCalculator.ticketPrice']()}</label
 				>
-					<X class="h-5 w-5" />
-				</button>
+				<div class="relative">
+					<span class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">€</span>
+					<input
+						id="ticket-price"
+						type="number"
+						min="0"
+						step="0.01"
+						bind:value={ticketPrice}
+						class="w-full rounded-md border border-input bg-background py-2 pl-8 pr-4 text-lg focus:outline-none focus:ring-2 focus:ring-primary"
+					/>
+				</div>
 			</div>
 
-			<!-- Content -->
-			<div class="space-y-6 px-6 py-4">
-				<!-- Ticket Price Input -->
-				<div>
-					<label for="ticket-price" class="mb-2 block text-sm font-medium"
-						>{m['learnMore.feeCalculator.ticketPrice']()}</label
-					>
-					<div class="relative">
-						<span class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">€</span>
-						<input
-							id="ticket-price"
-							type="number"
-							min="0"
-							step="0.01"
-							bind:value={ticketPrice}
-							class="w-full rounded-md border border-input bg-background py-2 pl-8 pr-4 text-lg focus:outline-none focus:ring-2 focus:ring-primary"
-						/>
+			<!-- Fee Breakdown -->
+			<div class="space-y-4">
+				<!-- Stripe Fees -->
+				<div class="rounded-lg border bg-muted/30 p-4">
+					<div class="flex items-center justify-between">
+						<span class="font-medium">{m['learnMore.feeCalculator.creditCardFees']()}</span>
+						<span class="text-lg font-bold text-orange-600 dark:text-orange-400">
+							{formatCurrency(stripeFee)}
+						</span>
 					</div>
+					<p class="mt-1 text-xs text-muted-foreground">
+						{m['learnMore.feeCalculator.creditCardFeesDescription']()}
+						<a
+							href="https://stripe.com/en-at/pricing"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="text-primary hover:underline"
+						>
+							{m['learnMore.feeCalculator.viewStripePricing']()}
+						</a>
+					</p>
 				</div>
 
-				<!-- Fee Breakdown -->
-				<div class="space-y-4">
-					<!-- Stripe Fees -->
-					<div class="rounded-lg border bg-muted/30 p-4">
-						<div class="flex items-center justify-between">
-							<span class="font-medium">{m['learnMore.feeCalculator.creditCardFees']()}</span>
-							<span class="text-lg font-bold text-orange-600 dark:text-orange-400">
-								{formatCurrency(stripeFee)}
-							</span>
-						</div>
-						<p class="mt-1 text-xs text-muted-foreground">
-							{m['learnMore.feeCalculator.creditCardFeesDescription']()}
-							<a
-								href="https://stripe.com/en-at/pricing"
-								target="_blank"
-								rel="noopener noreferrer"
-								class="text-primary hover:underline"
-							>
-								{m['learnMore.feeCalculator.viewStripePricing']()}
-							</a>
-						</p>
+				<!-- Revel Platform Fee -->
+				<div class="rounded-lg border bg-muted/30 p-4">
+					<div class="flex items-center justify-between">
+						<span class="font-medium">{m['learnMore.feeCalculator.platformFee']()}</span>
+						<span class="text-lg font-bold text-primary">
+							{formatCurrency(revelFee)}
+						</span>
 					</div>
-
-					<!-- Revel Platform Fee -->
-					<div class="rounded-lg border bg-muted/30 p-4">
-						<div class="flex items-center justify-between">
-							<span class="font-medium">{m['learnMore.feeCalculator.platformFee']()}</span>
-							<span class="text-lg font-bold text-primary">
-								{formatCurrency(revelFee)}
-							</span>
-						</div>
-						<p class="mt-1 text-xs text-muted-foreground">
-							{m['learnMore.feeCalculator.platformFeeDescription']()}
-						</p>
-					</div>
-
-					<!-- Divider -->
-					<div class="border-t"></div>
-
-					<!-- Organization Receives -->
-					<div class="rounded-lg border-2 border-green-500 bg-green-50 p-4 dark:bg-green-950/30">
-						<div class="flex items-center justify-between">
-							<span class="font-semibold"
-								>{m['learnMore.feeCalculator.organizationReceives']()}</span
-							>
-							<span class="text-2xl font-bold text-green-600 dark:text-green-400">
-								{formatCurrency(organizerReceives)}
-							</span>
-						</div>
-						<p class="mt-1 text-xs text-muted-foreground">
-							{m['learnMore.feeCalculator.perTicketSoldAt']({
-								price: formatCurrency(safeTicketPrice)
-							})}
-						</p>
-					</div>
+					<p class="mt-1 text-xs text-muted-foreground">
+						{m['learnMore.feeCalculator.platformFeeDescription']()}
+					</p>
 				</div>
 
-				<!-- Summary -->
-				<p class="text-center text-xs text-muted-foreground">
-					{m['learnMore.feeCalculator.totalFees']({
-						fees: formatCurrency(totalFees),
-						percentage: feePercentage
-					})}
-				</p>
-				<p class="text-center text-xs text-muted-foreground/70">
-					{m['learnMore.feesExcludeVat']()}
-				</p>
+				<!-- Divider -->
+				<div class="border-t"></div>
+
+				<!-- Organization Receives -->
+				<div class="rounded-lg border-2 border-green-500 bg-green-50 p-4 dark:bg-green-950/30">
+					<div class="flex items-center justify-between">
+						<span class="font-semibold">{m['learnMore.feeCalculator.organizationReceives']()}</span>
+						<span class="text-2xl font-bold text-green-600 dark:text-green-400">
+							{formatCurrency(organizerReceives)}
+						</span>
+					</div>
+					<p class="mt-1 text-xs text-muted-foreground">
+						{m['learnMore.feeCalculator.perTicketSoldAt']({
+							price: formatCurrency(safeTicketPrice)
+						})}
+					</p>
+				</div>
 			</div>
 
-			<!-- Footer -->
-			<div class="border-t px-6 py-4">
-				<p class="text-center text-sm text-muted-foreground">
-					{m['learnMore.feeCalculator.questionsAboutFees']()}
-					<a
-						href="mailto:contact@letsrevel.io?subject=Revel%20Fee%20Question"
-						class="text-primary hover:underline"
-					>
-						{m['learnMore.feeCalculator.contactUs']()}
-					</a>
-				</p>
-			</div>
+			<!-- Summary -->
+			<p class="text-center text-xs text-muted-foreground">
+				{m['learnMore.feeCalculator.totalFees']({
+					fees: formatCurrency(totalFees),
+					percentage: feePercentage
+				})}
+			</p>
+			<p class="text-center text-xs text-muted-foreground/70">
+				{m['learnMore.feesExcludeVat']()}
+			</p>
 		</div>
-	</div>
-{/if}
+
+		<!-- Footer -->
+		<div class="border-t pt-4">
+			<p class="text-center text-sm text-muted-foreground">
+				{m['learnMore.feeCalculator.questionsAboutFees']()}
+				<a
+					href="mailto:contact@letsrevel.io?subject=Revel%20Fee%20Question"
+					class="text-primary hover:underline"
+				>
+					{m['learnMore.feeCalculator.contactUs']()}
+				</a>
+			</p>
+		</div>
+	</DialogContent>
+</Dialog>

--- a/src/lib/components/tickets/ConfirmPaymentDialog.svelte
+++ b/src/lib/components/tickets/ConfirmPaymentDialog.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { fade, scale } from 'svelte/transition';
 	import { isPwycTicket, getPwycWarning } from '$lib/utils/ticket-helpers';
 	import { Input } from '$lib/components/ui/input';
-	import { AlertTriangle, X } from '@lucide/svelte';
+	import {
+		Dialog,
+		DialogContent,
+		DialogDescription,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle
+	} from '$lib/components/ui/dialog';
+	import { AlertTriangle } from '@lucide/svelte';
 	import type { AdminTicketSchema } from '$lib/api/generated/types.gen';
 
 	interface Props {
@@ -26,67 +33,34 @@
 </script>
 
 <!-- Confirm Payment Dialog -->
-{#if isOpen && ticket}
-	{@const pwyc = isPwycTicket(ticket)}
-	{@const pwycWarning = pwyc ? getPwycWarning(ticket, pwycPricePaid) : null}
-	{@const pwycValid = !pwyc || (pwycPricePaid !== '' && parseFloat(pwycPricePaid) > 0)}
-	<div
-		role="presentation"
-		onclick={(e) => {
-			if (e.target === e.currentTarget) {
-				onClose();
-			}
-		}}
-		onkeydown={(e) => {
-			if (e.key === 'Escape') {
-				onClose();
-			}
-		}}
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
-		transition:fade={{ duration: 150 }}
-	>
-		<div
-			role="dialog"
-			aria-modal="true"
-			aria-labelledby="confirm-payment-dialog-title"
-			class="relative mx-4 w-full max-w-lg rounded-lg border bg-card p-6 shadow-lg"
-			transition:scale={{ duration: 150, start: 0.95 }}
-		>
-			<!-- Close button -->
-			<button
-				type="button"
-				onclick={onClose}
-				aria-label={m['eventTicketsAdmin.closeDialog']()}
-				class="absolute right-4 top-4 rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			>
-				<X class="h-4 w-4" aria-hidden="true" />
-			</button>
-
-			<!-- Icon + Title -->
-			<div class="flex items-start gap-4">
-				<div
-					class="shrink-0 rounded-full bg-blue-100 p-3 text-blue-600 dark:bg-blue-950 dark:text-blue-400"
-					aria-hidden="true"
-				>
-					<AlertTriangle class="h-6 w-6" />
+<Dialog open={isOpen && !!ticket} onOpenChange={(open) => !open && onClose()}>
+	<DialogContent class="max-w-lg">
+		{#if ticket}
+			{@const pwyc = isPwycTicket(ticket)}
+			{@const pwycWarning = pwyc ? getPwycWarning(ticket, pwycPricePaid) : null}
+			{@const pwycValid = !pwyc || (pwycPricePaid !== '' && parseFloat(pwycPricePaid) > 0)}
+			<DialogHeader>
+				<div class="flex items-start gap-4">
+					<div
+						class="shrink-0 rounded-full bg-blue-100 p-3 text-blue-600 dark:bg-blue-950 dark:text-blue-400"
+						aria-hidden="true"
+					>
+						<AlertTriangle class="h-6 w-6" />
+					</div>
+					<div class="flex-1 pt-1 text-left">
+						<DialogTitle>{m['eventTicketsAdmin.confirmPaymentTitle']()}</DialogTitle>
+						<DialogDescription class="mt-2">
+							{ticket.status === 'cancelled'
+								? m['eventTicketsAdmin.confirmPaymentMessageReactivate']()
+								: m['eventTicketsAdmin.confirmPaymentMessageActivate']()}
+						</DialogDescription>
+					</div>
 				</div>
-				<div class="flex-1 pt-1">
-					<h2 id="confirm-payment-dialog-title" class="text-lg font-semibold text-foreground">
-						{m['eventTicketsAdmin.confirmPaymentTitle']()}
-					</h2>
-				</div>
-			</div>
-
-			<!-- Message -->
-			<div class="mt-4 text-sm text-muted-foreground">
-				{ticket.status === 'cancelled'
-					? m['eventTicketsAdmin.confirmPaymentMessageReactivate']()
-					: m['eventTicketsAdmin.confirmPaymentMessageActivate']()}
-			</div>
+			</DialogHeader>
 
 			<!-- PWYC Price Input -->
 			{#if pwyc}
-				<div class="mt-4 space-y-2">
+				<div class="space-y-2">
 					<label for="pwyc-price-input" class="block text-sm font-medium text-foreground">
 						{m['eventTicketsAdmin.amountPaidLabel']({
 							currency: ticket.tier?.currency?.toUpperCase() || 'EUR'
@@ -120,7 +94,7 @@
 			{/if}
 
 			<!-- Actions -->
-			<div class="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+			<DialogFooter class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
 				<button
 					type="button"
 					onclick={onClose}
@@ -140,7 +114,7 @@
 						{m['eventTicketsAdmin.confirmPaymentButton']()}
 					{/if}
 				</button>
-			</div>
-		</div>
-	</div>
-{/if}
+			</DialogFooter>
+		{/if}
+	</DialogContent>
+</Dialog>


### PR DESCRIPTION
## Summary

Bundles #560 and #564 (the two items deliberately left out of the #566 quickwins PR).

### #560 — Dashboard: no way to see more than 3 organizations

Went with the issue's recommended cheap option: an **in-page show-all/show-fewer toggle** in `DashboardOrganizationsSection.svelte`. The query already loads up to 50 orgs client-side, so the button just expands the already-loaded list — no new route, no new fetch.

- Toggle carries `aria-expanded` + `aria-controls` on the list container
- Reuses the orphaned `dashboard.seeAllOrganizations` key ("See all {count} organizations") left behind when the dead link was removed in #555; adds a `showFewerOrganizations` counterpart
- Empty-state and new-user views untouched; only renders when there are 4+ orgs

### #564 — a11y: post-#544 split surfaces

1. **`aria-pressed` on status filter toggles** — the four buttons in `AttendeeFilters.svelte` now announce their toggle state, matching the dashboard toggle-group idiom.
2. **Unlabeled icon-only selection buttons** — `InvitationTable.svelte` select-all and per-row buttons get `aria-label` + `aria-pressed`. Per-row labels include the invitee's display name (registered) or email (pending) via the existing `getUserDisplayName` helper.
3. **Modal focus management** — `FeeCalculatorModal.svelte` and `ConfirmPaymentDialog.svelte` migrated from hand-rolled overlays to the shadcn/bits-ui `Dialog` (as the issue suggested), which provides focus-into-dialog on open, focus trap, Escape handling, and focus restoration for free. `ConfirmPaymentDialog` keeps its existing `isOpen`/`onClose` prop contract using the same `{open}` + `onOpenChange` idiom as `EventModal.svelte`.

### i18n

New keys (`dashboard.showFewerOrganizations`, `eventInvitationsAdmin.selectAll`, `eventInvitationsAdmin.selectInvitation`) added to **all four locales** (en/de/it/fr); the now-orphaned `learnMore.feeCalculator.close` and `eventTicketsAdmin.closeDialog` keys removed from all four.

## Verification

- `make check` fully green (format, lint 0/0, types, i18n parity, file-length, image-alt)
- `svelte-autofixer` clean on all four modified components
- **Live smoke** (Playwright against dev server) on the Fee Calculator dialog — the exact acceptance criteria of #564:
  - focus moves into the dialog on open (autofocuses the price input)
  - **Escape closes immediately after opening** (no click-inside needed — the reported bug)
  - focus returns to the "Calculate your fees" trigger on close
- `ConfirmPaymentDialog` is behind org-admin auth so it wasn't smoke-tested live, but it uses the identical Dialog component and proven controlled-mode pattern

Closes #560
Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)