### PR TITLE
test(e2e): Phase 3a — j03/j17 @p2 account & lifecycle suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"glob": "^13.0.6",
 		"globals": "^17.7.0",
 		"jsdom": "^29.1.1",
+		"otplib": "^12.0.1",
 		"postcss": "^8.5.16",
 		"prettier": "~3.9.4",
 		"prettier-plugin-svelte": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 2.3.8
       isomorphic-dompurify:
         specifier: ^3.18.0
-        version: 3.18.0
+        version: 3.18.0(@noble/hashes@2.2.0)
       marked:
         specifier: ^18.0.5
         version: 18.0.5
@@ -183,7 +183,10 @@ importers:
         version: 17.7.0
       jsdom:
         specifier: ^29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
+      otplib:
+        specifier: ^12.0.1
+        version: 12.0.1
       postcss:
         specifier: ^8.5.16
         version: 8.5.16
@@ -222,7 +225,7 @@ importers:
         version: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0))
 
 packages:
 
@@ -635,6 +638,10 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -650,6 +657,24 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@otplib/core@12.0.1':
+    resolution: {integrity: sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==}
+
+  '@otplib/plugin-crypto@12.0.1':
+    resolution: {integrity: sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==}
+    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+
+  '@otplib/plugin-thirty-two@12.0.1':
+    resolution: {integrity: sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==}
+    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+
+  '@otplib/preset-default@12.0.1':
+    resolution: {integrity: sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==}
+    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+
+  '@otplib/preset-v11@12.0.1':
+    resolution: {integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==}
 
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
@@ -2206,6 +2231,9 @@ packages:
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
+  otplib@12.0.1:
+    resolution: {integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -2746,6 +2774,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thirty-two@1.0.2:
+    resolution: {integrity: sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==}
+    engines: {node: '>=0.2.6'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3216,7 +3248,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.1': {}
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -3377,6 +3411,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@noble/hashes@2.2.0':
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3390,6 +3427,29 @@ snapshots:
       fastq: 1.20.1
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@otplib/core@12.0.1': {}
+
+  '@otplib/plugin-crypto@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+
+  '@otplib/plugin-thirty-two@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      thirty-two: 1.0.2
+
+  '@otplib/preset-default@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/plugin-crypto': 12.0.1
+      '@otplib/plugin-thirty-two': 12.0.1
+
+  '@otplib/preset-v11@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/plugin-crypto': 12.0.1
+      '@otplib/plugin-thirty-two': 12.0.1
 
   '@oxc-project/types@0.138.0': {}
 
@@ -3666,7 +3726,7 @@ snapshots:
       svelte: 5.56.4(@typescript-eslint/types@8.62.1)
     optionalDependencies:
       vite: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0)
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0))
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -3996,7 +4056,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.9':
     dependencies:
@@ -4203,10 +4263,10 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -4516,9 +4576,9 @@ snapshots:
 
   heic2any@0.0.4: {}
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -4580,10 +4640,10 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-dompurify@3.18.0:
+  isomorphic-dompurify@3.18.0(@noble/hashes@2.2.0):
     dependencies:
       dompurify: 3.4.11
-      jsdom: 29.1.1
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - canvas
@@ -4600,17 +4660,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.1.1:
+  jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.1
       parse5: 8.0.1
@@ -4621,7 +4681,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -4798,6 +4858,12 @@ snapshots:
       word-wrap: 1.2.5
 
   orderedmap@2.1.1: {}
+
+  otplib@12.0.1:
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/preset-default': 12.0.1
+      '@otplib/preset-v11': 12.0.1
 
   p-limit@2.3.0:
     dependencies:
@@ -5363,6 +5429,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thirty-two@1.0.2: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -5471,7 +5539,7 @@ snapshots:
     optionalDependencies:
       vite: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0)
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.0)(yaml@2.9.0))
@@ -5497,7 +5565,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.20.0
       '@vitest/ui': 4.1.9(vitest@4.1.9)
-      jsdom: 29.1.1
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -5513,9 +5581,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:

--- a/tests/e2e/journeys/j03-account/billing-profile.spec.ts
+++ b/tests/e2e/journeys/j03-account/billing-profile.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '../../support/fixtures';
+import { createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J3.x (USER_JOURNEYS.md) — buyer billing profile on /account/settings:
+// create the profile through the "Billing Information" card, verify it
+// persists across a reload (the save button flips to "Update billing
+// information" and the VAT ID section appears once a profile exists).
+//
+// SPEC DRIFT, deliberate scope cut: the self-billing agreement checkbox is
+// behind BillingProfileForm's `showSelfBilling` prop, which only the
+// /account/referral page sets — and that page redirects any user without a
+// referral code to /dashboard, so a throwaway can never reach it. It's not
+// reachable from settings, so this spec covers the settings billing fields
+// only; self-billing is exercised by the referrer-authenticated j21 suite.
+
+test.describe('J03 billing profile @p2', () => {
+	test('creates the billing profile and it persists', async ({ browser }) => {
+		const user = await createVerifiedUser('Billing');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/settings');
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Billing Information' })).toBeVisible();
+
+		await page.getByLabel(/Legal Name/).fill('E2E Billing GmbH');
+		await page.getByLabel(/Billing Address/).fill('Teststraße 1, 1010 Wien');
+		await page.getByLabel(/^Country/).fill('at');
+		// The country input auto-uppercases.
+		await expect(page.getByLabel(/^Country/)).toHaveValue('AT');
+		await page.getByLabel(/Billing Email/).fill(user.email);
+
+		await page.getByRole('button', { name: 'Save billing information' }).click();
+		await expect(page.getByText('Billing information saved').first()).toBeVisible();
+
+		// Reload → fields hydrate from GET /api/me/billing; the form is now in
+		// update mode and the VAT ID section renders.
+		await gotoHydrated(page, '/account/settings');
+		await waitForClientAuth(page);
+		await expect(page.getByLabel(/Legal Name/)).toHaveValue('E2E Billing GmbH');
+		await expect(page.getByLabel(/Billing Address/)).toHaveValue('Teststraße 1, 1010 Wien');
+		await expect(page.getByLabel(/^Country/)).toHaveValue('AT');
+		await expect(page.getByRole('button', { name: 'Update billing information' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'VAT ID' })).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j03-account/dietary.spec.ts
+++ b/tests/e2e/journeys/j03-account/dietary.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '../../support/fixtures';
+import { createVerifiedUser, uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J3.7 (USER_JOURNEYS.md) — dietary profile on /account/profile: add a
+// preference (private), flip its visibility, add a restriction backed by a
+// NEWLY created food item (unique name — the autocomplete must offer to
+// create it), and remove both. Deletes go through a native confirm().
+//
+// Throwaway users: dietary rows accumulate per-user, and seeded personas'
+// profiles are off-limits (j08 asserts on their display names).
+
+test.describe('J03 dietary profile @p2', () => {
+	test('adds a private preference, toggles visibility, removes it', async ({ browser }) => {
+		const user = await createVerifiedUser('Dietary');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/profile');
+		await waitForClientAuth(page);
+		await expect(
+			page.getByRole('heading', { name: 'Dietary Preferences & Restrictions' })
+		).toBeVisible();
+
+		// Add a preference from the seeded reference list, private.
+		await page.getByRole('button', { name: 'Add Preference' }).click();
+		const dialog = page.getByRole('dialog', { name: 'Add Dietary Preference' });
+		await expect(dialog).toBeVisible();
+		// Native select — index 0 is the placeholder; read back what we picked
+		// so the card assertion doesn't hardcode reference data.
+		const select = dialog.getByLabel('Preference');
+		await expect(async () => {
+			await select.selectOption({ index: 1 });
+			expect(await select.inputValue()).not.toBe('');
+		}).toPass({ timeout: 15_000 });
+		const chosen = (await select.locator('option:checked').textContent())?.trim() ?? '';
+		expect(chosen).toBeTruthy();
+		await dialog.getByLabel(/Additional notes/).fill('E2E preference note');
+		await dialog.getByRole('radio', { name: /^Private - / }).check();
+		await dialog.getByRole('button', { name: 'Add Preference' }).click();
+		await expect(page.getByText('Dietary preference added successfully')).toBeVisible();
+		await expect(dialog).toBeHidden();
+
+		// The card survives a reload and carries its Private visibility toggle.
+		await gotoHydrated(page, '/account/profile');
+		await waitForClientAuth(page);
+		await expect(page.getByText(chosen, { exact: true })).toBeVisible();
+		await page.getByRole('button', { name: 'Private', exact: true }).click();
+		await expect(page.getByRole('button', { name: 'Public', exact: true })).toBeVisible();
+
+		// Remove (native confirm) → back to the empty state.
+		page.once('dialog', (d) => d.accept());
+		await page.getByRole('button', { name: `Remove ${chosen}` }).click();
+		await expect(page.getByText('Dietary preference removed')).toBeVisible();
+		await expect(page.getByText('No dietary preferences added yet')).toBeVisible();
+
+		await context.close();
+	});
+
+	test('adds a restriction with a new food item and removes it', async ({ browser }) => {
+		const user = await createVerifiedUser('Restrict');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/profile');
+		await waitForClientAuth(page);
+
+		// Unique food name → the autocomplete finds nothing and offers to
+		// create the item on save (also keeps parallel workers collision-free).
+		const foodName = uniqueName('Peanut');
+		await page.getByRole('button', { name: 'Add Restriction' }).click();
+		const dialog = page.getByRole('dialog', { name: 'Add Restriction' });
+		await expect(dialog).toBeVisible();
+		const foodInput = dialog.getByLabel(/Food or ingredient/);
+		await expect(async () => {
+			await foodInput.fill(foodName);
+			await expect(foodInput).toHaveValue(foodName, { timeout: 2_000 });
+		}).toPass({ timeout: 15_000 });
+		await expect(dialog.getByText('Will create new food item')).toBeVisible();
+		await dialog.getByLabel('Severity').selectOption('allergy');
+		await dialog.getByLabel('Notes').fill('E2E restriction note');
+		// Visibility defaults to public — leave it.
+		await dialog.getByRole('button', { name: 'Add Restriction' }).click();
+		await expect(page.getByText('Dietary restriction added successfully')).toBeVisible();
+		await expect(dialog).toBeHidden();
+
+		await expect(page.getByText(foodName)).toBeVisible();
+		await expect(page.getByText('Allergy', { exact: true })).toBeVisible();
+
+		page.once('dialog', (d) => d.accept());
+		await page.getByRole('button', { name: `Remove ${foodName}` }).click();
+		await expect(page.getByText('Dietary restriction removed')).toBeVisible();
+		await expect(page.getByText('No dietary restrictions added yet')).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j03-account/login-logout.spec.ts
+++ b/tests/e2e/journeys/j03-account/login-logout.spec.ts
@@ -32,10 +32,15 @@ async function expectAuthenticatedChrome(page: Page, isMobile: boolean): Promise
 	if (isMobile) {
 		await openMobileNav(page);
 		const drawer = mobileDrawer(page);
-		// The drawer body scrolls; Log Out sits at the bottom of the menu.
+		// The drawer body scrolls; Log Out sits at the bottom of the menu. The
+		// authenticated nav is still settling as client auth bootstraps, so the
+		// button can detach mid-scroll ("element is not stable") — retry the
+		// scroll+viewport assertion together, re-resolving the locator each pass.
 		const logoutButton = drawer.getByRole('button', { name: 'Log Out' });
-		await logoutButton.scrollIntoViewIfNeeded();
-		await expect(logoutButton).toBeInViewport();
+		await expect(async () => {
+			await logoutButton.scrollIntoViewIfNeeded();
+			await expect(logoutButton).toBeInViewport({ timeout: 1_000 });
+		}).toPass({ timeout: 15_000 });
 		await expect(drawer.getByRole('link', { name: 'Login', exact: true })).toBeHidden();
 		await drawer.getByRole('button', { name: 'Close menu' }).click();
 	} else {
@@ -48,9 +53,12 @@ async function expectLoggedOutChrome(page: Page, isMobile: boolean): Promise<voi
 	if (isMobile) {
 		await openMobileNav(page);
 		const drawer = mobileDrawer(page);
+		// Same re-render race as the authenticated variant (see above).
 		const loginLink = drawer.getByRole('link', { name: 'Login', exact: true });
-		await loginLink.scrollIntoViewIfNeeded();
-		await expect(loginLink).toBeInViewport();
+		await expect(async () => {
+			await loginLink.scrollIntoViewIfNeeded();
+			await expect(loginLink).toBeInViewport({ timeout: 1_000 });
+		}).toPass({ timeout: 15_000 });
 		await expect(drawer.getByRole('button', { name: 'Log Out' })).toBeHidden();
 		await drawer.getByRole('button', { name: 'Close menu' }).click();
 	} else {

--- a/tests/e2e/journeys/j03-account/notification-prefs.spec.ts
+++ b/tests/e2e/journeys/j03-account/notification-prefs.spec.ts
@@ -46,8 +46,8 @@ test.describe('J03 notification preferences @p2', () => {
 		await expect(sendTime).toBeVisible();
 		await sendTime.fill('09:00');
 
-		// The advanced per-type section carries its own "Save Changes"; the
-		// master form's is the last one on the page.
+		// The settings page's general-preferences section has its own "Save
+		// Changes" button; the notification form's master save is the last one.
 		await page.getByRole('button', { name: 'Save Changes' }).last().click();
 		await expect(page.getByText('Notification preferences updated successfully')).toBeVisible();
 

--- a/tests/e2e/journeys/j03-account/notification-prefs.spec.ts
+++ b/tests/e2e/journeys/j03-account/notification-prefs.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '../../support/fixtures';
+import { createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J3.5 (USER_JOURNEYS.md) — notification preferences on /account/settings:
+// master toggles, channel checkboxes, digest frequency (+ send time revealed
+// for daily/weekly), all persisted through a single "Save Changes" PATCH.
+// The controls are bits-ui (role=checkbox buttons / role=radio group), not
+// native inputs.
+//
+// Throwaway user: preferences are per-user singletons — mutating a seeded
+// persona's would leak into every other suite's notification expectations.
+
+test.describe('J03 notification preferences @p2', () => {
+	test('saves channel, reminder and digest changes and they persist', async ({ browser }) => {
+		const user = await createVerifiedUser('NotifPrefs');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/settings');
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Master Controls' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Notification Channels' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Digest Settings' })).toBeVisible();
+
+		// Silence-all disables every other control while checked.
+		const silenceAll = page.getByRole('checkbox', { name: 'Silence all notifications' });
+		const eventReminders = page.getByRole('checkbox', { name: 'Event reminders' });
+		await silenceAll.check();
+		await expect(eventReminders).toBeDisabled();
+		await silenceAll.uncheck();
+		await expect(eventReminders).toBeEnabled();
+
+		// Defaults: in_app + email enabled, digest immediate. Drop the email
+		// channel and switch to a daily 09:00 digest.
+		const emailChannel = page.getByRole('checkbox', { name: 'Email', exact: true });
+		await expect(emailChannel).toBeChecked();
+		await emailChannel.uncheck();
+		// Telegram stays disabled until an account is linked.
+		await expect(page.getByRole('checkbox', { name: 'Telegram' })).toBeDisabled();
+
+		await page.getByRole('radio', { name: 'Daily' }).check();
+		const sendTime = page.getByLabel('Send time');
+		await expect(sendTime).toBeVisible();
+		await sendTime.fill('09:00');
+
+		// The advanced per-type section carries its own "Save Changes"; the
+		// master form's is the last one on the page.
+		await page.getByRole('button', { name: 'Save Changes' }).last().click();
+		await expect(page.getByText('Notification preferences updated successfully')).toBeVisible();
+
+		// Reload → the server-loaded form reflects the saved state.
+		await gotoHydrated(page, '/account/settings');
+		await waitForClientAuth(page);
+		await expect(page.getByRole('checkbox', { name: 'Email', exact: true })).not.toBeChecked();
+		await expect(page.getByRole('checkbox', { name: 'In-App' })).toBeChecked();
+		await expect(page.getByRole('radio', { name: 'Daily' })).toBeChecked();
+		// The backend stores seconds; the native time input reads back 09:00:00.
+		await expect(page.getByLabel('Send time')).toHaveValue(/^09:00(:00)?$/);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j17-account-lifecycle/2fa.spec.ts
+++ b/tests/e2e/journeys/j17-account-lifecycle/2fa.spec.ts
@@ -20,10 +20,10 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 // retries in an outcome-keyed loop — a code minted near a 30s boundary can
 // expire between generate and verify.
 
-/** Fill the 6-digit TwoFactorInput; each box is #otp-input-N. */
+/** Fill the 6-digit TwoFactorInput; each box is labelled "Digit N". */
 async function fillOtp(page: Page, code: string): Promise<void> {
 	for (let i = 0; i < 6; i++) {
-		await page.locator(`#otp-input-${i}`).fill(code[i]);
+		await page.getByLabel(`Digit ${i + 1}`, { exact: true }).fill(code[i]);
 	}
 }
 

--- a/tests/e2e/journeys/j17-account-lifecycle/2fa.spec.ts
+++ b/tests/e2e/journeys/j17-account-lifecycle/2fa.spec.ts
@@ -1,0 +1,128 @@
+import { authenticator } from 'otplib';
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { obtainTokenPair } from '../../support/api';
+import { createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { revealLoginForm } from '../../support/auth-forms';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J17.2 (USER_JOURNEYS.md) — TOTP 2FA lifecycle: enable on
+// /account/security (the base32 secret is exposed behind "Can't scan?
+// Enter manually" — otplib generates codes from it), then prove login now
+// requires the code (the password step answers with a temp token and the
+// login page swaps to the 6-digit form), then disable again.
+//
+// Throwaway user: 2FA on a seeded persona would lock every other worker's
+// API login for that persona out (obtainTokenPair has no OTP step).
+//
+// TOTP codes are time-windowed, so every submit generates a FRESH code and
+// retries in an outcome-keyed loop — a code minted near a 30s boundary can
+// expire between generate and verify.
+
+/** Fill the 6-digit TwoFactorInput; each box is #otp-input-N. */
+async function fillOtp(page: Page, code: string): Promise<void> {
+	for (let i = 0; i < 6; i++) {
+		await page.locator(`#otp-input-${i}`).fill(code[i]);
+	}
+}
+
+/** Generate-fill-submit with fresh codes until `success` becomes visible. */
+async function submitOtpUntil(
+	page: Page,
+	secret: string,
+	submitName: string,
+	success: () => Promise<void>
+): Promise<void> {
+	for (let attempt = 1; ; attempt++) {
+		await fillOtp(page, authenticator.generate(secret));
+		const submit = page.getByRole('button', { name: submitName });
+		await expect(submit).toBeEnabled();
+		await submit.click();
+		try {
+			await success();
+			return;
+		} catch (error) {
+			if (attempt >= 4) throw error;
+		}
+	}
+}
+
+test.describe('J17 two-factor authentication @p2', () => {
+	test('enables TOTP, login requires the code, then disables it', async ({ browser }) => {
+		test.setTimeout(240_000);
+		const user = await createVerifiedUser('TwoFA');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/security');
+		await waitForClientAuth(page);
+		await expect(
+			page.getByRole('heading', { name: 'Two-Factor Authentication (2FA)' })
+		).toBeVisible();
+		await expect(page.getByText('Disabled', { exact: true })).toBeVisible();
+
+		// Enable: the setup panel exposes the provisioning secret as text.
+		await page.getByRole('button', { name: 'Enable 2FA' }).click();
+		await expect(
+			page.getByRole('heading', { name: 'Set up Two-Factor Authentication' })
+		).toBeVisible();
+		await page.getByText("Can't scan? Enter manually").click();
+		const secret = (await page.locator('details code').innerText()).trim();
+		expect(secret).toMatch(/^[A-Z2-7]+$/);
+
+		await submitOtpUntil(page, secret, 'Verify and Enable 2FA', async () => {
+			await expect(page.getByText('Enabled', { exact: true })).toBeVisible({ timeout: 15_000 });
+		});
+
+		// The plain password grant no longer yields a token pair…
+		await expect(obtainTokenPair(user.email, user.password)).rejects.toThrow(/2FA/);
+
+		// …and a UI login gets the second, 6-digit step. Fresh context: the
+		// first one still holds a valid session.
+		const loginContext = await browser.newContext();
+		const loginPage = await loginContext.newPage();
+		await gotoHydrated(loginPage, '/login');
+		await revealLoginForm(loginPage);
+		const emailInput = loginPage.getByLabel('Email address');
+		const passwordInput = loginPage.getByLabel('Password', { exact: true });
+		await expect(async () => {
+			await emailInput.fill(user.email);
+			await passwordInput.fill(user.password);
+			await expect(emailInput).toHaveValue(user.email, { timeout: 2_000 });
+			await expect(passwordInput).toHaveValue(user.password, { timeout: 2_000 });
+		}).toPass({ timeout: 30_000 });
+		await loginPage.getByRole('button', { name: 'Sign in', exact: true }).click();
+		await expect(
+			loginPage.getByRole('heading', { name: 'Two-factor authentication' })
+		).toBeVisible();
+
+		await submitOtpUntil(loginPage, secret, 'Verify and sign in', async () => {
+			await loginPage.waitForURL(/\/dashboard(\/|$|\?)/, { timeout: 15_000 });
+		});
+
+		// Disable from the freshly logged-in session. The card's toggle button
+		// unmounts once the panel opens, so the panel submit's identical name
+		// stays unique.
+		await gotoHydrated(loginPage, '/account/security');
+		await waitForClientAuth(loginPage);
+		await expect(loginPage.getByText('Enabled', { exact: true })).toBeVisible();
+		await loginPage.getByRole('button', { name: 'Disable 2FA' }).click();
+		await expect(
+			loginPage.getByRole('heading', { name: 'Disable Two-Factor Authentication' })
+		).toBeVisible();
+
+		await submitOtpUntil(loginPage, secret, 'Disable 2FA', async () => {
+			await expect(loginPage.getByText('Disabled', { exact: true })).toBeVisible({
+				timeout: 15_000
+			});
+		});
+
+		// Password-only login works again.
+		await obtainTokenPair(user.email, user.password);
+
+		await loginContext.close();
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j17-account-lifecycle/account-deletion.spec.ts
+++ b/tests/e2e/journeys/j17-account-lifecycle/account-deletion.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '../../support/fixtures';
+import { obtainTokenPair } from '../../support/api';
+import { createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+
+// J17.5 (USER_JOURNEYS.md) — account deletion: the Danger Zone modal on
+// /account/privacy requires an explicit "I understand" checkbox and only
+// EMAILS a confirmation link; the account dies when the link's page's
+// "Permanently Delete Account" is pressed. Afterwards the credentials are
+// dead. Deletion itself runs async (eager Celery inline here), so the final
+// login check polls instead of asserting once.
+//
+// Throwaway user, obviously. It must not own an org (the backend 403s
+// deletion for active org owners) — createVerifiedUser doesn't create one.
+
+test.describe('J17 account deletion @p2', () => {
+	test('deletes the account via the emailed confirmation and login dies', async ({ browser }) => {
+		test.setTimeout(150_000);
+		const user = await createVerifiedUser('Delete');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/privacy');
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Danger Zone' })).toBeVisible();
+
+		await page.getByRole('button', { name: 'Delete My Account' }).click();
+		const modal = page.getByRole('dialog', { name: 'Permanently Delete Account?' });
+		await expect(modal).toBeVisible();
+		const confirmSend = modal.getByRole('button', { name: 'Send Confirmation Email' });
+		await expect(confirmSend).toBeDisabled();
+		await modal.getByLabel('I understand this action is permanent and cannot be reversed').check();
+		await confirmSend.click();
+		await expect(page.getByText('Deletion confirmation email sent')).toBeVisible();
+
+		const message = await waitForEmail({ to: user.email, subject: 'Confirm Account Deletion' });
+		const link = extractLink(message, /confirm-deletion\?token=/);
+
+		await gotoHydrated(page, link);
+		await expect(
+			page.getByRole('heading', { level: 1, name: 'Confirm Account Deletion' })
+		).toBeVisible();
+		await page.getByRole('button', { name: 'Permanently Delete Account' }).click();
+		await expect(page.getByRole('heading', { name: 'Account Deleted' })).toBeVisible();
+
+		// The credentials stop working once the (async) deletion lands.
+		await expect
+			.poll(
+				async () => {
+					try {
+						await obtainTokenPair(user.email, user.password);
+						return 'alive';
+					} catch {
+						return 'gone';
+					}
+				},
+				{ timeout: 30_000 }
+			)
+			.toBe('gone');
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j17-account-lifecycle/email-change.spec.ts
+++ b/tests/e2e/journeys/j17-account-lifecycle/email-change.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '../../support/fixtures';
+import { obtainTokenPair } from '../../support/api';
+import { createVerifiedUser, uniqueEmail } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+
+// J17.3 (USER_JOURNEYS.md) — email change: request with the current password
+// on /account/security, the OLD address is notified immediately, the NEW
+// address gets the confirmation link, and confirming (an explicit button on
+// /account/confirm-email-change) re-issues a fresh token pair to THIS
+// session — every other device is signed out, but the confirming one
+// survives. Both addresses then get the "has been changed" notice.
+//
+// Throwaway user: changes the account's login identity — never a persona.
+
+test.describe('J17 email change @p2', () => {
+	test('changes the sign-in email via the confirmation link, session survives', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const user = await createVerifiedUser('EmailChange');
+		const newEmail = uniqueEmail('emailchangenew');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/security');
+		await waitForClientAuth(page);
+		await page.getByRole('button', { name: 'Change email' }).click();
+		await expect(page.getByRole('heading', { name: 'Change your email' })).toBeVisible();
+
+		const emailInput = page.getByLabel('New email address');
+		const passwordInput = page.getByLabel('Current password');
+		await expect(async () => {
+			await emailInput.fill(newEmail);
+			await passwordInput.fill(user.password);
+			await expect(emailInput).toHaveValue(newEmail, { timeout: 2_000 });
+			await expect(passwordInput).toHaveValue(user.password, { timeout: 2_000 });
+		}).toPass({ timeout: 30_000 });
+		await page.getByRole('button', { name: 'Send confirmation link' }).click();
+		await expect(page.getByRole('heading', { name: 'Check your inbox' })).toBeVisible();
+
+		// Old address is warned at REQUEST time; new address gets the link.
+		await waitForEmail({
+			to: user.email,
+			subject: 'An email change was requested on your account'
+		});
+		const confirmation = await waitForEmail({
+			to: newEmail,
+			subject: 'Confirm your new email address'
+		});
+		const link = extractLink(confirmation, /confirm-email-change\?token=/);
+
+		// Confirm in the SAME context — the action swaps in a fresh token pair.
+		await gotoHydrated(page, link);
+		await expect(page.getByRole('heading', { name: 'Confirm your new email' })).toBeVisible();
+		await page.getByRole('button', { name: 'Confirm change' }).click();
+		await expect(page.getByRole('heading', { name: 'Email updated' })).toBeVisible();
+		await expect(page.getByText(`Your email has been updated to ${newEmail}`)).toBeVisible();
+
+		// Completion notices go to BOTH addresses.
+		await waitForEmail({ to: user.email, subject: 'Your Revel email address has been changed' });
+		await waitForEmail({ to: newEmail, subject: 'Your Revel email address has been changed' });
+
+		// The confirming session survives and shows the new address…
+		await gotoHydrated(page, '/account/security');
+		await waitForClientAuth(page);
+		await expect(page.getByText(newEmail).filter({ visible: true }).first()).toBeVisible();
+
+		// …and only the new email signs in from now on.
+		await obtainTokenPair(newEmail, user.password);
+		await expect(obtainTokenPair(user.email, user.password)).rejects.toThrow();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j17-account-lifecycle/gdpr-export.spec.ts
+++ b/tests/e2e/journeys/j17-account-lifecycle/gdpr-export.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../../support/fixtures';
+import { API_URL } from '../../support/api';
+import { createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+
+// J17.4 (USER_JOURNEYS.md) — GDPR data export: request on /account/privacy,
+// the export generates inline (eager Celery) and the download link arrives
+// BY EMAIL — a time-limited signed BACKEND url (/media/...?exp=&sig=), not a
+// frontend route, so it's fetched directly rather than page.goto'd.
+//
+// Throwaway user: the endpoint is rate-limited to one export per 24h.
+
+test.describe('J17 GDPR export @p2', () => {
+	test('requests an export and downloads it via the emailed signed link', async ({ browser }) => {
+		test.setTimeout(150_000);
+		const user = await createVerifiedUser('Gdpr');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/privacy');
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Export Your Data' })).toBeVisible();
+
+		await page.getByRole('button', { name: 'Request Data Export' }).click();
+		await expect(page.getByText('Data export request received')).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Export Requested' })).toBeDisabled();
+
+		// Eager Celery generates the file and sends the "ready" email as soon
+		// as the request transaction commits (the failure path has a distinct
+		// subject, so this also asserts generation succeeded).
+		const message = await waitForEmail(
+			{ to: user.email, subject: 'Your Revel Data Export is Ready' },
+			60_000
+		);
+		// The signed URL keeps its query HTML-encoded (&amp;sig=) until
+		// extractLink decodes it — match on the protected media path instead.
+		const link = extractLink(message, /\/media\/protected\//);
+
+		// The link is built from the backend's BASE_URL (the frontend origin in
+		// this env), but the protected media is served by the backend — the
+		// signature covers only the path, so re-point the host at the API.
+		const backendLink = link.replace(/^https?:\/\/[^/]+/, API_URL);
+		const response = await fetch(backendLink);
+		expect(response.status).toBe(200);
+		const body = await response.arrayBuffer();
+		expect(body.byteLength).toBeGreaterThan(0);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/support/api.ts
+++ b/tests/e2e/support/api.ts
@@ -28,23 +28,33 @@ export class ApiError extends Error {
 }
 
 /**
+ * fetch() with the same bounded 5xx retry ApiClient uses. Unauthenticated
+ * ARRANGE calls (register, verify, guest RSVP) bypass ApiClient, so they need
+ * their own guard against the dev backend's transient 500s under parallel
+ * load (observed: Postgres "sorry, too many clients already" when the
+ * threaded runserver piles connections past max_connections at peak). 4xx is
+ * returned as-is — callers assert on those deliberately.
+ */
+export async function fetchWithRetry(url: string, init?: RequestInit): Promise<Response> {
+	for (let attempt = 1; ; attempt++) {
+		const response = await fetch(url, init);
+		if (response.status < 500 || attempt >= 3) return response;
+		await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+	}
+}
+
+/**
  * Exchange credentials for a JWT pair (POST /api/auth/token/pair).
  * Retries transient 5xx responses — the dev backend can hiccup under the
  * parallel load of a full suite run.
  */
 export async function obtainTokenPair(email: string, password: string): Promise<TokenPair> {
-	let response: Response;
-	let text: string;
-	for (let attempt = 1; ; attempt++) {
-		response = await fetch(`${API_URL}/api/auth/token/pair`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ username: email, password })
-		});
-		text = await response.text();
-		if (response.status < 500 || attempt >= 3) break;
-		await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
-	}
+	const response = await fetchWithRetry(`${API_URL}/api/auth/token/pair`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ username: email, password })
+	});
+	const text = await response.text();
 	if (!response.ok) {
 		throw new ApiError(response.status, 'POST', '/api/auth/token/pair', text);
 	}

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import { API_URL, ApiClient, ApiError } from './api';
+import { API_URL, ApiClient, ApiError, fetchWithRetry } from './api';
 import { extractLink, waitForEmail } from './mailpit';
 import { PERSONAS, type PersonaName } from './personas';
 
@@ -48,7 +48,7 @@ export async function createVerifiedUser(label: string): Promise<ThrowawayUser> 
 	const firstName = 'E2E';
 	const lastName = label;
 
-	const register = await fetch(`${API_URL}/api/account/register`, {
+	const register = await fetchWithRetry(`${API_URL}/api/account/register`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({
@@ -71,7 +71,7 @@ export async function createVerifiedUser(label: string): Promise<ThrowawayUser> 
 	if (!token) {
 		throw new Error(`Verification link has no token: ${link}`);
 	}
-	const verify = await fetch(`${API_URL}/api/account/verify`, {
+	const verify = await fetchWithRetry(`${API_URL}/api/account/verify`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ token })
@@ -335,7 +335,7 @@ export async function createGuestRsvp(eventId: string, label = 'Guest'): Promise
 	const firstName = 'E2E';
 	const lastName = label;
 
-	const rsvp = await fetch(`${API_URL}/api/events/${eventId}/rsvp/yes/public`, {
+	const rsvp = await fetchWithRetry(`${API_URL}/api/events/${eventId}/rsvp/yes/public`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ email, first_name: firstName, last_name: lastName })
@@ -355,7 +355,7 @@ export async function createGuestRsvp(eventId: string, label = 'Guest'): Promise
 	if (!token) {
 		throw new Error(`Guest confirmation link has no token: ${link}`);
 	}
-	const confirm = await fetch(`${API_URL}/api/events/guest-actions/confirm`, {
+	const confirm = await fetchWithRetry(`${API_URL}/api/events/guest-actions/confirm`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ token })


### PR DESCRIPTION
Part of #591 (E2E suite v2 — Phase 3, @p2). First of the grouped PRs; groups b–f follow.

## New @p2 journey specs (16 test instances, green on chromium + mobile-chrome, `--retries=0 --repeat-each=3`, zero flakes)

**j03 — account basics**
- `dietary` — add preference (private) + restriction backed by a newly-created food item; visibility toggle; remove via native `confirm()`.
- `notification-prefs` — silence-all disables dependent controls; drop the email channel; daily digest + send-time; persistence across reload (bits-ui checkbox/radio controls).
- `billing-profile` — create the buyer billing profile and confirm it persists (form flips to "Update", VAT-ID section appears).

**j17 — account lifecycle** (all register throwaway users — these mutate/destroy the login identity)
- `2fa` — enable TOTP from the exposed base32 secret (adds `otplib` devDep), prove login now requires the second 6-digit step, disable.
- `email-change` — request with password → old address notified + new address confirms → the confirming session survives (fresh token pair) → only the new email logs in.
- `gdpr-export` — request → emailed signed backend link → direct fetch returns the export (200, non-empty).
- `account-deletion` — Danger-Zone modal → emailed confirmation → account gone, credentials dead.

## Support kit & in-PR fixes

- **`fetchWithRetry`** extracted in `support/api.ts`; the unauthenticated arrange calls (`register`/`verify`/guest RSVP + confirm) now use it, matching the bounded 5xx retry `ApiClient` already had (#610). These previously hard-failed on the dev backend's Postgres *"sorry, too many clients already"* transient under parallel load; now they ride over it.
- **Pre-existing @p0 flake fixed** in `login-logout` (surfaced by the full-suite run): `scrollIntoViewIfNeeded` on the mobile drawer's Log Out / Login button raced the auth-bootstrap re-render (`element is not stable`). Both scroll sites now retry the scroll+viewport assertion together, re-resolving the locator each pass — the same pattern `openMobileNav` already uses. Verified 12× stable on mobile-chrome.

## Gate

- Group specs: **48 passed** (both projects × repeat-each=3), zero flakes.
- Fresh-DB full suite: **230 passed / 2 mobile-viewport skips / 0 flaky** (tally 217 → 233).
- `make check` ✅ · `make test` (844) ✅

## Notes / drift

- The **self-billing agreement** checkbox only renders on `/account/referral` (behind `showSelfBilling`), which redirects non-referrers away — unreachable for a throwaway on `/account/settings`. `billing-profile` covers the settings fields only; self-billing belongs to the referrer-authenticated j21 suite.
- `otplib` pinned to `^12` (v13 is a plugin-based rewrite that drops the `authenticator` API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for billing profiles, dietary preferences, notification settings, TOTP two-factor authentication, account deletion, email changes, and GDPR data export.
  - Validates that settings persist after reload, critical security flows behave correctly, confirmation emails and export readiness work, and account lifecycle outcomes complete as expected.
  - Improved test reliability by adding retry handling for transient failures and adjusting mobile login/logout UI assertions to tolerate brief UI re-renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->