### PR TITLE
feat(attendees): multi-select RSVP status filter (#616 partial)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -532,6 +532,7 @@
 		"statsNo": "No",
 		"searchPlaceholder": "Search by name or email...",
 		"filterAll": "All ({count})",
+		"filterByStatus": "Nach Status filtern",
 		"noRsvpsHeading": "No RSVPs found",
 		"noRsvpsFiltered": "Try adjusting your filters or search query.",
 		"noRsvpsEmpty": "No one has RSVP'd to this event yet.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -532,6 +532,7 @@
 		"statsNo": "No",
 		"searchPlaceholder": "Search by name or email...",
 		"filterAll": "All ({count})",
+		"filterByStatus": "Filter by status",
 		"noRsvpsHeading": "No RSVPs found",
 		"noRsvpsFiltered": "Try adjusting your filters or search query.",
 		"noRsvpsEmpty": "No one has RSVP'd to this event yet.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -419,6 +419,7 @@
 		"statsNo": "Non",
 		"searchPlaceholder": "Rechercher par nom ou e-mail...",
 		"filterAll": "Tous ({count})",
+		"filterByStatus": "Filtrer par statut",
 		"noRsvpsHeading": "Aucun RSVP trouvé",
 		"noRsvpsFiltered": "Essaie d'ajuster tes filtres ou ta recherche.",
 		"noRsvpsEmpty": "Personne n'a encore répondu à cet événement.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -532,6 +532,7 @@
 		"statsNo": "No",
 		"searchPlaceholder": "Search by name or email...",
 		"filterAll": "All ({count})",
+		"filterByStatus": "Filtra per stato",
 		"noRsvpsHeading": "No RSVPs found",
 		"noRsvpsFiltered": "Try adjusting your filters or search query.",
 		"noRsvpsEmpty": "No one has RSVP'd to this event yet.",

--- a/src/lib/components/attendees/AttendeeFilters.svelte
+++ b/src/lib/components/attendees/AttendeeFilters.svelte
@@ -5,13 +5,14 @@
 
 	interface Props {
 		searchInput: string;
-		activeStatusFilter: string | null;
+		activeStatusFilters: string[];
 		totalCount: number;
 		onSearch: (value: string) => void;
 		onStatusFilter: (status: string | null) => void;
 	}
 
-	const { searchInput, activeStatusFilter, totalCount, onSearch, onStatusFilter }: Props = $props();
+	const { searchInput, activeStatusFilters, totalCount, onSearch, onStatusFilter }: Props =
+		$props();
 </script>
 
 <div class="space-y-4">
@@ -24,14 +25,14 @@
 	/>
 
 	<!-- Filter buttons -->
-	<div class="flex flex-wrap gap-2">
+	<div class="flex flex-wrap gap-2" role="group" aria-label={m['attendeesAdmin.filterByStatus']()}>
 		<button
 			type="button"
 			onclick={() => onStatusFilter(null)}
-			aria-pressed={!activeStatusFilter}
+			aria-pressed={activeStatusFilters.length === 0}
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-				!activeStatusFilter
+				activeStatusFilters.length === 0
 					? 'bg-primary text-primary-foreground'
 					: 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
 			)}
@@ -41,10 +42,10 @@
 		<button
 			type="button"
 			onclick={() => onStatusFilter('yes')}
-			aria-pressed={activeStatusFilter === 'yes'}
+			aria-pressed={activeStatusFilters.includes('yes')}
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-				activeStatusFilter === 'yes'
+				activeStatusFilters.includes('yes')
 					? 'bg-green-600 text-white'
 					: 'border border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-green-950'
 			)}
@@ -54,10 +55,10 @@
 		<button
 			type="button"
 			onclick={() => onStatusFilter('maybe')}
-			aria-pressed={activeStatusFilter === 'maybe'}
+			aria-pressed={activeStatusFilters.includes('maybe')}
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-				activeStatusFilter === 'maybe'
+				activeStatusFilters.includes('maybe')
 					? 'bg-yellow-600 text-white'
 					: 'border border-yellow-600 text-yellow-600 hover:bg-yellow-50 dark:hover:bg-yellow-950'
 			)}
@@ -67,10 +68,10 @@
 		<button
 			type="button"
 			onclick={() => onStatusFilter('no')}
-			aria-pressed={activeStatusFilter === 'no'}
+			aria-pressed={activeStatusFilters.includes('no')}
 			class={cn(
 				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-				activeStatusFilter === 'no'
+				activeStatusFilters.includes('no')
 					? 'bg-red-600 text-white'
 					: 'border border-red-600 text-red-600 hover:bg-red-50 dark:hover:bg-red-950'
 			)}

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.server.ts
@@ -65,15 +65,19 @@ export const load: PageServerLoad = async ({ parent, params, locals, fetch, url 
 		redirect(302, `/org/${params.slug}/admin/events/${params.event_id}/tickets`);
 	}
 
-	// Get query parameters for filtering. `status` is untrusted external input,
-	// so validate it against the allowed RSVP statuses; anything else (incl. a
-	// crafted value that would 422 the API and silently empty the list) falls
-	// back to undefined = "all statuses".
-	const status = z
-		.enum(['yes', 'no', 'maybe'])
-		.optional()
-		.catch(undefined)
-		.parse(url.searchParams.get('status') || undefined);
+	// Get query parameters for filtering. `status` is untrusted external input:
+	// a comma-separated list of RSVP statuses (`status__in` on the backend).
+	// Validate each entry against the allowed statuses and drop anything else
+	// (incl. crafted values that would 422 the API and silently empty the list);
+	// dedupe while preserving order. An empty result degrades to "all statuses".
+	const statusItemSchema = z.enum(['yes', 'no', 'maybe']).optional().catch(undefined);
+	const statuses = (url.searchParams.get('status') || '')
+		.split(',')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0)
+		.map((s) => statusItemSchema.parse(s))
+		.filter((s): s is 'yes' | 'no' | 'maybe' => s !== undefined)
+		.filter((s, i, arr) => arr.indexOf(s) === i);
 	const search = url.searchParams.get('search') || undefined;
 	const page = parseInt(url.searchParams.get('page') || '1');
 	const pageSize = 100; // Fixed page size
@@ -89,7 +93,7 @@ export const load: PageServerLoad = async ({ parent, params, locals, fetch, url 
 			fetch,
 			path: { event_id: params.event_id },
 			query: {
-				status: status ? [status] : undefined,
+				status: statuses.length ? statuses : undefined,
 				search,
 				page,
 				page_size: pageSize,
@@ -121,7 +125,7 @@ export const load: PageServerLoad = async ({ parent, params, locals, fetch, url 
 		currentPage: page,
 		pageSize,
 		filters: {
-			status,
+			status: statuses,
 			search
 		}
 	};

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
@@ -36,7 +36,7 @@
 	// Filter state
 	let searchQuery = $state(data.filters.search || '');
 	let searchInput = $state(searchQuery); // For debouncing
-	let activeStatusFilter = $state<string | null>(data.filters.status || null);
+	let activeStatusFilters = $state<string[]>(data.filters.status ?? []);
 
 	// Modal states
 	let editingRsvp = $state<RsvpDetailSchema | null>(null);
@@ -272,7 +272,7 @@
 		const params = new URLSearchParams();
 
 		if (searchQuery) params.set('search', searchQuery);
-		if (activeStatusFilter) params.set('status', activeStatusFilter);
+		if (activeStatusFilters.length) params.set('status', activeStatusFilters.join(','));
 
 		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params)
 		goto(`?${params.toString()}`, { replaceState: true, keepFocus: true });
@@ -292,7 +292,13 @@
 	 * Filter by status
 	 */
 	function filterByStatus(status: string | null) {
-		activeStatusFilter = status;
+		if (status === null) {
+			activeStatusFilters = [];
+		} else if (activeStatusFilters.includes(status)) {
+			activeStatusFilters = activeStatusFilters.filter((s) => s !== status);
+		} else {
+			activeStatusFilters = [...activeStatusFilters, status];
+		}
 		applyFilters();
 	}
 
@@ -438,7 +444,7 @@
 	<!-- Filters & Search -->
 	<AttendeeFilters
 		{searchInput}
-		{activeStatusFilter}
+		{activeStatusFilters}
 		totalCount={data.totalCount}
 		onSearch={handleSearch}
 		onStatusFilter={filterByStatus}
@@ -450,7 +456,7 @@
 			<Users class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
 			<h3 class="mt-4 text-lg font-semibold">{m['attendeesAdmin.noRsvpsHeading']()}</h3>
 			<p class="mt-2 text-sm text-muted-foreground">
-				{#if activeStatusFilter || searchQuery}
+				{#if activeStatusFilters.length || searchQuery}
 					{m['attendeesAdmin.noRsvpsFiltered']()}
 				{:else}
 					{m['attendeesAdmin.noRsvpsEmpty']()}


### PR DESCRIPTION
## Summary

Widens the event-admin **Manage Attendees** status filter from single-select to **multi-select**. The backend already supports multiple statuses (`RSVPFilterSchema.status` is `list[RsvpStatus]` via `status__in`; the FE already sent `status` as a one-element array), so **no backend change is required** — this ships against the backend as it exists today.

- `+page.server.ts` — parse `status` as a comma-separated, validated, de-duplicated list; unknown values degrade to "all statuses".
- `AttendeeFilters.svelte` — status chips toggle additively; wrapped in a `role="group"` labelled by a new `attendeesAdmin.filterByStatus` message.
- `+page.svelte` — filter state is now `string[]`; add/remove toggle; joined on `,`.
- i18n — `attendeesAdmin.filterByStatus` added to en/de/fr/it.

`make check` green (format, lint `--max-warnings 0`, types, i18n, file-length).

## Scope / related issues

This is the **FE-unblocked half of #616**. It does **not** close #616 — the headline "create RSVP on behalf" feature is backend-blocked (`create_rsvp` needs a `user_id`, but no user-search / email→user endpoint exists) and is tracked in **letsrevel/revel-backend#686**. The FE user-picker will follow once that lands.

Surfaced-but-deferred siblings from the same E2E audit:
- **#617** — event-admin statistics: scoped down to the existing `AttendeeStats` surface (no new endpoint); left open with next-steps documented.
- **#618** — membership-tier reorder: backend-blocked, tracked in **letsrevel/revel-backend#687**.
- **#619** — already handled by #620 (excluded).

Refs #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)