### PR TITLE
test(e2e): Phase 2a — j06 @p1 ticket suites (Stripe, management, check-in) (#590)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,7 +80,12 @@ export default [
 			'src/lib/api/generated/**',
 			'src/lib/paraglide/**',
 			'*.config.js',
-			'*.config.ts'
+			'*.config.ts',
+			// Transient Playwright output (gitignored); the HTML report ships
+			// minified trace-viewer JS that otherwise floods the lint.
+			'playwright-report/',
+			'test-results/',
+			'.playwright-mcp/'
 		]
 	}
 ];

--- a/src/routes/(auth)/dashboard/rsvps/+page.svelte
+++ b/src/routes/(auth)/dashboard/rsvps/+page.svelte
@@ -44,11 +44,14 @@
 	let searchDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 	let debouncedSearch = $state('');
 
-	// Update debounced search after delay
+	// Update debounced search after delay. searchQuery must be read
+	// SYNCHRONOUSLY here — reads inside the setTimeout callback are not
+	// tracked by $effect, so the effect would never re-run on typing.
 	$effect(() => {
+		const query = searchQuery;
 		if (searchDebounceTimeout) clearTimeout(searchDebounceTimeout);
 		searchDebounceTimeout = setTimeout(() => {
-			debouncedSearch = searchQuery;
+			debouncedSearch = query;
 		}, 300);
 	});
 

--- a/src/routes/(auth)/dashboard/tickets/+page.svelte
+++ b/src/routes/(auth)/dashboard/tickets/+page.svelte
@@ -48,11 +48,14 @@
 	let searchDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
 	let debouncedSearch = $state('');
 
-	// Update debounced search after delay
+	// Update debounced search after delay. searchQuery must be read
+	// SYNCHRONOUSLY here — reads inside the setTimeout callback are not
+	// tracked by $effect, so the effect would never re-run on typing.
 	$effect(() => {
+		const query = searchQuery;
 		if (searchDebounceTimeout) clearTimeout(searchDebounceTimeout);
 		searchDebounceTimeout = setTimeout(() => {
-			debouncedSearch = searchQuery;
+			debouncedSearch = query;
 		}, 300);
 	});
 

