### PR TITLE
fix(components): TagInput label association + EventStatusBadge Full/Past priority

### DIFF
--- a/src/lib/components/events/EventStatusBadge.showcase.md
+++ b/src/lib/components/events/EventStatusBadge.showcase.md
@@ -16,8 +16,8 @@ A visual indicator that displays the current temporal status of an event with se
 The badge displays one of the following statuses based on priority:
 
 1. **Cancelled** (Red/Destructive) - Event status is 'rejected'
-2. **Full** (Red/Destructive) - Event has reached maximum capacity
-3. **Past** (Gray/Secondary) - Event has ended
+2. **Past** (Gray/Secondary) - Event has ended (wins over Full: an ended event is over, regardless of capacity)
+3. **Full** (Red/Destructive) - Event has reached maximum capacity
 4. **Ongoing** (Green/Success) - Event is currently happening
 5. **Happening Today** (Green/Success) - Event starts today but hasn't started yet
 6. **Upcoming** (Blue/Default) - Event is scheduled for the future
@@ -85,16 +85,16 @@ The component uses the following logic to determine status (in priority order):
 event.status === 'rejected';
 ```
 
-### 2. Full
-
-```typescript
-event.max_attendees > 0 && event.attendee_count >= event.max_attendees;
-```
-
-### 3. Past
+### 2. Past
 
 ```typescript
 new Date(event.end) < new Date();
+```
+
+### 3. Full
+
+```typescript
+event.max_attendees > 0 && event.attendee_count >= event.max_attendees;
 ```
 
 ### 4. Ongoing

--- a/src/lib/components/events/EventStatusBadge.showcase.md
+++ b/src/lib/components/events/EventStatusBadge.showcase.md
@@ -15,7 +15,7 @@ A visual indicator that displays the current temporal status of an event with se
 
 The badge displays one of the following statuses based on priority:
 
-1. **Cancelled** (Red/Destructive) - Event status is 'rejected'
+1. **Cancelled** (Orange) - Event status is 'cancelled'
 2. **Past** (Gray/Secondary) - Event has ended (wins over Full: an ended event is over, regardless of capacity)
 3. **Full** (Red/Destructive) - Event has reached maximum capacity
 4. **Ongoing** (Green/Success) - Event is currently happening
@@ -82,7 +82,7 @@ The component uses the following logic to determine status (in priority order):
 ### 1. Cancelled
 
 ```typescript
-event.status === 'rejected';
+event.status === 'cancelled';
 ```
 
 ### 2. Past
@@ -134,7 +134,8 @@ The component follows WCAG 2.1 AA guidelines:
 - **Success** (Green): Ongoing, Happening Today
 - **Default** (Blue): Upcoming
 - **Secondary** (Gray): Past
-- **Destructive** (Red): Cancelled, Full
+- **Destructive** (Red): Full
+- **Cancelled** (Orange): Cancelled
 
 ### Icons
 
@@ -143,7 +144,7 @@ Each status includes a relevant icon from `lucide-svelte`:
 - **Calendar**: Upcoming, Happening Today
 - **Clock**: Ongoing
 - **CheckCircle**: Past
-- **XCircle**: Cancelled
+- **Ban**: Cancelled
 - **AlertCircle**: Full
 
 ## Examples
@@ -219,13 +220,13 @@ Each status includes a relevant icon from `lucide-svelte`:
 	event={{
 		start: '2025-12-15T18:00:00Z',
 		end: '2025-12-15T22:00:00Z',
-		status: 'rejected', // Cancelled
+		status: 'cancelled',
 		max_attendees: 50,
 		attendee_count: 25
 		// ... other fields
 	}}
 />
-<!-- Result: Red badge with XCircle icon showing "Cancelled" -->
+<!-- Result: Orange badge with Ban icon showing "Cancelled" -->
 ```
 
 ### Past Event

--- a/src/lib/components/events/EventStatusBadge.svelte
+++ b/src/lib/components/events/EventStatusBadge.svelte
@@ -43,10 +43,10 @@
 	 * Determine the event status based on various conditions
 	 * Priority order:
 	 * 0. Administrative Status (draft, closed, cancelled) - HIGHEST PRIORITY
-	 * 1. Full (if at capacity)
-	 * 2. Happening Today (if start date is today)
+	 * 1. Past (if end time has passed — an ended event is "Past" even if it was full)
+	 * 2. Full (if at capacity)
 	 * 3. Ongoing (if current time is between start and end)
-	 * 4. Past (if end time has passed)
+	 * 4. Happening Today (if start date is today)
 	 * 5. Upcoming (default for future events)
 	 *
 	 * Note: Administrative status takes precedence over temporal status
@@ -82,22 +82,22 @@
 		const startDate = new Date(event.start);
 		const endDate = new Date(event.end);
 
-		// 1. Check if full (has capacity and reached it)
+		// 1. Check if past (an ended event is "Past" even if it was full)
+		if (endDate < now) {
+			return {
+				label: m['eventStatus.past'](),
+				variant: 'secondary',
+				icon: CheckCircle
+			};
+		}
+
+		// 2. Check if full (has capacity and reached it)
 		const maxAttendees = event.max_attendees ?? 0;
 		if (maxAttendees > 0 && event.attendee_count >= maxAttendees) {
 			return {
 				label: m['eventStatus.full'](),
 				variant: 'destructive',
 				icon: AlertCircle
-			};
-		}
-
-		// 2. Check if past
-		if (endDate < now) {
-			return {
-				label: m['eventStatus.past'](),
-				variant: 'secondary',
-				icon: CheckCircle
 			};
 		}
 

