### PR TITLE
test(e2e): Phase 2d — j03 account/social + j14 potluck + j15 inbox @p1 suites

### DIFF
--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -114,6 +114,15 @@
 		}
 	}
 
+	// Mark-as-read on card open — skipped while either toggle mutation is in
+	// flight, so a rapid body click can't race the explicit read/unread
+	// toggle and clobber its optimistic state.
+	function markReadOnOpen(): void {
+		if (!isRead && !markReadMutation.isPending && !markUnreadMutation.isPending) {
+			markReadMutation.mutate();
+		}
+	}
+
 	// Handle navigation to related content
 	function handleClick(event: MouseEvent): void {
 		// Check if the click was on a link inside the notification body
@@ -121,18 +130,14 @@
 		const target = event.target as HTMLElement;
 		if (target.tagName === 'A' || target.closest('a')) {
 			// Mark as read but don't navigate - let the link handle it
-			if (!isRead) {
-				markReadMutation.mutate();
-			}
+			markReadOnOpen();
 			// Close the dropdown if callback provided
 			onNavigate?.();
 			return;
 		}
 
 		// Mark as read on click (if not already)
-		if (!isRead) {
-			markReadMutation.mutate();
-		}
+		markReadOnOpen();
 
 		// Extract URL from context if available
 		const url = extractUrlFromContext(notification.context);
@@ -261,9 +266,7 @@
 		event.stopPropagation();
 		const data = waitlistSpotData;
 		if (!data) return;
-		if (!isRead) {
-			markReadMutation.mutate();
-		}
+		markReadOnOpen();
 		onNavigate?.();
 		// eslint-disable-next-line svelte/no-navigation-without-resolve -- deep-link path supplied by the notification payload (API-provided), not a static route id
 		goto(data.claimUrl);

--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -33,8 +33,16 @@
 		class: className
 	}: Props = $props();
 
-	// Reactive state for optimistic updates
-	let isRead = $state(notification.read_at !== null);
+	// Optimistic override for this card's own in-flight mutations. Server
+	// truth (the prop) must win again whenever fresh data arrives — e.g. the
+	// list's mark-all-read invalidation refetch — otherwise cards keep
+	// rendering a stale unread state until a full reload.
+	let optimisticIsRead = $state<boolean | null>(null);
+	$effect(() => {
+		void notification.read_at;
+		optimisticIsRead = null;
+	});
+	const isRead = $derived(optimisticIsRead ?? notification.read_at !== null);
 
 	// Derived values
 	const relativeTime = $derived(formatRelativeTime(notification.created_at));
@@ -49,7 +57,7 @@
 		},
 		onMutate: () => {
 			// Optimistic update
-			isRead = true;
+			optimisticIsRead = true;
 		},
 		onSuccess: () => {
 			// The mark-read endpoint returns no body, so set read_at locally
@@ -61,7 +69,7 @@
 		},
 		onError: (error) => {
 			// Revert optimistic update
-			isRead = false;
+			optimisticIsRead = null;
 			toast.error(m['notificationItem.toast_markReadFailed']());
 			console.error('Failed to mark notification as read:', error);
 		}
@@ -77,7 +85,7 @@
 		},
 		onMutate: () => {
 			// Optimistic update
-			isRead = false;
+			optimisticIsRead = false;
 		},
 		onSuccess: () => {
 			// Update the notification with read_at set to null
@@ -89,7 +97,7 @@
 		},
 		onError: (error) => {
 			// Revert optimistic update
-			isRead = true;
+			optimisticIsRead = null;
 			toast.error(m['notificationItem.toast_markUnreadFailed']());
 			console.error('Failed to mark notification as unread:', error);
 		}