--- a/tests/e2e/journeys/j06-tickets/check-in.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/check-in.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createVerifiedUser,
+	claimTicketViaApi
+} from '../../support/factories';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J6.6 (USER_JOURNEYS.md) — staff check-in via the QR scanner's MANUAL-ENTRY
+// path (no camera in headless runs; the field is always available as the
+// camera fallback): enter the ticket code → attendee confirmation dialog →
+// Check In → ticket flips ACTIVE → CHECKED_IN in the admin list.
+//
+// Isolation: own event + free tier + a throwaway attendee whose API-claimed
+// ticket is the one checked in — the seeded festival tickets stay untouched
+// for other suites.
+
+test.describe('J6 check-in @p1', () => {
+	test('manual-entry check-in flips the ticket to Checked In', async ({ asOwner }) => {
+		// Check-in is only open between check_in_starts_at (default: event
+		// start) and check_in_ends_at — open the window explicitly, since the
+		// arranged event itself starts days in the future.
+		const [event, attendee] = await Promise.all([
+			createTicketedEvent({
+				event: { check_in_starts_at: new Date(Date.now() - 60 * 60 * 1000).toISOString() }
+			}),
+			createVerifiedUser('CheckIn')
+		]);
+		if (!event.freeTierId) throw new Error('arranged event is missing its free tier');
+		const ticket = await claimTicketViaApi(attendee, event.id, event.freeTierId);
+		expect(ticket.status).toBe('active');
+
+		const page = asOwner;
+		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/tickets`);
+		await waitForClientAuth(page);
+
+		// Open the scanner and use the manual-entry fallback with the ticket id
+		// (the QR payload IS the ticket id).
+		await page.getByRole('button', { name: 'Scan QR Code to Check In' }).click();
+		const scanner = page.getByRole('dialog', { name: 'Scan QR Code' });
+		await scanner.getByLabel('Enter ticket code manually').fill(ticket.id);
+		await scanner.getByRole('button', { name: 'Check in' }).click();
+
+		// The attendee-confirmation dialog previews who is being checked in.
+		const confirm = page.getByRole('dialog', { name: 'Check In Attendee' });
+		await expect(confirm).toBeVisible({ timeout: 15_000 });
+		await expect(confirm.getByText(attendee.email)).toBeVisible();
+		await confirm.getByRole('button', { name: 'Check In', exact: true }).click();
+		await expect(confirm).not.toBeVisible({ timeout: 15_000 });
+
+		// The refreshed list (table on desktop, cards on mobile) shows the
+		// attendee's ticket as Checked In.
+		const checkedInRow = page
+			.locator('tr, article, li, div')
+			.filter({ hasText: `${attendee.firstName} ${attendee.lastName}` })
+			.filter({ hasText: /Checked In/i })
+			.first();
+		await expect(checkedInRow).toBeVisible({ timeout: 15_000 });
+	});
+});

--- a/tests/e2e/journeys/j06-tickets/stripe-online.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/stripe-online.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent, createTicketTier, createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { completeStripeCheckout } from '../../support/stripe';
+
+// J6.3 (USER_JOURNEYS.md) — online fixed-price ticket via Stripe HOSTED
+// checkout: purchase → redirect to checkout.stripe.com → the reserved ticket
+// is PENDING pre-payment → pay with the test card → the `stripe listen`
+// webhook flips it ACTIVE.
+//
+// Requires the full Stripe test-mode setup from tests/e2e/README.md (backend
+// bootstrapped with CONNECTED_TEST_STRIPE_ID + `stripe listen` forwarder).
+//
+// Isolation: API-arranged event on the Stripe-connected Org Alpha with an
+// online tier, and a throwaway buyer (per-user ticket limits).
+
+test.describe('J6 Stripe online checkout @p1', () => {
+	test('purchase → PENDING pre-payment → pay on Stripe → webhook → ACTIVE', async ({ browser }) => {
+		// Stripe's hosted page + webhook round-trip don't fit the default budget.
+		test.setTimeout(240_000);
+
+		const [event, user] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('StripeBuyer')
+		]);
+		await createTicketTier(event.id, { name: 'Online Entry' });
+
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		await expect(page.getByRole('heading', { name: 'Online Entry' }).first()).toBeVisible();
+
+		// CTA → tier dialog → confirm-purchase dialog → redirect to Stripe.
+		// Same idempotent-loop shape as free-tier.spec.ts: clicks during dialog
+		// re-renders are occasionally dropped, so retry from whatever state the
+		// UI is in until the Stripe URL is reached.
+		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+		const proceed = page.getByRole('button', { name: 'Proceed to Payment' });
+		await expect(async () => {
+			if (page.url().includes('checkout.stripe.com')) return;
+			if (await proceed.isVisible()) {
+				await proceed.click();
+			} else if (await tierDialog.isVisible()) {
+				await tierDialog.getByRole('button', { name: 'Buy Ticket' }).click();
+				await proceed.click();
+			} else {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+				await tierDialog.getByRole('button', { name: 'Buy Ticket' }).click();
+				await proceed.click();
+			}
+			await page.waitForURL(/checkout\.stripe\.com/, { timeout: 15_000 });
+		}).toPass({ timeout: 90_000 });
+
+		// The checkout session stays open — remember it, then verify the
+		// reserved ticket is visibly PENDING before any payment happened.
+		const stripeUrl = page.url();
+
+		const pendingCard = page
+			.locator('article, li, div')
+			.filter({ hasText: event.name })
+			.filter({ hasText: /Pending/i })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await expect(pendingCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		// Resume the same session and pay with the Stripe test card.
+		await page.goto(stripeUrl);
+		await completeStripeCheckout(page);
+
+		// Activation arrives via the webhook, not the redirect — poll the
+		// dashboard until the ticket flips ACTIVE.
+		const activeCard = page
+			.locator('article, li, div')
+			.filter({ hasText: event.name })
+			.filter({ hasText: /Active/i })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await expect(activeCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 90_000 });
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j06-tickets/ticket-management.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/ticket-management.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createVerifiedUser,
+	claimTicketViaApi
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J6.5 (USER_JOURNEYS.md) — managing held tickets in /dashboard/tickets:
+// list, status + payment-method filters, search, QR display, PDF download.
+//
+// Isolation: instead of charlie's seeded tickets (whose statuses/dates drift
+// with the clock and with other suites mutating them), a throwaway user holds
+// exactly ONE known ticket — an API-claimed free ticket on a fresh event — so
+// every filter has a deterministic expected result.
+
+test.describe('J6 ticket management @p1', () => {
+	test('dashboard list: filters, search, QR display, PDF download', async ({ browser }) => {
+		const [event, user] = await Promise.all([
+			createTicketedEvent(),
+			createVerifiedUser('TicketMgmt')
+		]);
+		if (!event.freeTierId) throw new Error('arranged event is missing its free tier');
+		await claimTicketViaApi(user, event.id, event.freeTierId);
+
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		// The one held ticket renders as an Active card. Reload-retry: a
+		// silently unauthorized my-tickets query renders the empty state and
+		// heals on a fresh load (see free-tier.spec.ts).
+		const ticketCard = page
+			.locator('article, li, div')
+			.filter({ hasText: event.name })
+			.filter({ hasText: /Active/i })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await waitForClientAuth(page);
+			await expect(ticketCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		const emptyState = page.getByRole('heading', { name: 'No tickets found' });
+
+		// Status filter: Active keeps the ticket, Cancelled filters it out.
+		await page.getByRole('button', { name: 'Active', exact: true }).click();
+		await expect(ticketCard).toBeVisible();
+		await page.getByRole('button', { name: 'Cancelled', exact: true }).click();
+		await expect(emptyState).toBeVisible();
+		await page.getByRole('button', { name: 'Clear Filters' }).click();
+		await expect(ticketCard).toBeVisible();
+
+		// Payment-method filter: Free keeps it, Paid filters it out.
+		await page.getByRole('button', { name: 'Free', exact: true }).click();
+		await expect(ticketCard).toBeVisible();
+		await page.getByRole('button', { name: 'Paid', exact: true }).click();
+		await expect(emptyState).toBeVisible();
+		await page.getByRole('button', { name: 'Clear Filters' }).click();
+
+		// Search matches the event name (debounced input), garbage matches nothing.
+		const search = page.getByRole('searchbox');
+		await search.fill(event.name);
+		await expect(ticketCard).toBeVisible();
+		await search.fill('zzz-no-such-event-zzz');
+		await expect(emptyState).toBeVisible();
+		await search.fill('');
+		await expect(ticketCard).toBeVisible();
+
+		// QR display: the ticket modal renders the QR image and the ticket id.
+		await ticketCard.getByRole('button', { name: 'View ticket and QR code' }).click();
+		const modal = page.getByRole('dialog', { name: 'Your Ticket' });
+		await expect(modal).toBeVisible();
+		await expect(modal.getByRole('img', { name: 'Ticket QR Code' })).toBeVisible();
+		await expect(modal.getByText('Ticket ID:')).toBeVisible();
+
+		// PDF download: served either as a blob download or (with a pre-signed
+		// URL) a new tab — accept both, reject the inline error alert.
+		const downloadOrPopup = Promise.race([
+			page
+				.waitForEvent('download', { timeout: 30_000 })
+				.then(() => 'download' as const)
+				.catch(() => null),
+			page
+				.waitForEvent('popup', { timeout: 30_000 })
+				.then(() => 'popup' as const)
+				.catch(() => null)
+		]);
+		await modal.getByRole('button', { name: 'Download PDF' }).click();
+		expect(['download', 'popup']).toContain(await downloadOrPopup);
+		await expect(modal.getByRole('alert')).not.toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -90,6 +90,8 @@ export interface CreatedEvent {
 	/** Public detail path, e.g. /events/<org>/<slug>. */
 	path: string;
 	name: string;
+	/** Set when the event was created with `freeTier: true`. */
+	freeTierId?: string;
 }
 
 /**
@@ -129,8 +131,9 @@ export async function createTicketedEvent(
 		}
 	);
 
+	let freeTierId: string | undefined;
 	if (freeTier) {
-		await api.post(`/api/event-admin/${event.id}/ticket-tier`, {
+		const tier = await api.post<{ id: string }>(`/api/event-admin/${event.id}/ticket-tier`, {
 			name: 'Free Entry',
 			payment_method: 'free',
 			price: '0.00',
@@ -139,6 +142,7 @@ export async function createTicketedEvent(
 			sales_start_at: new Date(Date.now() - dayMs).toISOString(),
 			sales_end_at: end.toISOString()
 		});
+		freeTierId = tier.id;
 	}
 
 	return {
@@ -146,6 +150,58 @@ export async function createTicketedEvent(
 		slug: event.slug,
 		orgSlug,
 		path: `/events/${orgSlug}/${event.slug}`,
-		name
+		name,
+		freeTierId
 	};
+}
+
+/**
+ * API-create a ticket tier on an event owned by a seeded persona. Sales open
+ * immediately. Pass payment_method/price/etc. in `tier` — defaults make a
+ * fixed-price ONLINE (Stripe) tier, which needs the org to be
+ * Stripe-connected (Org Alpha is; see tests/e2e/README.md).
+ */
+export async function createTicketTier(
+	eventId: string,
+	tier: Record<string, unknown> = {},
+	owner: PersonaName = 'owner'
+): Promise<{ id: string; name: string }> {
+	const persona = PERSONAS[owner];
+	const api = await ApiClient.login(persona.email, persona.password);
+	const dayMs = 24 * 60 * 60 * 1000;
+	const name = (tier.name as string) ?? 'Online Tier';
+	const created = await api.post<{ id: string }>(`/api/event-admin/${eventId}/ticket-tier`, {
+		name,
+		payment_method: 'online',
+		price: '10.00',
+		price_type: 'fixed',
+		total_quantity: 100,
+		sales_start_at: new Date(Date.now() - dayMs).toISOString(),
+		sales_end_at: new Date(Date.now() + 30 * dayMs).toISOString(),
+		...tier
+	});
+	return { id: created.id, name };
+}
+
+/**
+ * Claim/reserve a ticket for a throwaway user straight through the public
+ * checkout API — the ARRANGE step for specs whose journey starts from an
+ * already-held ticket (check-in, ticket management). Free/offline tiers only:
+ * an online tier answers with a Stripe checkout URL instead of tickets.
+ */
+export async function claimTicketViaApi(
+	user: ThrowawayUser,
+	eventId: string,
+	tierId: string
+): Promise<{ id: string; status: string }> {
+	const api = await ApiClient.login(user.email, user.password);
+	const response = await api.post<{ tickets?: Array<{ id: string; status: string }> }>(
+		`/api/events/${eventId}/tickets/${tierId}/checkout`,
+		{ tickets: [{ guest_name: `${user.firstName} ${user.lastName}` }] }
+	);
+	const ticket = response.tickets?.[0];
+	if (!ticket) {
+		throw new Error(`Checkout for tier ${tierId} returned no tickets (online tier?)`);
+	}
+	return ticket;
 }

--- a/tests/e2e/support/stripe.ts
+++ b/tests/e2e/support/stripe.ts
@@ -27,22 +27,50 @@ export async function completeStripeCheckout(
 ): Promise<void> {
 	await page.waitForURL(/checkout\.stripe\.com/, { timeout: 20_000 });
 
-	// Stripe's hosted form. Email may be prefilled (session created server-side
-	// with the buyer's email) — only fill it when the field is empty & editable.
+	// The hosted page lists payment methods as a radio accordion (Card,
+	// Klarna, iDEAL, …) and only renders the card fields once Card is
+	// expanded. Single-method sessions show the fields directly, so expand
+	// only when they aren't already there. The Card radio is COVERED by a
+	// zero-size "Pay with card" button that intercepts pointer events, so a
+	// normal click can never land — dispatch the click straight to it.
+	const cardNumber = page.getByLabel('Card number');
+	await expect(async () => {
+		if (await cardNumber.isVisible()) return;
+		await page.locator('[data-testid="card-accordion-item-button"]').dispatchEvent('click');
+		await expect(cardNumber).toBeVisible({ timeout: 5_000 });
+	}).toPass({ timeout: 60_000 });
+
+	// Email may be prefilled (session created server-side with the buyer's
+	// email — sometimes rendered as plain text) — only fill an empty input.
 	const email = page.getByLabel('Email');
-	if ((await email.count()) > 0 && (await email.first().inputValue()) === '') {
+	if (
+		(await email.count()) > 0 &&
+		(await email.first().isEditable()) &&
+		(await email.first().inputValue()) === ''
+	) {
 		await email.first().fill('e2e-buyer@example.com');
 	}
 
-	await page.getByLabel('Card number').fill(card.number);
-	await page.getByLabel('Expiration').fill(card.expiry);
-	await page.getByLabel(/CVC|Security code/).fill(card.cvc);
-	await page.getByLabel(/Cardholder name|Name on card/).fill(card.name);
+	// textbox-scoped: plain getByLabel also matches Stripe's decorative
+	// labelled icons (e.g. the CVC card graphic) and trips strict mode.
+	await cardNumber.fill(card.number);
+	await page.getByRole('textbox', { name: 'Expiration' }).fill(card.expiry);
+	await page.getByRole('textbox', { name: /CVC|Security code/ }).fill(card.cvc);
+	// The cardholder-name field is not part of every checkout layout.
+	const holder = page.getByRole('textbox', { name: /Cardholder name|Name on card/ });
+	if ((await holder.count()) > 0) {
+		await holder.first().fill(card.name);
+	}
 
 	// Stripe sometimes shows extra opt-ins (Link, save-my-info) — leave defaults.
-	await page.getByTestId('hosted-payment-submit-button').click();
+	const submit = page.getByTestId('hosted-payment-submit-button');
+	if ((await submit.count()) > 0) {
+		await submit.click();
+	} else {
+		await page.getByRole('button', { name: 'Pay', exact: true }).click();
+	}
 
 	// Back on the app after payment (success URL is app-origin).
-	await page.waitForURL(/localhost:5173/, { timeout: 30_000 });
+	await page.waitForURL(/localhost:5173/, { timeout: 45_000 });
 	await expect(page).not.toHaveURL(/checkout\.stripe\.com/);
 }


### PR DESCRIPTION
Part of #590 (E2E v2 Phase 2, group **a: Tickets**). Does **not** close #590 — groups b–g follow in separate PRs. Umbrella: #28.

## New specs (`tests/e2e/journeys/j06-tickets/`)

- **`stripe-online.spec.ts`** — fixed-price online tier through the REAL Stripe test-mode hosted checkout: purchase → redirect to checkout.stripe.com → asserts the reserved ticket is **PENDING pre-payment** in `/dashboard/tickets` → resumes the session and pays with the 4242 test card → the `stripe listen` webhook flips it **ACTIVE**. ~23s per project.
- **`ticket-management.spec.ts`** — `/dashboard/tickets`: status + payment-method filters, debounced search, QR display modal (QR image + ticket id), PDF download (accepts blob-download or pre-signed-URL popup). *Deviation from the spec's "seed (charlie's tickets)"*: uses one API-arranged ticket on a throwaway user so every filter has a deterministic expected result (seeded ticket statuses/dates drift with the clock and other suites).
- **`check-in.spec.ts`** — staff check-in via the QR scanner modal's manual-entry path (no camera headless): enter ticket code → attendee confirmation dialog → Check In → list shows **Checked In**. Arranged event opens its check-in window explicitly (`check_in_starts_at` in the past) since backend `is_check_in_open()` gates on it.

## Bug found & fixed (caught by the new suite)

**Search was dead on `/dashboard/tickets` and `/dashboard/rsvps`.** The debounce effect read `searchQuery` only inside the `setTimeout` callback — Svelte 5 `$effect` tracks only synchronous reads, so the effect ran once on mount and never re-ran on typing. Fixed by reading the value synchronously; `MemberCombobox`/`SubscriptionsTab` already used the correct pattern. The ticket-management spec now guards this.

## Support changes

- `factories.ts`: `createTicketedEvent` returns `freeTierId`; new `createTicketTier()` (defaults to a fixed-price online tier) and `claimTicketViaApi()` (arrange an already-held ticket).
- `stripe.ts`: rewritten for Stripe's current accordion hosted checkout — the Card radio is covered by a zero-size "Pay with card" button that intercepts pointer events, so the helper dispatches the click to it directly; field fills are textbox-scoped (plain `getByLabel` also matches Stripe's decorative labelled icons and trips strict mode). Verified end-to-end interactively (payment + webhook activation).
- `eslint.config.js`: ignore transient `playwright-report/`, `test-results/`, `.playwright-mcp/` — a trace-bearing HTML report ships minified viewer JS that flooded lint with 3550 errors.

## Verification

- Full `tests/e2e/journeys` run on a fresh `reset_events --no-input` + `make bootstrap-tests` DB: **85 passed, 10 known skips, 1 flaky** (backend register 500 — the known silk deadlock, revel-backend#671, healed by retry).
- `make check` green (format, lint 0/0, types, i18n, file-length, ssr-token, image-alt).
- `make test` green (844 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RSVP and ticket dashboard search so debounced results consistently reflect the latest entered text.
  * Increased reliability of Stripe-hosted checkout completion across varying payment form layouts.

* **Tests**
  * Added end-to-end coverage for ticket management, Stripe online purchases, and staff check-in through manual QR entry.
  * Expanded test support for creating ticket tiers and claiming tickets during automated journeys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->