--- a/src/lib/components/events/EventStatusBadge.test.ts
+++ b/src/lib/components/events/EventStatusBadge.test.ts
@@ -70,6 +70,8 @@ describe('EventStatusBadge', () => {
 
 	describe('Full Status', () => {
 		it('shows "Full" when event is at capacity', () => {
+			vi.setSystemTime(new Date('2025-12-01T10:00:00Z'));
+
 			const event = createMockEvent({
 				max_attendees: 50,
 				attendee_count: 50,
@@ -84,6 +86,8 @@ describe('EventStatusBadge', () => {
 		});
 
 		it('shows "Full" when attendee count exceeds capacity', () => {
+			vi.setSystemTime(new Date('2025-12-01T10:00:00Z'));
+
 			const event = createMockEvent({
 				max_attendees: 50,
 				attendee_count: 55,
@@ -257,7 +261,7 @@ describe('EventStatusBadge', () => {
 			expect(screen.getByRole('status')).toHaveTextContent('Full');
 		});
 
-		it('prioritizes "Full" over "Past" (capacity is checked before temporal status)', () => {
+		it('prioritizes "Past" over "Full" (an ended event is over, regardless of capacity)', () => {
 			vi.setSystemTime(new Date('2025-12-02T10:00:00Z'));
 
 			const event = createMockEvent({
@@ -269,7 +273,7 @@ describe('EventStatusBadge', () => {
 
 			render(EventStatusBadge, { props: { event } });
 
-			expect(screen.getByRole('status')).toHaveTextContent('Full');
+			expect(screen.getByRole('status')).toHaveTextContent('Past');
 		});
 	});
 

--- a/src/lib/components/forms/TagInput.svelte
+++ b/src/lib/components/forms/TagInput.svelte
@@ -239,7 +239,7 @@
 			<input
 				bind:this={input}
 				type="text"
-				{id}
+				id={inputId}
 				name={inputId}
 				bind:value={inputValue}
 				oninput={handleInput}

--- a/src/lib/components/forms/TagInput.test.ts
+++ b/src/lib/components/forms/TagInput.test.ts
@@ -4,10 +4,6 @@ import userEvent from '@testing-library/user-event';
 import TagInput from './TagInput.svelte';
 
 describe('TagInput', () => {
-	// NOTE: the component only assigns the input's `id` attribute when the `id`
-	// prop is provided (the auto-generated fallback is used for `for`/`name` but
-	// not the input itself), so tests pass an explicit `id` to get a working
-	// label association for getByLabelText queries.
 	it('renders with label', () => {
 		render(TagInput, {
 			props: {
@@ -17,6 +13,18 @@ describe('TagInput', () => {
 		});
 
 		expect(screen.getByLabelText('Event Tags')).toBeInTheDocument();
+	});
+
+	it('associates the label with the input when no id prop is passed', () => {
+		render(TagInput, {
+			props: {
+				label: 'Event Tags'
+			}
+		});
+
+		// The auto-generated fallback id must land on the input itself,
+		// not just the label's `for` attribute (#569).
+		expect(screen.getByLabelText('Event Tags')).toBeInstanceOf(HTMLInputElement);
 	});
 
 	it('shows required indicator when required', () => {


### PR DESCRIPTION
Closes #569

Two low-severity component soft spots surfaced during the vitest-baseline repair for #571, deliberately left untouched there (fix-tests-not-components rule) and filed as #569. This PR fixes both.

## 1. `TagInput.svelte` — label/input association broken without an `id` prop

The component rendered `<label for={inputId}>` (fallback-aware auto-generated id) but put the raw `{id}` prop on the `<input>`. With no `id` prop, the input had no id at all, so the label pointed at nothing — WCAG 1.3.1/4.1.2 (unlabeled input for screen readers; clicking the label didn't focus the field).

**Fix:** the input now uses `id={inputId}`. The stale test-side note explaining the always-pass-an-id workaround is removed, and a regression test asserts `getByLabelText` resolves to the input with no `id` prop passed.

Note: the component is currently an orphan (no production usages), so this is latent hardening. Kept rather than deleted since it's a complete, tested, accessible form control.

## 2. `EventStatusBadge.svelte` — Past now wins over Full

The doc comment promised **Full > Today > Ongoing > Past**, but the code checked capacity before temporal status, so an event that was both full and already ended showed **"Full"**. Per the issue's reasoning, the event being over is more relevant than it having been at capacity, so the Past check now runs before the capacity check (option (a) from the issue).

- Doc comment and `EventStatusBadge.showcase.md` aligned with the actual priority: Cancelled/admin > Past > Full > Ongoing > Today > Upcoming.
- The priority-pinning test flipped to assert "Past over Full".
- The two plain "Full" tests now pin `vi.setSystemTime` to a moment while the mock event is still upcoming — they only passed before because Full short-circuited ahead of Past for an event date that is now in the real past.

## Verification

- `pnpm vitest run` (full suite): 83 files, 814 passed, 1 todo
- `make check`: green (format, lint, types, i18n, file-length, no-ssr-token, audit-images)

## Ride-along: showcase doc staleness

The code review surfaced pre-existing stale facts in `EventStatusBadge.showcase.md`: it described Cancelled as `status === 'rejected'` with a red XCircle badge, but the component checks `'cancelled'` and renders the orange `cancelled` variant with the `Ban` icon (XCircle/red belong to Closed). Corrected in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
