### PR TITLE
test(e2e): Phase 3e — j05/j10 @p2 event-admin suites + gate-surfaced fixes (#591)

### DIFF
--- a/src/lib/components/attendees/AttendeeCardList.svelte
+++ b/src/lib/components/attendees/AttendeeCardList.svelte
@@ -95,6 +95,9 @@
 						type="button"
 						onclick={() => onEdit(rsvp)}
 						class="inline-flex flex-1 items-center justify-center gap-1 rounded-md bg-secondary px-3 py-2 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80"
+						aria-label={m['attendeesAdmin.editRsvpAriaLabel']({
+							name: getUserDisplayName(rsvp.user)
+						})}
 					>
 						<Edit class="h-4 w-4" aria-hidden="true" />
 						{m['attendeesAdmin.actionEdit']()}
@@ -103,6 +106,9 @@
 						type="button"
 						onclick={() => onDelete(rsvp)}
 						class="inline-flex flex-1 items-center justify-center gap-1 rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground transition-colors hover:bg-destructive/90"
+						aria-label={m['attendeesAdmin.deleteRsvpAriaLabel']({
+							name: getUserDisplayName(rsvp.user)
+						})}
 					>
 						<Trash2 class="h-4 w-4" aria-hidden="true" />
 						{m['attendeesAdmin.actionDelete']()}
@@ -115,7 +121,9 @@
 									<button
 										{...props}
 										class="inline-flex items-center justify-center rounded-md bg-secondary p-2 text-muted-foreground transition-colors hover:bg-secondary/80 hover:text-foreground"
-										aria-label={m['attendeesAdmin.moreActions']()}
+										aria-label={m['attendeesAdmin.moreActionsForAriaLabel']({
+											name: getUserDisplayName(rsvp.user)
+										})}
 									>
 										<MoreVertical class="h-4 w-4" aria-hidden="true" />
 									</button>

--- a/src/lib/components/events/EventActionSidebar.svelte
+++ b/src/lib/components/events/EventActionSidebar.svelte
@@ -429,6 +429,8 @@
 					{event}
 					{eventTokenDetails}
 					{onGuestRsvpClick}
+					{onInvitationRequestSuccess}
+					{onWhitelistRequestSuccess}
 				/>
 			{:else}
 				<!-- Ticket purchase flow -->

--- a/src/lib/components/events/EventRSVP.svelte
+++ b/src/lib/components/events/EventRSVP.svelte
@@ -29,6 +29,10 @@
 		event?: EventDetailSchema;
 		eventTokenDetails?: EventTokenSchema | null;
 		onGuestRsvpClick?: () => void;
+		/** Refresh eligibility after an invitation request succeeds (the gate
+		 * renders from parent-owned userStatus, which nothing else updates). */
+		onInvitationRequestSuccess?: () => void;
+		onWhitelistRequestSuccess?: () => void;
 		class?: string;
 	}
 
@@ -41,6 +45,8 @@
 		event,
 		eventTokenDetails,
 		onGuestRsvpClick,
+		onInvitationRequestSuccess,
+		onWhitelistRequestSuccess,
 		class: className
 	}: Props = $props();
 
@@ -405,6 +411,8 @@
 				organizationName={event.organization.name}
 				{eventTokenDetails}
 				applyBefore={event.apply_before}
+				{onInvitationRequestSuccess}
+				{onWhitelistRequestSuccess}
 			/>
 		{/if}
 

--- a/src/lib/components/events/IneligibilityMessage.svelte
+++ b/src/lib/components/events/IneligibilityMessage.svelte
@@ -28,6 +28,9 @@
 		organizationName: string;
 		eventTokenDetails?: EventTokenSchema | null;
 		applyBefore?: string | null;
+		/** Refresh eligibility after a successful invitation/whitelist request. */
+		onInvitationRequestSuccess?: () => void;
+		onWhitelistRequestSuccess?: () => void;
 		class?: string;
 	}
 
@@ -39,6 +42,8 @@
 		organizationName,
 		eventTokenDetails,
 		applyBefore,
+		onInvitationRequestSuccess,
+		onWhitelistRequestSuccess,
 		class: className
 	}: Props = $props();
 
@@ -474,6 +479,8 @@
 						{organizationSlug}
 						{eventTokenDetails}
 						questionnaireIds={eligibility.questionnaires_missing}
+						{onInvitationRequestSuccess}
+						{onWhitelistRequestSuccess}
 					/>
 				</div>
 			{/if}

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
@@ -380,16 +380,22 @@
 		</div>
 	</div>
 
