### PR TITLE
chore(quality): per-file cap override for file-length gate (#557)

### DIFF
--- a/scripts/check-file-length.sh
+++ b/scripts/check-file-length.sh
@@ -9,10 +9,9 @@
 #   - src/lib/data/            (static data files)
 #   - *.test.ts, *.spec.ts     (test files)
 #   - *.d.ts                   (type declarations)
-#   - src/lib/stores/auth.svelte.ts (517): token race guards + single-flight
-#     refresh thread all state through one class; split rejected twice as
-#     invariant-threatening (#544 Task 12/13 analyses). Cleanup already applied
-#     (580→517). Cap stays 500 for everything else.
+#
+# Per-file cap overrides: see max_for() below. An override raises the cap for
+# one file (with rationale) instead of un-gating it entirely (#557).
 
 set -e
 
@@ -20,11 +19,25 @@ SVELTE_MAX=${1:-750}
 TS_MAX=${2:-500}
 FAILED=0
 
+# Per-file cap overrides — the only sanctioned way for a file to exceed the
+# default cap. Each entry needs a rationale; the override IS the ceiling
+# (no hardcoded current line counts).
+#   auth.svelte.ts → 550: token race guards + single-flight refresh thread all
+#   state through one class; split rejected twice as invariant-threatening
+#   (#544 Task 12/13 analyses, #557).
+max_for() {
+    case "$1" in
+        src/lib/stores/auth.svelte.ts) echo 550 ;;
+        *) echo "$2" ;;
+    esac
+}
+
 # Check Svelte files
 while IFS= read -r -d '' file; do
     lines=$(wc -l < "$file")
-    if [ "$lines" -gt "$SVELTE_MAX" ]; then
-        echo "❌ $file has $lines lines (max: $SVELTE_MAX)"
+    max=$(max_for "$file" "$SVELTE_MAX")
+    if [ "$lines" -gt "$max" ]; then
+        echo "❌ $file has $lines lines (max: $max)"
         FAILED=1
     fi
 done < <(find src -name "*.svelte" \
@@ -35,8 +48,9 @@ done < <(find src -name "*.svelte" \
 # Check TypeScript/JavaScript files
 while IFS= read -r -d '' file; do
     lines=$(wc -l < "$file")
-    if [ "$lines" -gt "$TS_MAX" ]; then
-        echo "❌ $file has $lines lines (max: $TS_MAX)"
+    max=$(max_for "$file" "$TS_MAX")
+    if [ "$lines" -gt "$max" ]; then
+        echo "❌ $file has $lines lines (max: $max)"
         FAILED=1
     fi
 done < <(find src \( -name "*.ts" -o -name "*.js" \) \
@@ -48,7 +62,6 @@ done < <(find src \( -name "*.ts" -o -name "*.js" \) \
     -not -path "*/api/generated/*" \
     -not -path "*/paraglide/*" \
     -not -path "*/data/*" \
-    -not -path "src/lib/stores/auth.svelte.ts" \
     -print0)
 
 if [ "$FAILED" -eq 0 ]; then


### PR DESCRIPTION
Closes #557

## What

Hardens the file-length gate per #557 (post-#556 follow-up):

- **Per-file cap override map** in `scripts/check-file-length.sh` via a `max_for()` lookup (case statement — macOS bash 3.2 has no associative arrays), applied to both the Svelte and TS/JS loops so future overrides work for either file type.
- **`auth.svelte.ts` moved from the exclusion list to an override of 550.** It is gated again (was fully un-gated since #556) with ~33 lines of headroom over its current 517, honoring the twice-analyzed no-split decision (#544 Task 12/13). The override is the source of truth — the comment no longer hardcodes a current line count.

## Near-cap files decision: wait-for-touch

For the three near-cap Svelte files (`TicketConfirmationDialog.svelte` 749/750, `TemplateEditDialog.svelte` 748/750, attendee-invoices `+page.svelte` 744/750): **wait-for-touch**, not proactive splits. Rationale documented in an issue comment on #557 — splitting now with no pending feature is pure churn risk with zero behavior payoff; the next feature that touches one of them splits it first (the #544 method: cohesive seams, zero behavior change), which is when the best seam is actually visible.

## Verification

- `./scripts/check-file-length.sh` → ✅ green
- Negative test: lowered the auth override to 510 in a scratch copy → correctly fails `auth.svelte.ts` (517 > 510) with the per-file max in the message, exit 1. Confirms the file is genuinely gated again and the override value is what's enforced.
- `make check` → fully green (format, lint, types, i18n, file-length, no-ssr-token, image-alt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved file-length checks to allow different line limits for specific files.
  * Updated validation so one larger file can pass without being excluded from checks.
  * Kept the overall line-limit enforcement intact for the rest of the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->