### PR TITLE
fix(e2e): register hydration/focus-steal flakes + lifecycle strict-mode locator

### DIFF
--- a/src/routes/(public)/register/+page.svelte
+++ b/src/routes/(public)/register/+page.svelte
@@ -61,7 +61,12 @@
 
 	function dismissNudge() {
 		nudgeDismissed = true;
-		requestAnimationFrame(() => document.getElementById('email')?.focus());
+		// Focus synchronously — a deferred handoff (rAF/timeout) can fire
+		// seconds late under load and steal focus from a field the user (or a
+		// password manager) is already typing into, spraying keystrokes into
+		// the email field. The input exists in the DOM under the overlay, so
+		// it is focusable right now.
+		document.getElementById('email')?.focus();
 	}
 
 	function onNudgeKeydown(event: KeyboardEvent) {
@@ -97,6 +102,8 @@
 	// Sync browser autofill/form restoration with reactive state.
 	// Chrome may fill fields before Svelte hydration (SSR) or restore them
 	// from bfcache/session restore without firing input events.
+	let formEl: HTMLFormElement | null = null;
+
 	function syncFormValues() {
 		const get = (id: string) => document.getElementById(id) as HTMLInputElement | null;
 		const emailEl = get('email');
@@ -115,6 +122,16 @@
 		const t1 = setTimeout(syncFormValues, 100);
 		const t2 = setTimeout(syncFormValues, 1000);
 
+		// A value written into the DOM during the hydration-settling window
+		// (browser autofill, password managers) fires its input event before
+		// Svelte's bindings listen, so $state never learns about it and the
+		// submit button stays disabled. The timers above only cover the first
+		// second — recover continuously instead: any later native activity on
+		// the form (typing in another field, focus moving, a checkbox toggle)
+		// re-runs the sync and picks up whatever the bindings missed.
+		const syncEvents = ['input', 'change', 'focusout'] as const;
+		for (const evt of syncEvents) formEl?.addEventListener(evt, syncFormValues);
+
 		// Handle bfcache restoration (back/forward navigation)
 		const handlePageShow = (e: PageTransitionEvent) => {
 			if (e.persisted) {
@@ -127,6 +144,7 @@
 		return () => {
 			clearTimeout(t1);
 			clearTimeout(t2);
+			for (const evt of syncEvents) formEl?.removeEventListener(evt, syncFormValues);
 			window.removeEventListener('pageshow', handlePageShow);
 		};
 	});
@@ -200,6 +218,7 @@
 		<!-- Registration Form -->
 		<form
 			method="POST"
+			bind:this={formEl}
 			use:enhance={() => {
 				// Prevent duplicate submissions
 				if (isSubmitting) return;

--- a/tests/e2e/journeys/j02-registration/register-verify.spec.ts
+++ b/tests/e2e/journeys/j02-registration/register-verify.spec.ts
@@ -14,13 +14,42 @@ import { revealRegistrationForm } from '../../support/auth-forms';
 
 const STRONG_PASSWORD = 'E2e-test-Pass!123';
 
-async function fillRegistrationForm(page: Page, email: string, password: string): Promise<void> {
+async function fillRegistrationForm(
+	page: Page,
+	email: string,
+	password: string,
+	{ expectSubmittable = true }: { expectSubmittable?: boolean } = {}
+): Promise<void> {
 	await gotoHydrated(page, '/register');
 	await revealRegistrationForm(page);
-	await page.getByLabel('Email address').fill(email);
-	await page.getByLabel('Password', { exact: true }).fill(password);
-	await page.getByLabel('Confirm password').fill(password);
-	await page.getByLabel(/I accept the/).check();
+
+	const emailInput = page.getByLabel('Email address');
+	const passwordInput = page.getByLabel('Password', { exact: true });
+	const confirmInput = page.getByLabel('Confirm password');
+	const terms = page.getByLabel(/I accept the/);
+	const submit = page.getByRole('button', { name: 'Create your account' });
+
+	// Outcome-keyed fill loop (same medicine as the questionnaire builder's
+	// Tiptap re-fill): a fill landing in the hydration-settling window can
+	// update the DOM without Svelte's $state ever learning about it, so the
+	// submit button (disabled on $state-derived canSubmit) never enables.
+	// Re-fill until the RENDERED state proves the values landed: the button
+	// enables (strong path) or the strength panel appears (weak path — it
+	// renders only when the password $state is non-empty). fill() replaces
+	// the whole value, so a retry also repairs a corrupted field.
+	await expect(async () => {
+		await emailInput.fill(email);
+		await passwordInput.fill(password);
+		await confirmInput.fill(password);
+		if (!(await terms.isChecked())) await terms.check();
+		await expect(emailInput).toHaveValue(email, { timeout: 2_000 });
+		if (expectSubmittable) {
+			await expect(submit).toBeEnabled({ timeout: 2_000 });
+		} else {
+			await expect(passwordInput).toHaveValue(password, { timeout: 2_000 });
+			await expect(page.getByText('Password strength:')).toBeVisible({ timeout: 2_000 });
+		}
+	}).toPass({ timeout: 45_000 });
 }
 
 test.describe('J2 registration & email verification @p0', () => {
@@ -50,7 +79,7 @@ test.describe('J2 registration & email verification @p0', () => {
 	});
 
 	test('rejects a weak password inline', async ({ page }) => {
-		await fillRegistrationForm(page, uniqueEmail('WeakPw'), 'weak');
+		await fillRegistrationForm(page, uniqueEmail('WeakPw'), 'weak', { expectSubmittable: false });
 
 		// Client-side validation blocks submission with an accessible error.
 		const submit = page.getByRole('button', { name: 'Create your account' });

--- a/tests/e2e/journeys/j10-event-admin/lifecycle.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/lifecycle.spec.ts
@@ -46,7 +46,12 @@ test.describe('J10 event lifecycle @p1', () => {
 		const cancelDialog = page.getByRole('dialog', { name: 'Cancel this event' });
 		await cancelDialog.getByLabel('Reason (optional)').fill(reason);
 		await cancelDialog.getByRole('button', { name: 'Cancel event' }).click();
-		await expect(page.getByText('Event cancelled')).toBeVisible({ timeout: 20_000 });
+		// { exact: true } — the edit-page header concatenates "... Event cancelled",
+		// so a substring match resolves to 2 elements (strict-mode violation) with
+		// render-order-dependent timing; the status badge is the exact-text one.
+		await expect(page.getByText('Event cancelled', { exact: true })).toBeVisible({
+			timeout: 20_000
+		});
 
 		// The attendee sees the banner WITH the organizer's reason.
 		const attendeeContext = await browser.newContext();


### PR DESCRIPTION
## Summary

Fixes the two known FE flakiness causes from the 2026-07-11 full-run forensics (7 flakes total), so the E2E suite v2 Phase 2f (polls, #590) starts from a clean baseline.

### Fix 1 — j02 register hydration/focus races (5/7 flakes; product bug, first found via flake forensics)

Two trace-verified mechanisms, both fixed app-side in `register/+page.svelte`:

1. **Hydration-window value swallow** — a fill landing while bindings attach updates the DOM but the `input` event never reaches Svelte, so `$state` stays empty and the `canSubmit`-gated button never enables (174 × "element is not enabled" over ~90s). `syncFormValues()` existed for exactly this (real browser autofill hits it too) but only fired at 100ms/1000ms post-mount. Recovery is now **continuous**: native `input`/`change`/`focusout` listeners on the form re-run the sync on any later activity.
2. **Nudge-dismiss focus steal** — `dismissNudge()` handed focus to `#email` in a `requestAnimationFrame`; under load the rAF fired seconds late, mid-fill, and the failure snapshot showed the password appended *inside the email field*. Focus is now handed off synchronously.

Test-side, `fillRegistrationForm` uses the suite's outcome-keyed re-fill loop (same medicine as the questionnaire builder's Tiptap loop): re-fill until the rendered state proves the values landed — submit enabled (strong path) or strength panel visible (weak path). Assertions are unchanged.

**Sibling audit**: login, password-reset, and reset-password gate their submits only on `isSubmitting`, and all are native form POSTs — register was the only page with a `$state`-gated submit.

### Fix 2 — j10 lifecycle under-scoped locator (2/7 flakes; spec bug)

`getByText('Event cancelled')` also matched the edit-page header's concatenated text → strict-mode violation, racy on render order. Now `{ exact: true }`. Suite-wide grep found no other bare substring asserts near status changes.

## Verification

- j02 + j10 lifecycle, **both projects**, `--retries=0 --repeat-each=3`, on a cold rebuilt preview → **24/24 passed**
- `make check` green; `make test` 844 passed
- `retries: 1` in config untouched (stays as insurance)

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved registration form reliability with browser autofill and password managers.
  - Registration fields now stay synchronized correctly, helping ensure entered values are recognized.
  - The email field receives focus immediately when dismissing the demo-mode prompt.
  - Improved handling and validation of weak passwords during registration.
  - Event cancellation confirmation checks are now more precise and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->