-	<!-- Event Editor Component -->
+	<!-- Event Editor Component. Keyed by event id: EventEditor snapshots
+	     existingEvent (incl. the id it saves to) into $state once, so a
+	     client-side navigation between two events' edit pages (e.g. the
+	     duplicate flow's goto) must remount it or it keeps editing the
+	     previous event. -->
 	<div class="rounded-lg border bg-card text-card-foreground shadow-sm">
-		<EventEditor
-			{organization}
-			existingEvent={event}
-			userCity={data.userCity}
-			orgCity={data.orgCity}
-			eventSeries={data.eventSeries}
-			initialTab={($page.url.searchParams.get('tab') as 'details' | 'ticketing') ?? undefined}
-		/>
+		{#key event.id}
+			<EventEditor
+				{organization}
+				existingEvent={event}
+				userCity={data.userCity}
+				orgCity={data.orgCity}
+				eventSeries={data.eventSeries}
+				initialTab={($page.url.searchParams.get('tab') as 'details' | 'ticketing') ?? undefined}
+			/>
+		{/key}
 	</div>
 </div>
 

--- a/tests/e2e/journeys/j05-rsvp/waitlist.spec.ts
+++ b/tests/e2e/journeys/j05-rsvp/waitlist.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent, createVerifiedUser, rsvpViaApi } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J5 waitlist join/leave — the mutating counterpart to the read-only
+// eligibility matrix (which only asserts the "Join Waitlist" CTA renders on
+// the seeded full events). A fresh 1-seat RSVP event is filled by a
+// throwaway, so joining/leaving here never touches seeded waitlist state.
+//
+// UX quirks encoded: join success is an inline "Success!" status (no toast)
+// followed by window.location.reload() after 1.5s; leave goes through a
+// native confirm() and also reloads.
+
+test.describe('J5 waitlist @p2', () => {
+	test('join and leave the waitlist on a full RSVP event', async ({ browser }) => {
+		const [event, filler, joiner] = await Promise.all([
+			createTicketedEvent({
+				freeTier: false,
+				event: { requires_ticket: false, max_attendees: 1, waitlist_open: true }
+			}),
+			createVerifiedUser('Filler'),
+			createVerifiedUser('Waitlister')
+		]);
+		// The single seat goes to the filler — the event is now full.
+		await rsvpViaApi(filler, event.id, 'yes');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, joiner);
+		const page = await context.newPage();
+		// Leaving the waitlist fires a native confirm() — auto-accept.
+		page.on('dialog', (dialog) => void dialog.accept());
+
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Event is full' })).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Join: inline success state, then the page reloads itself into the
+		// on-waitlist gate (disabled status button + Leave).
+		await page.getByRole('button', { name: 'Join Waitlist' }).click();
+		await expect(page.getByText('Success!')).toBeVisible({ timeout: 15_000 });
+		const onWaitlistButton = page.getByRole('button', { name: "You're on the Waitlist" });
+		await expect(onWaitlistButton).toBeVisible({ timeout: 30_000 });
+		await expect(onWaitlistButton).toBeDisabled();
+
+		// Leave: confirm() accepted above; the reload lands back on the
+		// join-able full-event gate.
+		await page.getByRole('button', { name: 'Leave', exact: true }).click();
+		await expect(page.getByRole('button', { name: 'Join Waitlist' })).toBeVisible({
+			timeout: 30_000
+		});
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j10-event-admin/edit-duplicate.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/edit-duplicate.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent, uniqueName } from '../../support/factories';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J10 edit + duplicate — rename an event through the editor's SaveBar, then
+// duplicate it from the "More actions" kebab. The duplicate modal prefills
+// "Copy of {name}" and a future start; on success it navigates straight to
+// the NEW event's edit page (no toast) with the copy reset to DRAFT.
+
+test.describe('J10 edit & duplicate @p2', () => {
+	test('rename persists; duplicate creates a draft copy', async ({ asOwner }) => {
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: { requires_ticket: false }
+		});
+		const page = asOwner;
+		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/edit`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Edit Event', level: 1 })).toBeVisible();
+
+		// Edit: rename and Save (SaveBar keeps you on the page).
+		const newName = uniqueName('Renamed');
+		await page.locator('#event-name').fill(newName);
+		// Two SaveBars render (top + bottom of the editor) — take the first.
+		await page.getByRole('button', { name: 'Save', exact: true }).first().click();
+		await expect(page.getByText('Event updated successfully!')).toBeVisible({ timeout: 20_000 });
+		// The rename survives a fresh load.
+		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/edit`);
+		await waitForClientAuth(page);
+		await expect(page.locator('#event-name')).toHaveValue(newName, { timeout: 15_000 });
+
+		// Duplicate: kebab → "Duplicate" → modal prefilled "Copy of {name}".
+		await page.getByRole('button', { name: 'More actions' }).click();
+		await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+		const dialog = page.getByRole('dialog', { name: 'Duplicate Event' });
+		await expect(dialog).toBeVisible();
+		await expect(dialog.getByLabel('New Event Name')).toHaveValue(`Copy of ${newName}`);
+		await dialog.getByRole('button', { name: 'Duplicate Event' }).click();
+
+		// Success navigates to the copy's edit page — a DIFFERENT event id (a
+		// bare pattern would match the CURRENT edit URL and resolve instantly).
+		await page.waitForURL(
+			(url) =>
+				/\/admin\/events\/[0-9a-f-]+\/edit/.test(url.pathname) && !url.pathname.includes(event.id),
+			{ timeout: 30_000 }
+		);
+		const copyId = page.url().match(/\/admin\/events\/([0-9a-f-]+)\/edit/)?.[1];
+		expect(copyId).toBeTruthy();
+		expect(copyId).not.toBe(event.id);
+
+		// The copy carries the new name and is reset to DRAFT.
+		await expect(page.locator('#event-name')).toHaveValue(`Copy of ${newName}`, {
+			timeout: 15_000
+		});
+		await expect(page.getByText('Draft', { exact: true })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Publish Event' })).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j10-event-admin/invitation-requests.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/invitation-requests.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent, createVerifiedUser, rsvpViaApi } from '../../support/factories';
+import { ApiClient, ApiError } from '../../support/api';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J10 invitation requests — a private event with accept_invitation_requests
+// gates strangers behind "Request Invitation"; the admin decides on the
+// Manage Invitations page (default ?tab=requests).
+//
+// Backend contract: approve takes NO tier — it's a bare POST on the request
+// id (spec drift confirmed in recon: the tier picker some journeys mention
+// does not exist). Approval grants an invitation, which we prove by the
+// requester's RSVP succeeding via the API while the rejected user stays 400.
+//
+// Admin decision feedback is an inline role=alert banner, NOT a toast.
+
+test.describe('J10 invitation requests @p2', () => {
+	test('user requests an invitation; admin approves and rejects', async ({ asOwner, browser }) => {
+		const [event, requester, rejectedUser] = await Promise.all([
+			createTicketedEvent({
+				freeTier: false,
+				event: {
+					requires_ticket: false,
+					event_type: 'private',
+					accept_invitation_requests: true
+				}
+			}),
+			createVerifiedUser('Requester'),
+			createVerifiedUser('Rejected')
+		]);
+		const requesterName = `${requester.firstName} ${requester.lastName}`;
+		const rejectedName = `${rejectedUser.firstName} ${rejectedUser.lastName}`;
+
+		// The requester asks through the UI (dialog with optional message).
+		const requesterContext = await browser.newContext();
+		await authenticateContext(requesterContext, requester);
+		const requesterPage = await requesterContext.newPage();
+		await gotoHydrated(requesterPage, event.path);
+		await waitForClientAuth(requesterPage);
+		await requesterPage.getByRole('button', { name: 'Request Invitation' }).click();
+		const requestDialog = requesterPage.getByRole('dialog', { name: 'Request Invitation' });
+		await requestDialog
+			.getByLabel('Message (Optional)')
+			.fill('E2E: please let me in, I love private events.');
+		await requestDialog.getByRole('button', { name: 'Submit Request' }).click();
+		await expect(requesterPage.getByText('Request Submitted')).toBeVisible({ timeout: 15_000 });
+		// The dialog auto-closes (~2s) and onInvitationRequestSuccess refreshes
+		// eligibility → next_step wait_for_invitation_approval renders the
+		// disabled "Pending Approval" gate (this refresh was broken on the
+		// RSVP path before this PR — the callback chain stopped at EventRSVP).
+		const pendingButton = requesterPage.getByRole('button', { name: 'Pending Approval' });
+		await expect(pendingButton).toBeVisible({ timeout: 15_000 });
+		await expect(pendingButton).toBeDisabled();
+
+		// The second request arrives via the API.
+		const rejectedApi = await ApiClient.login(rejectedUser.email, rejectedUser.password);
+		await rejectedApi.post(`/api/events/${event.id}/invitation-requests`, {
+			message: 'E2E: reject me'
+		});
+
+		// Admin: approve one, reject the other (plain table rows, no tier picker).
+		const page = asOwner;
+		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/invitations`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Manage Invitations', level: 1 })).toBeVisible();
+
+		const rowFor = (name: string) => page.getByRole('row').filter({ hasText: name });
+		await expect(rowFor(requesterName)).toBeVisible({ timeout: 15_000 });
+		await rowFor(requesterName).getByRole('button', { name: 'Approve' }).click();
+		await expect(page.getByText('Request approved successfully.')).toBeVisible({
+			timeout: 15_000
+		});
+		// Both the status badge and the actions cell read "Approved".
+		await expect(rowFor(requesterName).getByText('Approved').first()).toBeVisible();
+
+		await rowFor(rejectedName).getByRole('button', { name: 'Reject' }).click();
+		await expect(page.getByText('Request rejected successfully.')).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(rowFor(rejectedName).getByText('Rejected').first()).toBeVisible();
+
+		// The approval granted a real invitation: the requester can now RSVP
+		// to the private event; the rejected user still can't.
+		await rsvpViaApi(requester, event.id, 'yes');
+		await expect(rsvpViaApi(rejectedUser, event.id, 'yes')).rejects.toThrowError(ApiError);
+
+		await requesterContext.close();
+	});
+});

--- a/tests/e2e/journeys/j10-event-admin/manage-rsvps.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/manage-rsvps.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser,
+	requestMembership,
+	approveMembershipRequest,
+	rsvpViaApi
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J10 manage RSVPs (#616, shipped as PRs #621+#622) — the Manage Attendees
+// page: create an RSVP on behalf of an org member ("Add attendee" dialog,
+// backend upserts on (event, user)) and the multi-select status filter
+// (aria-pressed toggle buttons that combine into ?status=a,b and reload the
+// list through the load function).
+//
+// Isolation: everything is arranged fresh. The member combobox searches ORG
+// MEMBERS only, so the create-on-behalf target must be approved into a
+// throwaway org first; the event must have requires_ticket=false (the
+// attendees page 302s ticketed events to .../tickets).
+
+test.describe('J10 manage RSVPs @p2', () => {
+	test('owner creates an RSVP on behalf of a member; re-submitting upserts', async ({
+		browser
+	}) => {
+		const [org, member] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('OnBehalf')
+		]);
+		const [event, request] = await Promise.all([
+			createTicketedEvent({
+				owner: org.owner,
+				orgSlug: org.slug,
+				freeTier: false,
+				event: { requires_ticket: false }
+			}),
+			requestMembership(member, org.slug)
+		]);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		const memberName = `${member.firstName} ${member.lastName}`;
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/events/${event.id}/attendees`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Manage Attendees', level: 1 })).toBeVisible();
+		await expect(page.getByText("No one has RSVP'd to this event yet.")).toBeVisible();
+
+		// Create on behalf — search by email (unique per run), default status Yes.
+		await page.getByRole('button', { name: 'Add attendee' }).click();
+		const dialog = page.getByRole('dialog', { name: 'Add attendee' });
+		await expect(dialog).toBeVisible();
+		// Submit stays disabled until a member is actually picked.
+		await expect(dialog.getByRole('button', { name: 'Add attendee' })).toBeDisabled();
+		const combobox = dialog.getByRole('combobox', { name: 'Member' });
+		await combobox.click();
+		await combobox.fill(member.email);
+		// String name = substring match (a RegExp would need the '+' escaped).
+		const option = page.getByRole('option', { name: member.email });
+		await expect(option).toBeVisible({ timeout: 15_000 });
+		await option.click();
+		await dialog.getByRole('button', { name: 'Add attendee' }).click();
+		await expect(page.getByText('RSVP saved')).toBeVisible({ timeout: 15_000 });
+		await expect(dialog).not.toBeVisible();
+		// The new row lands without a full reload (invalidateAll refresh).
+		const memberRow = page.getByRole('button', { name: `Edit RSVP for ${memberName}` });
+		await expect(memberRow).toBeVisible({ timeout: 15_000 });
+
+		// Upsert: submit the SAME member again with status No — the endpoint
+		// updates in place, so the row's status flips and nothing duplicates.
+		await page.getByRole('button', { name: 'Add attendee' }).first().click();
+		await expect(dialog).toBeVisible();
+		await combobox.click();
+		await combobox.fill(member.email);
+		await expect(option).toBeVisible({ timeout: 15_000 });
+		await option.click();
+		await dialog.getByRole('radio', { name: 'No - Not attending' }).check();
+		await dialog.getByRole('button', { name: 'Add attendee' }).click();
+		await expect(dialog).not.toBeVisible({ timeout: 15_000 });
+
+		// Status is now No: the Yes-only filter hides the row, the No filter
+		// shows exactly one (no duplicate from the upsert).
+		const filters = page.getByRole('group', { name: 'Filter by status' });
+		await filters.getByRole('button', { name: 'Yes', exact: true }).click();
+		await expect(page).toHaveURL(/status=yes/);
+		await expect(memberRow).toHaveCount(0);
+		await filters.getByRole('button', { name: 'Yes', exact: true }).click(); // untoggle
+		await filters.getByRole('button', { name: 'No', exact: true }).click();
+		await expect(page).toHaveURL(/status=no/);
+		await expect(memberRow).toHaveCount(1);
+
+		await context.close();
+	});
+
+	test('multi-select status filter combines statuses', async ({ asOwner }) => {
+		const [event, yesUser, maybeUser, noUser] = await Promise.all([
+			createTicketedEvent({ freeTier: false, event: { requires_ticket: false } }),
+			createVerifiedUser('FilterYes'),
+			createVerifiedUser('FilterMaybe'),
+			createVerifiedUser('FilterNo')
+		]);
+		await Promise.all([
+			rsvpViaApi(yesUser, event.id, 'yes'),
+			rsvpViaApi(maybeUser, event.id, 'maybe'),
+			rsvpViaApi(noUser, event.id, 'no')
+		]);
+		const rowFor = (u: { firstName: string; lastName: string }) =>
+			asOwner.getByRole('button', { name: `Edit RSVP for ${u.firstName} ${u.lastName}` });
+
+		const page = asOwner;
+		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/attendees`);
+		await waitForClientAuth(page);
+
+		// Unfiltered: "All" is pressed and every row shows.
+		const filters = page.getByRole('group', { name: 'Filter by status' });
+		await expect(filters.getByRole('button', { name: /^All \(/ })).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		await expect(rowFor(yesUser)).toBeVisible();
+		await expect(rowFor(maybeUser)).toBeVisible();
+		await expect(rowFor(noUser)).toBeVisible();
+
+		// Single select: Yes only.
+		await filters.getByRole('button', { name: 'Yes', exact: true }).click();
+		await expect(filters.getByRole('button', { name: 'Yes', exact: true })).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		await expect(page).toHaveURL(/status=yes/);
+		await expect(rowFor(yesUser)).toBeVisible();
+		await expect(rowFor(maybeUser)).toHaveCount(0);
+		await expect(rowFor(noUser)).toHaveCount(0);
+
+		// Multi select: Yes + Maybe combined.
+		await filters.getByRole('button', { name: 'Maybe', exact: true }).click();
+		await expect(rowFor(yesUser)).toBeVisible();
+		await expect(rowFor(maybeUser)).toBeVisible();
+		await expect(rowFor(noUser)).toHaveCount(0);
+
+		// "All" clears the filter set.
+		await filters.getByRole('button', { name: /^All \(/ }).click();
+		await expect(filters.getByRole('button', { name: 'Yes', exact: true })).toHaveAttribute(
+			'aria-pressed',
+			'false'
+		);
+		await expect(rowFor(noUser)).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j10-event-admin/stats-schedule-resources.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/stats-schedule-resources.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createVerifiedUser,
+	rsvpViaApi,
+	uniqueName
+} from '../../support/factories';
+import { ApiError, API_URL, fetchWithRetry, obtainTokenPair } from '../../support/api';
+import { PERSONAS } from '../../support/personas';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J10 stats + schedule + resources.
+//
+// "Stats" redefined (#617): there is NO statistics tab — the stats surface
+// is the AttendeeStats tile row on Manage Attendees, so that's what the
+// counts are asserted against.
+//
+// Schedule and resources are SECTIONS of the event editor (no tabs at all on
+// non-ticketed events), saved through the page-level SaveBar; resources are
+// an org-level pool the editor merely attaches. Both must then show on the
+// public event page (schedule <section>, "Event Resources" with an Open
+// action for link resources).
+
+function toDatetimeLocal(date: Date): string {
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+test.describe('J10 stats, schedule & resources @p2', () => {
+	test('attendee stats tiles count the RSVP mix', async ({ asOwner }) => {
+		const [event, yes1, yes2, maybe1, no1] = await Promise.all([
+			createTicketedEvent({ freeTier: false, event: { requires_ticket: false } }),
+			createVerifiedUser('StatsYesA'),
+			createVerifiedUser('StatsYesB'),
+			createVerifiedUser('StatsMaybe'),
+			createVerifiedUser('StatsNo')
+		]);
+		await Promise.all([
+			rsvpViaApi(yes1, event.id, 'yes'),
+			rsvpViaApi(yes2, event.id, 'yes'),
+			rsvpViaApi(maybe1, event.id, 'maybe'),
+			rsvpViaApi(no1, event.id, 'no')
+		]);
+
+		const page = asOwner;
+		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/attendees`);
+		await waitForClientAuth(page);
+
+		// Each stat tile is a bordered card: label <p class="text-sm"> above
+		// the count <p class="text-2xl"> (no roles to hook into).
+		const tileCount = (label: string) =>
+			page
+				.locator('div.rounded-lg', {
+					has: page.locator('p.text-sm', { hasText: new RegExp(`^${label}$`) })
+				})
+				.locator('p.text-2xl');
+		await expect(tileCount('Total')).toHaveText('4', { timeout: 15_000 });
+		await expect(tileCount('Yes')).toHaveText('2');
+		await expect(tileCount('Maybe')).toHaveText('1');
+		await expect(tileCount('No')).toHaveText('1');
+		// The filter bar's "All" pill carries the same total.
+		await expect(
+			page.getByRole('group', { name: 'Filter by status' }).getByRole('button', { name: 'All (4)' })
+		).toBeVisible();
+	});
+
+	test('schedule sessions and attached resources reach the public page', async ({
+		asOwner,
+		browser
+	}) => {
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: { requires_ticket: false }
+		});
+		// The editor only ATTACHES org-pool resources, so arrange one via the
+		// org-admin API (public visibility so a guest can see it; kept off the
+		// org page to avoid polluting unrelated specs).
+		const resourceName = uniqueName('Resource');
+		// The create-resource endpoint takes multipart FORM fields (files ride
+		// along for `file` resources), not JSON — post FormData directly.
+		const { access } = await obtainTokenPair(PERSONAS.owner.email, PERSONAS.owner.password);
+		const form = new FormData();
+		form.set('name', resourceName);
+		form.set('resource_type', 'link');
+		form.set('link', 'https://example.com/e2e-resource');
+		form.set('visibility', 'public');
+		form.set('display_on_organization_page', 'false');
+		const resourceResponse = await fetchWithRetry(
+			`${API_URL}/api/organization-admin/${event.orgSlug}/resources`,
+			{ method: 'POST', headers: { Authorization: `Bearer ${access}` }, body: form }
+		);
+		if (!resourceResponse.ok) {
+			throw new ApiError(
+				resourceResponse.status,
+				'POST',
+				'/resources',
+				await resourceResponse.text()
+			);
+		}
+
+		const page = asOwner;
+		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/edit`);
+		await waitForClientAuth(page);
+
+		// Schedule section: add one session (times are relative to event start).
+		await expect(page.getByRole('heading', { name: 'Schedule', exact: true })).toBeVisible();
+		await page.getByRole('button', { name: 'Add session' }).click();
+		const sessionTitle = uniqueName('Keynote');
+		await page.getByLabel('Session title').fill(sessionTitle);
+		// The factory event starts +7 days out; place the session an hour in.
+		const sessionStart = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000);
+		await page.getByLabel('Starts at').fill(toDatetimeLocal(sessionStart));
+
+		// Resources section: toggle the org resource on (row is a button
+		// named by the resource).
+		await expect(page.getByRole('heading', { name: 'Attach Resources' })).toBeVisible();
+		await page.getByRole('button', { name: new RegExp(resourceName) }).click();
+		await expect(page.getByText('1 resource attached')).toBeVisible();
+
+		// Persist through the SaveBar (two render — top + bottom of the editor).
+		await page.getByRole('button', { name: 'Save', exact: true }).first().click();
+		await expect(page.getByText('Event updated successfully!')).toBeVisible({ timeout: 20_000 });
+
+		// A logged-out guest sees both on the public event page (SSR).
+		const guestContext = await browser.newContext();
+		const guestPage = await guestContext.newPage();
+		await guestPage.goto(event.path);
+		await expect(guestPage.getByRole('heading', { name: 'Schedule', exact: true })).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(guestPage.getByText(sessionTitle)).toBeVisible();
+		await expect(guestPage.getByRole('heading', { name: 'Event Resources' })).toBeVisible();
+		await expect(guestPage.getByText(resourceName)).toBeVisible();
+		await expect(guestPage.getByRole('button', { name: /Open/ })).toBeVisible();
+		await guestContext.close();
+	});
+});

--- a/tests/e2e/journeys/j10-event-admin/waitlist-admin.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/waitlist-admin.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent, createVerifiedUser, rsvpViaApi } from '../../support/factories';
+import { ApiClient } from '../../support/api';
+import { PERSONAS } from '../../support/personas';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J10 waitlist admin — the /waitlist admin page: issue, revoke and
+// reactivate offers for a waitlist entry, then remove the entry.
+//
+// Arrange: a 1-seat RSVP event fills up, a throwaway joins the waitlist via
+// the public API, then the seat is freed (filler flips to No) so offers can
+// actually be issued — the backend answers 409 while at capacity.
+//
+// Locator gotcha: every row renders twice (table + md:hidden mobile card),
+// so all row-level lookups filter on visibility. Removing an entry uses a
+// native confirm().
+
+test.describe('J10 waitlist admin @p2', () => {
+	test('issue, revoke and reactivate an offer; remove the entry', async ({ asOwner }) => {
+		const [event, filler, waiter] = await Promise.all([
+			createTicketedEvent({
+				freeTier: false,
+				event: { requires_ticket: false, max_attendees: 1, waitlist_open: true }
+			}),
+			createVerifiedUser('Filler'),
+			createVerifiedUser('Waiter')
+		]);
+		await rsvpViaApi(filler, event.id, 'yes');
+		// The waiter joins the (now full) waitlist through the public API.
+		const waiterApi = await ApiClient.login(waiter.email, waiter.password);
+		await waiterApi.post(`/api/events/${event.id}/waitlist/join`, {});
+		// Free the seat so issuing an offer doesn't 409 at capacity. The admin
+		// deletes the filler's RSVP — the filler can't downgrade it themselves
+		// on a full event (BE #691: rsvp() asserts capacity even for yes→no).
+		const ownerApi = await ApiClient.login(PERSONAS.owner.email, PERSONAS.owner.password);
+		const rsvps = await ownerApi.get<{ results: { id: string }[] }>(
+			`/api/event-admin/${event.id}/rsvps`
+		);
+		await ownerApi.delete(`/api/event-admin/${event.id}/rsvps/${rsvps.results[0].id}`);
+		const waiterName = `${waiter.firstName} ${waiter.lastName}`;
+
+		const page = asOwner;
+		page.on('dialog', (dialog) => void dialog.accept());
+		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/waitlist`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Event Waitlist', level: 1 })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Waitlist Settings' })).toBeVisible();
+		await expect(page.getByText(waiterName).filter({ visible: true }).first()).toBeVisible({
+			timeout: 15_000
+		});
+
+		const visibleButton = (name: string) =>
+			page.getByRole('button', { name }).filter({ visible: true }).first();
+
+		// Issue an offer (the expiry dialog is prefilled with a default window).
+		await visibleButton('Issue offer').click();
+		const issueDialog = page.getByRole('dialog', { name: `Issue offer to ${waiterName}` });
+		await expect(issueDialog).toBeVisible();
+		await issueDialog.getByRole('button', { name: 'Issue offer' }).click();
+		await expect(issueDialog).not.toBeVisible({ timeout: 15_000 });
+		await expect(visibleButton('Revoke offer')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText('Pending').filter({ visible: true }).first()).toBeVisible();
+
+		// The offer also shows up on the Offers tab (default filter: Pending).
+		await page.getByRole('tab', { name: 'Offers' }).click();
+		await expect(page.getByText(waiterName).filter({ visible: true }).first()).toBeVisible({
+			timeout: 15_000
+		});
+		await page.getByRole('tab', { name: 'Entries' }).click();
+
+		// Revoke — immediate, no confirm. Only PENDING offers surface as an
+		// entry's current_offer, so the row reverts to "Issue offer";
+		// reactivation lives on the Offers tab behind the Revoked chip.
+		await visibleButton('Revoke offer').click();
+		await expect(visibleButton('Issue offer')).toBeVisible({ timeout: 15_000 });
+
+		await page.getByRole('tab', { name: 'Offers' }).click();
+		await page.getByRole('button', { name: 'Revoked', exact: true }).click();
+		await visibleButton('Reactivate').click();
+		const reactivateDialog = page.getByRole('dialog', {
+			name: `Reactivate offer for ${waiterName}`
+		});
+		await expect(reactivateDialog).toBeVisible();
+		await reactivateDialog.getByRole('button', { name: 'Reactivate' }).click();
+		await expect(reactivateDialog).not.toBeVisible({ timeout: 15_000 });
+
+		// Back on Entries the offer is pending again → revocable.
+		await page.getByRole('tab', { name: 'Entries' }).click();
+		await expect(visibleButton('Revoke offer')).toBeVisible({ timeout: 15_000 });
+
+		// Remove the entry (native confirm auto-accepted) → empty state.
+		await visibleButton('Remove').click();
+		await expect(page.getByRole('heading', { name: 'No Waitlist Entries' })).toBeVisible({
+			timeout: 15_000
+		});
+	});
+});