--- a/tests/e2e/journeys/j03-account/bookmarks.spec.ts
+++ b/tests/e2e/journeys/j03-account/bookmarks.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J3.4 (USER_JOURNEYS.md) — bookmarks: add from the event detail sidebar,
+// find the event under the dashboard "Bookmarked" preset, remove it from the
+// event card's overlay button.
+//
+// Isolation: each project bookmarks its OWN API-created event as a DIFFERENT
+// persona (hannah / ivan) — parallel projects never race one user's bookmark
+// state, and a stale bookmark left by a failed earlier run can't collide with
+// a freshly created event.
+
+test.describe('J3 bookmarks @p1', () => {
+	test('bookmark on detail, listed under Bookmarked facet, unbookmark on card', async ({
+		browser,
+		isMobile
+	}) => {
+		test.setTimeout(120_000);
+		const event = await createTicketedEvent();
+		const context = await browser.newContext();
+		await authenticateContext(context, isMobile ? 'user2' : 'user');
+		const page = await context.newPage();
+
+		// Add on the event detail sidebar (bookmarking is a client mutation —
+		// it needs the bootstrapped in-memory token).
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+		const addButton = page.getByRole('button', { name: 'Bookmark this event' });
+		await addButton.click();
+		await expect(page.getByText('Event bookmarked')).toBeVisible({ timeout: 15_000 });
+		// The same control flips to its remove state.
+		const removeOnDetail = page.getByRole('button', { name: 'Remove bookmark' });
+		await expect(removeOnDetail).toBeVisible();
+		await expect(removeOnDetail).toHaveAttribute('aria-pressed', 'true');
+
+		// The Bookmarked dashboard preset lists it. Scope to the "Your Events"
+		// region — the dashboard's public discover section can also surface this
+		// (public, soon-starting) event, and that copy never goes away.
+		await gotoHydrated(page, '/dashboard');
+		await page.getByRole('button', { name: 'Bookmarked' }).click();
+		const yourEvents = page.getByRole('region', { name: /^Your Events/ });
+		const card = yourEvents.locator('article').filter({ hasText: event.name }).first();
+		await expect(card.getByRole('heading', { name: event.name })).toBeVisible();
+
+		// Cards overlay a remove-bookmark button (only when bookmarked) — use it.
+		await card.getByRole('button', { name: 'Remove bookmark' }).click();
+		await expect(page.getByText('Bookmark removed')).toBeVisible({ timeout: 15_000 });
+		await expect(yourEvents.getByRole('heading', { name: event.name })).toBeHidden();
+
+		// Gone server-side too: the detail page renders the add state again.
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('button', { name: 'Bookmark this event' })).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j03-account/create-org.spec.ts
+++ b/tests/e2e/journeys/j03-account/create-org.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../../support/fixtures';
+import { createVerifiedUser, uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated } from '../../support/navigation';
+
+// J3.6 (USER_JOURNEYS.md) — create an organization through the form: a name
+// slugifying to a reserved token is rejected with the backend's message, a
+// valid name lands the new owner on the org admin settings page, and a
+// revisit shows the one-org-per-owner guard.
+//
+// Isolation: throwaway verified user — every seeded owner persona already
+// owns an org and could never pass the one-org rule.
+
+test.describe('J3 create organization @p1', () => {
+	test('reserved-word name rejected; valid name creates org; one-org guard', async ({
+		browser
+	}) => {
+		test.setTimeout(120_000);
+		const user = await createVerifiedUser('OrgCreator');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/create-org');
+		await expect(page.getByRole('heading', { name: 'Create Your Organization' })).toBeVisible();
+
+		// The primary button opens a custom confirmation overlay (no dialog
+		// role); it closes itself before submitting, so each attempt sees
+		// exactly one 'Create Organization' button at a time.
+		async function submitName(name: string): Promise<void> {
+			await page.locator('#name').fill(name);
+			await page.locator('#contact_email').fill(user.email);
+			await page.getByRole('button', { name: 'Create Organization' }).click();
+			await expect(page.getByText('Confirm Organization Creation')).toBeVisible();
+			await page
+				.locator('div.fixed.inset-0')
+				.getByRole('button', { name: 'Create Organization' })
+				.click();
+		}
+
+		// "dashboard" is a reserved slug token — backend 400 surfaces verbatim.
+		await submitName('Dashboard Collective');
+		await expect(page.getByText('Failed to create organization')).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(page.getByText(/reserved word: "dashboard"/)).toBeVisible();
+
+		// A valid name creates the org and redirects to its admin settings.
+		const orgName = uniqueName('Org');
+		await submitName(orgName);
+		await page.waitForURL(/\/org\/[^/]+\/admin\/settings/, { timeout: 30_000 });
+		await expect(page.getByText(orgName).first()).toBeVisible();
+
+		// One org per owner: the form is replaced by the already-owner guard.
+		await gotoHydrated(page, '/create-org');
+		await expect(page.getByText('You already own an organization')).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j03-account/dashboard-facets.spec.ts
+++ b/tests/e2e/journeys/j03-account/dashboard-facets.spec.ts
@@ -1,0 +1,101 @@
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated } from '../../support/navigation';
+
+// J3.2 (USER_JOURNEYS.md) — dashboard relationship facets: the "Your Events"
+// preset buttons (All / Organizing / Attending / Invited / Bookmarked) scope
+// the list to the right relationship per persona.
+//
+// Read-only on seeded bootstrap data, with personas chosen so their facet
+// sets stay stable across full-suite runs:
+// - hannah/ivan are avoided for Attending — j05 rsvp-flow toggles their
+//   spring-potluck RSVP and deliberately leaves it at "No".
+// - Org Beta anchors Organizing — factories only ever create events on Org
+//   Alpha, so diana's owned set is exactly the seed.
+// - The list renders at most 6 cards (page_size 10, sliced to 6, ordered by
+//   start): every asserted facet set is ≤ 6 events, so presence checks can't
+//   be pushed off the grid by ordering.
+// All assertions scope to the "Your Events" region — the dashboard's public
+// discover section can surface the same (public) events regardless of facet.
+
+function yourEvents(page: Page): Locator {
+	return page.getByRole('region', { name: /^Your Events/ });
+}
+
+test.describe('J3 dashboard facets @p1', () => {
+	test('Organizing scopes to events of the org the user runs (diana)', async ({ asBetaOwner }) => {
+		await gotoHydrated(asBetaOwner, '/dashboard');
+		await asBetaOwner.getByRole('button', { name: 'Organizing' }).click();
+
+		const region = yourEvents(asBetaOwner);
+		// Org Beta's seeded events — including its DRAFT, which only admins see.
+		await expect(
+			region.getByRole('heading', { name: 'FutureStack 2025: AI & Web3 Conference' })
+		).toBeVisible();
+		await expect(
+			region.getByRole('heading', { name: 'Hands-on Workshop: Building with AI APIs' })
+		).toBeVisible();
+		// Org Alpha events never appear — diana has no relationship with them.
+		await expect(
+			region.getByRole('heading', { name: 'Summer Sunset Music Festival' })
+		).toBeHidden();
+	});
+
+	test('Attending shows RSVPs and held tickets, not mere memberships (charlie)', async ({
+		asMember
+	}) => {
+		await gotoHydrated(asMember, '/dashboard');
+		await asMember.getByRole('button', { name: 'Attending' }).click();
+
+		const region = yourEvents(asMember);
+		// charlie's seeded RSVP-yes events…
+		await expect(
+			region.getByRole('heading', { name: 'Spring Community Potluck & Garden Party' })
+		).toBeVisible();
+		await expect(
+			region.getByRole('heading', { name: 'Contemporary Art Exhibition Opening' })
+		).toBeVisible();
+		// …and his ACTIVE ticket.
+		await expect(region.getByRole('heading', { name: 'Classical Music Evening' })).toBeVisible();
+		// Alpha events he is NOT attending stay out — the preset excludes the
+		// `member` relationship even though he could see this event.
+		await expect(
+			region.getByRole('heading', { name: 'Exclusive Wine Tasting & Pairing Dinner' })
+		).toBeHidden();
+	});
+
+	test('Invited isolates invitations from RSVPs and memberships (karen)', async ({
+		asMultiOrg
+	}) => {
+		await gotoHydrated(asMultiOrg, '/dashboard');
+		await asMultiOrg.getByRole('button', { name: 'Invited' }).click();
+
+		const region = yourEvents(asMultiOrg);
+		// karen's one seeded invitation…
+		await expect(
+			region.getByRole('heading', { name: 'Exclusive Wine Tasting & Pairing Dinner' })
+		).toBeVisible();
+		// …while her RSVP-yes event is filtered out by the preset.
+		await expect(
+			region.getByRole('heading', { name: 'Spring Community Potluck & Garden Party' })
+		).toBeHidden();
+	});
+
+	test('Bookmarked starts empty and is a distinct facet (karen)', async ({ asMultiOrg }) => {
+		// karen never bookmarks anywhere in the suite (the bookmarks spec uses
+		// hannah/ivan), so her Bookmarked facet is deterministically empty.
+		await gotoHydrated(asMultiOrg, '/dashboard');
+		await asMultiOrg.getByRole('button', { name: 'Bookmarked' }).click();
+		await expect(
+			yourEvents(asMultiOrg).getByRole('heading', { name: 'No events found' })
+		).toBeVisible();
+	});
+
+	test('Organizing preset is hidden from users who run no org (hannah)', async ({ asUser }) => {
+		await gotoHydrated(asUser, '/dashboard');
+		// The filter bar is rendered (hannah has events via tickets/RSVPs)…
+		await expect(asUser.getByRole('button', { name: 'Attending' })).toBeVisible();
+		// …but the owner/staff-only preset is not offered.
+		await expect(asUser.getByRole('button', { name: 'Organizing' })).toBeHidden();
+	});
+});

--- a/tests/e2e/journeys/j03-account/follow-org.spec.ts
+++ b/tests/e2e/journeys/j03-account/follow-org.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '../../support/fixtures';
+import { createOrganization, createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J3.5 (USER_JOURNEYS.md) — follow an organization (with notification
+// preferences), request membership with a message, and see the request land
+// in the org admin's queue; unfollow at the end.
+//
+// Isolation: throwaway-owned org (accepting requests) + throwaway follower —
+// seeded follow relationships (hannah→Alpha, ivan→Beta) stay untouched, and
+// parallel projects each build their own org/user pair.
+
+test.describe('J3 follow org & request membership @p1', () => {
+	test('follow with notify prefs, request membership → admin queue, unfollow', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const [org, follower] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Follower')
+		]);
+		const followerName = `${follower.firstName} ${follower.lastName}`;
+
+		const context = await browser.newContext();
+		await authenticateContext(context, follower);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+
+		// Follow ('Following' also matches 'Follow' as a prefix — exact match).
+		await page.getByRole('button', { name: 'Follow', exact: true }).click();
+		await expect(page.getByText(`You are now following ${org.name}`)).toBeVisible({
+			timeout: 15_000
+		});
+
+		// The control becomes a dropdown holding per-channel notify toggles.
+		await page.getByRole('button', { name: 'Following' }).click();
+		await page.getByRole('menuitemcheckbox', { name: 'Notify me about new events' }).click();
+		await expect(page.getByText('Preferences updated')).toBeVisible({ timeout: 15_000 });
+
+		// Request membership with a message.
+		await page.getByRole('button', { name: 'Request Membership' }).click();
+		const dialog = page.getByRole('dialog', { name: 'Request Membership' });
+		await expect(dialog).toBeVisible();
+		await dialog.getByLabel('Message (Optional)').fill('E2E: please let me in');
+		await dialog.getByRole('button', { name: 'Submit Request' }).click();
+		await expect(page.getByText('Request Submitted!')).toBeVisible({ timeout: 15_000 });
+
+		// Both are server-side: a fresh load still shows Following…
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('button', { name: 'Following' })).toBeVisible();
+
+		// …and the org admin's request queue lists the applicant + message.
+		const ownerContext = await browser.newContext();
+		await authenticateContext(ownerContext, org.owner);
+		const ownerPage = await ownerContext.newPage();
+		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(ownerPage);
+		// Real tabs here (unlike the event invitations page's URL-param buttons).
+		await ownerPage.getByRole('tab', { name: 'Requests' }).click();
+		await expect(
+			ownerPage.getByRole('button', { name: `Approve request from ${followerName}` })
+		).toBeVisible({ timeout: 15_000 });
+		// The applicant's message is shown in the request-details view.
+		await ownerPage
+			.getByRole('button', { name: `View request details from ${followerName}` })
+			.click();
+		await expect(
+			ownerPage.getByText('E2E: please let me in').filter({ visible: true }).first()
+		).toBeVisible();
+		await ownerContext.close();
+
+		// Unfollow via the dropdown; the plain Follow button returns.
+		await page.getByRole('button', { name: 'Following' }).click();
+		await page.getByRole('menuitem', { name: 'Unfollow' }).click();
+		await expect(page.getByText(`You have unfollowed ${org.name}`)).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(page.getByRole('button', { name: 'Follow', exact: true })).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j03-account/profile.spec.ts
+++ b/tests/e2e/journeys/j03-account/profile.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '../../support/fixtures';
+import { ApiClient } from '../../support/api';
+import { createVerifiedUser, uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated } from '../../support/navigation';
+import { PERSONAS } from '../../support/personas';
+
+// J3.3 (USER_JOURNEYS.md) — profile editing: names/pronouns/bio round-trip
+// through the /account/profile form, and the preferred-language choice
+// persists across reloads.
+//
+// Isolation:
+// - Desktop and mobile projects run in parallel, so each edits a DIFFERENT
+//   seeded persona (hannah / ivan); originals are captured via the API up
+//   front and restored in a finally block, keeping the spec re-runnable even
+//   after a mid-test failure.
+// - The language test uses a THROWAWAY user: a seeded persona left in German
+//   would break every other spec's English-label selectors.
+
+test.describe('J3 profile @p1', () => {
+	test('edits names, pronouns and bio; values persist across reload', async ({
+		browser,
+		isMobile
+	}) => {
+		test.setTimeout(120_000);
+		const personaName = isMobile ? 'user2' : 'user';
+		const persona = PERSONAS[personaName];
+		const api = await ApiClient.login(persona.email, persona.password);
+		const original = await api.get<{
+			preferred_name: string;
+			pronouns: string;
+			first_name: string;
+			last_name: string;
+			language: string;
+			bio: string;
+		}>('/api/account/me');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, personaName);
+		const page = await context.newPage();
+
+		try {
+			await gotoHydrated(page, '/account/profile');
+			await expect(page.getByRole('heading', { name: 'Profile', exact: true })).toBeVisible();
+
+			const newFirst = uniqueName('First');
+			const newPreferred = uniqueName('Preferred');
+			const newPronouns = 'ze/zir';
+			const newBio = uniqueName('Bio text');
+
+			await page.locator('#first_name').fill(newFirst);
+			await page.locator('#preferred_name').fill(newPreferred);
+			// Pronouns render as a common-options select unless the current value
+			// is already custom, in which case the free-text input shows directly.
+			const pronounsSelect = page.locator('#pronouns-select');
+			if (await pronounsSelect.isVisible()) {
+				await pronounsSelect.selectOption('custom');
+			}
+			await page.locator('#pronouns').fill(newPronouns);
+			// Bio is a Tiptap editor bound to a hidden input.
+			await page.locator('[contenteditable="true"]').first().fill(newBio);
+
+			await page.getByRole('button', { name: 'Save Changes' }).click();
+			await expect(page.getByText('Profile updated successfully')).toBeVisible({
+				timeout: 15_000
+			});
+
+			// The save is server-side: a fresh load renders the new values.
+			await gotoHydrated(page, '/account/profile');
+			await expect(page.locator('#first_name')).toHaveValue(newFirst);
+			await expect(page.locator('#preferred_name')).toHaveValue(newPreferred);
+			await expect(page.locator('#pronouns')).toHaveValue(newPronouns);
+			await expect(page.locator('[contenteditable="true"]').first()).toContainText(newBio);
+		} finally {
+			await api.put('/api/account/me', {
+				preferred_name: original.preferred_name ?? '',
+				pronouns: original.pronouns ?? '',
+				first_name: original.first_name ?? '',
+				last_name: original.last_name ?? '',
+				language: original.language ?? 'en',
+				bio: original.bio ?? ''
+			});
+			await context.close();
+		}
+	});
+
+	test('preferred language persists across reloads', async ({ browser }) => {
+		test.setTimeout(120_000);
+		const user = await createVerifiedUser('Polyglot');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/profile');
+		await page.locator('#language').selectOption('de');
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+
+		// A successful save calls setLocale('de'), which reloads into German.
+		await expect(page.getByRole('heading', { name: 'Profil', exact: true })).toBeVisible({
+			timeout: 20_000
+		});
+
+		// Persisted, not just client state: a hard reload stays German and the
+		// backend profile carries the language.
+		await gotoHydrated(page, '/account/profile');
+		await expect(page.getByRole('heading', { name: 'Profil', exact: true })).toBeVisible();
+		await expect(page.locator('#language')).toHaveValue('de');
+		const api = await ApiClient.login(user.email, user.password);
+		const me = await api.get<{ language: string }>('/api/account/me');
+		expect(me.language).toBe('de');
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j03-account/profile.spec.ts
+++ b/tests/e2e/journeys/j03-account/profile.spec.ts
@@ -3,85 +3,59 @@ import { ApiClient } from '../../support/api';
 import { createVerifiedUser, uniqueName } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated } from '../../support/navigation';
-import { PERSONAS } from '../../support/personas';
 
 // J3.3 (USER_JOURNEYS.md) — profile editing: names/pronouns/bio round-trip
 // through the /account/profile form, and the preferred-language choice
 // persists across reloads.
 //
-// Isolation:
-// - Desktop and mobile projects run in parallel, so each edits a DIFFERENT
-//   seeded persona (hannah / ivan); originals are captured via the API up
-//   front and restored in a finally block, keeping the spec re-runnable even
-//   after a mid-test failure.
-// - The language test uses a THROWAWAY user: a seeded persona left in German
-//   would break every other spec's English-label selectors.
+// Isolation: BOTH tests register throwaway users. Editing a seeded persona
+// in place — even with a restore step — races other specs that assert on
+// seeded display names (j08 org-tokens hardcodes "Ivan Attendee"), and a
+// crashed run would leave the seed altered; personas.ts forbids mutating
+// shared persona accounts. A seeded persona left in German would likewise
+// break every other spec's English-label selectors.
 
 test.describe('J3 profile @p1', () => {
-	test('edits names, pronouns and bio; values persist across reload', async ({
-		browser,
-		isMobile
-	}) => {
+	test('edits names, pronouns and bio; values persist across reload', async ({ browser }) => {
 		test.setTimeout(120_000);
-		const personaName = isMobile ? 'user2' : 'user';
-		const persona = PERSONAS[personaName];
-		const api = await ApiClient.login(persona.email, persona.password);
-		const original = await api.get<{
-			preferred_name: string;
-			pronouns: string;
-			first_name: string;
-			last_name: string;
-			language: string;
-			bio: string;
-		}>('/api/account/me');
-
+		const user = await createVerifiedUser('ProfileEditor');
 		const context = await browser.newContext();
-		await authenticateContext(context, personaName);
+		await authenticateContext(context, user);
 		const page = await context.newPage();
 
-		try {
-			await gotoHydrated(page, '/account/profile');
-			await expect(page.getByRole('heading', { name: 'Profile', exact: true })).toBeVisible();
+		await gotoHydrated(page, '/account/profile');
+		await expect(page.getByRole('heading', { name: 'Profile', exact: true })).toBeVisible();
 
-			const newFirst = uniqueName('First');
-			const newPreferred = uniqueName('Preferred');
-			const newPronouns = 'ze/zir';
-			const newBio = uniqueName('Bio text');
+		const newFirst = uniqueName('First');
+		const newPreferred = uniqueName('Preferred');
+		const newPronouns = 'ze/zir';
+		const newBio = uniqueName('Bio text');
 
-			await page.locator('#first_name').fill(newFirst);
-			await page.locator('#preferred_name').fill(newPreferred);
-			// Pronouns render as a common-options select unless the current value
-			// is already custom, in which case the free-text input shows directly.
-			const pronounsSelect = page.locator('#pronouns-select');
-			if (await pronounsSelect.isVisible()) {
-				await pronounsSelect.selectOption('custom');
-			}
-			await page.locator('#pronouns').fill(newPronouns);
-			// Bio is a Tiptap editor bound to a hidden input.
-			await page.locator('[contenteditable="true"]').first().fill(newBio);
-
-			await page.getByRole('button', { name: 'Save Changes' }).click();
-			await expect(page.getByText('Profile updated successfully')).toBeVisible({
-				timeout: 15_000
-			});
-
-			// The save is server-side: a fresh load renders the new values.
-			await gotoHydrated(page, '/account/profile');
-			await expect(page.locator('#first_name')).toHaveValue(newFirst);
-			await expect(page.locator('#preferred_name')).toHaveValue(newPreferred);
-			await expect(page.locator('#pronouns')).toHaveValue(newPronouns);
-			await expect(page.locator('[contenteditable="true"]').first()).toContainText(newBio);
-		} finally {
-			await api.put('/api/account/me', {
-				preferred_name: original.preferred_name ?? '',
-				pronouns: original.pronouns ?? '',
-				first_name: original.first_name ?? '',
-				last_name: original.last_name ?? '',
-				language: original.language ?? 'en',
-				bio: original.bio ?? ''
-			});
-			await context.close();
+		await page.locator('#first_name').fill(newFirst);
+		await page.locator('#preferred_name').fill(newPreferred);
+		// Pronouns render as a common-options select unless the current value
+		// is already custom, in which case the free-text input shows directly.
+		const pronounsSelect = page.locator('#pronouns-select');
+		if (await pronounsSelect.isVisible()) {
+			await pronounsSelect.selectOption('custom');
 		}
+		await page.locator('#pronouns').fill(newPronouns);
+		// Bio is a Tiptap editor bound to a hidden input.
+		await page.locator('[contenteditable="true"]').first().fill(newBio);
+
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(page.getByText('Profile updated successfully')).toBeVisible({
+			timeout: 15_000
+		});
+
+		// The save is server-side: a fresh load renders the new values.
+		await gotoHydrated(page, '/account/profile');
+		await expect(page.locator('#first_name')).toHaveValue(newFirst);
+		await expect(page.locator('#preferred_name')).toHaveValue(newPreferred);
+		await expect(page.locator('#pronouns')).toHaveValue(newPronouns);
+		await expect(page.locator('[contenteditable="true"]').first()).toContainText(newBio);
+
+		await context.close();
 	});
 
 	test('preferred language persists across reloads', async ({ browser }) => {

--- a/tests/e2e/journeys/j14-potluck/potluck.spec.ts
+++ b/tests/e2e/journeys/j14-potluck/potluck.spec.ts
@@ -1,0 +1,107 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J14 (USER_JOURNEYS.md) — potluck coordination on the seeded Spring
+// Community Potluck: the seeded items render with type labels and claim
+// states, an RSVP'd attendee adds their own item (auto-claimed), unclaims it
+// and claims it back; a non-attendee sees the RSVP gate.
+//
+// Isolation: claim/unclaim runs on the spec's OWN uniquely-named item — the
+// 12 seeded items are only read, so the seed stays pristine for j05 and for
+// repeated runs. Personas: charlie (desktop) / karen (mobile), both seeded
+// RSVP-yes and stable — j05 owns hannah/ivan's RSVPs here and leaves them at
+// "No", which would strip their claim permission mid-run.
+
+const EVENT_PATH = '/events/revel-events-collective/spring-community-potluck';
+
+/** The potluck list is a collapsible disclosure — expand it if collapsed. */
+async function openPotluckSection(page: Page): Promise<void> {
+	const section = page.getByRole('region', { name: /Potluck Coordination/ });
+	await expect(section).toBeVisible();
+	if ((await section.getByRole('button', { name: /^Claim |^Unclaim |bring/ }).count()) === 0) {
+		await section.getByRole('button', { name: /Potluck Coordination/ }).click();
+	}
+}
+
+function itemCard(page: Page, name: string) {
+	return page.locator('article').filter({ hasText: name }).first();
+}
+
+test.describe('J14 potluck @p1', () => {
+	test('seeded items render; add own item, unclaim, reclaim', async ({ browser, isMobile }) => {
+		test.setTimeout(120_000);
+		// Different persona per project — parallel runs never share claim state.
+		const persona = isMobile ? 'multiOrg' : 'member';
+		const ownSeededItem = isMobile ? 'Fresh Fruit Salad' : 'Fresh Lemonade';
+		const context = await browser.newContext();
+		await authenticateContext(context, persona);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, EVENT_PATH);
+		await waitForClientAuth(page);
+		await openPotluckSection(page);
+
+		// Seeded items render with type metadata and per-user claim states:
+		// someone else's claim is locked…
+		const lasagna = itemCard(page, 'Homemade Lasagna');
+		await expect(lasagna.getByText('Main Course')).toBeVisible();
+		await expect(lasagna.getByText('(Already claimed)')).toBeVisible();
+		await expect(lasagna.getByRole('button', { name: 'Claim Homemade Lasagna' })).toBeDisabled();
+		// …the persona's own seeded claim shows as theirs (read-only — never
+		// unclaim a seeded item).
+		await expect(itemCard(page, ownSeededItem).getByText("You're bringing")).toBeVisible();
+		// Host suggestions exist and are claimable.
+		await expect(
+			itemCard(page, 'Main Course (pasta, casserole, etc)').getByText('Unclaimed')
+		).toBeVisible();
+
+		// Add an own item — for a regular RSVP'd attendee the modal submits as
+		// "Add & claim". The section re-renders as queries settle (clicks/fills
+		// can be dropped), so run add-and-claim as an outcome-keyed loop.
+		const itemName = uniqueName('Dish');
+		const unclaimButton = page.getByRole('button', { name: `Unclaim ${itemName}` }).first();
+		await expect(async () => {
+			if (await unclaimButton.isVisible()) return;
+			// The modal title mirrors the trigger: organizers get "Add potluck
+			// item", regular attendees "Add item you'll bring".
+			const modal = page.getByRole('dialog', { name: /Add item you'll bring|Add potluck item/ });
+			if (!(await modal.isVisible())) {
+				await page
+					.getByRole('button', { name: /Add item you'll bring|Add potluck item/ })
+					.click({ timeout: 3_000 });
+			}
+			await modal.locator('#edit-item-name').fill(itemName);
+			await modal.locator('#edit-item-type').selectOption({ label: 'Dessert' });
+			await modal.getByRole('button', { name: 'Add & claim' }).click();
+			await expect(unclaimButton).toBeVisible({ timeout: 4_000 });
+		}).toPass({ timeout: 60_000 });
+		await expect(itemCard(page, itemName).getByText("You're bringing")).toBeVisible();
+		await expect(itemCard(page, itemName).getByText('Dessert', { exact: true })).toBeVisible();
+
+		// Unclaim it — back to a claimable suggestion…
+		await unclaimButton.click();
+		const claimButton = page.getByRole('button', { name: `Claim ${itemName}` }).first();
+		await expect(claimButton).toBeVisible({ timeout: 10_000 });
+		await expect(itemCard(page, itemName).getByText('Unclaimed')).toBeVisible();
+
+		// …and claim it back.
+		await claimButton.click();
+		await expect(unclaimButton).toBeVisible({ timeout: 10_000 });
+		await expect(itemCard(page, itemName).getByText("You're bringing")).toBeVisible();
+
+		await context.close();
+	});
+
+	test('non-attendee sees the RSVP gate instead of claim buttons', async ({ asBetaOwner }) => {
+		await gotoHydrated(asBetaOwner, EVENT_PATH);
+		await openPotluckSection(asBetaOwner);
+		const gated = asBetaOwner.getByRole('button', { name: /^Claim / }).filter({
+			hasText: 'RSVP "Yes" to claim'
+		});
+		await expect(gated.first()).toBeVisible();
+		await expect(gated.first()).toBeDisabled();
+	});
+});

--- a/tests/e2e/journeys/j15-notifications/inbox.spec.ts
+++ b/tests/e2e/journeys/j15-notifications/inbox.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	approveMembershipRequest,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser,
+	inviteToEvent,
+	requestMembership
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J15 (USER_JOURNEYS.md) — in-app inbox: a direct invitation raises the
+// bell's unread badge, the dropdown lists it, the full page marks it
+// read/unread, an API-approved membership request lands its notification
+// (regression: BE #673 — the approval notification used to die on missing
+// context keys), and mark-all clears the badge.
+//
+// Isolation: throwaway user — seeded personas accumulate notifications from
+// other suites, making unread counts meaningless. The membership approval is
+// arranged MID-test so the exact "1 unread" badge assertion still holds at
+// the start.
+
+test.describe('J15 inbox @p1', () => {
+	test('bell badge, dropdown, mark read/unread, approval notification, mark all', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const [user, event, org] = await Promise.all([
+			createVerifiedUser('Inboxer'),
+			createTicketedEvent({ freeTier: false }),
+			createOrganization({ acceptMembershipRequests: true })
+		]);
+		// The post_save signal raises INVITATION_RECEIVED synchronously.
+		await inviteToEvent(event.id, [user.email]);
+
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/dashboard');
+		await waitForClientAuth(page);
+
+		// Exactly one unread: the invitation (fresh account, nothing else).
+		await expect(page.getByRole('status', { name: '1 unread notification' })).toBeVisible({
+			timeout: 15_000
+		});
+
+		// The bell dropdown lists it and links to the full page.
+		await page.getByRole('button', { name: 'Open notifications' }).click();
+		await expect(page.getByText(`You're invited to ${event.name}`)).toBeVisible();
+		await page.getByRole('menuitem', { name: 'View all notifications' }).click();
+		await page.waitForURL(/\/account\/notifications/);
+		await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
+
+		// Mark read → the card flips state and the badge clears; mark unread
+		// brings both back (the mutations invalidate the unread-count query).
+		await page.getByRole('button', { name: 'Mark as read' }).click();
+		await expect(page.getByRole('button', { name: 'Mark as unread' })).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(page.getByRole('status', { name: /unread notification/ })).toBeHidden();
+		await page.getByRole('button', { name: 'Mark as unread' }).click();
+		await expect(page.getByRole('status', { name: '1 unread notification' })).toBeVisible({
+			timeout: 15_000
+		});
+
+		// An approved membership request notifies the applicant in-app (#673).
+		const request = await requestMembership(user, org.slug, 'E2E inbox membership');
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		await gotoHydrated(page, '/account/notifications');
+		await waitForClientAuth(page);
+		await expect(page.getByText(`Membership Request Approved: ${org.name}`)).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Mark all as read — toast confirms, no per-card unread actions remain,
+		// and the badge is gone.
+		await page.getByRole('button', { name: 'Mark all as read' }).click();
+		await expect(page.getByText('All notifications marked as read')).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(page.getByRole('button', { name: 'Mark as read' })).toHaveCount(0);
+		await expect(page.getByRole('status', { name: /unread notification/ })).toBeHidden();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -262,6 +262,21 @@ export async function createEventToken(
 	});
 }
 
+/**
+ * API-create direct invitations on an event owned by a seeded persona — the
+ * ARRANGE step for inbox specs (creating an EventInvitation fires the
+ * INVITATION_RECEIVED in-app notification via a post_save signal).
+ */
+export async function inviteToEvent(
+	eventId: string,
+	emails: string[],
+	owner: PersonaName = 'owner'
+): Promise<void> {
+	const persona = PERSONAS[owner];
+	const api = await ApiClient.login(persona.email, persona.password);
+	await api.post(`/api/event-admin/${eventId}/invitations`, { emails });
+}
+
 /** Add a membership tier to a throwaway-owned org. */
 export async function createMembershipTier(
 	owner: ThrowawayUser,


### PR DESCRIPTION
Part of #590 (Phase 2, group d — account & social).

## New specs (all @p1, both journey projects)

| Spec | Covers |
|---|---|
| `j03-account/dashboard-facets` | "Your Events" preset buttons scope per relationship (Organizing/Attending/Invited/Bookmarked), Organizing hidden for plain users — seeded personas, region-scoped assertions |
| `j03-account/profile` | names/pronouns/bio round-trip (originals captured via API, restored in `finally`); preferred-language persistence on a throwaway user |
| `j03-account/bookmarks` | add on detail sidebar → Bookmarked facet → remove via card overlay → server-side gone |
| `j03-account/follow-org` | follow + notify prefs, membership request with message → org admin request queue (details dialog), unfollow |
| `j03-account/create-org` | reserved-slug rejection with backend message, valid create → admin settings redirect, one-org-per-owner guard |
| `j14-potluck/potluck` | 12 seeded items with types + claim states, add/unclaim/reclaim on own item, RSVP gate for non-attendees |
| `j15-notifications/inbox` | bell unread badge, dropdown, mark read/unread, **BE #673 approval notification**, mark-all clears badge |

## App fix surfaced by the suite

`NotificationItem` initialized `let isRead = $state(notification.read_at !== null)` once from the prop — fresh server data (e.g. the mark-all-read invalidation refetch) never updated it, so "Mark all as read" kept rendering stale unread cards until a full reload. Trace-verified: backend returned 200 and the refetch carried `read_at` timestamps the UI ignored. Fixed with an optimistic override (`optimisticIsRead`) that yields to refetched prop data.

## Persona/parallelism choices baked into the specs

- hannah/ivan avoided for potluck claims & Attending assertions — j05 rsvp-flow owns their spring-potluck RSVP and leaves it at "No".
- Org Beta anchors the Organizing facet (factories only create events on Org Alpha).
- Dashboard assertions scope to the "Your Events" region — the public discover section surfaces the same events regardless of facet.
- Desktop/mobile projects use different personas (hannah/ivan, charlie/karen) wherever a seeded user's state is mutated.

## Gates

- Group specs: 26/26 green on chromium + mobile-chrome with `--retries=0`
- Fresh-DB full suite: 173 passed / 0 real failures / 2 expected mobile-viewport skips (flakies healed on retry: known j02 register + one j10 lifecycle transient)
- `make fix` + `make check` green; `make test` 844 passed

New factory: `inviteToEvent()` (direct invitations as arrange step for inbox flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification read/unread behavior to ensure server-refresh state correctly overrides optimistic UI changes.
  - Notifications now mark items as read at the right time during interaction, avoiding incorrect toggles.

- **Tests**
  - Added end-to-end coverage for event bookmarks, dashboard facets, organization creation, following organizations (with notifications), profile persistence (including language), potluck claim/unclaim flows, and inbox behaviors.
  - Added a new test factory helper for creating event invitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->