### PR TITLE
test(e2e): Phase 2b — j08 @p1 org-admin suites (settings, staff, members, tokens) (#590)

### DIFF
--- a/src/lib/components/members/MemberCard.svelte
+++ b/src/lib/components/members/MemberCard.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <div
-	class="rounded-lg border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md"
+	class="min-w-0 rounded-lg border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md"
 >
 	<div class="flex items-start justify-between gap-4">
 		<!-- Avatar -->

--- a/src/lib/components/members/MembershipRequestCard.svelte
+++ b/src/lib/components/members/MembershipRequestCard.svelte
@@ -72,7 +72,7 @@
 </script>
 
 <div
-	class="rounded-lg border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md"
+	class="min-w-0 rounded-lg border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md"
 >
 	<div class="space-y-3">
 		<!-- Request Info -->

--- a/src/lib/components/members/StaffCard.svelte
+++ b/src/lib/components/members/StaffCard.svelte
@@ -54,7 +54,7 @@
 </script>
 
 <div
-	class="rounded-lg border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md"
+	class="min-w-0 rounded-lg border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md"
 >
 	<div class="flex items-start justify-between gap-4">
 		<!-- Staff Info -->

--- a/tests/e2e/journeys/j08-org-owner/member-management.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/member-management.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createMembershipTier,
+	createOrganization,
+	createVerifiedUser,
+	requestMembership
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { closeDialog, pickSelectOption } from '../../support/ui';
+
+// J8.3 (USER_JOURNEYS.md) — member management: approve a membership request
+// with a tier, reject another, pause the approved member, remove them.
+//
+// Isolation: throwaway-owned org accepting requests; two throwaway
+// applicants. A SECOND membership tier is arranged so approval goes through
+// the tier-selection modal (with a single tier the UI auto-approves).
+//
+// Failure paths in these flows use native alert() — the dialog handler
+// accepts and records everything; unexpected messages fail the test.
+
+test.describe('J8 member management @p1', () => {
+	test('approve request with tier, reject request, pause and remove member', async ({
+		browser
+	}) => {
+		// Outcome-keyed retry loops below need headroom beyond the default 90s.
+		test.setTimeout(180_000);
+
+		const org = await createOrganization({ acceptMembershipRequests: true });
+		const [applicant, rejected] = await Promise.all([
+			createVerifiedUser('Applicant'),
+			createVerifiedUser('Rejected')
+		]);
+		await createMembershipTier(org.owner, org.slug, 'Premium');
+		await Promise.all([
+			requestMembership(applicant, org.slug, 'Please let me in'),
+			requestMembership(rejected, org.slug)
+		]);
+		const applicantName = `${applicant.firstName} ${applicant.lastName}`;
+		const rejectedName = `${rejected.firstName} ${rejected.lastName}`;
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+		const dialogs: string[] = [];
+		page.on('dialog', (dialog) => {
+			dialogs.push(dialog.message());
+			void dialog.accept();
+		});
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(page);
+		await page.getByRole('tab', { name: 'Requests' }).click();
+
+		// Approve with tier: two tiers exist, so the tier-selection modal opens.
+		await page.getByRole('button', { name: `Approve request from ${applicantName}` }).click();
+		const approveModal = page.getByRole('dialog', { name: 'Approve Membership Request' });
+		await expect(approveModal).toBeVisible();
+		await pickSelectOption(page, approveModal.getByLabel('Membership Tier'), 'Premium');
+		await approveModal.getByRole('button', { name: 'Approve Request' }).click();
+		await expect(approveModal).not.toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.getByRole('button', { name: `Approve request from ${applicantName}` })
+		).not.toBeVisible();
+
+		// Reject the other request → pending list is empty.
+		await page.getByRole('button', { name: `Reject request from ${rejectedName}` }).click();
+		await expect(page.getByText('No pending requests')).toBeVisible({ timeout: 15_000 });
+
+		// The approved applicant is an active member; pause them. (Tab names
+		// carry count badges, e.g. "Members (1)" — match on the prefix.) Small
+		// viewports occasionally drop clicks mid re-render, so the modal
+		// sequences run as idempotent loops keyed on the visible outcome.
+		await page.getByRole('tab', { name: /^Members/ }).click();
+		const manageModal = page.getByRole('dialog', { name: `Manage ${applicantName}` });
+		const pausedCard = page
+			.locator('article, li, div')
+			.filter({ hasText: applicantName })
+			.filter({ hasText: /Paused/ })
+			.first();
+		await expect(async () => {
+			await closeDialog(page, manageModal);
+			if (!(await pausedCard.isVisible())) {
+				await page.getByRole('button', { name: `Manage ${applicantName}` }).click({
+					timeout: 3_000
+				});
+				await pickSelectOption(page, manageModal.getByLabel('Membership Status'), 'Paused');
+				const save = manageModal.getByRole('button', { name: 'Save Changes' });
+				if (await save.isVisible()) {
+					await save.click({ timeout: 3_000 });
+				}
+				await closeDialog(page, manageModal);
+			}
+			await expect(pausedCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 90_000 });
+
+		// Remove the member entirely.
+		const membersEmpty = page.getByText('No members found');
+		await expect(async () => {
+			await closeDialog(page, manageModal);
+			if (!(await membersEmpty.isVisible())) {
+				await page.getByRole('button', { name: `Manage ${applicantName}` }).click({
+					timeout: 3_000
+				});
+				await manageModal
+					.getByRole('button', { name: 'Remove from Organization' })
+					.click({ timeout: 3_000 });
+				await manageModal.getByRole('button', { name: 'Yes, Remove' }).click({ timeout: 3_000 });
+			}
+			await expect(membersEmpty).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 90_000 });
+
+		expect(dialogs).toHaveLength(0);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/org-settings.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/org-settings.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '../../support/fixtures';
+import { createOrganization, uniqueEmail } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J8.1 (USER_JOURNEYS.md) — org settings: edit profile fields, visibility,
+// membership toggle; save persists (SvelteKit form action). Also the
+// contact_method rule: "Email link"/"Contact form" stay disabled until the
+// org's contact email is verified (a fresh org's never is).
+//
+// Isolation: the backend allows ONE org per owner, so the org is created via
+// API under a throwaway verified user who then drives the UI as owner.
+
+test.describe('J8 org settings @p1', () => {
+	test('owner edits settings, saves, and unverified email gates contact methods', async ({
+		browser
+	}) => {
+		// A contact email that differs from the owner's stays UNVERIFIED, which
+		// is what gates the contact-method options below.
+		const org = await createOrganization({ contactEmail: uniqueEmail('OrgContact') });
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await waitForClientAuth(page);
+
+		await expect(page.getByRole('heading', { name: 'Organization Settings' })).toBeVisible();
+
+		// contact_method rule: link/form options are disabled while the contact
+		// email is unverified, with the explanatory hint shown.
+		const contactMethod = page.locator('#contact_method');
+		await expect(contactMethod.locator('option', { hasText: 'Email link' })).toBeDisabled();
+		await expect(contactMethod.locator('option', { hasText: 'Contact form' })).toBeDisabled();
+		await expect(page.getByText('Verify your contact email above')).toBeVisible();
+
+		// Edit address, visibility, and the membership-requests toggle.
+		await page.getByLabel('Address').fill('42 E2E Test Street');
+		await page
+			.locator('#visibility')
+			.selectOption({ label: 'Members Only - Only organization members can view' });
+		await page.getByLabel('Accept membership requests').check();
+
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(
+			page.getByText('Your organization settings have been updated successfully.')
+		).toBeVisible({ timeout: 15_000 });
+
+		// The saved values survive a fresh load.
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await expect(page.getByLabel('Address')).toHaveValue('42 E2E Test Street');
+		await expect(page.locator('#visibility option:checked')).toHaveText(/Members Only/);
+		await expect(page.getByLabel('Accept membership requests')).toBeChecked();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/org-tokens.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/org-tokens.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '../../support/fixtures';
+import { createOrganization } from '../../support/factories';
+import { authenticateContext, uiLogin } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { closeDialog } from '../../support/ui';
+
+// J8.4 (USER_JOURNEYS.md) — org invitation tokens, fully through the UI:
+// owner creates a membership-granting link, and a fresh visitor follows the
+// ACTUAL share link (`/org/<slug>?ot=<code>`): the hook captures the token
+// into a cookie, the login that follows auto-claims it (claimPendingTokens),
+// and the visitor lands as an active member.
+//
+// The claimer is the SEEDED persona ivan (`user2`) because the share-link
+// journey requires a UI login — throwaway users can't use the demo-mode
+// account dropdown. The dedicated logged-in claim page (/join/org/<code>)
+// is 500-broken (renders token.organization.name but the API field is a
+// UUID) — tracked in #601, and j01 token-preview (group g) is blocked on it.
+//
+// Isolation: throwaway-owned org; parallel projects claim DIFFERENT orgs, so
+// sharing ivan is race-free.
+
+test.describe('J8 org tokens @p1', () => {
+	test('create membership link → claim via share link + login → member', async ({ browser }) => {
+		const org = await createOrganization();
+		const claimerName = 'Ivan Attendee';
+
+		// Owner creates the invitation link through the UI.
+		const ownerContext = await browser.newContext();
+		await authenticateContext(ownerContext, org.owner);
+		const ownerPage = await ownerContext.newPage();
+		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/tokens`);
+		await waitForClientAuth(ownerPage);
+
+		await ownerPage.getByRole('button', { name: 'Create Link' }).click();
+		const createModal = ownerPage.getByRole('dialog', { name: 'Create Invitation Token' });
+		await expect(createModal).toBeVisible();
+		await createModal.getByLabel('Name (optional)').fill('E2E membership link');
+		await createModal.getByLabel('Grant membership access').check();
+		await createModal.getByLabel('Membership Tier').selectOption({ label: 'General membership' });
+		await createModal.getByRole('button', { name: 'Create Token' }).click();
+		await expect(ownerPage.getByText(/Invitation link created successfully/)).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Grab the shareable URL from the token card's share dialog: the public
+		// org page with `?ot=<code>`, which the server hook captures into a
+		// cookie that the next login claims.
+		await ownerPage.getByRole('button', { name: 'Share token' }).click();
+		const shareDialog = ownerPage.getByRole('dialog', { name: 'Share Invitation Link' });
+		const shareUrl = await shareDialog.getByLabel('Shareable URL').inputValue();
+		const shareTarget = new URL(shareUrl);
+		expect(
+			shareTarget.searchParams.get('ot'),
+			`share URL carries the token code: ${shareUrl}`
+		).toBeTruthy();
+		await closeDialog(ownerPage, shareDialog);
+
+		// A logged-OUT visitor follows the share link: the ?ot= hook stores the
+		// token, and logging in claims it and flashes a confirmation toast.
+		const claimerContext = await browser.newContext();
+		const claimerPage = await claimerContext.newPage();
+		await gotoHydrated(claimerPage, shareTarget.pathname + shareTarget.search);
+		await expect(claimerPage.getByRole('heading', { name: org.name }).first()).toBeVisible();
+
+		await uiLogin(claimerPage, 'user2');
+		await expect(claimerPage.getByText(`You've been added to ${org.name}!`)).toBeVisible({
+			timeout: 15_000
+		});
+
+		// The owner sees the claimer as a member.
+		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/members`);
+		const memberCard = ownerPage
+			.locator('article, li, div')
+			.filter({ hasText: claimerName })
+			.filter({ hasText: /Active/ })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(ownerPage, `/org/${org.slug}/admin/members`);
+			await expect(memberCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		await claimerContext.close();
+		await ownerContext.close();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/staff-management.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/staff-management.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	approveMembershipRequest,
+	createOrganization,
+	createVerifiedUser,
+	requestMembership
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { closeDialog } from '../../support/ui';
+
+// J8.2 (USER_JOURNEYS.md) — staff management: promote an existing member to
+// staff, edit their permissions, remove them from staff.
+//
+// Isolation: throwaway-owned org; the promoted member is a throwaway user
+// arranged into ACTIVE membership via the request→approve API flow.
+//
+// Dialog note: staff removal uses a native confirm() and several failure
+// paths use native alert() — a page dialog handler accepts everything and
+// records the messages so unexpected alerts fail the test at the end.
+
+test.describe('J8 staff management @p1', () => {
+	test('promote member → staff, edit permissions, remove from staff', async ({ browser }) => {
+		// Outcome-keyed retry loops below need headroom beyond the default 90s.
+		test.setTimeout(180_000);
+
+		const [org, member] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('StaffCandidate')
+		]);
+		const request = await requestMembership(member, org.slug);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		const memberName = `${member.firstName} ${member.lastName}`;
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+		const dialogs: string[] = [];
+		page.on('dialog', (dialog) => {
+			dialogs.push(dialog.message());
+			void dialog.accept();
+		});
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(page);
+
+		// Promote: member card → manage modal → Make Staff Member → they show
+		// up on the staff tab. Clicks on the small viewport are occasionally
+		// dropped mid re-render (dialog open/close animations + query settles),
+		// so the whole sequence is an idempotent loop keyed on the outcome.
+		const manageModal = page.getByRole('dialog', { name: `Manage ${memberName}` });
+		const staffTab = page.getByRole('tab', { name: /^Staff/ });
+		const staffCard = page
+			.locator('article, li, div')
+			.filter({ hasText: memberName })
+			.filter({ has: page.getByRole('button', { name: `Edit permissions for ${memberName}` }) })
+			.first();
+		await expect(async () => {
+			await closeDialog(page, manageModal);
+			await staffTab.click({ timeout: 3_000 });
+			if (!(await staffCard.isVisible())) {
+				await page.getByRole('tab', { name: /^Members/ }).click({ timeout: 3_000 });
+				await page.getByRole('button', { name: `Manage ${memberName}` }).click({ timeout: 3_000 });
+				await manageModal
+					.getByRole('button', { name: 'Make Staff Member' })
+					.click({ timeout: 3_000 });
+				await closeDialog(page, manageModal);
+				await staffTab.click({ timeout: 3_000 });
+			}
+			await expect(staffCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 90_000 });
+
+		// Edit permissions: flip the first toggle, save, reopen, expect it kept.
+		const permissionsDialog = page.getByRole('dialog', {
+			name: `Edit Permissions for ${memberName}`
+		});
+		await expect(async () => {
+			if (!(await permissionsDialog.isVisible())) {
+				await page
+					.getByRole('button', { name: `Edit permissions for ${memberName}` })
+					.click({ timeout: 3_000 });
+			}
+			await expect(permissionsDialog).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+		const firstPermission = permissionsDialog.getByRole('checkbox').first();
+		const initialState = await firstPermission.isChecked();
+		await firstPermission.setChecked(!initialState);
+		await permissionsDialog.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(permissionsDialog).not.toBeVisible({ timeout: 15_000 });
+
+		await expect(async () => {
+			if (!(await permissionsDialog.isVisible())) {
+				await page
+					.getByRole('button', { name: `Edit permissions for ${memberName}` })
+					.click({ timeout: 3_000 });
+			}
+			await expect(permissionsDialog).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+		await expect(permissionsDialog.getByRole('checkbox').first()).toBeChecked({
+			checked: !initialState
+		});
+		await closeDialog(page, permissionsDialog);
+
+		// Remove from staff (native confirm, auto-accepted by the handler).
+		const staffEmpty = page.getByText('No staff members found');
+		await expect(async () => {
+			if (!(await staffEmpty.isVisible()) && (await staffCard.isVisible())) {
+				await staffCard
+					.getByRole('button', { name: `Remove ${memberName} from staff` })
+					.click({ timeout: 3_000 });
+			}
+			await expect(staffEmpty).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 60_000 });
+
+		// The only native dialog should have been the removal confirm.
+		expect(dialogs.filter((m) => !m.startsWith('Are you sure'))).toHaveLength(0);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/support/api.ts
+++ b/tests/e2e/support/api.ts
@@ -93,6 +93,10 @@ export class ApiClient {
 		return this.request<T>('POST', path, body);
 	}
 
+	put<T>(path: string, body?: unknown): Promise<T> {
+		return this.request<T>('PUT', path, body);
+	}
+
 	patch<T>(path: string, body?: unknown): Promise<T> {
 		return this.request<T>('PATCH', path, body);
 	}

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -183,6 +183,98 @@ export async function createTicketTier(
 	return { id: created.id, name };
 }
 
+export interface CreatedOrg {
+	id: string;
+	slug: string;
+	name: string;
+	/** The throwaway user who owns the org (backend allows ONE org per owner). */
+	owner: ThrowawayUser;
+	/** The "General membership" tier every new org gets from a post-save signal. */
+	defaultTierId: string;
+}
+
+/**
+ * Register a fresh verified user and have them create an organization — the
+ * backend allows one org per owner, so seeded personas (who already own orgs)
+ * can never be the owner here. Every new org automatically gets a
+ * "General membership" tier; its id is returned for approve-with-tier flows.
+ */
+export async function createOrganization(
+	options: { acceptMembershipRequests?: boolean; contactEmail?: string } = {}
+): Promise<CreatedOrg> {
+	const owner = await createVerifiedUser('OrgOwner');
+	const api = await ApiClient.login(owner.email, owner.password);
+	const name = uniqueName('Org');
+	// Defaults to the owner's email, which the backend treats as ALREADY
+	// VERIFIED (it matches a verified account). Pass a different contactEmail
+	// to get an org whose contact email is unverified.
+	const org = await api.post<{ id: string; slug: string }>('/api/organizations/', {
+		name,
+		contact_email: options.contactEmail ?? owner.email
+	});
+
+	if (options.acceptMembershipRequests) {
+		await api.put(`/api/organization-admin/${org.slug}`, {
+			visibility: 'public',
+			accept_membership_requests: true
+		});
+	}
+
+	// Plain array (not paginated).
+	const tiers = await api.get<Array<{ id: string; name: string }>>(
+		`/api/organization-admin/${org.slug}/membership-tiers`
+	);
+	const defaultTier = tiers.find((t) => t.name === 'General membership');
+	if (!defaultTier) {
+		throw new Error(`New org ${org.slug} is missing its default membership tier`);
+	}
+
+	return { id: org.id, slug: org.slug, name, owner, defaultTierId: defaultTier.id };
+}
+
+/** Add a membership tier to a throwaway-owned org. */
+export async function createMembershipTier(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	name: string
+): Promise<{ id: string }> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	return api.post<{ id: string }>(`/api/organization-admin/${orgSlug}/membership-tiers`, { name });
+}
+
+/**
+ * Have a throwaway user request membership of an org (the org must have been
+ * created with `acceptMembershipRequests: true`). Returns the request id the
+ * org admin sees.
+ */
+export async function requestMembership(
+	user: ThrowawayUser,
+	orgSlug: string,
+	message?: string
+): Promise<{ id: string }> {
+	const api = await ApiClient.login(user.email, user.password);
+	return api.post<{ id: string }>(
+		`/api/organizations/${orgSlug}/membership-requests`,
+		message ? { message } : {}
+	);
+}
+
+/**
+ * Approve a pending membership request as the org owner — ARRANGE step for
+ * specs that need an existing MEMBER (staff promotion, status changes).
+ */
+export async function approveMembershipRequest(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	requestId: string,
+	tierId: string
+): Promise<void> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	await api.post(`/api/organization-admin/${orgSlug}/membership-requests/${requestId}/approve`, {
+		tier_id: tierId
+	});
+}
+
 /**
  * Claim/reserve a ticket for a throwaway user straight through the public
  * checkout API — the ARRANGE step for specs whose journey starts from an

--- a/tests/e2e/support/ui.ts
+++ b/tests/e2e/support/ui.ts
@@ -1,0 +1,27 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * Pick an option from a bits-ui Select (shadcn-svelte): the "select" is a
+ * BUTTON trigger (aria-haspopup="listbox") that opens a floating listbox —
+ * Playwright's selectOption() only works on native <select> elements.
+ */
+export async function pickSelectOption(
+	page: Page,
+	trigger: Locator,
+	option: string | RegExp
+): Promise<void> {
+	await trigger.click();
+	await page.getByRole('option', { name: option }).click();
+}
+
+/**
+ * Close a bits-ui dialog via Escape — dialogs render TWO buttons named
+ * "Close" (footer + the corner X), so a role-based click trips strict mode,
+ * and the footer button is disabled while a mutation is in flight.
+ */
+export async function closeDialog(page: Page, dialog: Locator): Promise<void> {
+	if (await dialog.isVisible()) {
+		await page.keyboard.press('Escape');
+	}
+	await dialog.waitFor({ state: 'hidden', timeout: 10_000 });
+}


### PR DESCRIPTION
Part of #590 (E2E v2 Phase 2, group **b: Org admin**). Does **not** close #590 — groups c–g follow. Umbrella: #28. Follows #599 (group a).

## New specs (`tests/e2e/journeys/j08-org-owner/`)

- **`org-settings.spec.ts`** — owner edits address/visibility/accept-membership-requests, saves (form action), values persist across reload; asserts the contact-method rule: "Email link"/"Contact form" options stay disabled (with hint) while the org contact email is unverified. Arranged with a contact email ≠ owner email, since the backend auto-verifies matching ones.
- **`staff-management.spec.ts`** — promote an arranged ACTIVE member to staff, flip a permission in the Edit Permissions dialog and verify it persists after reopen, remove from staff. Native `confirm()`/`alert()` dialogs are auto-accepted and recorded; anything but the removal confirm fails the test.
- **`member-management.spec.ts`** — approve a membership request through the tier-selection modal (a second tier is arranged — with one tier the UI auto-approves), reject another request, pause the member via the manage modal, remove them.
- **`org-tokens.spec.ts`** — owner creates a membership-granting invitation link in the UI; a logged-out visitor follows the real `?ot=` share link, logs in, `claimPendingTokens` auto-claims ("You've been added to …!"), and the owner sees them as an active member. Claimer is seeded ivan: the share-link journey needs a UI login, and demo backends only offer seeded accounts.

All specs create their own org under a throwaway verified owner (backend allows one org per user), so seeded orgs stay untouched.

## Bug found & fixed (caught by the mobile project)

**Member/Staff/MembershipRequest cards lacked `min-w-0`**: a long member email defeats `truncate` (grid `min-width: auto` lets the item outgrow its track — card measured 512px in a 393px viewport), making the admin page horizontally scrollable on phones. In mobile emulation the expanded layout viewport (488px vs 393px visual) skewed every tap — root cause of persistent `mobile-chrome` click misses. One-class fix on the three card roots; mobile specs went from hard timeouts to green in seconds.

## Bugs filed (not fixed here)

- **#601** — `/join/org/[token_id]` SSR-500s for every token (`token.organization.name` vs UUID field); needs BE schema enrichment; blocks j01 `token-preview` (group g).
- **revel-backend#673** — approve-membership notification dies on missing `role`/`action` context keys (being fixed by BE).
- Commented on revel-backend#671: with silk off, parallel-load 500s are now Postgres `too many clients` — `retries: 1` still covers them locally.

## Support changes

- `factories.ts`: `createOrganization` (throwaway owner, optional unverified contact email, `accept_membership_requests`, returns default-tier id), `createMembershipTier`, `requestMembership`, `approveMembershipRequest`.
- `api.ts`: `ApiClient.put`.
- New `support/ui.ts`: `pickSelectOption` (bits-ui Selects are button-trigger listboxes — `selectOption()` doesn't work) and `closeDialog` (bits dialogs have two "Close" buttons; Escape avoids strict-mode + disabled-while-pending traps).

## Verification

- j08 green on chromium + mobile-chrome with `--retries=0`.
- Full `tests/e2e/journeys` on fresh `reset_events + bootstrap-tests` DB: **92 passed, 10 known demo-mode/mobile skips, 2 retry-healed backend flakes** (Postgres connection exhaustion, see #671 comment).
- `make check` and `make test` (844) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved member, membership request, and staff card layouts to prevent content from overflowing in narrow spaces.
  * Refined responsiveness and visual consistency across member management views.

* **Testing**
  * Added coverage for organization settings, membership requests, invitation tokens, and staff management workflows.
  * Expanded validation of membership approvals, rejections, permissions, and member removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->