--- a/tests/e2e/support/stripe.ts
+++ b/tests/e2e/support/stripe.ts
@@ -33,10 +33,25 @@ export async function completeStripeCheckout(
 	// only when they aren't already there. The Card radio is COVERED by a
 	// zero-size "Pay with card" button that intercepts pointer events, so a
 	// normal click can never land — dispatch the click straight to it.
-	const cardNumber = page.getByLabel('Card number');
+	// Role-scoped: the adaptive-pricing layout (shown when Stripe geolocates
+	// the runner outside the session's currency zone) names the field the
+	// same but getByLabel stops matching it.
+	const cardNumber = page.getByRole('textbox', { name: 'Card number' }).first();
 	await expect(async () => {
 		if (await cardNumber.isVisible()) return;
-		await page.locator('[data-testid="card-accordion-item-button"]').dispatchEvent('click');
+		// Adaptive pricing variant: a "Choose a currency:" toggle precedes the
+		// form. Selecting the original (€) price gets the standard layout —
+		// match the € button specifically so retries don't flip currencies.
+		const euro = page
+			.getByRole('group', { name: /Choose a currency/ })
+			.getByRole('button', { name: /€/, disabled: false });
+		if ((await euro.count()) > 0) {
+			await euro.first().click();
+		}
+		const accordion = page.locator('[data-testid="card-accordion-item-button"]');
+		if ((await accordion.count()) > 0) {
+			await accordion.dispatchEvent('click');
+		}
 		await expect(cardNumber).toBeVisible({ timeout: 5_000 });
 	}).toPass({ timeout: 60_000 });
 


### PR DESCRIPTION
Group **(e) event admin** of the @p2 phase — six new journey suites (8 tests × 2 projects), plus three product fixes and one E2E-infra fix the suites surfaced. Each fix is its own commit for easy cherry-picking.

Part of #591.

## New suites

| Spec | Covers |
|---|---|
| `j05-rsvp/waitlist` | Join + leave the waitlist on a full RSVP event (inline success → self-reload → on-waitlist gate; native confirm on leave) |
| `j10-event-admin/manage-rsvps` | **Create RSVP on behalf** (#622 dialog: members-only combobox, upsert on (event,user)) + **multi-select status filter** (#621, aria-pressed toggles → `?status=a,b`) — doubles as the runtime smoke both PRs deferred |
| `j10-event-admin/invitation-requests` | User requests via dialog on a private event; admin approves/rejects (inline alert banner, **no tier param** — confirmed against the controller); grant proven by requester's RSVP succeeding while the rejected user stays 400 |
| `j10-event-admin/waitlist-admin` | Issue → revoke → reactivate offers + remove entry. Reactivate lives on the **Offers tab behind the Revoked chip** (only PENDING offers surface as `current_offer` on Entries) |
| `j10-event-admin/edit-duplicate` | Rename persists; duplicate → draft copy on the **copy's** edit page |
| `j10-event-admin/stats-schedule-resources` | AttendeeStats tiles as the stats surface (no stats tab exists — #617); schedule session + attached org resource reach the public page for a guest |

## Fixes surfaced by the suites

1. **Stale eligibility gate after invitation/whitelist request on RSVP events** — the `onInvitationRequestSuccess`/`onWhitelistRequestSuccess` → `refreshUserStatus` chain was wired for the ticketed path but stopped at `EventRSVP` on the non-ticketed path, so the gate kept offering "Request Invitation" after a successful request. Threaded the callbacks through.
2. **Duplicate flow edited the wrong event** — `EventEditor` snapshots `existingEvent` (incl. the id it saves to) into `$state` once; the duplicate modal's client-side `goto` reused the mounted editor, so the copy's edit page still showed — and would have saved to — the *original* event. `{#key event.id}` remount.
3. **a11y: mobile attendee cards** — bare "Edit"/"Delete"/"More actions" on every row; now per-user labels mirroring the desktop table (existing i18n keys).
4. **E2E infra: Stripe adaptive pricing** — when Stripe geolocates the runner outside the currency zone, hosted checkout shows a "Choose a currency" variant that broke the card-form probe (both `stripe-online` runs). Role-based probe + pick the original € price.

## Backend issues filed (not touched)

- **revel-backend#691** — `rsvp()` asserts capacity unconditionally, so a YES attendee on a *full* event can't downgrade to no/maybe (exactly when freeing a seat matters; the YES→non-YES waitlist-processing branch is unreachable). Worked around in `waitlist-admin` via admin RSVP delete.

## Gates

- New suites: 16/16 both projects; **48/48** on `--repeat-each=3 --workers=4 --retries=0` against the gunicorn+PgBouncer backend (BE #688) — full parallelism, zero connection pressure (old runserver limits gone; full suite now ~6 min at workers=4).
- **Final full suite: 267 passed / 0 failed / 0 flaky / 2 skipped in 2.8 min** (`--workers=4`, fresh backend). Earlier runs on the way there: 260 passed / 6 failed — all 6 pre-existing environmental (org-list seed pollution from accumulated E2E orgs → `reset_events` + bootstrap; Stripe adaptive pricing → fix 4), re-verified green after remediation; one interim run hit the wedged backend now filed as BE #693 (113 passed / 0 failed / 152 self-skipped on the backend-down probe).
- `make check` green (format, lint `--max-warnings 0`, svelte-check 0 errors, i18n 4/4 locales, file-length, SSR-token, image-alt); unit tests 846 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb
