### PR TITLE
test(e2e): Phase 1 — @p0 journey suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"audit:images": "tsx scripts/audit-image-alt.ts"
 	},
 	"devDependencies": {
+		"@axe-core/playwright": "^4.12.1",
 		"@eslint/js": "^10.0.1",
 		"@hey-api/openapi-ts": "^0.99.0",
 		"@inlang/paraglide-js": "^2.20.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,8 +32,18 @@ export default defineConfig({
 	testDir: './tests/e2e',
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
-	workers: process.env.CI ? 1 : undefined,
+	// One local retry: a retried test gets a FRESH context (new token pair),
+	// which heals the known client-auth rotation race (see the E2E findings
+	// issue) without masking real regressions — those fail twice.
+	retries: process.env.CI ? 2 : 1,
+	// The journeys hit ONE local backend; unbounded workers overload it
+	// (slow renders, transient 500s). Four is fast and stable.
+	workers: process.env.CI ? 1 : 4,
+	// Real-stack renders under parallel load regularly exceed the 5s default,
+	// and specs with arrange-heavy retry loops need room beyond the 30s default
+	// test timeout (typical tests finish in seconds; these are ceilings).
+	timeout: 90_000,
+	expect: { timeout: 10_000 },
 	reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list'], ['html']],
 	use: {
 		baseURL: 'http://localhost:5173',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.61.1)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@1.21.7))
@@ -244,6 +247,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1367,6 +1375,10 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3033,6 +3045,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.1
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -4041,6 +4058,8 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.16
       postcss-value-parser: 4.2.0
+
+  axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -239,6 +239,9 @@
 
 	// Fetch backend version on initial mount
 	onMount(async () => {
+		// Hydration marker: interactions dispatched before hydration are silently
+		// lost, so the E2E goto() helper waits for this attribute (tests/e2e).
+		document.body.dataset.hydrated = 'true';
 		await appStore.fetchBackendVersion();
 	});
 </script>

--- a/tests/e2e/journeys/cross/a11y-smoke.spec.ts
+++ b/tests/e2e/journeys/cross/a11y-smoke.spec.ts
@@ -1,0 +1,78 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated } from '../../support/navigation';
+
+// Cross-cutting WCAG 2.1 AA smoke (@axe-core) over the key pages, public and
+// authenticated. Guards against NEW serious/critical violations — the page
+// set is small on purpose; deep audits stay with the accessibility-checker
+// flow, not E2E.
+
+interface PageCase {
+	name: string;
+	path: string;
+	persona?: 'asUser' | 'asOwner';
+}
+
+/**
+ * KNOWN pre-existing serious/critical violation RULES, baselined 2026-07-10
+ * so the smoke can gate NEW violation classes while the backlog is burned
+ * down (issue #595). Rule-level (not per-page): which page trips which rule
+ * varies with seeded/arranged data, and a flapping gate is worse than a
+ * coarser one. DO NOT add to this list — fix the violation instead.
+ */
+const BASELINE = new Set([
+	'nested-interactive', // footer version tooltips (buttons wrapping links), every page
+	'aria-prohibited-attr',
+	'aria-allowed-attr',
+	'color-contrast',
+	'document-title', // /dashboard renders without a <title>
+	'definition-list' // ticket cards' <dl> structure
+]);
+
+const PAGES: PageCase[] = [
+	{ name: 'landing', path: '/' },
+	{ name: 'events list', path: '/events' },
+	{ name: 'event detail', path: '/events/revel-events-collective/summer-sunset-music-festival' },
+	{ name: 'organizations', path: '/organizations' },
+	{ name: 'org profile', path: '/org/revel-events-collective' },
+	{ name: 'login', path: '/login' },
+	{ name: 'dashboard', path: '/dashboard', persona: 'asUser' },
+	{ name: 'my tickets', path: '/dashboard/tickets', persona: 'asUser' },
+	{ name: 'account profile', path: '/account/profile', persona: 'asUser' },
+	{
+		name: 'org admin events',
+		path: '/org/revel-events-collective/admin/events',
+		persona: 'asOwner'
+	}
+];
+
+async function scan(page: Page, path: string, name: string): Promise<void> {
+	await gotoHydrated(page, path);
+	const results = await new AxeBuilder({ page })
+		.withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+		.analyze();
+
+	const severe = results.violations.filter(
+		(v) => (v.impact === 'serious' || v.impact === 'critical') && !BASELINE.has(v.id)
+	);
+	const report = severe
+		.map((v) => `[${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} nodes)`)
+		.join('\n');
+	expect(severe, `NEW serious/critical axe violations on ${name}:\n${report}`).toHaveLength(0);
+}
+
+test.describe('a11y smoke (axe, WCAG 2.1 AA) @p1', () => {
+	for (const pageCase of PAGES.filter((p) => !p.persona)) {
+		test(`${pageCase.name} has no serious/critical violations`, async ({ page }) => {
+			await scan(page, pageCase.path, pageCase.name);
+		});
+	}
+
+	for (const pageCase of PAGES.filter((p) => p.persona)) {
+		test(`${pageCase.name} has no serious/critical violations`, async ({ asUser, asOwner }) => {
+			const page = pageCase.persona === 'asOwner' ? asOwner : asUser;
+			await scan(page, pageCase.path, pageCase.name);
+		});
+	}
+});

