### PR TITLE
fix: E2E Phase 1 findings — auth-bootstrap race + a11y baseline to zero

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,9 +32,12 @@ export default defineConfig({
 	testDir: './tests/e2e',
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	// One local retry: a retried test gets a FRESH context (new token pair),
-	// which heals the known client-auth rotation race (see the E2E findings
-	// issue) without masking real regressions — those fail twice.
+	// One local retry. The client-auth rotation race that originally motivated
+	// this was fixed app-side (#596: API requests wait for the auth bootstrap
+	// gate) — retries: 0 was trialled and no auth flakes remained, but the
+	// local dev backend still throws unrelated transients under 4-worker load
+	// (django-silk profiling middleware deadlocks in Postgres → sporadic 500s),
+	// so one retry stays. Real regressions fail twice.
 	retries: process.env.CI ? 2 : 1,
 	// The journeys hit ONE local backend; unbounded workers overload it
 	// (slow renders, transient 500s). Four is fast and stable.

--- a/scripts/check-file-length.sh
+++ b/scripts/check-file-length.sh
@@ -22,12 +22,14 @@ FAILED=0
 # Per-file cap overrides — the only sanctioned way for a file to exceed the
 # default cap. Each entry needs a rationale; the override IS the ceiling
 # (no hardcoded current line counts).
-#   auth.svelte.ts → 550: token race guards + single-flight refresh thread all
+#   auth.svelte.ts → 620: token race guards + single-flight refresh thread all
 #   state through one class; split rejected twice as invariant-threatening
-#   (#544 Task 12/13 analyses, #557).
+#   (#544 Task 12/13 analyses, #557). Raised 550→620 for the bootstrap gate +
+#   interrupted-rotation retry (#596) — both must share the store's settle
+#   points (setAccessToken/logout), so they belong to the same class.
 max_for() {
     case "$1" in
-        src/lib/stores/auth.svelte.ts) echo 550 ;;
+        src/lib/stores/auth.svelte.ts) echo 620 ;;
         *) echo "$2" ;;
     esac
 }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -47,7 +47,13 @@ function processQueue(error: unknown | null, token: string | null = null) {
 
 // Use request interceptor to inject Authorization header dynamically
 // This is necessary because the generated client does not support header functions
-generatedClient.interceptors.request.use((request, _options) => {
+generatedClient.interceptors.request.use(async (request, _options) => {
+	// Hold the request while the post-load auth bootstrap is pending: firing
+	// now would go out WITHOUT an Authorization header and surface spurious
+	// "Unauthorized" errors (or empty states) to a logged-in user. No-op for
+	// guests and once a token is in memory (see authStore.markBootstrapPending).
+	await authStore.waitForAuthReady();
+
 	// Get the current access token from auth store
 	const token = authStore.accessToken;
 

--- a/src/lib/components/common/Footer.svelte
+++ b/src/lib/components/common/Footer.svelte
@@ -199,21 +199,27 @@
 				class="mt-8 flex flex-wrap items-center justify-center gap-4 border-t pt-6 text-xs text-muted-foreground"
 			>
 				<Tooltip.Root>
+					<!-- The link itself is the tooltip trigger (child snippet): a default
+					     Trigger renders a <button> AROUND the <a>, an interactive-inside-
+					     interactive WCAG violation flagged on every page (#595). -->
 					<Tooltip.Trigger
 						onmouseenter={() => fetchReleaseNotes('frontend', FRONTEND_VERSION)}
 						onfocus={() => fetchReleaseNotes('frontend', FRONTEND_VERSION)}
 					>
-						<a
-							href={FRONTEND_REPO}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="flex items-center gap-1.5 transition-colors hover:text-foreground"
-							aria-label="{m['footer.frontend']()} repository on GitHub"
-						>
-							<Github class="h-3.5 w-3.5" aria-hidden="true" />
-							<span>FE v{FRONTEND_VERSION}</span>
-							<Info class="h-3 w-3 text-muted-foreground/70" aria-hidden="true" />
-						</a>
+						{#snippet child({ props })}
+							<a
+								{...props}
+								href={FRONTEND_REPO}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="flex items-center gap-1.5 transition-colors hover:text-foreground"
+								aria-label="{m['footer.frontend']()} repository on GitHub"
+							>
+								<Github class="h-3.5 w-3.5" aria-hidden="true" />
+								<span>FE v{FRONTEND_VERSION}</span>
+								<Info class="h-3 w-3 text-muted-foreground/70" aria-hidden="true" />
+							</a>
+						{/snippet}
 					</Tooltip.Trigger>
 					<Tooltip.Content class="max-w-xs">
 						{#if loadingNotes[`frontend-${FRONTEND_VERSION}`]}
@@ -237,17 +243,20 @@
 						onmouseenter={() => fetchReleaseNotes('backend', backendVersion)}
 						onfocus={() => fetchReleaseNotes('backend', backendVersion)}
 					>
-						<a
-							href={BACKEND_REPO}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="flex items-center gap-1.5 transition-colors hover:text-foreground"
-							aria-label="{m['footer.backend']()} repository on GitHub"
-						>
-							<Github class="h-3.5 w-3.5" aria-hidden="true" />
-							<span>BE v{backendVersion}{isDemoMode ? ' (demo)' : ''}</span>
-							<Info class="h-3 w-3 text-muted-foreground/70" aria-hidden="true" />
-						</a>
+						{#snippet child({ props })}
+							<a
+								{...props}
+								href={BACKEND_REPO}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="flex items-center gap-1.5 transition-colors hover:text-foreground"
+								aria-label="{m['footer.backend']()} repository on GitHub"
+							>
+								<Github class="h-3.5 w-3.5" aria-hidden="true" />
+								<span>BE v{backendVersion}{isDemoMode ? ' (demo)' : ''}</span>
+								<Info class="h-3 w-3 text-muted-foreground/70" aria-hidden="true" />
+							</a>
+						{/snippet}
 					</Tooltip.Trigger>
 					<Tooltip.Content class="max-w-xs">
 						{#if loadingNotes[`backend-${backendVersion}`]}

--- a/src/lib/components/common/MarkdownContent.svelte
+++ b/src/lib/components/common/MarkdownContent.svelte
@@ -1,5 +1,23 @@
+<script lang="ts" module>
+	import { Marked } from 'marked';
+
+	// Scoped parser instance (not the global `marked` singleton) so the
+	// heading demotion below can't leak into other markdown consumers.
+	const markdownParser = new Marked({
+		breaks: true, // Convert \n to <br>
+		gfm: true, // GitHub Flavored Markdown
+		// Demote headings one level (h1→h2, …, capped at h6): the page itself
+		// owns the single <h1>, so user-authored "# Heading" markdown must not
+		// introduce additional h1s (WCAG heading structure, #596).
+		walkTokens: (token) => {
+			if (token.type === 'heading') {
+				token.depth = Math.min(token.depth + 1, 6);
+			}
+		}
+	});
+</script>
+
 <script lang="ts">
-	import { marked } from 'marked';
 	import { cn } from '$lib/utils/cn';
 	import { sanitizeHtml } from '$lib/utils/sanitize';
 
@@ -28,12 +46,6 @@
 
 	const { content, class: className, ariaLabel, inline = false }: Props = $props();
 
-	// Configure marked for safe rendering
-	marked.setOptions({
-		breaks: true, // Convert \n to <br>
-		gfm: true // GitHub Flavored Markdown
-	});
-
 	/**
 	 * Determine if we have valid content to display
 	 */
@@ -45,7 +57,7 @@
 	const renderedHtml = $derived.by(() => {
 		if (!hasContent || !content) return '';
 		try {
-			const raw = inline ? marked.parseInline(content) : marked.parse(content);
+			const raw = inline ? markdownParser.parseInline(content) : markdownParser.parse(content);
 			return sanitizeHtml(typeof raw === 'string' ? raw : String(raw));
 		} catch {
 			// If parsing fails, return the raw content escaped

--- a/src/lib/components/common/MarkdownContent.test.ts
+++ b/src/lib/components/common/MarkdownContent.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import MarkdownContent from './MarkdownContent.svelte';
+
+describe('MarkdownContent', () => {
+	it('demotes markdown headings one level so pages keep a single h1', () => {
+		const { container } = render(MarkdownContent, {
+			props: { content: '# Top\n\n## Section\n\ntext' }
+		});
+
+		expect(container.querySelector('h1')).toBeNull();
+		expect(container.querySelector('h2')?.textContent).toBe('Top');
+		expect(container.querySelector('h3')?.textContent).toBe('Section');
+	});
+
+	it('caps demotion at h6', () => {
+		const { container } = render(MarkdownContent, {
+			props: { content: '###### Deep' }
+		});
+
+		expect(container.querySelector('h6')?.textContent).toBe('Deep');
+	});
+
+	it('still renders plain markdown content', () => {
+		const { container } = render(MarkdownContent, {
+			props: { content: 'Hello **world**' }
+		});
+
+		expect(container.querySelector('strong')?.textContent).toBe('world');
+	});
+});

--- a/src/lib/components/events/admin/AdminEventCard.svelte
+++ b/src/lib/components/events/admin/AdminEventCard.svelte
@@ -134,7 +134,7 @@
 <div
 	class={cn(
 		'flex flex-col overflow-hidden rounded-lg border border-border bg-card shadow-sm transition-shadow hover:shadow-md',
-		faded && 'opacity-75'
+		faded && 'grayscale'
 	)}
 >
 	<!-- Cover Image -->
@@ -264,7 +264,7 @@
 				<button
 					type="button"
 					onclick={() => onPublish(event.id)}
-					class="inline-flex items-center gap-1 rounded-md bg-green-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-green-700"
+					class="inline-flex items-center gap-1 rounded-md bg-green-700 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-green-800"
 				>
 					<CheckCircle class="h-4 w-4" aria-hidden="true" />
 					{m['orgAdmin.events.actions.publish']()}
@@ -301,7 +301,7 @@
 				<button
 					type="button"
 					onclick={manageWaitlist}
-					class="inline-flex items-center gap-1 rounded-md bg-amber-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-amber-700"
+					class="inline-flex items-center gap-1 rounded-md bg-amber-700 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-amber-800"
 				>
 					<ListPlus class="h-4 w-4" aria-hidden="true" />
 					{m['orgAdmin.events.actions.waitlist']()}
@@ -311,7 +311,7 @@
 				<button
 					type="button"
 					onclick={() => onReopen(event.id)}
-					class="inline-flex items-center gap-1 rounded-md bg-green-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-green-700"
+					class="inline-flex items-center gap-1 rounded-md bg-green-700 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-green-800"
 				>
 					<CheckCircle class="h-4 w-4" aria-hidden="true" />
 					{m['orgAdmin.events.actions.reopen']()}

--- a/src/lib/components/events/filters/EventFilters.svelte
+++ b/src/lib/components/events/filters/EventFilters.svelte
@@ -145,6 +145,7 @@
 	<div class="space-y-2">
 		<label for="event-search" class="text-sm font-medium">{m['common.search_label']()}</label>
 		<SearchInput
+			id="event-search"
 			value={filters.search ?? ''}
 			onSearch={handleSearch}
 			placeholder={m['filters.search.eventsPlaceholder']()}

--- a/src/lib/components/events/filters/MobileFilterSheet.svelte
+++ b/src/lib/components/events/filters/MobileFilterSheet.svelte
@@ -255,6 +255,7 @@
 						>{m['common.search_label']()}</label
 					>
 					<SearchInput
+						id="mobile-event-search"
 						value={filters.search ?? ''}
 						onSearch={handleSearch}
 						placeholder={m['filters.search.eventsPlaceholder']()}

--- a/src/lib/components/events/filters/SearchInput.svelte
+++ b/src/lib/components/events/filters/SearchInput.svelte
@@ -8,6 +8,8 @@
 		onSearch: (value: string) => void;
 		placeholder?: string;
 		ariaLabel?: string;
+		/** id for the input, so an external visible <label for=...> can associate. */
+		id?: string;
 		debounceMs?: number;
 		class?: string;
 	}
@@ -17,6 +19,7 @@
 		onSearch,
 		placeholder = m['filters.search.eventsPlaceholder'](),
 		ariaLabel = m['filters.search.eventsLabel'](),
+		id,
 		debounceMs = 300,
 		class: className
 	}: Props = $props();
@@ -58,6 +61,7 @@
 		/>
 		<input
 			type="search"
+			{id}
 			value={inputValue}
 			oninput={handleInput}
 			{placeholder}

--- a/src/lib/components/forms/MarkdownEditor.svelte
+++ b/src/lib/components/forms/MarkdownEditor.svelte
@@ -105,6 +105,11 @@
 				extensions: createEditorExtensions(placeholder),
 				editorProps: {
 					attributes: {
+						// contenteditable divs have an implicit "generic" role, on which
+						// naming (aria-label/labelledby) and aria-multiline are PROHIBITED
+						// (axe aria-prohibited-attr/aria-allowed-attr, #595). role=textbox
+						// is the correct role for a rich-text editing surface.
+						role: 'textbox',
 						'aria-multiline': 'true',
 						...(label
 							? { 'aria-labelledby': `${inputId}-label` }
@@ -148,6 +153,7 @@
 	$effect(() => {
 		const dom = editor?.view?.dom as HTMLElement | undefined;
 		if (!dom) return;
+		dom.setAttribute('role', 'textbox');
 		dom.setAttribute('aria-multiline', 'true');
 		if (label) {
 			dom.setAttribute('aria-labelledby', `${inputId}-label`);

--- a/src/lib/components/forms/editor/source-toggle.test.ts
+++ b/src/lib/components/forms/editor/source-toggle.test.ts
@@ -14,7 +14,12 @@ describe('source toggle', () => {
 		render(MarkdownEditor, { props: { value: '**hi**', id: 'd', label: 'L', onValueChange } });
 		await waitFor(() => screen.getByRole('button', { name: /source/i }));
 		await user.click(screen.getByRole('button', { name: /source/i }));
-		const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+		// Two textboxes exist now: the tiptap surface (role=textbox, #595) and
+		// the source textarea — grab the actual <textarea>.
+		const ta = screen
+			.getAllByRole('textbox')
+			.find((el): el is HTMLTextAreaElement => el instanceof HTMLTextAreaElement);
+		if (!ta) throw new Error('source textarea not found');
 		expect(ta.value).toContain('**hi**');
 		await user.clear(ta);
 		await user.type(ta, '## new');
@@ -23,7 +28,7 @@ describe('source toggle', () => {
 			expect(onValueChange).toHaveBeenCalledWith(expect.stringContaining('## new'))
 		);
 		await user.click(screen.getByRole('button', { name: /back to editor|exit source|done/i }));
-		// back in WYSIWYG; value updated
-		await waitFor(() => expect(screen.queryByRole('textbox')).not.toBeInTheDocument());
+		// back in WYSIWYG; the source textarea is gone
+		await waitFor(() => expect(ta).not.toBeInTheDocument());
 	});
 });

--- a/src/lib/components/invitations/InvitationCard.svelte
+++ b/src/lib/components/invitations/InvitationCard.svelte
@@ -96,20 +96,20 @@
 				</div>
 
 				<!-- Event Metadata -->
-				<dl class="space-y-1.5 text-sm">
+				<ul class="space-y-1.5 text-sm">
 					{#if eventDate}
-						<div class="flex items-center gap-2 text-muted-foreground">
+						<li class="flex items-center gap-2 text-muted-foreground">
 							<Calendar class="h-4 w-4 shrink-0" aria-hidden="true" />
-							<dd class="truncate">{eventDate}</dd>
-						</div>
+							<span class="truncate">{eventDate}</span>
+						</li>
 					{/if}
 					{#if eventLocation}
-						<div class="flex items-center gap-2 text-muted-foreground">
+						<li class="flex items-center gap-2 text-muted-foreground">
 							<MapPin class="h-4 w-4 shrink-0" aria-hidden="true" />
-							<dd class="truncate">{eventLocation}</dd>
-						</div>
+							<span class="truncate">{eventLocation}</span>
+						</li>
 					{/if}
-				</dl>
+				</ul>
 			</div>
 		</div>
 

--- a/src/lib/components/invitations/InvitationRequestCard.svelte
+++ b/src/lib/components/invitations/InvitationRequestCard.svelte
@@ -145,20 +145,20 @@
 				</div>
 
 				<!-- Event Metadata -->
-				<dl class="space-y-1.5 text-sm">
+				<ul class="space-y-1.5 text-sm">
 					{#if eventDate}
-						<div class="flex items-center gap-2 text-muted-foreground">
+						<li class="flex items-center gap-2 text-muted-foreground">
 							<Calendar class="h-4 w-4 shrink-0" aria-hidden="true" />
-							<dd class="truncate">{eventDate}</dd>
-						</div>
+							<span class="truncate">{eventDate}</span>
+						</li>
 					{/if}
 					{#if eventLocation}
-						<div class="flex items-center gap-2 text-muted-foreground">
+						<li class="flex items-center gap-2 text-muted-foreground">
 							<MapPin class="h-4 w-4 shrink-0" aria-hidden="true" />
-							<dd class="truncate">{eventLocation}</dd>
-						</div>
+							<span class="truncate">{eventLocation}</span>
+						</li>
 					{/if}
-				</dl>
+				</ul>
 			</div>
 		</div>
 

--- a/src/lib/components/organizations/filters/MobileOrganizationFilterSheet.svelte
+++ b/src/lib/components/organizations/filters/MobileOrganizationFilterSheet.svelte
@@ -166,9 +166,11 @@
 						>{m['mobileOrganizationFilterSheet.search']()}</label
 					>
 					<SearchInput
+						id="mobile-organization-search"
 						value={filters.search ?? ''}
 						onSearch={handleSearch}
 						placeholder={m['mobileOrganizationFilterSheet.searchPlaceholder']()}
+						ariaLabel={m['filters.search.organizationsLabel']()}
 					/>
 				</div>
 

--- a/src/lib/components/organizations/filters/OrganizationFilters.svelte
+++ b/src/lib/components/organizations/filters/OrganizationFilters.svelte
@@ -109,9 +109,11 @@
 		<label for="organization-search" class="text-sm font-medium">{m['common.search_label']()}</label
 		>
 		<SearchInput
+			id="organization-search"
 			value={filters.search ?? ''}
 			onSearch={handleSearch}
 			placeholder={m['filters.search.organizationsPlaceholder']()}
+			ariaLabel={m['filters.search.organizationsLabel']()}
 		/>
 	</div>
 

--- a/src/lib/components/profile/TelegramConnectionManager.svelte
+++ b/src/lib/components/profile/TelegramConnectionManager.svelte
@@ -203,7 +203,7 @@
 			<p class="mb-3 text-sm text-muted-foreground">
 				{m['telegram.notConnected_description']()}
 			</p>
-			<Button onclick={handleOpenConnectDialog} class="bg-[#0088cc] hover:bg-[#0088cc]/90">
+			<Button onclick={handleOpenConnectDialog} class="bg-[#0072ab] hover:bg-[#0072ab]/90">
 				<MessageCircle class="mr-2 h-4 w-4" aria-hidden="true" />
 				{m['telegram.buttons_connect']()}
 			</Button>
@@ -246,7 +246,7 @@
 							href={botLink}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="inline-flex items-center gap-2 text-sm text-[#0088cc] underline-offset-4 hover:underline"
+							class="inline-flex items-center gap-2 text-sm text-[#0072ab] underline-offset-4 hover:underline"
 						>
 							<MessageCircle class="h-4 w-4" aria-hidden="true" />
 							<span>@{botName}</span>
@@ -333,7 +333,7 @@
 				type="button"
 				onclick={handleConnectSubmit}
 				disabled={connectMutation.isPending || !otpValue.trim()}
-				class="w-full bg-[#0088cc] hover:bg-[#0088cc]/90 sm:w-auto"
+				class="w-full bg-[#0072ab] hover:bg-[#0072ab]/90 sm:w-auto"
 			>
 				{#if connectMutation.isPending}
 					<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />

--- a/src/lib/components/rsvps/RSVPCard.svelte
+++ b/src/lib/components/rsvps/RSVPCard.svelte
@@ -125,20 +125,20 @@
 				</div>
 
 				<!-- Event Metadata -->
-				<dl class="space-y-1.5 text-sm">
+				<ul class="space-y-1.5 text-sm">
 					{#if eventDate}
-						<div class="flex items-center gap-2 text-muted-foreground">
+						<li class="flex items-center gap-2 text-muted-foreground">
 							<Calendar class="h-4 w-4 shrink-0" aria-hidden="true" />
-							<dd class="truncate">{eventDate}</dd>
-						</div>
+							<span class="truncate">{eventDate}</span>
+						</li>
 					{/if}
 					{#if eventLocation}
-						<div class="flex items-center gap-2 text-muted-foreground">
+						<li class="flex items-center gap-2 text-muted-foreground">
 							<MapPin class="h-4 w-4 shrink-0" aria-hidden="true" />
-							<dd class="truncate">{eventLocation}</dd>
-						</div>
+							<span class="truncate">{eventLocation}</span>
+						</li>
 					{/if}
-				</dl>
+				</ul>
 			</div>
 		</div>
 

--- a/src/lib/components/tickets/MyTicket.svelte
+++ b/src/lib/components/tickets/MyTicket.svelte
@@ -143,22 +143,22 @@
 
 		<!-- Ticket Holder & Seat Info -->
 		{#if ticket.guest_name || hasSeatInfo}
-			<dl class="space-y-2 rounded-lg border border-border bg-muted/30 p-4 text-sm">
+			<ul class="space-y-2 rounded-lg border border-border bg-muted/30 p-4 text-sm">
 				{#if ticket.guest_name}
-					<div class="flex items-center gap-2">
-						<dt class="sr-only">{m['myTicket.ticketHolder']()}</dt>
+					<li class="flex items-center gap-2">
+						<span class="sr-only">{m['myTicket.ticketHolder']()}</span>
 						<User class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-						<dd class="font-medium">{ticket.guest_name}</dd>
-					</div>
+						<span class="font-medium">{ticket.guest_name}</span>
+					</li>
 				{/if}
 				{#if seatInfo}
-					<div class="flex items-center gap-2">
-						<dt class="sr-only">{m['myTicket.seat']()}</dt>
+					<li class="flex items-center gap-2">
+						<span class="sr-only">{m['myTicket.seat']()}</span>
 						<Armchair class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-						<dd>{seatInfo}</dd>
-					</div>
+						<span>{seatInfo}</span>
+					</li>
 				{/if}
-			</dl>
+			</ul>
 		{/if}
 
 		<!-- Pending Payment Banner -->
@@ -233,20 +233,20 @@
 
 		<!-- Event Details -->
 		{#if eventDate || eventLocation}
-			<dl class="space-y-2 text-sm">
+			<ul class="space-y-2 text-sm">
 				{#if eventDate}
-					<div class="flex items-center gap-2">
+					<li class="flex items-center gap-2">
 						<Calendar class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-						<dd>{eventDate}</dd>
-					</div>
+						<span>{eventDate}</span>
+					</li>
 				{/if}
 				{#if eventLocation}
-					<div class="flex items-center gap-2">
+					<li class="flex items-center gap-2">
 						<MapPin class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-						<dd>{eventLocation}</dd>
-					</div>
+						<span>{eventLocation}</span>
+					</li>
 				{/if}
-			</dl>
+			</ul>
 		{/if}
 
 		<!-- QR Code -->

--- a/src/lib/components/tickets/TicketListCard.svelte
+++ b/src/lib/components/tickets/TicketListCard.svelte
@@ -117,25 +117,25 @@
 				</div>
 
 				<!-- Event Metadata -->
-				<dl class="space-y-1.5 text-sm">
+				<ul class="space-y-1.5 text-sm">
 					{#if eventDate}
-						<div class="flex items-center gap-2 text-muted-foreground">
+						<li class="flex items-center gap-2 text-muted-foreground">
 							<Calendar class="h-4 w-4 shrink-0" aria-hidden="true" />
-							<dd class="truncate">{eventDate}</dd>
-						</div>
+							<span class="truncate">{eventDate}</span>
+						</li>
 					{/if}
 					{#if eventLocation}
-						<div class="flex items-center gap-2 text-muted-foreground">
+						<li class="flex items-center gap-2 text-muted-foreground">
 							<MapPin class="h-4 w-4 shrink-0" aria-hidden="true" />
-							<dd class="truncate">{eventLocation}</dd>
-						</div>
+							<span class="truncate">{eventLocation}</span>
+						</li>
 					{/if}
 					<!-- Purchased Date -->
-					<div class="text-muted-foreground">
+					<li class="text-muted-foreground">
 						<span class="font-medium">{m['ticketListCard.purchased']()}</span>
 						{createdDate}
-					</div>
-				</dl>
+					</li>
+				</ul>
 			</div>
 		</div>
 

--- a/src/lib/server/features.test.ts
+++ b/src/lib/server/features.test.ts
@@ -5,7 +5,7 @@ vi.mock('$lib/api/generated/sdk.gen', () => ({
 }));
 
 import { apiApiVersion } from '$lib/api/generated/sdk.gen';
-import { getFeatures, __resetFeaturesCache } from './features';
+import { getFeatures, getDemoMode, __resetFeaturesCache } from './features';
 import { DEFAULT_FEATURES } from '$lib/utils/features';
 
 const mockedApiApiVersion = vi.mocked(apiApiVersion);
@@ -56,6 +56,42 @@ describe('getFeatures', () => {
 
 		await getFeatures(fakeFetch);
 		await getFeatures(fakeFetch);
+		expect(mockedApiApiVersion).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('getDemoMode', () => {
+	it('resolves demo from the /version payload', async () => {
+		mockedApiApiVersion.mockResolvedValue({
+			data: { version: '1.0.0', demo: true, features: DEFAULT_FEATURES },
+			error: undefined
+		} as never);
+
+		expect(await getDemoMode(fakeFetch)).toBe(true);
+	});
+
+	it('defaults to false when /version omits demo', async () => {
+		mockedApiApiVersion.mockResolvedValue({
+			data: { version: '1.0.0', features: DEFAULT_FEATURES },
+			error: undefined
+		} as never);
+
+		expect(await getDemoMode(fakeFetch)).toBe(false);
+	});
+
+	it('defaults to false when the call fails', async () => {
+		mockedApiApiVersion.mockRejectedValue(new Error('network'));
+		expect(await getDemoMode(fakeFetch)).toBe(false);
+	});
+
+	it('shares the cache with getFeatures (one upstream call total)', async () => {
+		mockedApiApiVersion.mockResolvedValue({
+			data: { version: '1.0.0', demo: true, features: DEFAULT_FEATURES },
+			error: undefined
+		} as never);
+
+		await getFeatures(fakeFetch);
+		expect(await getDemoMode(fakeFetch)).toBe(true);
 		expect(mockedApiApiVersion).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/lib/server/features.ts
+++ b/src/lib/server/features.ts
@@ -3,7 +3,14 @@ import { resolveFeatures, DEFAULT_FEATURES, type Features } from '$lib/utils/fea
 
 const TTL_MS = 5 * 60 * 1000;
 
-let cache: { value: Features; expiry: number } | null = null;
+interface VersionInfo {
+	features: Features;
+	demo: boolean;
+}
+
+const FALLBACK: VersionInfo = { features: DEFAULT_FEATURES, demo: false };
+
+let cache: { value: VersionInfo; expiry: number } | null = null;
 
 /** Test-only: clear the in-memory cache between cases. */
 export function __resetFeaturesCache(): void {
@@ -11,12 +18,13 @@ export function __resetFeaturesCache(): void {
 }
 
 /**
- * Fetch the backend feature flags from `GET /version`, cached for ~5 minutes.
+ * Fetch `GET /version` (feature flags + demo mode), cached for ~5 minutes.
  * `/version` is anonymous and identical for every user, so a shared cache is
- * safe. Fail-open: any failure yields DEFAULT_FEATURES so we never hide a
- * capability that is actually enabled.
+ * safe. Fail-open: any failure yields DEFAULT_FEATURES (never hide a
+ * capability that is actually enabled) and `demo: false` (render the normal
+ * UI rather than the demo variant).
  */
-export async function getFeatures(fetch: typeof globalThis.fetch): Promise<Features> {
+async function getVersionInfo(fetch: typeof globalThis.fetch): Promise<VersionInfo> {
 	if (cache && cache.expiry > Date.now()) {
 		return cache.value;
 	}
@@ -24,12 +32,30 @@ export async function getFeatures(fetch: typeof globalThis.fetch): Promise<Featu
 	try {
 		const { data, error } = await apiApiVersion({ fetch });
 		if (error || !data) {
-			return DEFAULT_FEATURES;
+			return FALLBACK;
 		}
-		const value = resolveFeatures(data.features);
+		const value: VersionInfo = {
+			features: resolveFeatures(data.features),
+			demo: data.demo ?? false
+		};
 		cache = { value, expiry: Date.now() + TTL_MS };
 		return value;
 	} catch {
-		return DEFAULT_FEATURES;
+		return FALLBACK;
 	}
+}
+
+/** Backend feature flags (cached, fail-open). */
+export async function getFeatures(fetch: typeof globalThis.fetch): Promise<Features> {
+	return (await getVersionInfo(fetch)).features;
+}
+
+/**
+ * Whether the backend runs in DEMO mode (cached, defaults to false). Lets
+ * SSR render the right variant immediately — e.g. the login page's
+ * demo-account dropdown — instead of swapping it in client-side after the
+ * app store learns `demo: true` (a swap that eats typed credentials, #596).
+ */
+export async function getDemoMode(fetch: typeof globalThis.fetch): Promise<boolean> {
+	return (await getVersionInfo(fetch)).demo;
 }

--- a/src/lib/stores/auth.svelte.test.ts
+++ b/src/lib/stores/auth.svelte.test.ts
@@ -260,4 +260,56 @@ describe('AuthStore', () => {
 			expect(authStore.accessToken).toBe('new-token');
 		});
 	});
+
+	describe('Bootstrap gate', () => {
+		/** True once waitForAuthReady() has resolved (after a microtask flush). */
+		async function isReady(): Promise<boolean> {
+			let resolved = false;
+			void authStore.waitForAuthReady().then(() => {
+				resolved = true;
+			});
+			// Flush microtasks without advancing timers.
+			await Promise.resolve();
+			await Promise.resolve();
+			return resolved;
+		}
+
+		it('resolves immediately when no bootstrap is pending', async () => {
+			expect(await isReady()).toBe(true);
+		});
+
+		it('holds requests while pending and releases on setAccessToken', async () => {
+			authStore.markBootstrapPending();
+			expect(await isReady()).toBe(false);
+
+			authStore.setAccessToken('bootstrapped-token');
+			expect(await isReady()).toBe(true);
+		});
+
+		it('releases on logout (session is truly gone)', async () => {
+			authStore.markBootstrapPending();
+			expect(await isReady()).toBe(false);
+
+			await authStore.logout();
+			expect(await isReady()).toBe(true);
+		});
+
+		it('is a no-op to arm twice', async () => {
+			authStore.markBootstrapPending();
+			authStore.markBootstrapPending();
+			authStore.setAccessToken('token');
+			expect(await isReady()).toBe(true);
+		});
+
+		it('re-arms on resetForSwap so the next identity bootstraps gated', async () => {
+			authStore.setAccessToken('old-identity-token');
+			expect(await isReady()).toBe(true);
+
+			authStore.resetForSwap();
+			expect(await isReady()).toBe(false);
+
+			authStore.setAccessToken('new-identity-token');
+			expect(await isReady()).toBe(true);
+		});
+	});
 });

--- a/src/lib/stores/auth.svelte.ts
+++ b/src/lib/stores/auth.svelte.ts
@@ -28,6 +28,14 @@ class AuthStore {
 	// gave a false positive during cold-hydration bootstrap (where the store
 	// is intentionally empty until the bootstrap refresh completes).
 	private _isLoggingOut = false;
+	// Bootstrap gate: while the post-load token bootstrap is pending, API
+	// requests must NOT go out without an Authorization header (they would
+	// surface "Unauthorized" errors / empty states to a logged-in user). The
+	// root layout arms this gate synchronously during hydration when the
+	// server session exists but the in-memory store is still empty; it settles
+	// as soon as a token lands (`setAccessToken`) or the session is truly gone
+	// (`logout`). See waitForAuthReady().
+	private _bootstrapGate: { promise: Promise<void>; resolve: () => void } | null = null;
 
 	// Public computed state using $derived
 	get user() {
@@ -66,6 +74,46 @@ class AuthStore {
 	 */
 	get isImpersonated(): boolean {
 		return this.impersonationInfo.isImpersonated;
+	}
+
+	/**
+	 * Arm the bootstrap gate: subsequent API requests wait (via
+	 * `waitForAuthReady`) until a token lands or the session is cleared.
+	 * Re-armable (used again on server-side session swaps); a no-op while a
+	 * gate is already pending. Must be called SYNCHRONOUSLY before components
+	 * whose queries/mutations need the token are initialized — the root
+	 * layout's component-init script does this (children init after it).
+	 */
+	markBootstrapPending(): void {
+		if (this._bootstrapGate) return;
+		let resolve!: () => void;
+		const promise = new Promise<void>((r) => {
+			resolve = r;
+		});
+		this._bootstrapGate = { promise, resolve };
+	}
+
+	private settleBootstrapGate(): void {
+		this._bootstrapGate?.resolve();
+		this._bootstrapGate = null;
+	}
+
+	/**
+	 * Resolve when it is safe to send an authenticated API request: either no
+	 * bootstrap is pending (guest, or token already in memory) or the pending
+	 * bootstrap settled. Bounded so a stalled bootstrap request can never hang
+	 * the entire API layer — after the cap, requests proceed and surface their
+	 * real 401s.
+	 */
+	async waitForAuthReady(): Promise<void> {
+		const gate = this._bootstrapGate;
+		if (!gate) return;
+		await Promise.race([
+			gate.promise,
+			new Promise<void>((r) => {
+				setTimeout(r, 15_000);
+			})
+		]);
 	}
 
 	/**
@@ -200,6 +248,10 @@ class AuthStore {
 		this._accessToken = null;
 		this._permissions = null;
 
+		// Release any request waiting on the bootstrap gate: the session is
+		// gone, so gated requests should proceed and surface their real 401s.
+		this.settleBootstrapGate();
+
 		// Note: Refresh token cookie will be cleared by server-side hook
 		// or by calling a logout endpoint if needed.
 		//
@@ -260,10 +312,26 @@ class AuthStore {
 			// Call our server-side refresh endpoint
 			// The refresh token is in httpOnly cookie, so client can't access it directly
 			// The server endpoint will read the cookie and call the backend
-			const response = await fetch('/api/auth/refresh', {
+			let response = await fetch('/api/auth/refresh', {
 				method: 'POST',
 				credentials: 'include' // Include cookies
 			});
+
+			// Interrupted-rotation heal: a reload that lands while a previous
+			// page's refresh is still in flight can read the OLD (already
+			// rotated → blacklisted) cookie and 401 here, even though the
+			// rotation's Set-Cookie is about to (or just did) land in the
+			// browser. One delayed retry re-reads the CURRENT cookies and
+			// rescues that case instead of silently logging the user out.
+			if (response.status === 401) {
+				await new Promise((r) => {
+					setTimeout(r, 400);
+				});
+				response = await fetch('/api/auth/refresh', {
+					method: 'POST',
+					credentials: 'include'
+				});
+			}
 
 			if (!response.ok) {
 				console.error('[AUTH STORE] Token refresh failed with status:', response.status);
@@ -377,6 +445,11 @@ class AuthStore {
 	 */
 	setAccessToken(token: string): void {
 		this._accessToken = token;
+		// The Authorization header is now available — release gated requests.
+		// Settling here (not after user/permissions load) is deliberate: those
+		// follow-up fetches use the API client themselves and would deadlock on
+		// the gate otherwise.
+		this.settleBootstrapGate();
 		// Schedule automatic refresh before token expires
 		this.scheduleTokenRefresh(token);
 	}
@@ -392,26 +465,33 @@ class AuthStore {
 	 * schedules a logout at expiry rather than a refresh).
 	 */
 	async loadSessionToken(): Promise<void> {
-		const response = await fetch('/api/auth/session-token', {
-			method: 'GET',
-			credentials: 'include'
-		});
+		try {
+			const response = await fetch('/api/auth/session-token', {
+				method: 'GET',
+				credentials: 'include'
+			});
 
-		if (!response.ok) {
-			throw new Error(`Session token bootstrap failed: ${response.status}`);
+			if (!response.ok) {
+				throw new Error(`Session token bootstrap failed: ${response.status}`);
+			}
+
+			const data = await response.json();
+			if (!data?.access) {
+				throw new Error('No access token returned from session-token endpoint');
+			}
+
+			// Respect a logout that happened while this fetch was in flight.
+			if (this._isLoggingOut) {
+				return;
+			}
+
+			this.setAccessToken(data.access);
+		} catch (error) {
+			// No token is coming from this bootstrap — release gated requests
+			// (unlike refresh failures, this path does not force a logout).
+			this.settleBootstrapGate();
+			throw error;
 		}
-
-		const data = await response.json();
-		if (!data?.access) {
-			throw new Error('No access token returned from session-token endpoint');
-		}
-
-		// Respect a logout that happened while this fetch was in flight.
-		if (this._isLoggingOut) {
-			return;
-		}
-
-		this.setAccessToken(data.access);
 	}
 
 	/**
@@ -430,6 +510,9 @@ class AuthStore {
 		this._user = null;
 		this._accessToken = null;
 		this._permissions = null;
+		// Until the new identity's token lands, API requests must wait again —
+		// otherwise they'd go out unauthenticated during the re-bootstrap.
+		this.markBootstrapPending();
 	}
 
 	/**

--- a/src/routes/(auth)/dashboard/+page.svelte
+++ b/src/routes/(auth)/dashboard/+page.svelte
@@ -297,6 +297,11 @@
 	}
 </script>
 
+<svelte:head>
+	<title>{m['userMenu.dashboard']()} - Revel</title>
+	<meta name="description" content={m['dashboard.pageSubtitle']()} />
+</svelte:head>
+
 <div class="container mx-auto px-4 py-6 md:py-8">
 	<!-- Welcome Header -->
 	<div class="mb-8">
@@ -527,7 +532,7 @@
 		<!-- My Organizations Section -->
 		<DashboardOrganizationsSection
 			{organizations}
-			isLoading={organizationsQuery.isLoading}
+			isLoading={organizationsQuery.isPending}
 			{permissions}
 		/>
 	</div>

--- a/src/routes/(auth)/dashboard/following/+page.svelte
+++ b/src/routes/(auth)/dashboard/following/+page.svelte
@@ -261,7 +261,7 @@
 	{#if activeTab === 'organizations'}
 		<!-- Organizations Tab -->
 		<div class="space-y-6">
-			{#if orgsQuery.isLoading}
+			{#if orgsQuery.isPending}
 				<div class="flex items-center justify-center py-12">
 					<Loader2 class="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
 				</div>
@@ -394,7 +394,7 @@
 	{:else}
 		<!-- Event Series Tab -->
 		<div class="space-y-6">
-			{#if seriesQuery.isLoading}
+			{#if seriesQuery.isPending}
 				<div class="flex items-center justify-center py-12">
 					<Loader2 class="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
 				</div>

--- a/src/routes/(auth)/dashboard/invitations/+page.svelte
+++ b/src/routes/(auth)/dashboard/invitations/+page.svelte
@@ -245,7 +245,7 @@
 			</div>
 
 			<!-- Invitations List -->
-			{#if invitationsQuery.isLoading}
+			{#if invitationsQuery.isPending}
 				<div class="flex items-center justify-center py-12">
 					<Loader2 class="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
 					<span class="sr-only">{m['dashboard.invitations.loadingInvitations']()}</span>
@@ -366,7 +366,7 @@
 			</div>
 
 			<!-- Requests List -->
-			{#if requestsQuery.isLoading}
+			{#if requestsQuery.isPending}
 				<div class="flex items-center justify-center py-12">
 					<Loader2 class="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
 					<span class="sr-only">{m['dashboard.invitations.loadingRequests']()}</span>

--- a/src/routes/(auth)/dashboard/passes/+page.svelte
+++ b/src/routes/(auth)/dashboard/passes/+page.svelte
@@ -66,7 +66,7 @@
 		<p class="text-muted-foreground">{m['seriesPass.myPassesDescription']()}</p>
 	</div>
 
-	{#if passesQuery.isLoading}
+	{#if passesQuery.isPending}
 		<div class="flex items-center justify-center py-16" role="status">
 			<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
 			<span class="sr-only">{m['seriesPass.loading']()}</span>

--- a/src/routes/(auth)/dashboard/rsvps/+page.svelte
+++ b/src/routes/(auth)/dashboard/rsvps/+page.svelte
@@ -124,7 +124,7 @@
 </script>
 
 <svelte:head>
-	{m['dashboard.rsvps.title']()} - Revel
+	<title>{m['dashboard.rsvps.title']()} - Revel</title>
 	<meta name="description" content={m['dashboard.rsvps.description']()} />
 </svelte:head>
 
@@ -142,7 +142,7 @@
 		</div>
 
 		<!-- RSVP Count -->
-		{#if !rsvpsQuery.isLoading && totalCount > 0}
+		{#if !rsvpsQuery.isPending && totalCount > 0}
 			<p class="mt-4 text-sm text-muted-foreground">
 				{m['dashboard.rsvps.showing']({
 					count: rsvps.length.toString(),
@@ -219,7 +219,7 @@
 	</div>
 
 	<!-- RSVPs List -->
-	{#if rsvpsQuery.isLoading}
+	{#if rsvpsQuery.isPending}
 		<!-- Loading State -->
 		<div class="flex items-center justify-center py-12">
 			<Loader2 class="h-8 w-8 animate-spin text-primary" aria-hidden="true" />

--- a/src/routes/(auth)/dashboard/tickets/+page.svelte
+++ b/src/routes/(auth)/dashboard/tickets/+page.svelte
@@ -171,7 +171,7 @@
 		</div>
 
 		<!-- Ticket Count -->
-		{#if !ticketsQuery.isLoading && totalCount > 0}
+		{#if !ticketsQuery.isPending && totalCount > 0}
 			<p class="mt-4 text-sm text-muted-foreground">
 				{m['dashboard.tickets.showing']({
 					count: tickets.length.toString(),
@@ -259,7 +259,7 @@
 	</div>
 
 	<!-- Tickets List -->
-	{#if ticketsQuery.isLoading}
+	{#if ticketsQuery.isPending}
 		<!-- Loading State -->
 		<div class="flex items-center justify-center py-12">
 			<Loader2 class="h-8 w-8 animate-spin text-primary" aria-hidden="true" />

--- a/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
@@ -364,7 +364,9 @@
 
 		<!-- Past Events -->
 		{#if pastEvents.length > 0}
-			<div class="space-y-4 opacity-75">
+			<!-- grayscale (not opacity): opacity-dimming blends buttons toward the page
+			     background and breaks WCAG contrast; grayscale preserves luminance (#595) -->
+			<div class="space-y-4 grayscale">
 				<h2 class="text-lg font-semibold">
 					{m['orgAdmin.events.sections.past']({
 						count: pastEvents.length,

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
@@ -238,7 +238,7 @@
 										type="button"
 										onclick={publishEvent}
 										disabled={updateStatusMutation.isPending}
-										class="inline-flex items-center gap-2 rounded-md bg-green-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-50"
+										class="inline-flex items-center gap-2 rounded-md bg-green-700 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-green-800 disabled:cursor-not-allowed disabled:opacity-50"
 									>
 										<CheckCircle class="h-4 w-4" aria-hidden="true" />
 										{m['eventEditPage.publishButton']()}
@@ -294,7 +294,7 @@
 										type="button"
 										onclick={reopenEvent}
 										disabled={updateStatusMutation.isPending}
-										class="inline-flex items-center gap-2 rounded-md bg-green-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-50"
+										class="inline-flex items-center gap-2 rounded-md bg-green-700 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-green-800 disabled:cursor-not-allowed disabled:opacity-50"
 									>
 										<CheckCircle class="h-4 w-4" aria-hidden="true" />
 										{m['eventEditPage.reopenButton']()}

--- a/src/routes/(auth)/org/[slug]/admin/members/requests/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/members/requests/+page.svelte
@@ -140,8 +140,8 @@
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
 				activeStatusFilter === 'approved'
-					? 'bg-green-600 text-white'
-					: 'border border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-green-950'
+					? 'bg-green-700 text-white'
+					: 'border border-green-700 text-green-700 hover:bg-green-50 dark:border-green-500 dark:text-green-500 dark:hover:bg-green-950'
 			)}
 		>
 			{m['membershipRequestsPage.filter_approved']()}
@@ -285,7 +285,7 @@
 												<button
 													type="submit"
 													disabled={processingRequestId === request.id}
-													class="inline-flex items-center gap-1 rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+													class="inline-flex items-center gap-1 rounded-md bg-green-700 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 													aria-label="Approve request from {request.user.first_name} {request.user
 														.last_name}"
 												>

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -420,7 +420,7 @@
 							{m['learnMore.pricingHappyToNegotiate']()}
 						</a>
 					</div>
-					<p class="mt-2 text-xs text-muted-foreground/70">
+					<p class="mt-2 text-xs text-muted-foreground">
 						{m['learnMore.feesExcludeVat']()}
 					</p>
 				</div>

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/questionnaire/[id]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/questionnaire/[id]/+page.svelte
@@ -119,6 +119,26 @@
 		return questions;
 	});
 
+	// Every visible mandatory question answered? Until then the Submit button
+	// stays DISABLED: the backend accepts a partial/empty submission (scored 0
+	// → rejected), which burns one of the limited attempts (#596).
+	const allRequiredAnswered = $derived.by(() => {
+		for (const q of allVisibleQuestions) {
+			if (!q.is_mandatory) continue;
+			if (q.type === 'multiple_choice') {
+				const answers = multipleChoiceAnswers.get(q.id);
+				if (!answers || answers.length === 0) return false;
+			} else if (q.type === 'free_text') {
+				const answer = freeTextAnswers.get(q.id);
+				if (!answer || answer.trim().length === 0) return false;
+			} else if (q.type === 'file_upload') {
+				const files = fileUploadAnswers.get(q.id);
+				if (!files || files.length === 0) return false;
+			}
+		}
+		return true;
+	});
+
 	// Submission mutation
 	const submitMutation = createMutation(() => ({
 		mutationFn: async () => {
@@ -396,31 +416,38 @@
 			{/if}
 
 			<!-- Submit Button -->
-			<div class="flex items-center justify-end gap-4 border-t pt-6">
-				<Button
-					type="button"
-					variant="outline"
-					onclick={() =>
-						goto(
-							resolve('/(public)/events/[org_slug]/[event_slug]', {
-								org_slug: data.event.organization.slug,
-								event_slug: data.event.slug
-							})
-						)}
-				>
-					{m['questionnaireSubmissionPage.button_cancel']()}
-				</Button>
-				<Button type="submit" disabled={submitMutation.isPending}>
-					{#if submitMutation.isPending}
-						<Loader2 class="h-5 w-5 animate-spin" />
-						{m['questionnaireSubmissionPage.button_submitting']()}
-					{:else if submitMutation.isSuccess}
-						<Check class="h-5 w-5" />
-						{m['questionnaireSubmissionPage.button_submitted']()}
-					{:else}
-						{m['questionnaireSubmissionPage.button_submit']()}
-					{/if}
-				</Button>
+			<div class="flex flex-col items-end gap-2 border-t pt-6">
+				{#if !allRequiredAnswered}
+					<p class="text-sm text-muted-foreground">
+						{m['questionnaireSubmissionPage.validation_allRequired']()}
+					</p>
+				{/if}
+				<div class="flex items-center justify-end gap-4">
+					<Button
+						type="button"
+						variant="outline"
+						onclick={() =>
+							goto(
+								resolve('/(public)/events/[org_slug]/[event_slug]', {
+									org_slug: data.event.organization.slug,
+									event_slug: data.event.slug
+								})
+							)}
+					>
+						{m['questionnaireSubmissionPage.button_cancel']()}
+					</Button>
+					<Button type="submit" disabled={submitMutation.isPending || !allRequiredAnswered}>
+						{#if submitMutation.isPending}
+							<Loader2 class="h-5 w-5 animate-spin" />
+							{m['questionnaireSubmissionPage.button_submitting']()}
+						{:else if submitMutation.isSuccess}
+							<Check class="h-5 w-5" />
+							{m['questionnaireSubmissionPage.button_submitted']()}
+						{:else}
+							{m['questionnaireSubmissionPage.button_submit']()}
+						{/if}
+					</Button>
+				</div>
 			</div>
 
 			<!-- Error message -->

--- a/src/routes/(public)/login/+page.server.ts
+++ b/src/routes/(public)/login/+page.server.ts
@@ -9,15 +9,21 @@ import {
 } from '$lib/utils/cookies';
 import { extractErrorMessage } from '$lib/utils/errors';
 import { claimPendingTokens, setClaimFlashCookie } from '$lib/server/token-claim';
+import { getDemoMode } from '$lib/server/features';
 import { log } from '$lib/server/logger';
 import { buildSeo } from '$lib/seo';
 import { resolveLang } from '$lib/seo/server';
 import { safeReturnUrl } from '$lib/utils/safe-redirect';
 
-export const load: PageServerLoad = ({ url, request }) => {
+export const load: PageServerLoad = async ({ url, request, fetch }) => {
 	const lang = resolveLang(request);
 	const seo = buildSeo({ kind: 'auth', url, lang, page: 'login' });
-	return { seo };
+	// SSR the correct login variant: on demo backends the page shows a
+	// demo-account dropdown instead of the email/password form. Deciding this
+	// client-side (appStore fetching /version after mount) visibly SWAPPED the
+	// form and ate credentials typed in the window (#596).
+	const demo = await getDemoMode(fetch);
+	return { seo, demo };
 };
 
 export const actions = {

--- a/src/routes/(public)/login/+page.svelte
+++ b/src/routes/(public)/login/+page.svelte
@@ -22,8 +22,10 @@
 
 	const { data, form }: Props = $props();
 
-	// Demo mode state
-	const isDemoMode = $derived(appStore.isDemoMode);
+	// Demo mode: the server already knows (data.demo, SSR — so the right
+	// variant renders immediately, no client-side form swap). The appStore
+	// fallback only matters if the server-side /version check failed.
+	const isDemoMode = $derived(data.demo || appStore.isDemoMode);
 
 	// A relative form action ("?/login") replaces the query string, so the
 	// returnUrl the server action reads (safeReturnUrl) would be dropped.

--- a/src/routes/(public)/register/+page.server.ts
+++ b/src/routes/(public)/register/+page.server.ts
@@ -1,27 +1,19 @@
 import { fail, redirect, isRedirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { registerSchema } from '$lib/schemas/auth';
-import { accountRegister, apiApiVersion } from '$lib/api/generated/sdk.gen';
+import { accountRegister } from '$lib/api/generated/sdk.gen';
 import { extractErrorMessage } from '$lib/utils/errors';
+import { getDemoMode } from '$lib/server/features';
 import { log } from '$lib/server/logger';
 import { buildSeo } from '$lib/seo';
 import { resolveLang } from '$lib/seo/server';
 
 export const load: PageServerLoad = async ({ fetch, cookies, url, request }) => {
-	// Check if backend is in demo mode
-	try {
-		const { data } = await apiApiVersion({ fetch });
-		if (data?.demo) {
-			// In demo mode, redirect to login page
-			throw redirect(303, '/login');
-		}
-	} catch (error) {
-		// Re-throw redirects
-		if (isRedirect(error)) {
-			throw error;
-		}
-		// If version check fails, allow registration to proceed
-		log.error('register_demo_check_failed', { error });
+	// In demo mode, registration is disabled — redirect to login. getDemoMode
+	// is cached and fail-open (false on errors), so registration proceeds if
+	// the version check fails.
+	if (await getDemoMode(fetch)) {
+		throw redirect(303, '/login');
 	}
 
 	const lang = resolveLang(request);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	import { afterNavigate } from '$app/navigation';
 	import { ModeWatcher } from 'mode-watcher';
 	import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
@@ -21,6 +22,20 @@
 	}
 
 	const { data, children }: Props = $props();
+
+	// Arm the auth bootstrap gate SYNCHRONOUSLY, before child components (and
+	// their queries/mutations) initialize: the $effect below that actually
+	// starts the bootstrap runs only AFTER children mounted, so without this a
+	// child's request would race the bootstrap and go out without an
+	// Authorization header ("Unauthorized" errors / empty list states on cold
+	// loads). The API client awaits authStore.waitForAuthReady() per request.
+	if (
+		browser &&
+		(data.auth.hasAccessToken || data.auth.hasRefreshToken) &&
+		!authStore.accessToken
+	) {
+		authStore.markBootstrapPending();
+	}
 
 	const queryClient = new QueryClient({
 		defaultOptions: {

--- a/tests/e2e/journeys/cross/a11y-smoke.spec.ts
+++ b/tests/e2e/journeys/cross/a11y-smoke.spec.ts
@@ -15,20 +15,13 @@ interface PageCase {
 }
 
 /**
- * KNOWN pre-existing serious/critical violation RULES, baselined 2026-07-10
- * so the smoke can gate NEW violation classes while the backlog is burned
- * down (issue #595). Rule-level (not per-page): which page trips which rule
- * varies with seeded/arranged data, and a flapping gate is worse than a
- * coarser one. DO NOT add to this list — fix the violation instead.
+ * KNOWN pre-existing serious/critical violation RULES, baselined so the smoke
+ * can gate NEW violation classes while a backlog is burned down. Rule-level
+ * (not per-page): which page trips which rule varies with seeded/arranged
+ * data, and a flapping gate is worse than a coarser one. DO NOT add to this
+ * list — fix the violation instead. Burned down to EMPTY in #595.
  */
-const BASELINE = new Set([
-	'nested-interactive', // footer version tooltips (buttons wrapping links), every page
-	'aria-prohibited-attr',
-	'aria-allowed-attr',
-	'color-contrast',
-	'document-title', // /dashboard renders without a <title>
-	'definition-list' // ticket cards' <dl> structure
-]);
+const BASELINE = new Set<string>([]);
 
 const PAGES: PageCase[] = [
 	{ name: 'landing', path: '/' },

--- a/tests/e2e/support/skip.ts
+++ b/tests/e2e/support/skip.ts
@@ -19,8 +19,11 @@ let probe: Promise<VersionInfo | null> | undefined;
 function versionInfo(): Promise<VersionInfo | null> {
 	probe ??= (async () => {
 		try {
+			// Generous timeout: the probe races the first burst of parallel-worker
+			// backend load; at 3s it intermittently timed out and silently skipped
+			// an entire project's tests (cached per worker).
 			const response = await fetch(`${API_URL}/api/version`, {
-				signal: AbortSignal.timeout(3_000)
+				signal: AbortSignal.timeout(10_000)
 			});
 			if (!response.ok) return null;
 			return (await response.json()) as VersionInfo;


### PR DESCRIPTION
Closes #596, closes #595

App-side fixes for everything the Phase 1 E2E suites (#589) surfaced.

## Functional (#596)

### 1. Auth-bootstrap mutation race (the recurring flake source)
- `+layout.svelte` arms a **bootstrap gate** synchronously during component init — before any child component (and its queries/mutations) initializes.
- The API client's request interceptor `await authStore.waitForAuthReady()` — so no client request goes out without an `Authorization` header while the post-load token bootstrap is in flight. No-op for guests and once a token is in memory; bounded at 15s so a stalled bootstrap can't hang the API layer.
- The gate settles the moment a token lands (`setAccessToken`) or the session is truly gone (`logout`), and **re-arms on session swaps** (`resetForSwap`) so the next identity bootstraps gated too.
- Interrupted-rotation heal: the bootstrap refresh retries once on 401 (a reload during an in-flight refresh can read the just-blacklisted cookie while the rotated one is still landing).
- **Unauthorized ≠ empty**: dashboard list pages (tickets/rsvps/passes/invitations/following/orgs section) now gate empty states on `isPending` — a query disabled during bootstrap has `isLoading === false` and previously fell straight into "No tickets found".
- Unit tests for the gate lifecycle added to `auth.svelte.test.ts`.

### 2. Empty questionnaire submission burned an attempt
Submit is disabled (with a hint) until every *visible* mandatory question is answered. Server-side enforcement filed as letsrevel/revel-backend#670.

### 3. Potluck input loss — investigated, not reproducible
Three live repro attempts (steady-state across refetch cycles, the post-RSVP settle window, and a true RSVP no→yes flip while typing) all show the add-item form keeps element identity and typed input. The historical flake was most plausibly pre-hydration interaction (covered by the `data-hydrated` marker) plus the auth race above. No blind fix applied; the test-side idempotent loop stays.

### 4. Multiple h1 per page
`MarkdownContent` demotes rendered markdown headings one level (h1→h2, … capped at h6) via a scoped `Marked` instance. Component tests added.

### 5. Demo login form swap
`getDemoMode()` (shared, cached `/version` helper next to `getFeatures`) lets the login page **SSR the demo-account dropdown directly** — no client-side swap eating typed credentials. Register's demo redirect reuses it.

## A11y (#595) — BASELINE is now the empty set

| Violation | Fix |
| --- | --- |
| `nested-interactive` (every page) | Footer version tooltips: the GitHub `<a>` is now the trigger via bits-ui `child` snippet (was `<button>` wrapping `<a>`) |
| `document-title` | `<title>` added to /dashboard; also fixed /dashboard/rsvps' malformed head (title text without `<title>`) |
| `color-contrast` | Landing VAT note → full `text-muted-foreground`; AdminEventCard green-600→700 & amber-600→700 (+ same pattern on member-requests/edit pages); Telegram `#0088cc`→`#0072ab` (5.26:1); past/closed cards use `grayscale` instead of `opacity-75` (opacity blends buttons toward the page background — even 6.99:1 primary dropped to 3.09:1) |
| `aria-prohibited-attr` / `aria-allowed-attr` | Tiptap editing surface gets `role="textbox"` (naming + `aria-multiline` are prohibited on the implicit generic role) |
| `definition-list` | Ticket/RSVP/invitation cards' fake `<dl>`s (dd without dt) → semantic `<ul>` (billing invoices' real dt/dd lists untouched) |
| Bonus | /organizations searchbox was labelled "Search events" → org label; `SearchInput` gained an `id` prop so the visible filter labels associate |

Verified with a full axe sweep of all 10 smoke pages on **both** desktop and mobile viewports: 0 serious/critical violations.

## E2E harness

- Backend probe timeout 3s→10s: it raced the parallel-worker load burst and silently skipped entire projects (one full run reported 49 skips with the whole mobile project absent).
- **`retries` stays 1 locally**: per the retries:0 trial (2 full runs), no auth flakes remain, but the local dev backend throws unrelated transients under 4-worker load — django-silk's profiling middleware deadlocks in Postgres → sporadic 500s (filed as letsrevel/revel-backend#671). Comment updated to reflect the real remaining reason.

## Verification

- Fresh `reset_events --no-input` + `bootstrap` + `bootstrap-tests` DB, Mailpit, Stripe forwarder, `pnpm build && pnpm preview`.
- `pnpm exec playwright test tests/e2e/journeys`: **80 passed, 10 skipped (deliberate demo/viewport skips), 0 failed, 0 flaky**.
- `make check` and `make test` (844 passed) green.
- `scripts/check-file-length.sh`: auth.svelte.ts override raised 550→620 with rationale (gate + retry share the store's settle points; prior split analyses rejected extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb