### PR TITLE
test(e2e): Phase 2e — j11 @p1 questionnaire builder + manual-review suites

### DIFF
--- a/tests/e2e/journeys/j11-questionnaires/builder.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/builder.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser,
+	uniqueName
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J11.1–11.2 (USER_JOURNEYS.md) — the questionnaire BUILDER: an organizer
+// creates an admission questionnaire (top-level MCQ with weights + a section
+// holding a free-text question), publishes it, attaches it to an event, and
+// the admission gate arms for an attendee.
+//
+// Everything lives in a THROWAWAY org + event: attaching an ADMISSION
+// questionnaire to a seeded event would gate that event for every other spec,
+// and an isolated org keeps the assignment modal down to exactly one row.
+
+test.describe('J11 questionnaire builder @p1', () => {
+	test('owner builds, publishes and attaches a questionnaire; the event gate arms', async ({
+		browser
+	}) => {
+		// ---- Arrange via API: fresh org + open ticketed event with a free tier.
+		const org = await createOrganization();
+		const event = await createTicketedEvent({ owner: org.owner, orgSlug: org.slug });
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		// ---- Build. Defaults are already Admission type + Manual evaluation.
+		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires/new`);
+		await waitForClientAuth(page);
+		const qName = uniqueName('Screening');
+		await page.getByLabel('Questionnaire Name').fill(qName);
+		await page.getByLabel('Minimum Score (%)').fill('50');
+
+		const MCQ_TEXT = 'Do you agree to the house rules?';
+		const FT_TEXT = 'What draws you to this event?';
+
+		// Top-level MCQ. First add-click happens in the empty state, where the
+		// card header holds the only "Multiple Choice" button.
+		await page.getByRole('button', { name: 'Multiple Choice' }).first().click();
+		// Question text is a Tiptap contenteditable named by its linked label.
+		const mcqEditor = page.getByRole('textbox', { name: 'Question Text (Markdown)' }).first();
+		await mcqEditor.fill(MCQ_TEXT);
+		await page.getByPlaceholder('Option 1').fill('Yes, I agree');
+		await page.getByPlaceholder('Option 2').fill('No');
+		// The correct-answer checkbox carries only a title attribute.
+		await page.getByRole('checkbox', { name: 'Mark as correct answer' }).first().check();
+		// Weights live behind the per-question Advanced Settings disclosure.
+		await page.getByRole('button', { name: 'Advanced Settings' }).click();
+		await page.getByLabel('Positive Weight').fill('5');
+		await page.getByLabel('Negative Weight').fill('1');
+
+		// Section with a free-text question inside. The SectionEditor card is the
+		// dashed-border container; scope into it so the section's own add-question
+		// buttons don't collide with the page-level ones.
+		await page.getByRole('button', { name: 'Add Section' }).first().click();
+		const section = page.locator('div.border-2.border-dashed');
+		await section.getByPlaceholder('Section name...').fill('About you');
+		await section.getByRole('button', { name: 'Free Text' }).click();
+		const ftEditor = section.getByRole('textbox', { name: 'Question Text (Markdown)' });
+		await ftEditor.fill(FT_TEXT);
+
+		// A freshly-mounted Tiptap editor can silently drop a fill() while it
+		// settles ("All questions must have text" then blocks the save with no
+		// navigation) — re-fill anything that got lost, then save; keyed on the
+		// redirect to the new questionnaire's edit page.
+		await expect(async () => {
+			for (const [editor, text] of [
+				[mcqEditor, MCQ_TEXT],
+				[ftEditor, FT_TEXT]
+			] as const) {
+				if (!(await editor.innerText()).includes(text)) {
+					await editor.fill(text);
+				}
+			}
+			await page.getByRole('button', { name: 'Save Questionnaire' }).click();
+			await page.waitForURL(/\/admin\/questionnaires\/(?!new)[0-9a-f-]+$/, { timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+		await expect(page.getByText(qName).first()).toBeVisible();
+		// The created structure renders read-only on the edit page.
+		await expect(page.getByText('Do you agree to the house rules?').first()).toBeVisible();
+		await expect(page.getByText('What draws you to this event?').first()).toBeVisible();
+
+		// ---- Publish (status changes fire a native confirm()).
+		page.once('dialog', (dialog) => void dialog.accept());
+		await page.getByRole('button', { name: 'Publish' }).click();
+		// Published state swaps the action set to Unpublish/Mark as Draft.
+		await expect(page.getByRole('button', { name: 'Unpublish' })).toBeVisible();
+
+		// ---- Attach to the event from the event editor's Admission & Screening.
+		await gotoHydrated(page, `/org/${org.slug}/admin/events/${event.id}/edit`);
+		const admissionToggle = page.getByRole('button', { name: 'Admission & Screening' });
+		await expect(admissionToggle).toBeVisible();
+		if ((await admissionToggle.getAttribute('aria-expanded')) !== 'true') {
+			await admissionToggle.click();
+		}
+		await page.getByRole('button', { name: 'Assign Questionnaires' }).click();
+		const dialog = page.getByRole('dialog', { name: 'Assign Questionnaires to Event' });
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole('checkbox', { name: `Select ${qName}` }).check();
+		await dialog.getByRole('button', { name: 'Save Assignments' }).click();
+		await expect(dialog).toBeHidden();
+		// The assignment lands in the Required Questionnaires list (its remove
+		// button is the row's unambiguous accessible handle).
+		await expect(page.getByRole('button', { name: `Remove ${qName}` })).toBeVisible();
+
+		await page.context().close();
+
+		// ---- The gate arms: a fresh attendee sees the questionnaire prompt
+		// instead of the ticket CTA (same gate copy fill-auto-eval consumes).
+		const visitor = await createVerifiedUser('GateCheck');
+		const visitorContext = await browser.newContext();
+		await authenticateContext(visitorContext, visitor);
+		const visitorPage = await visitorContext.newPage();
+		await gotoHydrated(visitorPage, event.path);
+		await waitForClientAuth(visitorPage);
+		await expect(
+			visitorPage
+				.getByText(/Complete the required questionnaire/)
+				.filter({ visible: true })
+				.first()
+		).toBeVisible();
+		await expect(
+			visitorPage
+				.getByRole('button', { name: 'Complete Questionnaire' })
+				.filter({ visible: true })
+				.first()
+		).toBeVisible();
+		await expect(
+			visitorPage
+				.getByRole('button', { name: 'Get Tickets', exact: true })
+				.filter({ visible: true })
+		).toBeHidden();
+
+		await visitorContext.close();
+	});
+});

--- a/tests/e2e/journeys/j11-questionnaires/manual-review.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/manual-review.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '../../support/fixtures';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J11.5–11.6 (USER_JOURNEYS.md) — MANUAL review of the seeded wine-tasting
+// admission questionnaire ("Wine Tasting Dinner Application", Org Alpha,
+// evaluation_mode=manual, 10 seeded submissions).
+//
+// Re-runnability: the backend evaluates via update_or_create keyed on the
+// submission, so approving is IDEMPOTENT — but it does mutate the seed until
+// the next `make reset-events && make bootstrap`. The spec therefore finds
+// its row through the default "All" filter (a pending-only filter would come
+// up empty on the second run) and asserts only the post-state. Desktop and
+// mobile projects review DIFFERENT seeded applicants so concurrently running
+// projects never race on the same evaluation row.
+
+const QUESTIONNAIRES_PATH = '/org/revel-events-collective/admin/questionnaires';
+const EVENT_PATH = '/events/revel-events-collective/exclusive-wine-tasting-dinner';
+const QUESTIONNAIRE_NAME = 'Wine Tasting Dinner Application';
+
+test.describe('J11 questionnaire manual review @p1', () => {
+	test('owner approves a submission with notes and the applicant is unblocked', async ({
+		asOwner: page,
+		isMobile,
+		browser
+	}) => {
+		// Both start seeded as PENDING_REVIEW (jordan/sam); taylor/nina (no
+		// evaluation row yet) stay untouched as manual-repro spares.
+		const applicant = isMobile
+			? { name: 'Sam Okafor', email: 'sam.wine@example.com' }
+			: { name: 'Jordan Kim', email: 'jordan.wine@example.com' };
+
+		// Index → wine questionnaire card → its Submissions list.
+		await gotoHydrated(page, QUESTIONNAIRES_PATH);
+		await waitForClientAuth(page);
+		await page
+			.locator('div.bg-card')
+			.filter({ hasText: QUESTIONNAIRE_NAME })
+			.getByRole('link', { name: 'Submissions' })
+			.click();
+		await page.waitForURL(/\/submissions$/);
+
+		// The desktop table and mobile card list render in parallel — scope to
+		// the visible container holding ONLY this applicant (the desktop table's
+		// own wrapping Card matches div.bg-card too and holds every name, so
+		// exclude anything that also contains another seeded respondent).
+		await page
+			.locator('tbody tr, div.bg-card')
+			.filter({ hasText: applicant.name })
+			.filter({ hasNot: page.getByText('Sophie Laurent', { exact: true }) })
+			.filter({ visible: true })
+			.getByRole('link', { name: 'Review' })
+			.click();
+		await expect(page.getByRole('heading', { name: 'Review Submission' })).toBeVisible();
+
+		// Approve WITH notes: comments hide behind the Advanced Options
+		// disclosure; the whole evaluation is one native form POST.
+		await page.getByRole('button', { name: 'Advanced Options (Score & Comments)' }).click();
+		await page
+			.getByLabel('Comments (Optional)')
+			.fill(`Great fit for the tasting — welcome! (e2e ${Date.now()})`);
+		await page.getByRole('button', { name: 'Approve' }).click();
+
+		// The evaluate action 303-redirects back to the same submission; the
+		// approved state marks the Approve button as current.
+		await expect(page.getByRole('button', { name: /Approve/ }).getByText('Current')).toBeVisible();
+
+		// The applicant is unblocked: the admission gate clears and the ticket
+		// CTA appears (the seeded event has open, purchasable tiers).
+		const applicantContext = await browser.newContext();
+		await authenticateContext(applicantContext, {
+			email: applicant.email,
+			password: 'password123'
+		});
+		const applicantPage = await applicantContext.newPage();
+		await expect(async () => {
+			await gotoHydrated(applicantPage, EVENT_PATH);
+			await expect(
+				applicantPage
+					.getByRole('button', { name: 'Get Tickets', exact: true })
+					.filter({ visible: true })
+					.first()
+			).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+		await expect(applicantPage.getByText(/being reviewed|under review/i)).toBeHidden();
+
+		await applicantContext.close();
+	});
+
+	test('submissions list shows seeded evaluation states and filters by status', async ({
+		asOwner: page
+	}) => {
+		await gotoHydrated(page, QUESTIONNAIRES_PATH);
+		await waitForClientAuth(page);
+		await page
+			.locator('div.bg-card')
+			.filter({ hasText: QUESTIONNAIRE_NAME })
+			.getByRole('link', { name: 'Submissions' })
+			.click();
+		await page.waitForURL(/\/submissions$/);
+
+		const visibleName = (name: string) =>
+			page.getByText(name, { exact: true }).filter({ visible: true }).first();
+
+		// Default "All": every seeded submission fits on one page.
+		await expect(page.getByText(/of 10 submissions/).first()).toBeVisible();
+		await expect(visibleName('Sophie Laurent')).toBeVisible();
+
+		// Approved: seeded approvals stay approved forever (the approve test
+		// only ever ADDS to this set, so presence is run-order-proof); a seeded
+		// rejection must not leak in.
+		await page.getByRole('button', { name: 'Approved' }).click();
+		await expect(page).toHaveURL(/evaluation_status=approved/);
+		await expect(visibleName('Sophie Laurent')).toBeVisible();
+		await expect(visibleName('Marco Bianchi')).toBeVisible();
+		await expect(page.getByText('Elena Volkov', { exact: true })).toBeHidden();
+
+		// Rejected: the two seeded rejections, and no approved name.
+		await page.getByRole('button', { name: 'Rejected' }).click();
+		await expect(page).toHaveURL(/evaluation_status=rejected/);
+		await expect(visibleName('Elena Volkov')).toBeVisible();
+		await expect(visibleName('Chris Park')).toBeVisible();
+		await expect(page.getByText('Sophie Laurent', { exact: true })).toBeHidden();
+	});
+});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -95,21 +95,22 @@ export interface CreatedEvent {
 }
 
 /**
- * API-create an OPEN, public event (owned by a seeded org owner), optionally
+ * API-create an OPEN, public event (owned by a seeded org owner — or, when
+ * `owner` is a ThrowawayUser, by that user on their own org), optionally
  * with an immediately-purchasable free tier. Specs use this instead of relying
  * on seeded events whose sales windows / capacity drift with the clock.
  */
 export async function createTicketedEvent(
 	options: {
-		owner?: PersonaName;
+		owner?: PersonaName | ThrowawayUser;
 		orgSlug?: string;
 		freeTier?: boolean;
 		event?: Record<string, unknown>;
 	} = {}
 ): Promise<CreatedEvent> {
 	const { owner = 'owner', orgSlug = 'revel-events-collective', freeTier = true } = options;
-	const persona = PERSONAS[owner];
-	const api = await ApiClient.login(persona.email, persona.password);
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
 
 	const name = uniqueName('Event');
 	const dayMs = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

Phase 2 group (e) of the E2E suite v2 build-out: the two remaining @p1 j11-questionnaires suites (spec §7; `fill-auto-eval` landed in Phase 1). Follows #599/#602/#605/#606.

### `builder.spec.ts` (1 test)
Full organizer journey through the org-admin questionnaire builder:
- create with defaults (Admission type, Manual evaluation), min score, top-level **MCQ with weights** (correct-answer marking + positive/negative weights behind the per-question Advanced Settings disclosure), and a **section** holding a **free-text** question
- save → publish from the status bar (native `confirm()`)
- attach to an event via the event editor's *Admission & Screening* → *Assign Questionnaires* dialog
- outcome: a fresh attendee sees the questionnaire gate instead of the ticket CTA

Runs entirely in a **throwaway org + event** — attaching an ADMISSION questionnaire to a seeded event would gate it for every other spec, and the isolated org keeps the assignment modal deterministic.

### `manual-review.spec.ts` (2 tests)
- **approve with notes** on the seeded "Wine Tasting Dinner Application" (Org Alpha, manual mode, 10 seeded submissions): review page → Advanced Options → comments → Approve (native form POST, 303 back) → applicant's *Get Tickets* CTA unlocks
- **status filters**: All/Approved/Rejected assertions on stable seeded respondent names

**Re-runnability without a DB reset**: backend evaluation is `update_or_create` keyed on the submission (idempotent); rows are found via the default *All* filter (a pending-only filter empties after the first run) and assertions target post-state only. Desktop reviews *Jordan Kim*, mobile reviews *Sam Okafor* — parallel projects never race on one evaluation row.

### Support kit
- `factories.ts`: `createTicketedEvent` now accepts a `ThrowawayUser` owner (previously seeded personas only).

### New trap documented in-spec
A freshly-mounted Tiptap editor can silently drop a `.fill()` while settling (builder validation then blocks the save with no navigation). The save loop re-fills any dropped editor and retries, outcome-keyed on the redirect.

## Gate

- j11 suite green on chromium + mobile-chrome at `--retries=0` across repeated runs, including against an already-mutated seed (re-runnability proof)
- fresh-DB full run: **185 tests → 176 passed + 7 flaky (all known j02-register / j10-lifecycle dev-stack transients, healed by the configured retries:1) + 2 mobile-viewport skips — 0 real failures**
- `make check` green; `make test` 844 passed

Part of #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb