### PR TITLE
test(e2e): Phase 3b — j01/j02/j12/j15/j21 @p2 guest & public edges

### DIFF
--- a/tests/e2e/journeys/j01-guest/contact-org.spec.ts
+++ b/tests/e2e/journeys/j01-guest/contact-org.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '../../support/fixtures';
+import { ApiClient } from '../../support/api';
+import { createOrganization, createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { waitForEmail } from '../../support/mailpit';
+
+// J1.7 (USER_JOURNEYS.md) — public org contact form: a signed-in visitor sends
+// a message from the org page, the organizer receives it by email (subject
+// "[{org}] {subject}", Reply-To the sender). Seeded orgs default to
+// contact_method=none, so arrange an own public org with the form enabled.
+
+test.describe('J01 contact organizer @p2', () => {
+	test('submits the contact form and the organizer gets the email', async ({ browser }) => {
+		const [org, sender] = await Promise.all([
+			createOrganization(),
+			createVerifiedUser('Contacter')
+		]);
+		// Make the org publicly visible and switch its contact method to the form.
+		const ownerApi = await ApiClient.login(org.owner.email, org.owner.password);
+		await ownerApi.put(`/api/organization-admin/${org.slug}`, {
+			visibility: 'public',
+			contact_method: 'form'
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, sender);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+		await page.getByRole('button', { name: 'Contact organizer' }).click();
+		const dialog = page.getByRole('dialog', { name: `Contact ${org.name}` });
+		await expect(dialog).toBeVisible();
+
+		const subject = `E2E hello ${org.slug}`;
+		await dialog.getByLabel(/Subject/).fill(subject);
+		await dialog.getByLabel('Message').fill('Is this event wheelchair accessible?');
+		await dialog.getByRole('button', { name: 'Send message' }).click();
+
+		await expect(page.getByText('Your message has been sent.')).toBeVisible();
+		// On success the dialog's own title flips to "Message sent" (so the
+		// name-scoped `dialog` locator above is now stale) — assert at page level.
+		await expect(page.getByText('Message sent', { exact: true })).toBeVisible();
+
+		// The organizer's mailbox (the throwaway owner's address) receives it.
+		const mail = await waitForEmail({ to: org.owner.email, subject: `[${org.name}] ${subject}` });
+		expect(mail.Subject).toContain(subject);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j01-guest/legal-marketing.spec.ts
+++ b/tests/e2e/journeys/j01-guest/legal-marketing.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '../../support/fixtures';
+
+// J1.9 (USER_JOURNEYS.md) — the public legal pages (privacy/terms, backend
+// Markdown) and a representative marketing landing page render in English
+// with a level-1 heading and a 200 response. Read-only, no arrange.
+
+test.describe('J01 legal & marketing pages @p2', () => {
+	const pages = [
+		{ path: '/legal/privacy', heading: 'Privacy Policy' },
+		{ path: '/legal/terms', heading: 'Terms of Service' },
+		{ path: '/privacy-focused-events', heading: 'Event Management That Respects Privacy' }
+	];
+
+	for (const { path, heading } of pages) {
+		test(`renders ${path}`, async ({ page }) => {
+			const response = await page.goto(path);
+			expect(response?.status()).toBe(200);
+			await expect(page.getByRole('heading', { level: 1, name: heading })).toBeVisible();
+		});
+	}
+});

--- a/tests/e2e/journeys/j02-registration/referral-code-registration.spec.ts
+++ b/tests/e2e/journeys/j02-registration/referral-code-registration.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '../../support/fixtures';
+import { uniqueEmail } from '../../support/factories';
+import { revealRegistrationForm } from '../../support/auth-forms';
+import { gotoHydrated } from '../../support/navigation';
+
+// J2.4 (USER_JOURNEYS.md) — registering with a referral code. The seeded code
+// B2CREF01 (referrer.b2c@example.com) enters via ?ref= and auto-validates;
+// submitting lands on the check-email page. A bogus code is rejected inline.
+//
+// SPEC DRIFT (noted): the design's "verify via referrer payout page" isn't
+// achievable — a fresh registration creates the Referral row immediately but
+// no ReferralPayout (payouts only exist for periods with real payments), and
+// there's no referred-users list surface. So we assert the FE-observable
+// applied/rejected states and a successful submit instead.
+
+const CODE = 'B2CREF01';
+const PASSWORD = 'E2e-test-Pass!123';
+
+test.describe('J02 referral-code registration @p2', () => {
+	test('applies a valid code from ?ref= and registers', async ({ page }) => {
+		await gotoHydrated(page, `/register?ref=${CODE}`);
+		await revealRegistrationForm(page);
+
+		// The code auto-fills and validates on mount.
+		await expect(page.getByText('Referral code applied')).toBeVisible();
+		await expect(page.getByText(CODE, { exact: true })).toBeVisible();
+
+		const email = uniqueEmail('Referred');
+		const emailInput = page.getByLabel('Email address');
+		const passwordInput = page.getByLabel('Password', { exact: true });
+		const confirmInput = page.getByLabel('Confirm password');
+		const terms = page.getByLabel(/I accept the/);
+		const submit = page.getByRole('button', { name: 'Create your account' });
+		await expect(async () => {
+			await emailInput.fill(email);
+			await passwordInput.fill(PASSWORD);
+			await confirmInput.fill(PASSWORD);
+			if (!(await terms.isChecked())) await terms.check();
+			await expect(emailInput).toHaveValue(email, { timeout: 2_000 });
+			await expect(submit).toBeEnabled({ timeout: 2_000 });
+		}).toPass({ timeout: 45_000 });
+		await submit.click();
+
+		await page.waitForURL(/\/register\/check-email/);
+	});
+
+	test('rejects an invalid referral code inline', async ({ page }) => {
+		await gotoHydrated(page, '/register?ref=NOTAREALCODE');
+		await revealRegistrationForm(page);
+		await expect(page.getByText('Invalid referral code')).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j12-invitations-tokens/token-expiry.spec.ts
+++ b/tests/e2e/journeys/j12-invitations-tokens/token-expiry.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../../support/fixtures';
+import { ApiClient } from '../../support/api';
+import {
+	createEventToken,
+	createOrganization,
+	createOrgToken,
+	createTicketedEvent,
+	createVerifiedUser
+} from '../../support/factories';
+import { gotoHydrated } from '../../support/navigation';
+
+// J12.2 (USER_JOURNEYS.md) — expired vs used-up invitation tokens render
+// distinct 410 guidance (revel-backend#681). The existing j01 token-preview
+// spec already covers used-up ORG + expired EVENT; this fills the other two
+// quadrants: expired ORG and used-up EVENT. Both must show the reason and
+// offer NO "Sign In to Claim".
+
+test.describe('J12 token expiry guidance @p2', () => {
+	test('an expired org token explains expiry, not a claim CTA', async ({ page }) => {
+		const org = await createOrganization();
+		const token = await createOrgToken(org.owner, org.slug, org.defaultTierId);
+		// Backdate the expiry through the admin API (the factory has no expiry arg).
+		const ownerApi = await ApiClient.login(org.owner.email, org.owner.password);
+		await ownerApi.put(`/api/organization-admin/${org.slug}/tokens/${token.id}`, {
+			expires_at: new Date(Date.now() - 60_000).toISOString()
+		});
+
+		await gotoHydrated(page, `/join/org/${token.id}`);
+
+		await expect(page.getByText('This invitation is no longer valid')).toBeVisible();
+		await expect(page.getByText(`Your invitation to ${org.name} has expired.`)).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Sign In to Claim' })).toHaveCount(0);
+	});
+
+	test('a fully-used event token explains it is used up, not a claim CTA', async ({ page }) => {
+		const [event, claimer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('TokenExhauster')
+		]);
+		const token = await createEventToken(event.id, { maxUses: 1 });
+		// Exhaust the single use so the next viewer sees the used-up reason.
+		const claimerApi = await ApiClient.login(claimer.email, claimer.password);
+		await claimerApi.post(`/api/events/claim-invitation/${token.id}`);
+
+		await gotoHydrated(page, `/join/event/${token.id}`);
+
+		await expect(page.getByText('This invitation is no longer valid')).toBeVisible();
+		await expect(
+			page.getByText(`This invitation link to ${event.name} has already been fully used.`)
+		).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Sign In to Claim' })).toHaveCount(0);
+	});
+});

--- a/tests/e2e/journeys/j15-notifications/unsubscribe.spec.ts
+++ b/tests/e2e/journeys/j15-notifications/unsubscribe.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent, createVerifiedUser, inviteToEvent } from '../../support/factories';
+import { gotoHydrated } from '../../support/navigation';
+import { extractLink, waitForEmail } from '../../support/mailpit';
+
+// J15.2 (USER_JOURNEYS.md) — one-click unsubscribe: every notification email
+// carries a tokened /unsubscribe link; following it (no auth) and saving
+// confirms the preference change. A fresh user defaults to in_app+email
+// channels, so an invitation notification emails them with the footer link.
+
+test.describe('J15 unsubscribe @p2', () => {
+	test('follows the emailed unsubscribe link and saves preferences', async ({ page }) => {
+		const [user, event] = await Promise.all([
+			createVerifiedUser('Unsub'),
+			createTicketedEvent({ freeTier: false })
+		]);
+		// The invitation fires INVITATION_RECEIVED → email with the footer link.
+		await inviteToEvent(event.id, [user.email]);
+
+		const message = await waitForEmail({ to: user.email, subject: "You're invited" });
+		const link = extractLink(message, /\/unsubscribe\?token=/);
+
+		await gotoHydrated(page, link);
+		await expect(
+			page.getByRole('heading', { name: 'Unsubscribe from Notifications' })
+		).toBeVisible();
+
+		await page.getByRole('button', { name: 'Save Changes' }).last().click();
+		await expect(page.getByRole('heading', { name: 'Preferences Updated' })).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j21-referral/referral.spec.ts
+++ b/tests/e2e/journeys/j21-referral/referral.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../../support/fixtures';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J21 (USER_JOURNEYS.md) — the referrer surface: a seeded B2B referrer sees
+// their code on /account/referral and a PAID payout with a downloadable
+// self-billing statement on /account/referral/payouts. The referrer accounts
+// use password "password" (NOT the persona bootstrap password), and both
+// referral routes redirect users without a referral code away — so this must
+// run as an actual referrer.
+//
+// Payout amounts are computed from the previous month's real payments, so we
+// assert the "Paid" status + a viewable statement, never an exact figure.
+
+const REFERRER = { email: 'referrer.b2b@example.com', password: 'password' };
+
+test.describe('J21 referral program @p2', () => {
+	test('shows the referral code and a paid payout statement', async ({ browser }) => {
+		const context = await browser.newContext();
+		await authenticateContext(context, REFERRER);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, '/account/referral');
+		await waitForClientAuth(page);
+		// The mobile nav drawer also has a "Referral Program" heading — scope to h1.
+		await expect(page.getByRole('heading', { level: 1, name: 'Referral Program' })).toBeVisible();
+		await expect(page.getByText('Your referral code')).toBeVisible();
+		await expect(page.getByText('B2BREF01', { exact: true })).toBeVisible();
+
+		await gotoHydrated(page, '/account/referral/payouts');
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { level: 1, name: 'Payout History' })).toBeVisible();
+		// The seeded payout is PAID with a generated statement.
+		await expect(page.getByText('Paid', { exact: true }).first()).toBeVisible();
+		await page.getByRole('button', { name: 'View Statement' }).first().click();
+		// The mobile nav drawer is also role=dialog — scope to the statement one.
+		const dialog = page.getByRole('dialog', { name: 'Payout Statement' });
+		await expect(dialog).toBeVisible();
+		// B2B (VAT-registered) referrer → self-billing invoice document type.
+		await expect(dialog.getByText('Self-Billing Invoice (Gutschrift)')).toBeVisible();
+		await expect(dialog.getByRole('button', { name: 'Download PDF' })).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j21-referral/referral.spec.ts
+++ b/tests/e2e/journeys/j21-referral/referral.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../support/fixtures';
+import { API_URL } from '../../support/api';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 
@@ -17,29 +18,50 @@ const REFERRER = { email: 'referrer.b2b@example.com', password: 'password' };
 test.describe('J21 referral program @p2', () => {
 	test('shows the referral code and a paid payout statement', async ({ browser }) => {
 		const context = await browser.newContext();
-		await authenticateContext(context, REFERRER);
-		const page = await context.newPage();
+		try {
+			await authenticateContext(context, REFERRER);
+			const page = await context.newPage();
 
-		await gotoHydrated(page, '/account/referral');
-		await waitForClientAuth(page);
-		// The mobile nav drawer also has a "Referral Program" heading — scope to h1.
-		await expect(page.getByRole('heading', { level: 1, name: 'Referral Program' })).toBeVisible();
-		await expect(page.getByText('Your referral code')).toBeVisible();
-		await expect(page.getByText('B2BREF01', { exact: true })).toBeVisible();
+			await gotoHydrated(page, '/account/referral');
+			await waitForClientAuth(page);
+			// The mobile nav drawer also has a "Referral Program" heading — scope to h1.
+			await expect(page.getByRole('heading', { level: 1, name: 'Referral Program' })).toBeVisible();
+			await expect(page.getByText('Your referral code')).toBeVisible();
+			await expect(page.getByText('B2BREF01', { exact: true })).toBeVisible();
 
-		await gotoHydrated(page, '/account/referral/payouts');
-		await waitForClientAuth(page);
-		await expect(page.getByRole('heading', { level: 1, name: 'Payout History' })).toBeVisible();
-		// The seeded payout is PAID with a generated statement.
-		await expect(page.getByText('Paid', { exact: true }).first()).toBeVisible();
-		await page.getByRole('button', { name: 'View Statement' }).first().click();
-		// The mobile nav drawer is also role=dialog — scope to the statement one.
-		const dialog = page.getByRole('dialog', { name: 'Payout Statement' });
-		await expect(dialog).toBeVisible();
-		// B2B (VAT-registered) referrer → self-billing invoice document type.
-		await expect(dialog.getByText('Self-Billing Invoice (Gutschrift)')).toBeVisible();
-		await expect(dialog.getByRole('button', { name: 'Download PDF' })).toBeVisible();
+			await gotoHydrated(page, '/account/referral/payouts');
+			await waitForClientAuth(page);
+			await expect(page.getByRole('heading', { level: 1, name: 'Payout History' })).toBeVisible();
 
-		await context.close();
+			// Scope the status and the action to the SAME payout row (so a future
+			// second payout can't let us assert "Paid" on one and open another).
+			const paidRow = page.getByRole('row').filter({ hasText: 'Paid' }).first();
+			await expect(paidRow).toBeVisible();
+			await paidRow.getByRole('button', { name: 'View Statement' }).click();
+
+			// The mobile nav drawer is also role=dialog — scope to the statement one.
+			const dialog = page.getByRole('dialog', { name: 'Payout Statement' });
+			await expect(dialog).toBeVisible();
+			// B2B (VAT-registered) referrer → self-billing invoice document type.
+			await expect(dialog.getByText('Self-Billing Invoice (Gutschrift)')).toBeVisible();
+
+			// Exercise the actual download: the button hits the statement-download
+			// endpoint for a signed PDF URL (then opens it in a new tab). Assert the
+			// request succeeds and the signed URL it returns is itself fetchable.
+			const [downloadResponse] = await Promise.all([
+				page.waitForResponse(
+					(r) => r.url().includes('/statement/download') && r.request().method() === 'GET'
+				),
+				dialog.getByRole('button', { name: 'Download PDF' }).click()
+			]);
+			expect(downloadResponse.status()).toBe(200);
+			const { download_url } = (await downloadResponse.json()) as { download_url: string };
+			expect(download_url).toContain('/media/');
+			const pdf = await fetch(`${API_URL}${download_url}`);
+			expect(pdf.status).toBe(200);
+			expect((await pdf.arrayBuffer()).byteLength).toBeGreaterThan(0);
+		} finally {
+			await context.close();
+		}
 	});
 });


### PR DESCRIPTION
Part of #591 (E2E suite v2 — Phase 3, @p2). Second grouped PR; independent of #614 (group a).

## New @p2 journey specs (10 tests, green on chromium + mobile-chrome, `--retries=0 --repeat-each=3`, zero flakes)

- **j01/legal-marketing** — `/legal/privacy`, `/legal/terms`, and a marketing landing page each render (200 + level-1 heading).
- **j01/contact-org** — arrange an own public org with `contact_method=form`; a signed-in visitor sends a message and the organizer's mailbox receives it (subject `[{org}] {subject}`).
- **j02/referral-code-registration** — `?ref=B2CREF01` auto-applies ("Referral code applied") and registration lands on the check-email page; a bogus code is rejected inline.
- **j12/token-expiry** — the two 410 quadrants `j01/token-preview` didn't cover: an **expired org** token and a **used-up event** token, each showing the reason and no "Sign In to Claim".
- **j15/unsubscribe** — an invitation email's tokened `/unsubscribe` link (no auth) → save → "Preferences Updated".
- **j21/referral** — the seeded B2B referrer (`referrer.b2b@`, password `password`) sees code `B2BREF01` on `/account/referral` and a **Paid** payout with a self-billing statement + Download PDF on `/account/referral/payouts`.

## Gate

- Group specs: **60 passed** (both projects × repeat-each=3), zero flakes.
- Fresh-DB full suite: **235 passed / 2 mobile-viewport skips / 0 flaky** (branch tally 217 → 237).
- `make check` ✅ (no src/support-kit changes, so the unit suite is unaffected).

## Notes / drift

- **Referrer accounts use password `password`**, not the persona bootstrap `password123`; both `/account/referral*` routes redirect non-referrers to `/dashboard`, so this runs as an actual referrer.
- "Verify referral via referrer payout page" (the design's wording) isn't achievable for a *new* registration — the `Referral` row is created immediately but no `ReferralPayout` (payouts only exist for periods with real payments) and there's no referred-users surface. Spec asserts the FE-observable applied/rejected states + a successful submit instead.
- Mobile gotcha encoded: the mobile nav drawer is itself `role="dialog"` and carries section headings, so headings/dialogs are scoped (`level: 1`, dialog `name`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for contacting organizers and confirming message delivery.
  * Added checks for legal and marketing pages, including headings and successful page loads.
  * Added referral-code registration scenarios for valid and invalid codes.
  * Added invitation-token coverage for expired and fully used invitations.
  * Added notification unsubscribe flow validation.
  * Added referral program, payout history, statement, and PDF download checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->