### PR TITLE
test(e2e): Phase 2f — j24 @p1 poll admin + voting suites (#590)

### DIFF
--- a/tests/e2e/journeys/j24-polls/poll-admin.spec.ts
+++ b/tests/e2e/journeys/j24-polls/poll-admin.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../../support/fixtures';
+import { uniqueName } from '../../support/factories';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { pickSelectOption } from '../../support/ui';
+
+// J24 (USER_JOURNEYS.md) — poll administration: create a poll through the
+// builder (audience, result timing, anonymity, vote-change policy, one MC
+// question), open it, verify the share URL, close it. Rewrite of the pre-v2
+// polls-admin smoke onto the v2 infra.
+//
+// The poll lives on the seeded org: polls gate nothing suite-wide (unlike
+// admission questionnaires) and carry uniqueName()s, so parallel workers and
+// re-runs never collide.
+
+const ORG_SLUG = 'revel-events-collective';
+const QUESTION = 'Which snack should we bring?';
+
+test.describe('J24 poll admin @p1', () => {
+	test('create with audience/anonymity/timing config → open → share → close', async ({
+		asOwner: page
+	}) => {
+		await gotoHydrated(page, `/org/${ORG_SLUG}/admin/polls/new`);
+		await waitForClientAuth(page);
+
+		const name = uniqueName('PollAdmin');
+		await page.getByLabel('Poll name').fill(name);
+
+		// Audience + results configuration: the dropdowns are bits-ui Selects
+		// (portalled listboxes), the anonymity/vote-change toggles are native
+		// checkboxes.
+		await pickSelectOption(page, page.locator('#vote-visibility'), 'Public');
+		await pickSelectOption(page, page.locator('#result-timing'), 'After voting');
+		await page.getByLabel('Hide voter identities from staff').uncheck();
+		await page.getByLabel(/Allow voters to change their vote/).check();
+
+		// Add one MC question — outcome-keyed: the "Questions (N)" header count
+		// proves the click landed (a pre-hydration click no-ops silently).
+		const questionCount = page.getByRole('heading', { name: 'Questions (1)' });
+		await expect(async () => {
+			if (!(await questionCount.isVisible())) {
+				await page.getByRole('button', { name: 'Multiple Choice' }).first().click();
+			}
+			await expect(questionCount).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 20_000 });
+
+		const questionEditor = page.getByRole('textbox', { name: 'Question Text (Markdown)' }).first();
+		await questionEditor.fill(QUESTION);
+		await page.getByPlaceholder('Option 1').fill('Pretzels');
+		await page.getByPlaceholder('Option 2').fill('Popcorn');
+
+		// A freshly-mounted Tiptap editor can silently drop its fill() while it
+		// settles (same trap as the questionnaire builder) — re-fill inside the
+		// outcome-keyed save loop, keyed on the redirect to the detail page.
+		await expect(async () => {
+			if (!(await questionEditor.innerText()).includes(QUESTION)) {
+				await questionEditor.fill(QUESTION);
+			}
+			await page.getByRole('button', { name: 'Create poll' }).click();
+			await page.waitForURL(/\/admin\/polls\/(?!new)[0-9a-f-]+/, { timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+
+		// The detail page round-trips the config: DRAFT status, staff anonymity
+		// off, vote changes allowed (the anonymity boxes render locked here —
+		// they are immutable after create).
+		await expect(page.getByText(name).first()).toBeVisible();
+		await expect(
+			page.getByText('Draft', { exact: true }).filter({ visible: true }).first()
+		).toBeVisible();
+		await expect(page.getByLabel('Hide voter identities from staff')).not.toBeChecked();
+		await expect(page.getByLabel(/Allow voters to change their vote/)).toBeChecked();
+
+		// Open → the share strip appears carrying THIS poll's voter URL.
+		await page.getByRole('button', { name: 'Open poll' }).click();
+		await expect(page.getByRole('button', { name: 'Close poll' })).toBeVisible({
+			timeout: 20_000
+		});
+		const pollId = page.url().match(/\/admin\/polls\/([0-9a-f-]+)/)?.[1];
+		expect(pollId, `poll id extractable from ${page.url()}`).toBeTruthy();
+		await expect(page.getByLabel('Poll share URL')).toHaveValue(
+			new RegExp(`/org/${ORG_SLUG}/polls/${pollId}$`)
+		);
+
+		// Close → the reopen affordance replaces it.
+		await page.getByRole('button', { name: 'Close poll' }).click();
+		await expect(page.getByRole('button', { name: 'Reopen poll' })).toBeVisible({
+			timeout: 20_000
+		});
+	});
+});

--- a/tests/e2e/journeys/j24-polls/poll-vote.spec.ts
+++ b/tests/e2e/journeys/j24-polls/poll-vote.spec.ts
@@ -1,0 +1,108 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { createPoll } from '../../support/factories';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J24 (USER_JOURNEYS.md) — poll voting: a member casts a vote, the
+// vote-change policy gates re-vote/withdraw, and result visibility + timing
+// gate the Results card. Rewrite of the pre-v2 polls-voter smoke.
+//
+// Isolation: polls are never seeded — each test API-creates its own on the
+// seeded org (charlie is a member, so the members-only default audience lets
+// him vote). Voters reach a poll only via its direct share URL: there is no
+// public poll listing.
+
+/**
+ * Cast (or re-cast) a vote, outcome-keyed on the voted banner: re-click the
+ * option + submit until the vote sticks. Safe to call while the ballot is
+ * showing; exits immediately if the banner is already up.
+ */
+async function castVote(page: Page, optionIndex: number): Promise<void> {
+	const banner = page.getByText('You voted on this poll.');
+	await expect(async () => {
+		if (!(await banner.isVisible())) {
+			const radios = page.getByRole('radio');
+			await expect(radios).toHaveCount(2, { timeout: 3_000 });
+			await radios.nth(optionIndex).click();
+			await page.getByRole('button', { name: 'Submit vote' }).click();
+		}
+		await expect(banner).toBeVisible({ timeout: 5_000 });
+	}).toPass({ timeout: 30_000 });
+}
+
+test.describe('J24 poll voting @p1', () => {
+	test('locked poll: vote sticks, no change/withdraw, results stay hidden', async ({
+		asMember: page
+	}) => {
+		// Backend/create defaults: allow_vote_changes=false, result_timing=never.
+		const poll = await createPoll();
+
+		await gotoHydrated(page, poll.path);
+		await waitForClientAuth(page);
+
+		// The ballot renders the question with its two options.
+		await expect(page.getByText('Are you in?').first()).toBeVisible();
+		await castVote(page, 0);
+
+		// allow_vote_changes=false → no re-vote affordances…
+		await expect(page.getByRole('button', { name: 'Change my vote' })).toHaveCount(0);
+		await expect(page.getByRole('button', { name: 'Withdraw vote' })).toHaveCount(0);
+		// …and result_timing=never keeps results hidden even after voting.
+		await expect(page.getByRole('heading', { name: 'Results' })).toHaveCount(0);
+	});
+
+	test('changes allowed: results after voting, change vote, withdraw restores ballot', async ({
+		asMember: page
+	}) => {
+		const poll = await createPoll({
+			poll: {
+				allow_vote_changes: true,
+				result_visibility: 'members-only',
+				result_timing: 'after_vote'
+			}
+		});
+
+		await gotoHydrated(page, poll.path);
+		await waitForClientAuth(page);
+		await castVote(page, 0);
+
+		// result_timing=after_vote + members-only: the Results card appears
+		// once this member has voted, with the vote tallied.
+		await expect(page.getByRole('heading', { name: 'Results' })).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(page.getByText('1 voter', { exact: true })).toBeVisible();
+
+		// Change the vote: the ballot comes back prefilled; flip the answer.
+		await page.getByRole('button', { name: 'Change my vote' }).click();
+		await expect(page.getByRole('button', { name: 'Submit vote' })).toBeVisible();
+		await castVote(page, 1);
+
+		// The changed vote round-trips: re-entering edit mode shows the OTHER
+		// option preselected (prefill comes from the server's user_vote).
+		await page.getByRole('button', { name: 'Change my vote' }).click();
+		const radios = page.getByRole('radio');
+		await expect(radios).toHaveCount(2);
+		await expect(radios.nth(1)).toBeChecked();
+		await expect(radios.nth(0)).not.toBeChecked();
+
+		// Withdraw (from edit mode the banner controls are hidden — go back to
+		// it by reloading the poll, then confirm through the danger dialog).
+		await gotoHydrated(page, poll.path);
+		await waitForClientAuth(page);
+		const withdrawDialog = page.getByRole('dialog', { name: 'Withdraw your vote' });
+		await expect(async () => {
+			if (!(await withdrawDialog.isVisible())) {
+				await page.getByRole('button', { name: 'Withdraw vote' }).click();
+			}
+			await withdrawDialog.getByRole('button', { name: 'Withdraw vote' }).click();
+			// Outcome: the submission is gone, so the ballot is offered again.
+			await expect(page.getByRole('button', { name: 'Submit vote' })).toBeVisible({
+				timeout: 5_000
+			});
+		}).toPass({ timeout: 30_000 });
+		await expect(page.getByText('You voted on this poll.')).toHaveCount(0);
+		// No submission → after_vote timing hides the results again.
+		await expect(page.getByRole('heading', { name: 'Results' })).toHaveCount(0);
+	});
+});

--- a/tests/e2e/support/api.ts
+++ b/tests/e2e/support/api.ts
@@ -70,15 +70,25 @@ export class ApiClient {
 	}
 
 	async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-		const response = await fetch(`${API_URL}${path}`, {
-			method,
-			headers: {
-				Authorization: `Bearer ${this.accessToken}`,
-				...(body !== undefined ? { 'Content-Type': 'application/json' } : {})
-			},
-			body: body !== undefined ? JSON.stringify(body) : undefined
-		});
-		const text = await response.text();
+		// Bounded 5xx retry, mirroring obtainTokenPair: under parallel worker
+		// load the dev backend can transiently 500 (observed: Postgres "sorry,
+		// too many clients already" surfacing as OperationalError). 4xx is
+		// NEVER retried — specs assert on those deliberately.
+		let response: Response;
+		let text: string;
+		for (let attempt = 1; ; attempt++) {
+			response = await fetch(`${API_URL}${path}`, {
+				method,
+				headers: {
+					Authorization: `Bearer ${this.accessToken}`,
+					...(body !== undefined ? { 'Content-Type': 'application/json' } : {})
+				},
+				body: body !== undefined ? JSON.stringify(body) : undefined
+			});
+			text = await response.text();
+			if (response.status < 500 || attempt >= 3) break;
+			await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+		}
 		if (!response.ok) {
 			throw new ApiError(response.status, method, path, text);
 		}

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -321,6 +321,71 @@ export async function approveMembershipRequest(
 	});
 }
 
+export interface CreatedPoll {
+	id: string;
+	orgSlug: string;
+	/** Voter share path, e.g. /org/<org>/polls/<id>. */
+	path: string;
+	name: string;
+	/** The single MC question's id + option ids (creation order) for API votes. */
+	questionId: string;
+	optionIds: string[];
+}
+
+/**
+ * API-create a poll with one two-option MC question ("Yes"/"No"), optionally
+ * opening it for votes. Polls are NEVER seeded — every poll spec arranges its
+ * own. Defaults mirror the backend/create-form defaults: members-only vote,
+ * staff-only results, result timing "never", fully anonymous, no vote changes
+ * — override per-scenario via `poll` (e.g. `allow_vote_changes`,
+ * `result_timing`, `result_visibility`).
+ */
+export async function createPoll(
+	options: {
+		owner?: PersonaName | ThrowawayUser;
+		orgSlug?: string;
+		open?: boolean;
+		poll?: Record<string, unknown>;
+	} = {}
+): Promise<CreatedPoll> {
+	const { owner = 'owner', orgSlug = 'revel-events-collective', open = true } = options;
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+
+	const org = await api.get<{ id: string }>(`/api/organizations/${orgSlug}`);
+	const name = uniqueName('Poll');
+	const poll = await api.post<{
+		id: string;
+		questionnaire: {
+			multiple_choice_questions: Array<{ id: string; options: Array<{ id: string }> }>;
+		} | null;
+	}>(`/api/polls/organizations/${org.id}`, {
+		name,
+		vote_visibility: 'members-only',
+		multiplechoicequestion_questions: [
+			{ question: 'Are you in?', options: [{ option: 'Yes' }, { option: 'No' }] }
+		],
+		...options.poll
+	});
+
+	if (open) {
+		await api.post(`/api/polls/${poll.id}/open`);
+	}
+
+	const question = poll.questionnaire?.multiple_choice_questions[0];
+	if (!question) {
+		throw new Error(`Poll ${poll.id} came back without its MC question`);
+	}
+	return {
+		id: poll.id,
+		orgSlug,
+		path: `/org/${orgSlug}/polls/${poll.id}`,
+		name,
+		questionId: question.id,
+		optionIds: question.options.map((o) => o.id)
+	};
+}
+
 /**
  * RSVP a throwaway user to a non-ticketed event via the public API. Throws
  * ApiError (status 400) when the event is not accepting RSVPs — specs use


### PR DESCRIPTION
## Summary

Phase 2 group (f) of the E2E suite v2 (umbrella #28): **j24 polls** — rewrites of the two pre-v2 poll specs onto the new journey infra (originals removed in de9fe360, recovered for selector/flow reference). `poll-duplicate` is @p3 and stays for #592.

### New specs (`tests/e2e/journeys/j24-polls/`)

- **`poll-admin.spec.ts`** (@p1, ui) — owner creates a poll through the builder: audience + result-timing via the bits-ui selects (`pickSelectOption`), anonymity + vote-change policy via the native checkboxes, one MC question through the Tiptap editor using the questionnaire builder's outcome-keyed re-fill save loop. Asserts the config round-trips on the detail page (anonymity is immutable post-create), opens the poll (share-URL strip asserted by input **value** — no clipboard permissions, so it runs on both projects, unlike the old chromium-only smoke), closes it.
- **`poll-vote.spec.ts`** (@p1, api-arranged) — polls created + opened via the new `createPoll` factory; charlie (seeded member) votes through the UI:
  - locked poll (defaults): vote sticks, **no** change/withdraw affordances, results stay hidden under `result_timing=never`;
  - permissive poll (`allow_vote_changes` + `members-only`/`after_vote` results): Results card appears after voting ("1 voter"), vote change proven end-to-end via the server-side prefill (re-entering edit mode shows the OTHER option selected), withdraw through the danger dialog restores the ballot and re-hides the results.

### Support kit

- **`createPoll` factory** — polls are **never seeded**; one API call creates a poll with a two-option MC question and optionally opens it. Assertions never depend on option order (the backend serves a per-viewer stable option shuffle).
- **`ApiClient.request` bounded 5xx retry** — a factory GET transiently 500'd mid-run; root-caused via container logs to Postgres `sorry, too many clients already` (connection exhaustion under parallel workers — not silk; the backend runs `FEATURE_OBSERVABILITY=False`). The client now retries 5xx up to 3× with backoff, exactly like `obtainTokenPair` already did. **4xx is never retried** — specs assert on those deliberately.

## Verification

- j24 alone: **18/18** on both projects, `--retries=0 --repeat-each=3`
- Fresh-DB full run (`reset_events` + `make bootstrap-tests`): **191 tests = 189 passed + 2 known mobile-viewport skips, zero failures, empty flaky list** (retries:1 in effect, none consumed) — first run at the new post-#609 baseline
- `make check` green; `make test` 844 passed

Part of #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb