### PR TITLE
fix: stop scanner 404s from tripping the FrontendSSRErrors alert

### DIFF
--- a/src/lib/server/request-logging.test.ts
+++ b/src/lib/server/request-logging.test.ts
@@ -127,9 +127,58 @@ describe('handleSsrError', () => {
 				path: '/login',
 				method: 'POST',
 				status_code: 500,
-				request_id: 'req-1'
+				request_id: 'req-1',
+				ip_address: '203.0.113.7',
+				user_agent: 'vitest-ua'
 			})
 		);
+		expect(log.warning).not.toHaveBeenCalled();
 		expect(result).toEqual({ message: 'Internal Error' });
+	});
+
+	it('does NOT count 4xx (scanner 404s) into the metric and logs them at warning', () => {
+		const event = fakeEvent({
+			url: new URL('https://letsrevel.io/w3lls.php'),
+			route: { id: null } as RequestEvent['route'],
+			locals: { requestId: 'req-2' } as RequestEvent['locals']
+		});
+		const result = (handleSsrError as HandleServerError)({
+			error: new Error('Not Found'),
+			event,
+			status: 404,
+			message: 'Not Found'
+		});
+
+		expect(recordSsrError).not.toHaveBeenCalled();
+		expect(log.error).not.toHaveBeenCalled();
+		expect(log.warning).toHaveBeenCalledWith(
+			'ssr_client_error',
+			expect.objectContaining({
+				route_id: null,
+				path: '/w3lls.php',
+				status_code: 404,
+				request_id: 'req-2',
+				ip_address: '203.0.113.7',
+				user_agent: 'vitest-ua'
+			})
+		);
+		expect(result).toEqual({ message: 'Not Found' });
+	});
+
+	it('omits ip_address when getClientAddress throws (prerender)', () => {
+		const event = fakeEvent({
+			locals: { requestId: 'req-3' } as RequestEvent['locals'],
+			getClientAddress: () => {
+				throw new Error('prerendering');
+			}
+		});
+		(handleSsrError as HandleServerError)({
+			error: new Error('render failed'),
+			event,
+			status: 500,
+			message: 'Internal Error'
+		});
+		const [, fields] = vi.mocked(log.error).mock.calls[0];
+		expect(fields?.ip_address).toBeUndefined();
 	});
 });

--- a/src/lib/server/request-logging.ts
+++ b/src/lib/server/request-logging.ts
@@ -67,21 +67,41 @@ export const handleRequestLogging: Handle = async ({ event, resolve }) => {
 
 /**
  * Unhandled SSR error hook. SvelteKit calls this for any error thrown during
- * load/render/actions that it did not turn into an expected HttpError. Logs it
- * at error level with a stack and the request context, and increments the SSR
- * error metric that `FrontendSSRErrors` alerts on. The returned shape becomes
- * `$page.error` — kept minimal so we never leak internals to the browser.
+ * load/render/actions that it did not turn into an expected HttpError, AND for
+ * unmatched routes (status 404). The returned shape becomes `$page.error` —
+ * kept minimal so we never leak internals to the browser.
+ *
+ * Only genuine server faults (status >= 500) are logged at error level and
+ * counted into the SSR error metric that `FrontendSSRErrors` alerts on. Client
+ * errors (4xx — overwhelmingly 404s from bots probing `/*.php`, `/.env`,
+ * `/.git/*`, …) are logged at warning WITHOUT touching the metric, so scanner
+ * noise can never trip the alert. IP/UA are included so scans stay traceable.
  */
 export const handleSsrError: HandleServerError = ({ error, event, status, message }) => {
 	const routeId = event.route.id;
-	recordSsrError(routeId);
-	log.error('unhandled_ssr_error', {
+	let ipAddress: string | undefined;
+	try {
+		ipAddress = event.getClientAddress();
+	} catch {
+		// getClientAddress() throws during prerendering — omit it.
+	}
+	const context = {
 		error,
 		route_id: routeId,
 		path: event.url.pathname,
 		method: event.request.method,
 		status_code: status,
-		request_id: event.locals.requestId
-	});
+		request_id: event.locals.requestId,
+		ip_address: ipAddress,
+		user_agent: event.request.headers.get('user-agent') ?? undefined
+	};
+
+	if (status < 500) {
+		log.warning('ssr_client_error', context);
+		return { message };
+	}
+
+	recordSsrError(routeId);
+	log.error('unhandled_ssr_error', context);
 	return { message };
 };


### PR DESCRIPTION
## Problem

Warning alerts fired for *elevated frontend errors*. Investigation of production Loki logs showed **315 `unhandled_ssr_error` lines in 12h, every one a 404** — an automated vulnerability scanner probing nonexistent paths (`/*.php` web shells, `/.env`, `/.git/config`, `/.svn/*`, `/.DS_Store`). Two bursts (~140 req each, ~0.7/sec) blew past the `FrontendSSRErrors` threshold. Backend/API/Celery were clean — no real fault.

SvelteKit's `handleError` hook is invoked for unmatched routes (404s), not just genuine failures. Every 404 was logged at **error** level and counted into `frontend_ssr_errors_total`, which is exactly the metric `FrontendSSRErrors` (`>0.05/sec for 10m`) alerts on. So bot noise paged us.

## Change

`handleSsrError` now splits by status:
- **5xx** (genuine server faults) → `log.error('unhandled_ssr_error')` + `recordSsrError()` — still alerts.
- **4xx** (client errors, overwhelmingly scanner 404s) → `log.warning('ssr_client_error')`, **without** incrementing the metric — can no longer trip the alert.

Also attaches **`ip_address` / `user_agent`** to the SSR error context (both branches) so scans and real errors stay traceable — previously only `request_finished` carried them.

## Tests

- 5xx path: asserts error-level log + metric + IP/UA, and that no warning is emitted.
- 4xx path: asserts **no** metric, warning-level `ssr_client_error`, IP/UA present.
- Prerender: `ip_address` omitted when `getClientAddress()` throws.

## Related

Paired with an infra change (edge `@scanner_probe` rule in the Caddyfiles) that answers these probes with a 404 before they reach the Node SSR process — tracked separately in the `infra` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdApNfZ3YhwdGDT26aCvm4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side error handling so client errors (such as 404s) are treated as warnings and no longer count toward error metrics.
  * Enhanced error reports with more useful request context, including IP address and user agent when available.
* **New Features**
  * Added clearer distinction between client-side and server-side SSR failures for better observability and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->