### PR TITLE
chore(ci): ignore @types/node major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,13 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # @types/node must track the runtime Node major (22 — see `engines`,
+      # Dockerfile, CI), not the latest release; newer majors let code compile
+      # against APIs that don't exist at runtime. Bump manually with Node itself.
+      - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
     labels:
       - dependencies
     commit-message:


### PR DESCRIPTION
## Summary

Follow-up to closing #550: `@types/node` must track the runtime Node major (22 — `engines`, Dockerfile, CI all agree), not the newest release. Mismatched newer types let code compile against runtime APIs that don't exist. The `@dependabot ignore this major version` comment on #550 only covers v26; this config rule covers all future majors, and we bump the types deliberately whenever we bump Node itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SB4APg7Z1me678AiFQ6P3C