--- a/tests/e2e/journeys/j01-guest/browse-events.spec.ts
+++ b/tests/e2e/journeys/j01-guest/browse-events.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated } from '../../support/navigation';
+
+// J1.1 (USER_JOURNEYS.md) — anonymous browsing of /events against the
+// bootstrap seed: list rendering, filters, search, view toggle, click-through.
+// Read-only: no data is mutated.
+//
+// The filter sidebar is desktop-only (`hidden lg:block`); on mobile filters
+// live behind a floating "Filters" sheet, covered by later-phase specs. The
+// list itself and click-through run on both viewports.
+
+const eventCards = (page: import('@playwright/test').Page) =>
+	page.getByRole('list', { name: 'Event listings' }).getByRole('article');
+
+test.describe('J1 guest browses events @p0', () => {
+	test.beforeEach(async ({ page }) => {
+		await gotoHydrated(page, '/events');
+	});
+
+	test('renders the seeded event list', async ({ page }) => {
+		await expect(
+			page.getByRole('heading', { level: 1, name: 'Discover Events' }).first()
+		).toBeVisible();
+		await expect(page.getByText(/\d+ events? found/)).toBeVisible();
+
+		// The seed creates 20+ open public/members-only events. (No assertions on
+		// a SPECIFIC event here: page 1 shifts as other specs create events.)
+		expect(await eventCards(page).count()).toBeGreaterThanOrEqual(10);
+
+		// Cards carry the essentials: name heading and a price-type badge.
+		const first = eventCards(page).first();
+		await expect(first.getByRole('heading')).toBeVisible();
+		await expect(first.getByText(/Ticketed|Free RSVP/).first()).toBeVisible();
+	});
+
+	test('filters by ticket type', async ({ page, isMobile }) => {
+		test.skip(isMobile, 'Filter sidebar is desktop-only; the mobile sheet is covered separately.');
+
+		await page.getByRole('button', { name: 'Free RSVP' }).click();
+		await page.waitForURL(/ticket_type=free/);
+
+		// Every remaining card is a Free RSVP event.
+		await expect(eventCards(page).first()).toBeVisible();
+		await expect(eventCards(page).filter({ hasText: 'Ticketed' })).toHaveCount(0);
+	});
+
+	test('searches events by name', async ({ page, isMobile }) => {
+		test.skip(
+			isMobile,
+			'Search lives in the desktop sidebar; the mobile sheet is covered separately.'
+		);
+
+		const before = await eventCards(page).count();
+		await page.getByRole('searchbox', { name: 'Search events' }).fill('Sunset');
+
+		// Search is fuzzy (matches descriptions too) — assert it narrows the list
+		// and the obvious hit is present.
+		await expect(
+			eventCards(page).getByRole('heading', { name: 'Summer Sunset Music Festival' })
+		).toBeVisible({ timeout: 10_000 });
+		await expect(async () => {
+			expect(await eventCards(page).count()).toBeLessThan(before);
+		}).toPass();
+	});
+
+	test('toggles to the calendar view and back', async ({ page }) => {
+		await page.getByRole('button', { name: 'Calendar' }).click();
+		await expect(page.getByRole('list', { name: 'Event listings' })).toBeHidden();
+
+		await page.getByRole('button', { name: 'List' }).click();
+		await expect(page.getByRole('list', { name: 'Event listings' })).toBeVisible();
+	});
+
+	test('clicks through to the event detail page', async ({ page }) => {
+		// Any first-page card works (a specific event may have been paged out).
+		const firstCard = eventCards(page).first();
+		const name = await firstCard.getByRole('heading').innerText();
+		await firstCard.getByRole('link').first().click();
+
+		await page.waitForURL(/\/events\/[^/]+\/[^/]+/);
+		await expect(page.getByRole('heading', { level: 1, name }).first()).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j01-guest/event-detail-public.spec.ts
+++ b/tests/e2e/journeys/j01-guest/event-detail-public.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '../../support/fixtures';
+
+// J1.2 (USER_JOURNEYS.md) — anonymous event detail: public content is shown
+// (description, tiers, attendance count), member/attendee content is gated
+// behind a sign-in prompt, and there is no attendee list. Read-only.
+
+test.describe('J1 guest views event details @p0', () => {
+	test('shows public content and ticket tiers for a ticketed event', async ({ page }) => {
+		await page.goto('/events/revel-events-collective/summer-sunset-music-festival');
+
+		await expect(
+			page.getByRole('heading', { level: 1, name: 'Summer Sunset Music Festival' }).first()
+		).toBeVisible();
+		await expect(
+			page.getByRole('link', { name: /Organized by Revel Events Collective/ })
+		).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'About this event' })).toBeVisible();
+
+		// Event details sidebar: attendance count + type, no attendee names.
+		await expect(page.getByText(/\d+ attending/)).toBeVisible();
+		await expect(page.getByText('Ticketed event')).toBeVisible();
+
+		// Public tiers with price and a purchase CTA are visible to guests.
+		await expect(page.getByRole('heading', { name: 'Ticket Options' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Early Bird General Admission' })).toBeVisible();
+		await expect(page.getByText('USD 45.00')).toBeVisible();
+		expect(await page.getByRole('button', { name: 'Get Ticket' }).count()).toBeGreaterThan(0);
+
+		// The PRIVATE invited-only tier (wine-tasting style) must not leak; the
+		// festival has none, but member-only content is gated generally:
+		await expect(
+			page.getByRole('heading', { name: 'Sign in to see more of this event' })
+		).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Sign in' }).first()).toBeVisible();
+
+		// No attendee list for guests.
+		await expect(page.getByRole('heading', { name: /Attendees/ })).toBeHidden();
+	});
+
+	test('shows the RSVP card with a sign-in gate for a free-RSVP event', async ({ page }) => {
+		await page.goto('/events/revel-events-collective/spring-community-potluck');
+
+		await expect(
+			page
+				.getByRole('heading', { level: 1, name: 'Spring Community Potluck & Garden Party' })
+				.first()
+		).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+
+		// The sign-in link preserves the return URL back to this event.
+		const signIn = page.getByRole('link', { name: 'Sign in' }).first();
+		await expect(signIn).toBeVisible();
+		await expect(signIn).toHaveAttribute('href', /returnUrl=.*spring-community-potluck/);
+
+		// Potluck items are attendee-only — guests get no potluck signup list.
+		await expect(page.getByRole('button', { name: /I'll bring this/ })).toBeHidden();
+	});
+
+	test('unknown event returns the error page', async ({ page }) => {
+		const response = await page.goto('/events/revel-events-collective/does-not-exist');
+		expect(response?.status()).toBe(404);
+	});
+});

--- a/tests/e2e/journeys/j01-guest/organizations.spec.ts
+++ b/tests/e2e/journeys/j01-guest/organizations.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated } from '../../support/navigation';
+
+// J1.3 (USER_JOURNEYS.md) — anonymous browsing of /organizations and the
+// public org profile. Read-only.
+
+test.describe('J1 guest browses organizations @p0', () => {
+	test('renders the seeded organization list and searches it', async ({ page, isMobile }) => {
+		await gotoHydrated(page, '/organizations');
+
+		const cards = page.getByRole('list', { name: 'Organization listings' }).getByRole('article');
+		// Seed: Revel Events Collective, Tech Innovators Network, Eligibility Test Org.
+		await expect(cards.filter({ hasText: 'Revel Events Collective' })).toBeVisible();
+		await expect(cards.filter({ hasText: 'Tech Innovators Network' })).toBeVisible();
+		expect(await cards.count()).toBeGreaterThanOrEqual(3);
+
+		// Search lives in the desktop sidebar only.
+		// NOTE: the searchbox on /organizations is (mis)labelled "Search events".
+		if (!isMobile) {
+			await page.getByRole('searchbox').fill('Tech Innovators');
+			await expect(cards).toHaveCount(1);
+			await expect(cards.getByRole('heading', { name: 'Tech Innovators Network' })).toBeVisible();
+		}
+	});
+
+	test('clicks through to a public org profile', async ({ page }) => {
+		await gotoHydrated(page, '/organizations');
+
+		await page.getByRole('link', { name: /^Revel Events Collective,/ }).click();
+		await page.waitForURL(/\/org\/revel-events-collective/);
+
+		await expect(
+			page.getByRole('heading', { level: 1, name: 'Revel Events Collective' }).first()
+		).toBeVisible();
+		await expect(
+			page.getByRole('heading', { name: 'About Revel Events Collective' })
+		).toBeVisible();
+		// Public org page exposes follow/membership CTAs and its events.
+		await expect(page.getByRole('button', { name: 'Follow' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Request Membership' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j02-registration/register-verify.spec.ts
+++ b/tests/e2e/journeys/j02-registration/register-verify.spec.ts
@@ -1,0 +1,71 @@
+import type { Page } from '@playwright/test';
+import { test, expect, PERSONAS } from '../../support/fixtures';
+import { gotoHydrated } from '../../support/navigation';
+import { uniqueEmail } from '../../support/factories';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+import { isDemoMode } from '../../support/skip';
+
+// J2.1 (USER_JOURNEYS.md) — email registration: form → check-email page →
+// Mailpit verification link → verified. Unhappy paths: weak password,
+// already-registered email. Each run registers a unique throwaway address.
+
+const STRONG_PASSWORD = 'E2e-test-Pass!123';
+
+async function fillRegistrationForm(page: Page, email: string, password: string): Promise<void> {
+	await gotoHydrated(page, '/register');
+	await page.getByLabel('Email address').fill(email);
+	await page.getByLabel('Password', { exact: true }).fill(password);
+	await page.getByLabel('Confirm password').fill(password);
+	await page.getByLabel(/I accept the/).check();
+}
+
+test.describe('J2 registration & email verification @p0', () => {
+	test.beforeEach(async () => {
+		// /register deliberately redirects to /login on demo backends; the UI
+		// journey is only testable against a non-demo backend (CI covers it).
+		test.skip(await isDemoMode(), 'Registration UI is disabled in DEMO_MODE');
+	});
+
+	test('registers, receives the verification email, and verifies', async ({ page }) => {
+		const email = uniqueEmail('Register');
+
+		await fillRegistrationForm(page, email, STRONG_PASSWORD);
+		await page.getByRole('button', { name: 'Create your account' }).click();
+
+		// Check-email interstitial.
+		await page.waitForURL(/\/register\/check-email/);
+		await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
+
+		// The verification email arrives (inline Celery → immediate).
+		const message = await waitForEmail({ to: email });
+		const link = extractLink(message, /token=/);
+
+		// Following the link verifies the account and lands authenticated.
+		await page.goto(link);
+		await page.waitForURL(/\/account\/profile/);
+
+		// The session is live: the account page shows the verified address.
+		await expect(page.getByText(email).first()).toBeVisible();
+	});
+
+	test('rejects a weak password inline', async ({ page }) => {
+		await fillRegistrationForm(page, uniqueEmail('WeakPw'), 'weak');
+
+		// Client-side validation blocks submission with an accessible error.
+		const submit = page.getByRole('button', { name: 'Create your account' });
+		if (await submit.isEnabled()) {
+			await submit.click();
+		}
+		await expect(page.getByText(/at least|too short|8 characters|stronger/i).first()).toBeVisible();
+		expect(new URL(page.url()).pathname).toBe('/register');
+	});
+
+	test('rejects an already-registered email', async ({ page }) => {
+		await fillRegistrationForm(page, PERSONAS.user.email, STRONG_PASSWORD);
+		await page.getByRole('button', { name: 'Create your account' }).click();
+
+		// Stays on /register with an error surfaced (no check-email redirect).
+		await expect(page.getByRole('alert').filter({ hasNotText: 'Demo Mode' }).first()).toBeVisible();
+		expect(new URL(page.url()).pathname).toBe('/register');
+	});
+});

--- a/tests/e2e/journeys/j03-account/login-logout.spec.ts
+++ b/tests/e2e/journeys/j03-account/login-logout.spec.ts
@@ -1,5 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 import { test, expect, PERSONAS } from '../../support/fixtures';
+import { uiLogin } from '../../support/session';
+import { isDemoMode } from '../../support/skip';
 
 // J3 (USER_JOURNEYS.md) — session basics: login (happy + bad credentials),
 // persona-fixture session restore, logout. Also guards #485: the navbar must
@@ -70,22 +72,19 @@ async function logout(page: Page, isMobile: boolean): Promise<void> {
 }
 
 test.describe('J3 login & logout @p0', () => {
-	test('logs in via the form and the navbar reflects the session without a reload (#485)', async ({
+	test('logs in via the UI and the navbar reflects the session without a reload (#485)', async ({
 		page,
 		isMobile
 	}) => {
-		await page.goto('/login');
-		await page.getByLabel('Email address').fill(PERSONAS.user.email);
-		await page.getByLabel('Password', { exact: true }).fill(PERSONAS.user.password);
-		await page.getByRole('button', { name: 'Sign in', exact: true }).click();
-
-		await page.waitForURL(/\/dashboard(\/|$|\?)/);
+		await uiLogin(page, 'user');
 		await expectAuthenticatedChrome(page, isMobile);
 	});
 
 	test('rejects invalid credentials with an accessible error and stays on /login', async ({
 		page
 	}) => {
+		// Demo backends replace the password form with the test-account dropdown.
+		test.skip(await isDemoMode(), 'No password form on DEMO_MODE backends');
 		await page.goto('/login');
 		await page.getByLabel('Email address').fill(PERSONAS.user.email);
 		await page.getByLabel('Password', { exact: true }).fill('definitely-wrong-password');
@@ -112,11 +111,7 @@ test.describe('J3 login & logout @p0', () => {
 		// Log in via the UI so the whole login → logout cycle is exercised on one
 		// real session (logout blacklists the refresh token, so a session this
 		// test fully owns is also the safest thing to burn).
-		await page.goto('/login');
-		await page.getByLabel('Email address').fill(PERSONAS.member.email);
-		await page.getByLabel('Password', { exact: true }).fill(PERSONAS.member.password);
-		await page.getByRole('button', { name: 'Sign in', exact: true }).click();
-		await page.waitForURL(/\/dashboard(\/|$|\?)/);
+		await uiLogin(page, 'member');
 
 		await logout(page, isMobile);
 		await expectLoggedOutChrome(page, isMobile);

--- a/tests/e2e/journeys/j05-rsvp/eligibility-matrix.spec.ts
+++ b/tests/e2e/journeys/j05-rsvp/eligibility-matrix.spec.ts
@@ -1,0 +1,104 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { waitForClientAuth } from '../../support/navigation';
+
+// J5.2 (USER_JOURNEYS.md) — the implicit eligibility pipeline, exercised
+// against the 11 seeded `test-*` events of the Eligibility Test Organization
+// (bootstrap_test_events). Each event is built to trip exactly one gate; the
+// detail page must surface the matching CTA / explanation to a plain
+// authenticated user (hannah — no relationship with the org).
+//
+// Read-only: nothing is clicked, only the rendered gate is asserted.
+
+interface GateCase {
+	slug: string;
+	/** Gate headline rendered by EligibilityStatusDisplay / RSVP card. */
+	heading?: string;
+	/** Primary CTA that must be present (enabled or not). */
+	button?: string;
+	/** CTAs that must NOT be offered. */
+	absentButtons?: string[];
+}
+
+const MATRIX: GateCase[] = [
+	{ slug: 'test-accessible-event', heading: 'Will you attend?', button: 'RSVP Yes' },
+	{
+		slug: 'test-event-with-questionnaire',
+		heading: 'Questionnaire required',
+		button: 'Complete Questionnaire',
+		absentButtons: ['RSVP Yes']
+	},
+	{
+		slug: 'test-members-only-event',
+		heading: 'Members only',
+		button: 'Join Organization',
+		absentButtons: ['RSVP Yes']
+	},
+	{
+		slug: 'test-private-event',
+		heading: 'Invitation required',
+		absentButtons: ['RSVP Yes', 'Get Tickets']
+	},
+	{
+		slug: 'test-full-capacity-event',
+		heading: 'Event is full',
+		button: 'Join Waitlist',
+		absentButtons: ['RSVP Yes']
+	},
+	{
+		slug: 'test-rsvp-deadline-passed',
+		heading: 'RSVP deadline passed',
+		absentButtons: ['RSVP Yes', 'Join Waitlist']
+	},
+	{
+		slug: 'test-tickets-not-on-sale',
+		button: 'Not Available',
+		absentButtons: ['Get Tickets', 'Buy Ticket']
+	},
+	{ slug: 'test-finished-event', heading: 'Event has ended', absentButtons: ['RSVP Yes'] },
+	{ slug: 'test-requires-ticket', button: 'Get Tickets', absentButtons: ['RSVP Yes'] },
+	{
+		slug: 'test-sold-out-event',
+		button: 'Join Waitlist',
+		absentButtons: ['Get Tickets']
+	}
+];
+
+async function openEvent(page: Page, slug: string): Promise<void> {
+	await page.goto(`/events/eligibility-test-org/${slug}`);
+	await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+	// The gate/RSVP card renders from the AUTHENTICATED eligibility query —
+	// wait for the client auth bootstrap or the card can miss the assert window.
+	await waitForClientAuth(page);
+}
+
+test.describe('J5 eligibility gate matrix @p0', () => {
+	for (const gate of MATRIX) {
+		test(`${gate.slug} shows its gate`, async ({ asUser }) => {
+			await openEvent(asUser, gate.slug);
+
+			if (gate.heading) {
+				await expect(asUser.getByRole('heading', { name: gate.heading }).first()).toBeVisible();
+			}
+			if (gate.button) {
+				await expect(
+					asUser.getByRole('button', { name: new RegExp(`^${gate.button}`) }).first()
+				).toBeVisible();
+			}
+			for (const absent of gate.absentButtons ?? []) {
+				await expect(asUser.getByRole('button', { name: new RegExp(`^${absent}`) })).toBeHidden();
+			}
+		});
+	}
+
+	test('test-draft-event is hidden from non-staff (404)', async ({ asUser }) => {
+		const response = await asUser.goto('/events/eligibility-test-org/test-draft-event');
+		expect(response?.status()).toBe(404);
+	});
+
+	test('sold-out tier renders as Sold Out with waitlist fallback', async ({ asUser }) => {
+		await openEvent(asUser, 'test-sold-out-event');
+		await expect(asUser.getByRole('button', { name: 'Sold Out', exact: true })).toBeDisabled();
+		await expect(asUser.getByRole('heading', { name: 'Ticket Options' })).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j05-rsvp/rsvp-flow.spec.ts
+++ b/tests/e2e/journeys/j05-rsvp/rsvp-flow.spec.ts
@@ -1,0 +1,112 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { uniqueName } from '../../support/factories';
+
+// J5.3–5.4 + J14.2/14.5 (USER_JOURNEYS.md) — the core RSVP loop on the seeded
+// Spring Community Potluck: RSVP YES → attendee experience (potluck signup)
+// → add & claim an item → RSVP NO → the claimed item is auto-released.
+//
+// Isolation: desktop and mobile projects run concurrently, so each uses a
+// DIFFERENT persona (hannah / ivan) and creates its OWN uniquely-named potluck
+// item — no contention on seeded rows, and crashed runs can't poison later
+// ones. The flow ends on RSVP NO, so it is re-runnable without reseeding.
+
+const EVENT_PATH = '/events/revel-events-collective/spring-community-potluck';
+
+/**
+ * The RSVP card shows Yes/Maybe/No when the user has no answer yet, but a
+ * status + "Change RSVP" button when one exists (the seed pre-answers some
+ * personas). Normalize to the buttons being visible.
+ */
+async function openRsvpButtons(page: Page): Promise<void> {
+	const anyControl = page.getByRole('button', { name: /^RSVP Yes|^Change RSVP$/ }).first();
+	await expect(anyControl).toBeVisible();
+	if ((await anyControl.textContent())?.includes('Change RSVP')) {
+		await anyControl.click();
+	}
+}
+
+/** The potluck list is a collapsible disclosure — expand it if collapsed. */
+async function openPotluckSection(page: Page): Promise<void> {
+	const section = page.getByRole('region', { name: /Potluck Coordination/ });
+	await expect(section).toBeVisible();
+	if ((await section.getByRole('button', { name: /^Claim |^Unclaim |bring/ }).count()) === 0) {
+		await section.getByRole('button', { name: /Potluck Coordination/ }).click();
+	}
+}
+
+/**
+ * Changing an RSVP away from YES with claimed items pops a confirmation
+ * dialog ("Unclaim Potluck Items?"). Whether it fires depends on the client's
+ * claimed-count cache being fresh — confirm it when it shows, but don't
+ * require it (the release itself is asserted separately).
+ */
+async function confirmUnclaimDialogIfShown(page: Page): Promise<void> {
+	const confirmButton = page.getByRole('button', { name: 'Yes, change RSVP' });
+	const shown = await confirmButton
+		.waitFor({ state: 'visible', timeout: 2_000 })
+		.then(() => true)
+		.catch(() => false);
+	if (shown) {
+		await confirmButton.click();
+	}
+}
+
+test.describe('J5 RSVP flow with potluck auto-release @p0', () => {
+	test('YES → add & claim potluck item → NO releases it', async ({ browser, isMobile }) => {
+		const context = await browser.newContext();
+		await authenticateContext(context, isMobile ? 'user2' : 'user');
+		const page = await context.newPage();
+		await gotoHydrated(page, EVENT_PATH);
+		await waitForClientAuth(page);
+
+		// --- RSVP YES ---
+		await openRsvpButtons(page);
+		await page.getByRole('button', { name: /^RSVP Yes/ }).click();
+		await expect(page.getByRole('status').filter({ hasText: "You're attending" })).toBeVisible();
+
+		// --- Attendee experience: add & claim our own potluck item ---
+		await openPotluckSection(page);
+		const itemName = uniqueName('Dish');
+		// The section re-renders as the potluck query settles, which can remount
+		// the form and drop fills/clicks — run the whole add&claim as an
+		// idempotent loop that exits once our item is claimed.
+		const unclaimButton = page.getByRole('button', { name: `Unclaim ${itemName}` }).first();
+		await expect(async () => {
+			if (await unclaimButton.isVisible()) return;
+			const nameInput = page.getByLabel(/^Item name/);
+			if (!(await nameInput.isVisible())) {
+				await page.getByRole('button', { name: /Add item you'll bring|Add potluck item/ }).click();
+			}
+			await nameInput.fill(itemName);
+			await expect(nameInput).toHaveValue(itemName, { timeout: 500 });
+			await page.getByRole('button', { name: 'Add & claim' }).click();
+			await expect(unclaimButton).toBeVisible({ timeout: 4_000 });
+		}).toPass({ timeout: 40_000 });
+
+		// --- RSVP NO: claimed items are auto-released ---
+		await openRsvpButtons(page);
+		await page.getByRole('button', { name: /^RSVP No/ }).click();
+		await confirmUnclaimDialogIfShown(page);
+		// Released + no longer attending → the claim button renders disabled.
+		await expect(page.getByRole('button', { name: `Claim ${itemName}` }).first()).toBeDisabled();
+
+		// --- The release is server-side: after re-YES our item is claimable ---
+		await gotoHydrated(page, EVENT_PATH);
+		await openRsvpButtons(page);
+		await page.getByRole('button', { name: /^RSVP Yes/ }).click();
+		await expect(page.getByRole('status').filter({ hasText: "You're attending" })).toBeVisible();
+		await openPotluckSection(page);
+		await expect(page.getByRole('button', { name: `Claim ${itemName}` }).first()).toBeEnabled();
+
+		// Leave the loop closed: back to NO (no claims held).
+		await openRsvpButtons(page);
+		await page.getByRole('button', { name: /^RSVP No/ }).click();
+		await confirmUnclaimDialogIfShown(page);
+		await expect(page.getByRole('button', { name: `Claim ${itemName}` }).first()).toBeDisabled();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j06-tickets/free-tier.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/free-tier.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent, createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { waitForEmail } from '../../support/mailpit';
+
+// J6.2 (USER_JOURNEYS.md) — free-tier ticket: claim → ACTIVE immediately →
+// visible in /dashboard/tickets → transactional confirmation email.
+//
+// Isolation: an API-arranged event (the seeded events' free tiers only go on
+// sale 30 days before start, so they drift in and out of purchasability) and
+// a THROWAWAY registered+verified user (tickets consume per-user quotas, so a
+// persona would make the spec single-shot).
+
+test.describe('J6 free-tier ticket @p0', () => {
+	test('claim free ticket → active in dashboard → confirmation email', async ({ browser }) => {
+		const [event, user] = await Promise.all([
+			createTicketedEvent(),
+			createVerifiedUser('FreeTier')
+		]);
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		await expect(page.getByRole('heading', { name: 'Free Entry' }).first()).toBeVisible();
+
+		// Eligibility CTA → tier-selection dialog → confirmation → claim. Clicks
+		// during dialog re-renders are occasionally dropped, so run the whole
+		// sequence as an idempotent loop that exits on the success signal (the
+		// claimed-ticket modal showing the ticket id/QR).
+		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+		const claimTicket = page.getByRole('button', { name: 'Claim Ticket', exact: true });
+		const success = page.getByRole('dialog', { name: 'Your Ticket' });
+		await expect(async () => {
+			if (await success.isVisible()) return;
+			if (await claimTicket.isVisible()) {
+				await claimTicket.click();
+			} else if (await tierDialog.isVisible()) {
+				await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
+				await claimTicket.click();
+			} else {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+				await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
+				await claimTicket.click();
+			}
+			await expect(success).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+
+		// Dashboard shows the ticket as Active. Reload-retry: a silently
+		// unauthorized my-tickets query renders the empty state instead of an
+		// error (issue #596 item 1) and heals on a fresh load.
+		const ticketCard = page
+			.locator('article, li, div')
+			.filter({ hasText: event.name })
+			.filter({ hasText: /Active/i })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await expect(ticketCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		// Transactional confirmation email is delivered immediately (inline Celery).
+		const email = await waitForEmail({ to: user.email, subject: 'icket' });
+		expect(email.Subject).toMatch(/ticket/i);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j10-event-admin/create-event.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/create-event.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, PERSONAS } from '../../support/fixtures';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { uniqueName } from '../../support/factories';
+import { ApiClient } from '../../support/api';
+
+// J10.1–10.2 (USER_JOURNEYS.md) — organizer creates an event through the
+// wizard: draft (Save) → edit page → Publish (DRAFT → OPEN) → the event is
+// publicly visible to an anonymous visitor.
+//
+// Events are uniquely named and stay in the org afterwards (no cleanup — the
+// reset command in the README restores the seed).
+
+const ORG_SLUG = 'revel-events-collective';
+
+/** datetime-local inputs want the browser-local `YYYY-MM-DDTHH:mm` shape. */
+function toDatetimeLocal(date: Date): string {
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return (
+		`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+		`T${pad(date.getHours())}:${pad(date.getMinutes())}`
+	);
+}
+
+test.describe('J10 create event via wizard @p0', () => {
+	test('draft → publish → publicly visible', async ({ asOwner, browser }) => {
+		const name = uniqueName('Wizard');
+		const start = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+		const end = new Date(start.getTime() + 3 * 60 * 60 * 1000);
+
+		await gotoHydrated(asOwner, `/org/${ORG_SLUG}/admin/events/new`);
+		await waitForClientAuth(asOwner);
+		await asOwner.locator('#event-name').fill(name);
+		await asOwner.locator('#event-start').fill(toDatetimeLocal(start));
+		await asOwner.locator('#event-end').fill(toDatetimeLocal(end));
+
+		// Submit creates the DRAFT and lands on the edit page. The submit can be
+		// swallowed while the admin shell settles — retry until it navigates.
+		await expect(async () => {
+			await asOwner
+				.getByRole('button', { name: /^(Save|Create Event)$/ })
+				.first()
+				.click();
+			await asOwner.waitForURL(/\/admin\/events\/[0-9a-f-]+\/edit/, { timeout: 5_000 });
+		}).toPass({ timeout: 30_000 });
+		const eventId = asOwner.url().match(/events\/([0-9a-f-]+)\/edit/)?.[1];
+		if (!eventId) throw new Error(`No event id in URL: ${asOwner.url()}`);
+
+		// Publish (native confirm dialog) — DRAFT → OPEN.
+		asOwner.on('dialog', (dialog) => void dialog.accept());
+		await asOwner.getByRole('button', { name: 'Publish Event' }).click();
+		await expect(asOwner.getByRole('button', { name: 'Close Event' })).toBeVisible();
+
+		// The published event is publicly visible to an anonymous visitor.
+		const owner = await ApiClient.login(PERSONAS.owner.email, PERSONAS.owner.password);
+		const { slug } = await owner.get<{ slug: string }>(`/api/events/${eventId}`);
+
+		const guestContext = await browser.newContext();
+		const guest = await guestContext.newPage();
+		const response = await guest.goto(`/events/${ORG_SLUG}/${slug}`);
+		expect(response?.status()).toBe(200);
+		await expect(guest.getByRole('heading', { level: 1, name }).first()).toBeVisible();
+		// Open for attendance: the RSVP card renders (guests get the sign-in gate).
+		await expect(guest.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+		await guestContext.close();
+	});
+
+	test('a draft event is NOT publicly visible', async ({ asOwner, browser }) => {
+		const name = uniqueName('Draft');
+		const start = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+
+		await gotoHydrated(asOwner, `/org/${ORG_SLUG}/admin/events/new`);
+		await waitForClientAuth(asOwner);
+		await asOwner.locator('#event-name').fill(name);
+		await asOwner.locator('#event-start').fill(toDatetimeLocal(start));
+		await asOwner
+			.locator('#event-end')
+			.fill(toDatetimeLocal(new Date(start.getTime() + 60 * 60 * 1000)));
+		await expect(async () => {
+			await asOwner
+				.getByRole('button', { name: /^(Save|Create Event)$/ })
+				.first()
+				.click();
+			await asOwner.waitForURL(/\/admin\/events\/[0-9a-f-]+\/edit/, { timeout: 5_000 });
+		}).toPass({ timeout: 30_000 });
+		const eventId = asOwner.url().match(/events\/([0-9a-f-]+)\/edit/)?.[1];
+		if (!eventId) throw new Error(`No event id in URL: ${asOwner.url()}`);
+
+		const owner = await ApiClient.login(PERSONAS.owner.email, PERSONAS.owner.password);
+		const { slug } = await owner.get<{ slug: string }>(`/api/events/${eventId}`);
+
+		const guestContext = await browser.newContext();
+		const guest = await guestContext.newPage();
+		const response = await guest.goto(`/events/${ORG_SLUG}/${slug}`);
+		expect(response?.status()).toBe(404);
+		await guestContext.close();
+	});
+});

--- a/tests/e2e/journeys/j11-questionnaires/fill-auto-eval.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/fill-auto-eval.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '../../support/fixtures';
+import { createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J11.3–11.4 (USER_JOURNEYS.md) — fill an ADMISSION questionnaire with
+// AUTOMATIC evaluation (inline Celery + MOCK LLM): the seeded FutureStack
+// "Code of Conduct Agreement" (single fatal MCQ, min score 100).
+//
+// Each path uses its own THROWAWAY user: submissions are per-user state that
+// would make seeded personas single-shot.
+
+const EVENT_PATH = '/events/tech-innovators-network/futurestack-2025';
+const CORRECT = 'Yes, I agree to the Code of Conduct';
+const WRONG = 'No, I do not agree';
+
+async function openQuestionnaire(
+	browser: import('@playwright/test').Browser,
+	label: string
+): Promise<import('@playwright/test').Page> {
+	const user = await createVerifiedUser(label);
+	const context = await browser.newContext();
+	await authenticateContext(context, user);
+	const page = await context.newPage();
+	await gotoHydrated(page, EVENT_PATH);
+	await waitForClientAuth(page);
+
+	// The admission gate blocks ticket purchase until the questionnaire passes.
+	// (Ticketed events render the gate as text + CTA, not a headline.)
+	// (Rendered twice — desktop and mobile layouts — so filter to the visible one.)
+	await expect(
+		page
+			.getByText(/Complete the required questionnaire/)
+			.filter({ visible: true })
+			.first()
+	).toBeVisible();
+	await page
+		.getByRole('button', { name: 'Complete Questionnaire' })
+		.filter({ visible: true })
+		.first()
+		.click();
+	await page.waitForURL(/\/questionnaire\//);
+	// Let the questionnaire queries settle: a check() during the settling
+	// re-renders is silently dropped, and an empty submission BURNS AN ATTEMPT
+	// (accepted with score 0 → rejected).
+	await page.waitForLoadState('networkidle');
+	return page;
+}
+
+test.describe('J11 questionnaire fill & auto-evaluation @p1', () => {
+	test('passing submission is auto-approved and unlocks the event', async ({ browser }) => {
+		const page = await openQuestionnaire(browser, 'QuestPass');
+
+		// The answer state can lag the freshly-mounted form (a too-early check
+		// submits empty answers) — retry the select+submit loop until the app
+		// accepts it and returns to the event.
+		await expect(async () => {
+			await page.getByRole('radio', { name: CORRECT }).check();
+			await expect(page.getByRole('radio', { name: CORRECT })).toBeChecked();
+			await page.getByRole('button', { name: 'Submit Questionnaire' }).click();
+			await page.waitForURL(/futurestack-2025/, { timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+
+		// Auto-evaluation completes just after the redirect renders, so reload
+		// until the eligibility reflects the approval: gate gone, ticket CTA on.
+		await expect(async () => {
+			await gotoHydrated(page, EVENT_PATH);
+			await expect(
+				page
+					.getByRole('button', { name: 'Get Tickets', exact: true })
+					.filter({ visible: true })
+					.first()
+			).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+		await expect(page.getByRole('button', { name: 'Complete Questionnaire' })).toBeHidden();
+
+		await page.context().close();
+	});
+
+	test('failing submission is auto-rejected and the gate reflects it', async ({ browser }) => {
+		const page = await openQuestionnaire(browser, 'QuestFail');
+
+		await expect(async () => {
+			await page.getByRole('radio', { name: WRONG }).check();
+			await expect(page.getByRole('radio', { name: WRONG })).toBeChecked();
+			await page.getByRole('button', { name: 'Submit Questionnaire' }).click();
+			await page.waitForURL(/futurestack-2025/, { timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+
+		// Auto-evaluation rejects (fatal question answered wrong). The essential
+		// property: the ticket CTA stays withheld — true both while the
+		// evaluation is briefly pending AND once rejected (the gate then re-arms
+		// for a retake, since this questionnaire allows attempts).
+		await gotoHydrated(page, EVENT_PATH);
+		await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+		await expect(
+			page.getByRole('button', { name: 'Get Tickets', exact: true }).filter({ visible: true })
+		).toBeHidden();
+
+		await page.context().close();
+	});
+});

--- a/tests/e2e/support/api.ts
+++ b/tests/e2e/support/api.ts
@@ -27,14 +27,24 @@ export class ApiError extends Error {
 	}
 }
 
-/** Exchange credentials for a JWT pair (POST /api/auth/token/pair). */
+/**
+ * Exchange credentials for a JWT pair (POST /api/auth/token/pair).
+ * Retries transient 5xx responses — the dev backend can hiccup under the
+ * parallel load of a full suite run.
+ */
 export async function obtainTokenPair(email: string, password: string): Promise<TokenPair> {
-	const response = await fetch(`${API_URL}/api/auth/token/pair`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ username: email, password })
-	});
-	const text = await response.text();
+	let response: Response;
+	let text: string;
+	for (let attempt = 1; ; attempt++) {
+		response = await fetch(`${API_URL}/api/auth/token/pair`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ username: email, password })
+		});
+		text = await response.text();
+		if (response.status < 500 || attempt >= 3) break;
+		await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+	}
 	if (!response.ok) {
 		throw new ApiError(response.status, 'POST', '/api/auth/token/pair', text);
 	}

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1,4 +1,7 @@
 import crypto from 'node:crypto';
+import { API_URL, ApiClient, ApiError } from './api';
+import { extractLink, waitForEmail } from './mailpit';
+import { PERSONAS, type PersonaName } from './personas';
 
 /**
  * Arrange-data factories.
@@ -7,10 +10,8 @@ import crypto from 'node:crypto';
  * workers and repeated runs never collide (the bootstrap seed is reset only via
  * `make reset-events && make bootstrap`, never by tests).
  *
- * Factories grow here as the journey suites need them (createTicketedEvent,
- * createEventToken, createDiscountCode, …) — each a small wrapper over
- * ApiClient with a uniqueName()-based name. Phase 0 ships only the naming
- * helper; adding a factory before a spec needs it is premature.
+ * Factories grow here as the journey suites need them — each a small wrapper
+ * over the backend API with a uniqueName()-based name.
  */
 
 const RUN_ID = crypto.randomBytes(3).toString('hex');
@@ -26,4 +27,125 @@ export function uniqueName(label: string): string {
 export function uniqueEmail(label: string): string {
 	sequence += 1;
 	return `e2e+${label.toLowerCase()}-${RUN_ID}-${sequence}@example.com`;
+}
+
+export interface ThrowawayUser {
+	email: string;
+	password: string;
+	firstName: string;
+	lastName: string;
+}
+
+/**
+ * Register a fresh user via the API and complete email verification through
+ * Mailpit — for flows that consume per-user quotas (ticket limits,
+ * questionnaire attempts) or destroy their account, where reusing a seeded
+ * persona would make the spec non-re-runnable.
+ */
+export async function createVerifiedUser(label: string): Promise<ThrowawayUser> {
+	const email = uniqueEmail(label);
+	const password = 'E2e-test-Pass!123';
+	const firstName = 'E2E';
+	const lastName = label;
+
+	const register = await fetch(`${API_URL}/api/account/register`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			email,
+			password1: password,
+			password2: password,
+			first_name: firstName,
+			last_name: lastName,
+			accept_toc_and_privacy: true
+		})
+	});
+	if (!register.ok) {
+		throw new ApiError(register.status, 'POST', '/api/account/register', await register.text());
+	}
+
+	// Complete verification with the token from the emailed link.
+	const message = await waitForEmail({ to: email });
+	const link = extractLink(message, /token=/);
+	const token = new URL(link).searchParams.get('token');
+	if (!token) {
+		throw new Error(`Verification link has no token: ${link}`);
+	}
+	const verify = await fetch(`${API_URL}/api/account/verify`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ token })
+	});
+	if (!verify.ok) {
+		throw new ApiError(verify.status, 'POST', '/api/account/verify', await verify.text());
+	}
+
+	return { email, password, firstName, lastName };
+}
+
+export interface CreatedEvent {
+	id: string;
+	slug: string;
+	orgSlug: string;
+	/** Public detail path, e.g. /events/<org>/<slug>. */
+	path: string;
+	name: string;
+}
+
+/**
+ * API-create an OPEN, public event (owned by a seeded org owner), optionally
+ * with an immediately-purchasable free tier. Specs use this instead of relying
+ * on seeded events whose sales windows / capacity drift with the clock.
+ */
+export async function createTicketedEvent(
+	options: {
+		owner?: PersonaName;
+		orgSlug?: string;
+		freeTier?: boolean;
+		event?: Record<string, unknown>;
+	} = {}
+): Promise<CreatedEvent> {
+	const { owner = 'owner', orgSlug = 'revel-events-collective', freeTier = true } = options;
+	const persona = PERSONAS[owner];
+	const api = await ApiClient.login(persona.email, persona.password);
+
+	const name = uniqueName('Event');
+	const dayMs = 24 * 60 * 60 * 1000;
+	const start = new Date(Date.now() + 7 * dayMs);
+	const end = new Date(start.getTime() + 3 * 60 * 60 * 1000);
+
+	const event = await api.post<{ id: string; slug: string }>(
+		`/api/organization-admin/${orgSlug}/create-event`,
+		{
+			name,
+			start: start.toISOString(),
+			end: end.toISOString(),
+			status: 'open',
+			event_type: 'public',
+			visibility: 'public',
+			requires_ticket: true,
+			max_attendees: 500,
+			...options.event
+		}
+	);
+
+	if (freeTier) {
+		await api.post(`/api/event-admin/${event.id}/ticket-tier`, {
+			name: 'Free Entry',
+			payment_method: 'free',
+			price: '0.00',
+			price_type: 'fixed',
+			total_quantity: 200,
+			sales_start_at: new Date(Date.now() - dayMs).toISOString(),
+			sales_end_at: end.toISOString()
+		});
+	}
+
+	return {
+		id: event.id,
+		slug: event.slug,
+		orgSlug,
+		path: `/events/${orgSlug}/${event.slug}`,
+		name
+	};
 }

--- a/tests/e2e/support/fixtures.ts
+++ b/tests/e2e/support/fixtures.ts
@@ -1,6 +1,6 @@
 import { test as base, expect, type Browser, type Page } from '@playwright/test';
-import { obtainTokenPair } from './api';
 import { PERSONAS, type PersonaName } from './personas';
+import { authenticateContext } from './session';
 import { isBackendUp, BACKEND_DOWN_MESSAGE } from './skip';
 
 /**
@@ -21,21 +21,6 @@ import { isBackendUp, BACKEND_DOWN_MESSAGE } from './skip';
  * to that context. (Multiple token pairs per user coexist happily.)
  */
 
-const APP_HOST = 'localhost';
-
-function authCookie(name: string, value: string) {
-	return {
-		name,
-		value,
-		domain: APP_HOST,
-		path: '/',
-		expires: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 7,
-		httpOnly: true,
-		secure: false,
-		sameSite: 'Lax' as const
-	};
-}
-
 interface PersonaFixtures {
 	asOwner: Page;
 	asStaff: Page;
@@ -49,15 +34,8 @@ interface PersonaFixtures {
 
 function personaFixture(name: PersonaName) {
 	return async ({ browser }: { browser: Browser }, use: (page: Page) => Promise<void>) => {
-		const persona = PERSONAS[name];
-		const { access, refresh } = await obtainTokenPair(persona.email, persona.password);
 		const context = await browser.newContext();
-		await context.addCookies([
-			authCookie('access_token', access),
-			authCookie('refresh_token', refresh),
-			// 'true' → hooks.server.ts refreshes with persistent cookie options.
-			authCookie('remember_me', 'true')
-		]);
+		await authenticateContext(context, name);
 		const page = await context.newPage();
 		await use(page);
 		await context.close();

--- a/tests/e2e/support/navigation.ts
+++ b/tests/e2e/support/navigation.ts
@@ -1,0 +1,44 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Navigate and wait for the app to be HYDRATED before returning.
+ *
+ * SvelteKit serves interactive-looking SSR HTML, but clicks/fills dispatched
+ * before hydration are silently lost (buttons have no listeners yet, inputs
+ * have no bindings). The root layout stamps `data-hydrated` on <body> in
+ * onMount (see src/routes/+layout.svelte); waiting for it removes the whole
+ * class of "clicked too early, nothing happened" flakes.
+ *
+ * Use this instead of page.goto() in every journey spec that interacts with
+ * the page. Plain page.goto() is fine for read-only assertions on SSR content.
+ */
+export async function gotoHydrated(page: Page, path: string): Promise<void> {
+	await page.goto(path);
+	await page.locator('body[data-hydrated="true"]').waitFor({ state: 'attached' });
+	// Best-effort settle: interactions during the initial query burst can land
+	// on components that immediately re-render (dropping clicks/fills). Bounded
+	// so a polling endpoint can never hang navigation.
+	await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => undefined);
+}
+
+/**
+ * Wait until the CLIENT auth store finished bootstrapping (async token
+ * refresh after hydration). The notifications bell renders only once the
+ * in-memory access token exists, so it doubles as the readiness signal.
+ *
+ * Required before client-side MUTATIONS (claims, RSVPs, admin saves): a
+ * mutation fired during bootstrap goes out without an Authorization header
+ * and surfaces as "Unauthorized" in the UI.
+ */
+export async function waitForClientAuth(page: Page): Promise<void> {
+	const bell = page.getByRole('button', { name: 'Open notifications' });
+	try {
+		await bell.waitFor({ timeout: 15_000 });
+	} catch {
+		// Bootstrap stalled (slow backend or a lost refresh race) — a reload
+		// re-runs it against the CURRENT cookies and self-heals.
+		await page.reload();
+		await page.locator('body[data-hydrated="true"]').waitFor({ state: 'attached' });
+		await bell.waitFor({ timeout: 20_000 });
+	}
+}

--- a/tests/e2e/support/personas.ts
+++ b/tests/e2e/support/personas.ts
@@ -41,6 +41,11 @@ export const PERSONAS = {
 		'hannah.attendee@example.com',
 		'Plain user with no org membership; follows Org Alpha'
 	),
+	user2: persona(
+		'user2',
+		'ivan.attendee@example.com',
+		'Plain user with no org membership; follows Org Beta (parallel-safe twin of `user`)'
+	),
 	multiOrg: persona(
 		'multiOrg',
 		'karen.multiorg@example.com',

--- a/tests/e2e/support/session.ts
+++ b/tests/e2e/support/session.ts
@@ -1,0 +1,71 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { obtainTokenPair } from './api';
+import { PERSONAS, type PersonaName } from './personas';
+import { gotoHydrated } from './navigation';
+import { isDemoMode } from './skip';
+
+/**
+ * Authenticate a browser context as a persona by planting a FRESH token pair
+ * as the app's auth cookies. See fixtures.ts for why sessions are never
+ * shared between contexts (refresh rotation + blacklist).
+ *
+ * Prefer the persona fixtures (`asOwner`, …); use this directly when a spec
+ * needs to pick the persona dynamically (e.g. a different user per project so
+ * parallel desktop/mobile runs don't mutate the same seeded state).
+ */
+
+const APP_HOST = 'localhost';
+
+function authCookie(name: string, value: string) {
+	return {
+		name,
+		value,
+		domain: APP_HOST,
+		path: '/',
+		expires: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 7,
+		httpOnly: true,
+		secure: false,
+		sameSite: 'Lax' as const
+	};
+}
+
+export interface Credentials {
+	email: string;
+	password: string;
+}
+
+export async function authenticateContext(
+	context: BrowserContext,
+	who: PersonaName | Credentials
+): Promise<void> {
+	const persona = typeof who === 'string' ? PERSONAS[who] : who;
+	const { access, refresh } = await obtainTokenPair(persona.email, persona.password);
+	await context.addCookies([
+		authCookie('access_token', access),
+		authCookie('refresh_token', refresh),
+		// 'true' → hooks.server.ts refreshes with persistent cookie options.
+		authCookie('remember_me', 'true')
+	]);
+}
+
+/**
+ * Log in through the UI. On DEMO backends the login page REPLACES the
+ * email/password form with a test-account dropdown as soon as the client
+ * learns `demo: true` — filling the form races that swap, so pick the path
+ * deterministically from the backend mode. (The dropdown only offers seeded
+ * accounts; throwaway users need non-demo backends or authenticateContext.)
+ */
+export async function uiLogin(page: Page, who: PersonaName | Credentials): Promise<void> {
+	const persona = typeof who === 'string' ? PERSONAS[who] : who;
+	await gotoHydrated(page, '/login');
+	if (await isDemoMode()) {
+		const select = page.getByLabel('Select Test Account');
+		await select.selectOption(persona.email);
+		await page.getByRole('button', { name: /^Sign in as/ }).click();
+	} else {
+		await page.getByLabel('Email address').fill(persona.email);
+		await page.getByLabel('Password', { exact: true }).fill(persona.password);
+		await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+	}
+	await page.waitForURL(/\/dashboard(\/|$|\?)/);
+}

--- a/tests/e2e/support/skip.ts
+++ b/tests/e2e/support/skip.ts
@@ -9,20 +9,39 @@ import { API_URL } from './api';
  *
  * The probe result is cached for the lifetime of the worker process.
  */
-let probe: Promise<boolean> | undefined;
+interface VersionInfo {
+	demo?: boolean;
+	features?: Record<string, boolean>;
+}
 
-export function isBackendUp(): Promise<boolean> {
+let probe: Promise<VersionInfo | null> | undefined;
+
+function versionInfo(): Promise<VersionInfo | null> {
 	probe ??= (async () => {
 		try {
 			const response = await fetch(`${API_URL}/api/version`, {
 				signal: AbortSignal.timeout(3_000)
 			});
-			return response.ok;
+			if (!response.ok) return null;
+			return (await response.json()) as VersionInfo;
 		} catch {
-			return false;
+			return null;
 		}
 	})();
 	return probe;
+}
+
+export async function isBackendUp(): Promise<boolean> {
+	return (await versionInfo()) !== null;
+}
+
+/**
+ * Whether the backend runs in DEMO_MODE. A few UI flows are deliberately
+ * disabled on demo instances (e.g. /register redirects to /login) — the
+ * affected specs skip themselves with this.
+ */
+export async function isDemoMode(): Promise<boolean> {
+	return (await versionInfo())?.demo === true;
 }
 
 export const BACKEND_DOWN_MESSAGE =


### PR DESCRIPTION
Closes #589

Phase 1 of the E2E suite v2 (umbrella #28): the @p0 journey suites plus the two pulled-forward @p1 specs (a11y smoke, questionnaire auto-eval), on the Phase 0 foundation.

## Suites (Chromium + Mobile Chrome)

| Journey | Spec | Covers |
|---|---|---|
| J1 guest | `browse-events`, `event-detail-public`, `organizations` | list/filters/search/calendar, detail with sign-in gating & no attendee leak, org browse+profile |
| J2 registration | `register-verify` | full Mailpit verification loop, weak-password & duplicate-email unhappy paths (self-skips on DEMO_MODE — `/register` redirects there by design) |
| J5 RSVP | `eligibility-matrix`, `rsvp-flow` | all 11 seeded gate events show the right CTA; YES → potluck add&claim → NO auto-release, closed loop |
| J6 tickets | `free-tier` | claim → ticket modal → Active in dashboard → transactional email, throwaway user per run |
| J10 event admin | `create-event` | wizard draft → publish → publicly visible; draft 404s for guests |
| J11 questionnaires | `fill-auto-eval` | auto-eval pass unlocks ticket CTA; fail keeps it withheld |
| cross | `a11y-smoke` | axe WCAG 2.1 AA on 10 pages, gating NEW serious/critical rules over the #595 baseline |

## Infra additions (support/)

`gotoHydrated` (hydration marker + bounded network settle), `waitForClientAuth` (client store bootstrap signal + reload self-heal), `uiLogin` (demo-dropdown vs password form, mode-aware), `createVerifiedUser` (API register + Mailpit verify), `createTicketedEvent` (arranged events — seeded free tiers drift out of their sales windows), token obtainment with 5xx retry. Config: 4 local workers (one shared backend), 90s test / 10s expect timeouts, `retries: 1` locally — a retry gets a fresh context + token pair, which heals the known auth-rotation race (#596) without masking real regressions.

## Found & filed along the way

- **revel-backend#664** — search returned each event once per joined tag (fixed; test re-enabled and green)
- **revel-backend#665** — `reset_events` crashed on the global-ban seed (fixed)
- **#595** — axe a11y baseline burn-down (footer `nested-interactive` everywhere, `/dashboard` missing `<title>`, contrast, ARIA)
- **#596** — auth-bootstrap mutation race (silent "Unauthorized"/empty states), empty questionnaire submissions burning attempts, hydration-window input loss, multiple h1s, demo login form swap

## Verification

- Full suite green **3× consecutively** on a fresh `make bootstrap` baseline: 80/80, 80/79+1 retry-healed flaky, 80/80 (10 expected skips: DEMO_MODE registration variants + mobile sidebar-search)
- `make check` fully green; unit tests green
- One product-code touch: the `data-hydrated` marker in `+layout.svelte` (3 lines, test affordance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)