### PR TITLE
test(e2e): Phase 2g — group (g) misc @p1 journey suites (#590)

### DIFF
--- a/src/routes/(public)/login/+page.svelte
+++ b/src/routes/(public)/login/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { applyAction, enhance } from '$app/forms';
@@ -221,7 +222,14 @@
 								showLoginForm = true;
 								// The toggle unmounts itself in the swap — move focus to the
 								// revealed form so keyboard users aren't dropped on <body>.
-								requestAnimationFrame(() => document.getElementById('email')?.focus());
+								// tick(), not rAF: the input only exists after the swap
+								// flushes, but rAF is paint-bound and under load can fire
+								// seconds late, stealing focus from a field the user (or a
+								// password manager) is already typing into — the same
+								// keystroke-spray bug as the register nudge (#608/#609).
+								// tick()'s microtask resolves before any further input
+								// events can interleave.
+								void tick().then(() => document.getElementById('email')?.focus());
 							}}
 							class="text-primary underline-offset-4 hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						>

--- a/tests/e2e/journeys/j02-registration/guest-upgrade.spec.ts
+++ b/tests/e2e/journeys/j02-registration/guest-upgrade.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { createGuestRsvp, createTicketedEvent } from '../../support/factories';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+import { fillRegistrationForm } from '../../support/auth-forms';
+import { uiLogin } from '../../support/session';
+
+// J2.4 (USER_JOURNEYS.md) — guest → account upgrade. A guest RSVP creates a
+// passwordless guest RevelUser; registering the same email does NOT create a
+// second account: the backend rejects the registration (400) but sends an
+// "Activate your account" email whose link is a set-password flow. Completing
+// it converts the SAME user record in place — so the guest's RSVP history is
+// already there when they first sign in.
+
+const PASSWORD = 'E2e-upgrade-Pass!123';
+
+test.describe('J2 guest upgrade keeps history @p1', () => {
+	test('a guest who registers the same email keeps their RSVP', async ({ page }) => {
+		// Arrange the guest leg via API (the guest UI journey itself is j07):
+		// a confirmed guest RSVP on a no-login event.
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: { requires_ticket: false, can_attend_without_login: true }
+		});
+		const guest = await createGuestRsvp(event.id, 'GuestUpgrade');
+
+		// Registering that email through the UI is refused (the address is
+		// taken by the guest user)…
+		await fillRegistrationForm(page, guest.email, PASSWORD);
+		await page.getByRole('button', { name: 'Create your account' }).click();
+		await expect(page.getByRole('alert').filter({ hasNotText: 'Demo Mode' }).first()).toBeVisible();
+		expect(new URL(page.url()).pathname).toBe('/register');
+
+		// …but it triggers the activation email, whose link sets a password on
+		// the existing guest account (reset-password flow).
+		const activation = await waitForEmail({ to: guest.email, subject: 'Activate your account' });
+		const link = extractLink(activation, /reset-password\?token=/);
+		await gotoHydrated(page, link);
+
+		const password = page.getByLabel('New password');
+		const confirm = page.getByLabel('Confirm password');
+		await expect(async () => {
+			await password.fill(PASSWORD);
+			await confirm.fill(PASSWORD);
+			await expect(password).toHaveValue(PASSWORD, { timeout: 2_000 });
+			await expect(confirm).toHaveValue(PASSWORD, { timeout: 2_000 });
+		}).toPass({ timeout: 30_000 });
+		await page.getByRole('button', { name: 'Reset password' }).click();
+		await expect(page.getByRole('heading', { name: 'Password reset successful' })).toBeVisible();
+
+		// First real sign-in: the guest-era RSVP is already in the account.
+		// The RSVP list query is gated on the client auth bootstrap and shows
+		// the empty state until the token exists — wait for auth first.
+		await uiLogin(page, { email: guest.email, password: PASSWORD });
+		await gotoHydrated(page, '/dashboard/rsvps');
+		await waitForClientAuth(page);
+		await expect(page.getByText(event.name).first()).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j02-registration/pending-invitation.spec.ts
+++ b/tests/e2e/journeys/j02-registration/pending-invitation.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { createTicketedEvent, inviteToEvent, uniqueEmail } from '../../support/factories';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+import { fillRegistrationForm } from '../../support/auth-forms';
+
+// J2.3 (USER_JOURNEYS.md) — inviting an email with no account creates a
+// PendingEventInvitation (and sends the invite email with a sign-up nudge);
+// when that email registers, a post_save signal converts it into a real
+// EventInvitation, waivers and all, which the new user finds on
+// /dashboard/invitations without anyone re-inviting them.
+
+const STRONG_PASSWORD = 'E2e-test-Pass!123';
+
+test.describe('J2 pending invitation auto-links on registration @p1', () => {
+	test('an invited email registers and finds the invitation in the dashboard', async ({ page }) => {
+		const event = await createTicketedEvent();
+		const email = uniqueEmail('PendingInvite');
+
+		// Invite the not-yet-registered address, with a waiver that must
+		// survive the pending → real conversion.
+		await inviteToEvent(event.id, [email], {
+			invitation: { waives_purchase: true }
+		});
+
+		// The invite email reaches the address even without an account.
+		const invite = await waitForEmail({ to: email, subject: "You're invited" });
+		expect(invite.Subject).toContain(event.name);
+
+		// Register that exact email through the UI…
+		await fillRegistrationForm(page, email, STRONG_PASSWORD);
+		await page.getByRole('button', { name: 'Create your account' }).click();
+		await page.waitForURL(/\/register\/check-email/);
+
+		// …and verify it (subject filter keeps us off the invitation email).
+		const verification = await waitForEmail({ to: email, subject: 'Verify your email' });
+		const link = extractLink(verification, /token=/);
+		await page.goto(link);
+		await page.waitForURL(/\/account\/profile/);
+
+		// The pending invitation was auto-converted: it shows up as a real
+		// invitation, waiver included. This fresh account has exactly one
+		// invitation, so page-level assertions are unambiguous. The list query
+		// is gated on the client auth bootstrap and renders the empty state
+		// until the token exists — wait for auth before asserting.
+		await gotoHydrated(page, '/dashboard/invitations');
+		await waitForClientAuth(page);
+		await expect(page.getByRole('link', { name: event.name })).toBeVisible();
+		await expect(page.getByText('Special Invitation')).toBeVisible();
+		await expect(page.getByText('Free admission')).toBeVisible();
+		await expect(page.getByRole('link', { name: 'View Event' })).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j02-registration/register-verify.spec.ts
+++ b/tests/e2e/journeys/j02-registration/register-verify.spec.ts
@@ -1,56 +1,17 @@
-import type { Page } from '@playwright/test';
 import { test, expect, PERSONAS } from '../../support/fixtures';
-import { gotoHydrated } from '../../support/navigation';
 import { uniqueEmail } from '../../support/factories';
 import { extractLink, waitForEmail } from '../../support/mailpit';
-import { revealRegistrationForm } from '../../support/auth-forms';
+import { fillRegistrationForm } from '../../support/auth-forms';
 
 // J2.1 (USER_JOURNEYS.md) — email registration: form → check-email page →
 // Mailpit verification link → verified. Unhappy paths: weak password,
 // already-registered email. Each run registers a unique throwaway address.
 //
 // On DEMO_MODE backends the form is gated behind a nudge overlay (#600);
-// revealRegistrationForm dismisses it and is a no-op on non-demo backends.
+// fillRegistrationForm dismisses it (via revealRegistrationForm) and is a
+// no-op on non-demo backends.
 
 const STRONG_PASSWORD = 'E2e-test-Pass!123';
-
-async function fillRegistrationForm(
-	page: Page,
-	email: string,
-	password: string,
-	{ expectSubmittable = true }: { expectSubmittable?: boolean } = {}
-): Promise<void> {
-	await gotoHydrated(page, '/register');
-	await revealRegistrationForm(page);
-
-	const emailInput = page.getByLabel('Email address');
-	const passwordInput = page.getByLabel('Password', { exact: true });
-	const confirmInput = page.getByLabel('Confirm password');
-	const terms = page.getByLabel(/I accept the/);
-	const submit = page.getByRole('button', { name: 'Create your account' });
-
-	// Outcome-keyed fill loop (same medicine as the questionnaire builder's
-	// Tiptap re-fill): a fill landing in the hydration-settling window can
-	// update the DOM without Svelte's $state ever learning about it, so the
-	// submit button (disabled on $state-derived canSubmit) never enables.
-	// Re-fill until the RENDERED state proves the values landed: the button
-	// enables (strong path) or the strength panel appears (weak path — it
-	// renders only when the password $state is non-empty). fill() replaces
-	// the whole value, so a retry also repairs a corrupted field.
-	await expect(async () => {
-		await emailInput.fill(email);
-		await passwordInput.fill(password);
-		await confirmInput.fill(password);
-		if (!(await terms.isChecked())) await terms.check();
-		await expect(emailInput).toHaveValue(email, { timeout: 2_000 });
-		if (expectSubmittable) {
-			await expect(submit).toBeEnabled({ timeout: 2_000 });
-		} else {
-			await expect(passwordInput).toHaveValue(password, { timeout: 2_000 });
-			await expect(page.getByText('Password strength:')).toBeVisible({ timeout: 2_000 });
-		}
-	}).toPass({ timeout: 45_000 });
-}
 
 test.describe('J2 registration & email verification @p0', () => {
 	test('registers, receives the verification email, and verifies', async ({ page }) => {

--- a/tests/e2e/journeys/j04-member/member-access.spec.ts
+++ b/tests/e2e/journeys/j04-member/member-access.spec.ts
@@ -1,0 +1,85 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { waitForClientAuth } from '../../support/navigation';
+import { createTicketedEvent } from '../../support/factories';
+
+// J4 (USER_JOURNEYS.md) — members-only access is enforced per organization,
+// on both of the backend's independent axes:
+//
+// - `event_type: members-only` (the seeded Beta events): the event is
+//   publicly *visible*, but only members get the RSVP affordance — everyone
+//   else gets the "Members only" gate with a Join Organization CTA.
+// - `visibility: members-only` (arranged; nothing seeded uses it): the event
+//   is *hidden* from non-members outright — direct URL → 404.
+//
+// Frank (betaMember) is a Beta member with a seeded YES RSVP on the workshop;
+// all assertions here are read-only so his seeded state stays untouched.
+
+const BETA_WORKSHOP = '/events/tech-innovators-network/ai-apis-workshop';
+
+async function openEvent(page: Page, path: string): Promise<void> {
+	await page.goto(path);
+	await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+	// The RSVP card / gate renders from the authenticated eligibility query —
+	// wait for the client auth bootstrap before asserting on it.
+	await waitForClientAuth(page);
+}
+
+test.describe('J4 members-only access @p1', () => {
+	test('a Beta member gets the RSVP affordance on a Beta members-only event', async ({
+		asBetaMember
+	}) => {
+		await openEvent(asBetaMember, BETA_WORKSHOP);
+
+		// Frank arrives with his seeded YES RSVP, so instead of the "Will you
+		// attend?" ask he gets the attending state + a way to change it — and
+		// crucially, no membership gate. Read-only: nothing here mutates it.
+		await expect(
+			asBetaMember.getByRole('status').filter({ hasText: "You're attending" })
+		).toBeVisible();
+		await expect(asBetaMember.getByRole('button', { name: 'Change RSVP' })).toBeVisible();
+		await expect(asBetaMember.getByRole('heading', { name: 'Members only' })).toBeHidden();
+		await expect(asBetaMember.getByRole('button', { name: 'Join Organization' })).toBeHidden();
+	});
+
+	test('a non-member sees the join gate instead of the RSVP card', async ({ asUser }) => {
+		await openEvent(asUser, BETA_WORKSHOP);
+
+		await expect(asUser.getByRole('heading', { name: 'Members only' })).toBeVisible();
+		await expect(asUser.getByRole('button', { name: 'Join Organization' })).toBeVisible();
+		await expect(asUser.getByRole('button', { name: /^RSVP Yes/ })).toBeHidden();
+	});
+
+	test('membership does not cross organizations', async ({ asMember }) => {
+		// Charlie is an Org Alpha member — Beta's members-only event still gates him.
+		await openEvent(asMember, BETA_WORKSHOP);
+
+		await expect(asMember.getByRole('heading', { name: 'Members only' })).toBeVisible();
+		await expect(asMember.getByRole('button', { name: /^RSVP Yes/ })).toBeHidden();
+	});
+
+	test('a members-only-visibility event is hidden from non-members entirely', async ({
+		asMember,
+		asUser
+	}) => {
+		// Nothing seeded uses visibility=members-only — arrange an Org Alpha
+		// event so charlie (member) can see it and hannah (no membership) can't.
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: {
+				event_type: 'members-only',
+				visibility: 'members-only',
+				requires_ticket: false
+			}
+		});
+
+		// The member reaches the detail page and is eligible to RSVP.
+		await openEvent(asMember, event.path);
+		await expect(asMember.getByRole('heading', { name: event.name, level: 1 })).toBeVisible();
+		await expect(asMember.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+
+		// The non-member gets a 404 — the event does not exist for her.
+		const response = await asUser.goto(event.path);
+		expect(response?.status()).toBe(404);
+	});
+});

--- a/tests/e2e/journeys/j07-guest-attendee/guest-rsvp.spec.ts
+++ b/tests/e2e/journeys/j07-guest-attendee/guest-rsvp.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated } from '../../support/navigation';
+import { createTicketedEvent, uniqueEmail } from '../../support/factories';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+
+// J7.1 (USER_JOURNEYS.md) — RSVP without an account on a
+// `can_attend_without_login` event: name+email dialog → confirmation email
+// (the RSVP is NOT created yet) → following the emailed link confirms it.
+// The whole journey runs logged out.
+
+test.describe('J7 guest RSVP @p1', () => {
+	test('RSVPs with name and email and confirms via the emailed link', async ({ page }) => {
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: { requires_ticket: false, can_attend_without_login: true }
+		});
+		const email = uniqueEmail('GuestRsvp');
+
+		// Logged out, the RSVP card offers the guest path.
+		await gotoHydrated(page, event.path);
+		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+		await page.getByRole('button', { name: 'Submit RSVP' }).click();
+
+		// Guest dialog: identify + answer (defaults to yes). The dialog's submit
+		// shares its "Submit RSVP" label with the page CTA, so stay scoped to
+		// the dialog.
+		const dialog = page.getByRole('dialog', { name: 'RSVP without an account' });
+		await expect(dialog).toBeVisible();
+		await expect(async () => {
+			await dialog.getByLabel('Email address').fill(email);
+			await dialog.getByLabel('First name').fill('E2E');
+			await dialog.getByLabel('Last name').fill('Guest');
+			await expect(dialog.getByLabel('Email address')).toHaveValue(email, { timeout: 2_000 });
+		}).toPass({ timeout: 30_000 });
+		await dialog.getByRole('button', { name: 'Submit RSVP' }).click();
+
+		// Two-step contract: nothing is booked yet — the dialog says to go
+		// confirm from the inbox.
+		await expect(dialog.getByText('Check your email!')).toBeVisible();
+		await expect(dialog.getByText(email)).toBeVisible();
+
+		// The confirmation email names the event and links to /events/confirm-action.
+		const message = await waitForEmail({ to: email, subject: 'Confirm your RSVP to' });
+		expect(message.Subject).toContain(event.name);
+		const link = extractLink(message, /confirm-action\?token=/);
+
+		// Following the link creates the RSVP (the page confirms on mount; the
+		// heading role dodges the sr-only live-region twin of the same text).
+		// The confirm POST has no retry of its own, so a transient backend 5xx
+		// under parallel load surfaces as the failure state — retry through
+		// the UI's own Try Again button until the confirmation lands.
+		await page.goto(link);
+		await expect(async () => {
+			const retry = page.getByRole('button', { name: 'Try Again' });
+			if (await retry.isVisible()) await retry.click();
+			await expect(page.getByRole('heading', { name: 'RSVP Confirmed!' })).toBeVisible({
+				timeout: 10_000
+			});
+		}).toPass({ timeout: 45_000 });
+		await expect(page.getByRole('button', { name: 'View Event Details' })).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j12-invitations-tokens/direct-invitation.spec.ts
+++ b/tests/e2e/journeys/j12-invitations-tokens/direct-invitation.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import {
+	attachAdmissionQuestionnaire,
+	createTicketedEvent,
+	createVerifiedUser,
+	inviteToEvent
+} from '../../support/factories';
+import { waitForEmail } from '../../support/mailpit';
+import { authenticateContext } from '../../support/session';
+
+// J12.1 (USER_JOURNEYS.md) — direct invitation to a registered user: it
+// arrives in-app AND by email, shows on /dashboard/invitations with its
+// waiver privileges, and RSVPing from it skips the event's admission
+// questionnaire (waives_questionnaire). A second, uninvited user proves the
+// questionnaire gate is real — otherwise "the waiver worked" would be
+// indistinguishable from "there was no gate".
+
+const CUSTOM_MESSAGE = 'Come as our special guest — no questionnaire needed!';
+
+test.describe('J12 direct invitation @p1', () => {
+	test('delivers in-app + email, shows waivers, and skips the questionnaire on RSVP', async ({
+		browser
+	}) => {
+		// A non-ticketed event behind a published admission questionnaire.
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: { requires_ticket: false }
+		});
+		await attachAdmissionQuestionnaire(event);
+		const invitee = await createVerifiedUser('Invitee');
+		const control = await createVerifiedUser('Control');
+
+		await inviteToEvent(event.id, [invitee.email], {
+			invitation: { waives_questionnaire: true, custom_message: CUSTOM_MESSAGE }
+		});
+
+		// The invitation email goes out to the registered address.
+		const email = await waitForEmail({ to: invitee.email, subject: "You're invited" });
+		expect(email.Subject).toContain(event.name);
+
+		// CONTROL: without an invitation the questionnaire gate blocks the RSVP.
+		const controlContext = await browser.newContext();
+		await authenticateContext(controlContext, control);
+		const controlPage = await controlContext.newPage();
+		await controlPage.goto(event.path);
+		await expect(controlPage.getByRole('heading', { name: event.name, level: 1 })).toBeVisible();
+		await waitForClientAuth(controlPage);
+		await expect(
+			controlPage.getByRole('heading', { name: 'Questionnaire required' })
+		).toBeVisible();
+		await expect(controlPage.getByRole('button', { name: /^RSVP Yes/ })).toBeHidden();
+		await controlContext.close();
+
+		// INVITEE: the invitation reached the in-app inbox…
+		const context = await browser.newContext();
+		await authenticateContext(context, invitee);
+		const page = await context.newPage();
+		await gotoHydrated(page, '/dashboard');
+		await waitForClientAuth(page);
+		await page.getByRole('button', { name: 'Open notifications' }).click();
+		await expect(page.getByText(`You're invited to ${event.name}`)).toBeVisible();
+
+		// …and /dashboard/invitations shows the card with its privileges (the
+		// list query waits on the auth bootstrap — empty state until then).
+		await gotoHydrated(page, '/dashboard/invitations');
+		await waitForClientAuth(page);
+		await expect(page.getByRole('link', { name: event.name })).toBeVisible();
+		await expect(page.getByText('Special Invitation')).toBeVisible();
+		await expect(page.getByText('No questionnaire required')).toBeVisible();
+		await expect(page.getByText(CUSTOM_MESSAGE)).toBeVisible();
+
+		// View Event → the gate is waived: RSVP card instead of the
+		// questionnaire prompt.
+		await page.getByRole('link', { name: 'View Event' }).click();
+		await expect(page.getByRole('heading', { name: event.name, level: 1 })).toBeVisible();
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Questionnaire required' })).toBeHidden();
+		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+
+		// RSVP yes straight away. The attending status renders OPTIMISTICALLY
+		// (onMutate) — navigating on it aborts the in-flight POST and the RSVP
+		// never lands (the optimistic-mutation nav trap). Gate on the server
+		// response instead. (The onSuccess success banner is no good either:
+		// its local $state resets when invalidateAll() remounts the component.)
+		const [rsvpResponse] = await Promise.all([
+			page.waitForResponse(
+				(r) => r.request().method() === 'POST' && /\/rsvp\/yes$/.test(new URL(r.url()).pathname)
+			),
+			page.getByRole('button', { name: /^RSVP Yes/ }).click()
+		]);
+		expect(rsvpResponse.status()).toBe(200);
+		await expect(page.getByRole('status').filter({ hasText: "You're attending" })).toBeVisible();
+
+		// Accepted invitations drop off the default dashboard list
+		// (exclude_accepted) — this fresh account now shows none. Wait for
+		// auth first: the pre-bootstrap render shows the SAME empty state, so
+		// asserting it early would pass vacuously.
+		await gotoHydrated(page, '/dashboard/invitations');
+		await waitForClientAuth(page);
+		await expect(page.getByText("You haven't received any invitations")).toBeVisible();
+		await expect(page.getByRole('link', { name: event.name })).toBeHidden();
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j17-account-lifecycle/password-reset.spec.ts
+++ b/tests/e2e/journeys/j17-account-lifecycle/password-reset.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated } from '../../support/navigation';
+import { createVerifiedUser, uniqueEmail } from '../../support/factories';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+import { uiLogin } from '../../support/session';
+import { obtainTokenPair } from '../../support/api';
+
+// J17.1 (USER_JOURNEYS.md) — password reset: request at /password-reset →
+// Mailpit link → /login/reset-password → new password → login works with it
+// (and only it). The request response is deliberately generic — the same
+// success screen for unknown addresses, so accounts can't be enumerated.
+//
+// Registers a throwaway user per run: resetting a seeded persona's password
+// would break every parallel worker logging in as them.
+
+const NEW_PASSWORD = 'E2e-reset-Pass!456';
+
+test.describe('J17 password reset @p1', () => {
+	test('resets the password via the emailed link and signs in with it', async ({ page }) => {
+		const user = await createVerifiedUser('PwReset');
+
+		// Request the reset link.
+		await gotoHydrated(page, '/password-reset');
+		await page.getByLabel('Email address').fill(user.email);
+		await page.getByRole('button', { name: 'Send reset link' }).click();
+		await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
+
+		// Follow the emailed link (subject disambiguates from the signup
+		// verification email this address already received).
+		const message = await waitForEmail({ to: user.email, subject: 'Password reset request' });
+		const link = extractLink(message, /reset-password\?token=/);
+		await gotoHydrated(page, link);
+
+		// Set the new password. The submit is enabled from first render (gated
+		// only on isSubmitting), so re-fill until the values provably landed
+		// before clicking — a fill in the hydration-settling window can be
+		// swallowed by the input bindings catching up.
+		const password = page.getByLabel('New password');
+		const confirm = page.getByLabel('Confirm password');
+		await expect(async () => {
+			await password.fill(NEW_PASSWORD);
+			await confirm.fill(NEW_PASSWORD);
+			await expect(password).toHaveValue(NEW_PASSWORD, { timeout: 2_000 });
+			await expect(confirm).toHaveValue(NEW_PASSWORD, { timeout: 2_000 });
+		}).toPass({ timeout: 30_000 });
+		await page.getByRole('button', { name: 'Reset password' }).click();
+		await expect(page.getByRole('heading', { name: 'Password reset successful' })).toBeVisible();
+
+		// The old password is dead…
+		await expect(obtainTokenPair(user.email, user.password)).rejects.toThrow();
+
+		// …and the new one signs in through the UI (uiLogin lands on /dashboard).
+		await uiLogin(page, { email: user.email, password: NEW_PASSWORD });
+	});
+
+	test('answers an unknown email with the same generic success (no enumeration)', async ({
+		page
+	}) => {
+		await gotoHydrated(page, '/password-reset');
+		await page.getByLabel('Email address').fill(uniqueEmail('NoSuchAccount'));
+		await page.getByRole('button', { name: 'Send reset link' }).click();
+
+		// Identical outcome to the real-account path: same heading, same "if an
+		// account exists" phrasing, no error.
+		await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
+		await expect(page.getByText('If an account exists with that email')).toBeVisible();
+	});
+
+	test('explains an invalid or missing token instead of showing the form', async ({ page }) => {
+		await gotoHydrated(page, '/login/reset-password');
+
+		await expect(page.getByText('Invalid or missing reset token').first()).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Request new reset link' })).toBeVisible();
+		await expect(page.getByLabel('New password')).toBeHidden();
+	});
+});

--- a/tests/e2e/journeys/j18-series/series-page.spec.ts
+++ b/tests/e2e/journeys/j18-series/series-page.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated } from '../../support/navigation';
+
+// J18.1 (USER_JOURNEYS.md) — the public event-series page: hero with the
+// series badge, the events the series contains, and the way in from the org
+// profile. Read-only on seeded data.
+//
+// The seeded `monthly-tech-talks` series is a grouping-only series (no
+// RecurrenceRule → `is_recurring: false`), and the page's hero badge is the
+// unconditional "Event Series" badge — there is no separate "Recurring" badge
+// to assert with seeded data. Recurring-series authoring is j18
+// `recurring-admin` (@p2).
+
+const SERIES_PATH = '/events/tech-innovators-network/series/monthly-tech-talks';
+
+test.describe('J18 series page @p1', () => {
+	test('renders the series hero and lists its events', async ({ page }) => {
+		await gotoHydrated(page, SERIES_PATH);
+
+		// Hero: name, series badge, owning org attribution.
+		await expect(page.getByRole('heading', { name: 'Monthly Tech Talks', level: 1 })).toBeVisible();
+		await expect(page.getByText('Event Series', { exact: true }).first()).toBeVisible();
+		await expect(page.getByText('Tech Innovators Network').first()).toBeVisible();
+
+		// The seeded series contains the May tech talk, linked to its detail page.
+		await expect(page.getByRole('heading', { name: 'Events in this Series' })).toBeVisible();
+		const eventLink = page.getByRole('link', { name: /Tech Talk May: Scaling Microservices/ });
+		await expect(eventLink.first()).toBeVisible();
+
+		// Click-through lands on the event detail page.
+		await eventLink.first().click();
+		await page.waitForURL(/\/events\/tech-innovators-network\/tech-talk-may-2025/);
+		await expect(
+			page.getByRole('heading', { name: 'Tech Talk May: Scaling Microservices', level: 1 })
+		).toBeVisible();
+	});
+
+	test('is reachable from the org profile’s Event Series section', async ({ page }) => {
+		await gotoHydrated(page, '/org/tech-innovators-network');
+
+		await expect(page.getByRole('heading', { name: 'Event Series' })).toBeVisible();
+		// The card's overlay link accumulates the whole card into its
+		// accessible name ("Monthly Tech Talks, by Tech Innovators Network, …")
+		// — match on that prefix rather than the sr-only span.
+		const card = page.getByRole('link', {
+			name: /^Monthly Tech Talks, by Tech Innovators Network/
+		});
+		await card.first().click();
+
+		await page.waitForURL(/\/series\/monthly-tech-talks$/);
+		await expect(page.getByRole('heading', { name: 'Monthly Tech Talks', level: 1 })).toBeVisible();
+	});
+});

--- a/tests/e2e/support/auth-forms.ts
+++ b/tests/e2e/support/auth-forms.ts
@@ -1,5 +1,6 @@
-import type { Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { isDemoMode } from './skip';
+import { gotoHydrated } from './navigation';
 
 /**
  * Reach the real login / registration forms on DEMO_MODE backends (#600).
@@ -36,4 +37,47 @@ export async function revealRegistrationForm(page: Page): Promise<void> {
 			await page.getByLabel('Email address').waitFor({ timeout: 5_000 });
 		}
 	}
+}
+
+/**
+ * Navigate to /register and fill the registration form, leaving it ready to
+ * submit (shared by the j02 registration journeys).
+ *
+ * Outcome-keyed fill loop (same medicine as the questionnaire builder's
+ * Tiptap re-fill): a fill landing in the hydration-settling window can update
+ * the DOM without Svelte's $state ever learning about it, so the submit
+ * button (disabled on $state-derived canSubmit) never enables. Re-fill until
+ * the RENDERED state proves the values landed: the button enables (strong
+ * path) or the strength panel appears (weak path — it renders only when the
+ * password $state is non-empty). fill() replaces the whole value, so a retry
+ * also repairs a corrupted field.
+ */
+export async function fillRegistrationForm(
+	page: Page,
+	email: string,
+	password: string,
+	{ expectSubmittable = true }: { expectSubmittable?: boolean } = {}
+): Promise<void> {
+	await gotoHydrated(page, '/register');
+	await revealRegistrationForm(page);
+
+	const emailInput = page.getByLabel('Email address');
+	const passwordInput = page.getByLabel('Password', { exact: true });
+	const confirmInput = page.getByLabel('Confirm password');
+	const terms = page.getByLabel(/I accept the/);
+	const submit = page.getByRole('button', { name: 'Create your account' });
+
+	await expect(async () => {
+		await emailInput.fill(email);
+		await passwordInput.fill(password);
+		await confirmInput.fill(password);
+		if (!(await terms.isChecked())) await terms.check();
+		await expect(emailInput).toHaveValue(email, { timeout: 2_000 });
+		if (expectSubmittable) {
+			await expect(submit).toBeEnabled({ timeout: 2_000 });
+		} else {
+			await expect(passwordInput).toHaveValue(password, { timeout: 2_000 });
+			await expect(page.getByText('Password strength:')).toBeVisible({ timeout: 2_000 });
+		}
+	}).toPass({ timeout: 45_000 });
 }

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -264,18 +264,112 @@ export async function createEventToken(
 }
 
 /**
- * API-create direct invitations on an event owned by a seeded persona — the
- * ARRANGE step for inbox specs (creating an EventInvitation fires the
- * INVITATION_RECEIVED in-app notification via a post_save signal).
+ * API-create invitations on an event owned by a seeded persona (or a
+ * ThrowawayUser owner). The backend branches per email: a registered address
+ * gets a direct EventInvitation (which fires the INVITATION_RECEIVED in-app
+ * notification via a post_save signal), an unregistered one gets a
+ * PendingEventInvitation that auto-converts when that email registers.
+ * Waiver flags (`waives_questionnaire`, `waives_purchase`, …) and
+ * `custom_message` go in `options.invitation`.
  */
 export async function inviteToEvent(
 	eventId: string,
 	emails: string[],
-	owner: PersonaName = 'owner'
+	options: { owner?: PersonaName | ThrowawayUser; invitation?: Record<string, unknown> } = {}
 ): Promise<void> {
-	const persona = PERSONAS[owner];
-	const api = await ApiClient.login(persona.email, persona.password);
-	await api.post(`/api/event-admin/${eventId}/invitations`, { emails });
+	const { owner = 'owner' } = options;
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+	await api.post(`/api/event-admin/${eventId}/invitations`, {
+		emails,
+		...options.invitation
+	});
+}
+
+/**
+ * Create a PUBLISHED admission questionnaire (manual evaluation, one mandatory
+ * free-text question) on the event's org and assign it to the event — from
+ * then on the event's eligibility gate answers `next_step:
+ * "complete_questionnaire"` for users without a submission. Only ever attach
+ * to events the spec created itself, NEVER to seeded events (it would gate
+ * every other spec touching them).
+ */
+export async function attachAdmissionQuestionnaire(
+	event: CreatedEvent,
+	owner: PersonaName | ThrowawayUser = 'owner'
+): Promise<{ id: string; name: string }> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+
+	const org = await api.get<{ id: string }>(`/api/organizations/${event.orgSlug}`);
+	const name = uniqueName('Questionnaire');
+	const questionnaire = await api.post<{ id: string }>(
+		`/api/questionnaires/${org.id}/create-questionnaire`,
+		{
+			name,
+			min_score: 0,
+			evaluation_mode: 'manual',
+			status: 'published',
+			freetextquestion_questions: [{ question: 'Why do you want to attend?', is_mandatory: true }]
+		}
+	);
+	await api.post(`/api/questionnaires/${questionnaire.id}/events/${event.id}`);
+	return { id: questionnaire.id, name };
+}
+
+export interface GuestIdentity {
+	email: string;
+	firstName: string;
+	lastName: string;
+}
+
+/**
+ * Complete a full guest RSVP (no account) via the public API: submit the
+ * guest form payload, then confirm through the emailed token — only the
+ * confirmation actually creates the RSVP row (and its guest RevelUser). The
+ * event must have `can_attend_without_login: true`. ARRANGE step for the
+ * guest→account upgrade journey; the guest UI journey itself is j07.
+ */
+export async function createGuestRsvp(eventId: string, label = 'Guest'): Promise<GuestIdentity> {
+	const email = uniqueEmail(label);
+	const firstName = 'E2E';
+	const lastName = label;
+
+	const rsvp = await fetch(`${API_URL}/api/events/${eventId}/rsvp/yes/public`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ email, first_name: firstName, last_name: lastName })
+	});
+	if (!rsvp.ok) {
+		throw new ApiError(
+			rsvp.status,
+			'POST',
+			`/api/events/${eventId}/rsvp/yes/public`,
+			await rsvp.text()
+		);
+	}
+
+	const message = await waitForEmail({ to: email, subject: 'Confirm your RSVP' });
+	const link = extractLink(message, /confirm-action\?token=/);
+	const token = new URL(link).searchParams.get('token');
+	if (!token) {
+		throw new Error(`Guest confirmation link has no token: ${link}`);
+	}
+	const confirm = await fetch(`${API_URL}/api/events/guest-actions/confirm`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ token })
+	});
+	if (!confirm.ok) {
+		throw new ApiError(
+			confirm.status,
+			'POST',
+			'/api/events/guest-actions/confirm',
+			await confirm.text()
+		);
+	}
+
+	return { email, firstName, lastName };
 }
 
 /** Add a membership tier to a throwaway-owned org. */

--- a/tests/e2e/support/fixtures.ts
+++ b/tests/e2e/support/fixtures.ts
@@ -28,6 +28,7 @@ interface PersonaFixtures {
 	asUser: Page;
 	asMultiOrg: Page;
 	asBetaOwner: Page;
+	asBetaMember: Page;
 	asTestAdmin: Page;
 	asTestMember: Page;
 }
@@ -59,6 +60,7 @@ export const test = base.extend<PersonaFixtures & { _backendGuard: void }>({
 	asUser: personaFixture('user'),
 	asMultiOrg: personaFixture('multiOrg'),
 	asBetaOwner: personaFixture('betaOwner'),
+	asBetaMember: personaFixture('betaMember'),
 	asTestAdmin: personaFixture('testAdmin'),
 	asTestMember: personaFixture('testMember')
 });

--- a/tests/e2e/support/personas.ts
+++ b/tests/e2e/support/personas.ts
@@ -56,6 +56,11 @@ export const PERSONAS = {
 		'diana.owner@example.com',
 		'Org Beta (tech-innovators-network) owner — questionnaires, no Stripe'
 	),
+	betaMember: persona(
+		'betaMember',
+		'frank.member@example.com',
+		'Org Beta member (General tier), RSVP-yes on its seeded members-only events'
+	),
 	testAdmin: persona(
 		'testAdmin',
 		'test.admin@example.com',

--- a/tests/e2e/support/session.ts
+++ b/tests/e2e/support/session.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext, Page } from '@playwright/test';
+import { expect, type BrowserContext, type Page } from '@playwright/test';
 import { obtainTokenPair } from './api';
 import { PERSONAS, type PersonaName } from './personas';
 import { gotoHydrated } from './navigation';
@@ -67,8 +67,17 @@ export async function uiLogin(page: Page, who: PersonaName | Credentials): Promi
 		await page.getByRole('button', { name: /^Sign in as/ }).click();
 	} else {
 		if (demo) await revealLoginForm(page);
-		await page.getByLabel('Email address').fill(persona.email);
-		await page.getByLabel('Password', { exact: true }).fill(persona.password);
+		// Outcome-keyed re-fill: the form-reveal focus handoff (and any other
+		// late focus/hydration race) can spray a fill into the wrong field —
+		// re-fill until the rendered values prove both landed, then submit.
+		const emailInput = page.getByLabel('Email address');
+		const passwordInput = page.getByLabel('Password', { exact: true });
+		await expect(async () => {
+			await emailInput.fill(persona.email);
+			await passwordInput.fill(persona.password);
+			await expect(emailInput).toHaveValue(persona.email, { timeout: 2_000 });
+			await expect(passwordInput).toHaveValue(persona.password, { timeout: 2_000 });
+		}).toPass({ timeout: 30_000 });
 		await page.getByRole('button', { name: 'Sign in', exact: true }).click();
 	}
 	await page.waitForURL(/\/dashboard(\/|$|\?)/);


### PR DESCRIPTION
Part of #590 (umbrella #28) — **the last @p1 group**. Full-suite tally 191 → **217** (13 new tests × 2 projects).

## New suites
| Journey | Spec | Covers |
|---|---|---|
| j02 | `pending-invitation` | invite unregistered email → pending invitation email → UI registration → post_save auto-conversion → card on /dashboard/invitations with the waiver ("Free admission") preserved |
| j02 | `guest-upgrade` | confirmed guest RSVP (API-arranged) → registering the same email is refused (400) but sends "Activate your account" → set-password link converts the guest user in place → first sign-in already has the RSVP history |
| j04 | `member-access` | both members-only axes: `event_type` gates RSVP (frank sees attending state, hannah/charlie get the "Members only" + Join Organization gate — membership doesn't cross orgs) and `visibility` hides outright (member loads it, non-member 404s, API-arranged) |
| j07 | `guest-rsvp` | logged-out name+email RSVP dialog → "Check your email!" (two-step contract: nothing booked yet) → Mailpit link → RSVP Confirmed |
| j12 | `direct-invitation` | in-app + email delivery, waiver privileges on the card, `waives_questionnaire` skips a real gate (an uninvited control user proves the gate blocks), RSVP from the invitation, accepted invitations drop off the default list |
| j17 | `password-reset` | request → email link → new password → old password dead, new one signs in; identical generic success for unknown emails (no enumeration); invalid/missing token state |
| j18 | `series-page` | seeded `monthly-tech-talks` hero + events list + click-through, reachable from the org profile's Event Series section. (Seeded series is not recurring and the hero badge is the unconditional "Event Series" badge — recurring authoring is j18 `recurring-admin` @p2.) |

## App fix (same class as #608/#609)
The `/login` "Show login form" toggle focused `#email` in a rAF. Under load rAF fires seconds late — mid-fill — and sprays keystrokes into the email field (trace showed the password appended inside the email input). Now `tick()`: the input only exists after the swap flushes, so a sync focus can't work, but tick's microtask resolves before further input events can interleave. Small fix taken in-PR rather than filed, mirroring #609.

## Support kit
- `betaMember` (frank) persona + `asBetaMember` fixture (Beta member assertions).
- `inviteToEvent` gains an options bag (waivers, custom message, ThrowawayUser owner).
- New factories: `attachAdmissionQuestionnaire` (published admission questionnaire assigned to an arranged event — never seeded ones) and `createGuestRsvp` (guest RSVP + Mailpit token confirmation).
- `fillRegistrationForm` extracted from register-verify into `auth-forms.ts` for reuse.
- `uiLogin` credentials path hardened with the outcome-keyed re-fill loop.

## Trap notes encoded in the specs
- RSVP attending status renders **optimistically** (`onMutate`) — navigating on it aborts the in-flight POST; specs gate on the POST response (the onSuccess banner is no good either: `invalidateAll()` remounts the component and resets its `$state`).
- Dashboard list queries are gated on the client auth bootstrap and render their **empty state** until the token exists — `waitForClientAuth` before asserting (including before asserting an empty state, which would otherwise pass vacuously).
- The guest confirm-action page has no transient-5xx retry — specs drive its own Try Again button.

## Gates
- New specs: `--retries=0 --repeat-each=3`, both projects — **78/78 passed**.
- Fresh-DB full run (reset_events + bootstrap-tests): **215 passed + 2 expected mobile-viewport skips, zero flakes**, 2.0m.
- `make check` ✅ · `make test` **844 passed** ✅

Group (g) completes the @p1 tier; next up: #591 (@p2), #592 (@p3), #593 (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Login now places focus in the email field more reliably when the form appears.
  - Registration and authentication interactions are more dependable, including password validation, verification, and password reset flows.
  - Guest RSVPs, invitations, account upgrades, and membership-gated events now have expanded end-to-end coverage.
  - Event series pages and direct invitations now have broader validation across navigation, RSVP, questionnaire, and notification experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->