### PR TITLE
feat(ci): notify Discord when frontend image is published to GHCR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,3 +59,18 @@ jobs:
           tags: |
             ghcr.io/letsrevel/revel-frontend:latest
             ghcr.io/letsrevel/revel-frontend:${{ github.event.release.tag_name }}
+
+      # Ops signal: fires only after the image is pullable from GHCR. Failure
+      # (Discord down, missing secret) must never fail the publish job.
+      - name: Notify Discord
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_FRONTEND_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_FRONTEND_WEBHOOK_URL not set, skipping notification"
+            exit 0
+          fi
+          curl -sf --max-time 10 -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{\"content\": \"📦 \`ghcr.io/letsrevel/revel-frontend:${{ github.event.release.tag_name }}\` is published and ready to deploy — ${{ github.event.release.html_url }}\"}"


### PR DESCRIPTION
## Summary
- Adds a **Notify Discord** step to `publish.yaml` that fires only after the Docker image is pushed to GHCR — an ops signal that the image is pullable and safe to deploy.
- Best-effort by design: `continue-on-error: true`, a 10s curl timeout, and a skip-if-unset guard mean the publish job stays green even if Discord is down or the secret is missing.
- Uses the org-level `DISCORD_FRONTEND_WEBHOOK_URL` secret (already set, visibility: all repos).

## Test plan
- [ ] Merge, then verify on the next release that the publish run posts the "ready to deploy" message to Discord
- [ ] Confirm the job stays green (the step is non-blocking either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)