### PR TITLE
test(e2e): Phase 3d — j04/j08/j09/j13 @p2 org-admin journey suites + gate-surfaced fixes (#591)

### DIFF
--- a/src/lib/components/profile/DietaryPreferencesManager.svelte
+++ b/src/lib/components/profile/DietaryPreferencesManager.svelte
@@ -126,7 +126,15 @@
 	const availablePreferences = $derived(
 		(availablePreferencesQuery.data as DietaryPreferenceSchema[] | undefined) ?? []
 	);
-	const isLoading = $derived(userPreferencesQuery.isLoading || availablePreferencesQuery.isLoading);
+	// Read both queries' properties unconditionally: `||` short-circuiting
+	// would leave the second query's props untracked (TanStack notifies only
+	// on tracked-property changes), freezing it in its loading state forever
+	// when it resolves first. Same bug as the venue sectors page.
+	const isLoading = $derived.by(() => {
+		const userLoading = userPreferencesQuery.isLoading;
+		const availableLoading = availablePreferencesQuery.isLoading;
+		return userLoading || availableLoading;
+	});
 	const isAddingPreference = $derived(addPreferenceMutation.isPending);
 
 	// Get preferences that user hasn't added yet

--- a/src/lib/components/tickets/CancelTicketDialog.svelte
+++ b/src/lib/components/tickets/CancelTicketDialog.svelte
@@ -128,7 +128,14 @@
 	}));
 
 	const preview = $derived(previewQuery.data);
-	const isLoadingPreview = $derived(previewQuery.isLoading || previewQuery.isFetching);
+	// Read both properties unconditionally so TanStack tracks them both —
+	// `||` short-circuiting would leave `isFetching` untracked while
+	// `isLoading` is true (tracked-properties notification gotcha).
+	const isLoadingPreview = $derived.by(() => {
+		const loading = previewQuery.isLoading;
+		const fetching = previewQuery.isFetching;
+		return loading || fetching;
+	});
 
 	// If cancel mutation returned a 409 with stable code, surface it.
 	const blockedCode = $derived.by<CancellationBlockReason | null>(() => {

--- a/src/routes/(auth)/org/[slug]/admin/billing/+layout.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/billing/+layout.server.ts
@@ -1,0 +1,16 @@
+import type { LayoutServerLoad } from './$types';
+import { error } from '@sveltejs/kit';
+
+// Billing (and its invoice/credit-note sub-pages) talks exclusively to
+// owner-only backend endpoints. The admin nav already hides the item from
+// staff, but a direct URL used to render the page shell with every query
+// failing — guard the whole subtree like financials does.
+export const load: LayoutServerLoad = async ({ parent }) => {
+	const { isOwner } = await parent();
+
+	if (!isOwner) {
+		throw error(403, 'Only the organization owner can access billing.');
+	}
+
+	return {};
+};

--- a/src/routes/(auth)/org/[slug]/admin/events/new/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/events/new/+page.server.ts
@@ -6,11 +6,15 @@ import { log } from '$lib/server/logger';
 
 export const load: PageServerLoad = async ({ parent, locals, fetch, url }) => {
 	const parentData = await parent();
-	const { organization } = parentData;
+	const { organization, canCreateEvent } = parentData;
 	const user = locals.user;
 
 	if (!user) {
 		throw error(401, 'You must be logged in to create events');
+	}
+
+	if (!canCreateEvent) {
+		throw error(403, 'You do not have permission to create events for this organization');
 	}
 
 	const headers: HeadersInit = {

--- a/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { createQuery, createMutation, useQueryClient } from '@tanstack/svelte-query';
@@ -16,8 +16,8 @@
 	import SectorModal from '$lib/components/venues/SectorModal.svelte';
 	import { toast } from 'svelte-sonner';
 
-	const organization = $derived($page.data.organization);
-	const venueId = $derived($page.params.venue_id);
+	const organization = $derived(page.data.organization);
+	const venueId = $derived(page.params.venue_id);
 	const accessToken = $derived(authStore.accessToken);
 	const queryClient = useQueryClient();
 
@@ -131,8 +131,30 @@
 
 	const venue = $derived(venueQuery.data);
 	const sectors = $derived(sectorsQuery.data || []);
-	const isLoading = $derived(venueQuery.isLoading || sectorsQuery.isLoading);
-	const error = $derived(venueQuery.error || sectorsQuery.error);
+	// `isLoading`/`error` must read every query's property unconditionally
+	// (never via `||` short-circuiting) — see the comment inside `isLoading`.
+	const isLoading = $derived.by(() => {
+		// TanStack Query only pushes an update into Svelte state for a query
+		// once one of that query's *own* result properties has actually been
+		// read (its "tracked properties" optimization skips notifying
+		// subscribers otherwise). `venueQuery.isLoading || sectorsQuery.isLoading`
+		// short-circuits: while venueQuery.isLoading is still true, the `||`
+		// never evaluates `sectorsQuery.isLoading`, so sectorsQuery.isLoading
+		// (and .data) never get tracked. If sectorsQuery resolves first, its
+		// update is silently dropped and sectorsQuery.isLoading is frozen at
+		// `true` forever, which keeps this derived (and the {#if} chain that
+		// depends on it) stuck on the loading branch permanently. Reading both
+		// operands into locals first forces both properties to be tracked on
+		// every evaluation, regardless of which one is truthy.
+		const venueLoading = venueQuery.isLoading;
+		const sectorsLoading = sectorsQuery.isLoading;
+		return venueLoading || sectorsLoading;
+	});
+	const error = $derived.by(() => {
+		const venueError = venueQuery.error;
+		const sectorsError = sectorsQuery.error;
+		return venueError || sectorsError;
+	});
 </script>
 
 <svelte:head>

--- a/tests/e2e/journeys/j04-member/status-changes.spec.ts
+++ b/tests/e2e/journeys/j04-member/status-changes.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	approveMembershipRequest,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser,
+	requestMembership,
+	setMemberStatus
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J4 (USER_JOURNEYS.md) — membership status changes: pausing a member
+// degrades their access to members-only content; reactivating restores it.
+//
+// Isolation: throwaway-owned org with an arranged ACTIVE member and a
+// members-only (non-ticketed) event. Status flips happen via the org-admin
+// API (the admin UI for it is covered by j08 member-management); the journey
+// under test here is what the MEMBER experiences on each side of the flip.
+
+test.describe('J4 membership status changes @p2', () => {
+	test('paused member loses members-only access, reactivation restores it', async ({ browser }) => {
+		test.setTimeout(120_000);
+
+		const org = await createOrganization({ acceptMembershipRequests: true });
+		const member = await createVerifiedUser('PausedMember');
+		const request = await requestMembership(member, org.slug);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		const event = await createTicketedEvent({
+			owner: org.owner,
+			orgSlug: org.slug,
+			freeTier: false,
+			event: { event_type: 'members-only', requires_ticket: false }
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, member);
+		const page = await context.newPage();
+
+		// ACTIVE: the member gets the RSVP ask on the members-only event.
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+
+		// Pause → the eligibility gate flips to the inactive-membership message
+		// (the backend reason string renders as the gate header) and the RSVP
+		// affordance disappears.
+		await setMemberStatus(org.owner, org.slug, member.email, 'paused');
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+		// The gate renders twice (desktop sidebar + mobile flow); only one copy
+		// is visible per viewport.
+		await expect(
+			page.getByText('Your membership is not active.').filter({ visible: true })
+		).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeHidden();
+		await expect(page.getByRole('button', { name: /^RSVP Yes/ })).toBeHidden();
+
+		// The org profile reflects the paused state instead of offering a
+		// membership request.
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+		await expect(page.getByText('Paused', { exact: true })).toBeVisible();
+
+		// Reactivate → access is restored.
+		await setMemberStatus(org.owner, org.slug, member.email, 'active');
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j04-member/tier-benefits.spec.ts
+++ b/tests/e2e/journeys/j04-member/tier-benefits.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '../../support/fixtures';
+import { waitForClientAuth } from '../../support/navigation';
+
+// J4 (USER_JOURNEYS.md) — members-only ticket tiers: the seeded FutureStack
+// conference carries a "Member Discount" tier with visibility=members-only +
+// purchasable_by=members, so the tier list itself differs per viewer.
+//
+// Personas: karen (multiOrg) is an Org Beta member WITHOUT a FutureStack
+// ticket — the tier list only renders for users who hold no ticket, which
+// rules out frank (his seeded ticket IS on the Member Discount tier and
+// replaces the list with his ticket card). Hannah has no Beta membership.
+// All assertions are read-only.
+
+const FUTURESTACK = '/events/tech-innovators-network/futurestack-2025';
+const MEMBER_TIER = 'Member Discount';
+const PUBLIC_TIER = 'Standard - Full Access';
+
+test.describe('J4 member tier benefits @p2', () => {
+	test('a Beta member sees the members-only tier in the ticket options', async ({ asMultiOrg }) => {
+		await asMultiOrg.goto(FUTURESTACK);
+		// Tier visibility is resolved against the authenticated user — wait for
+		// the client auth bootstrap before trusting the rendered list.
+		await waitForClientAuth(asMultiOrg);
+
+		await expect(asMultiOrg.getByRole('heading', { name: 'Ticket Options' })).toBeVisible();
+		await expect(asMultiOrg.getByRole('heading', { name: MEMBER_TIER, level: 3 })).toBeVisible();
+		await expect(asMultiOrg.getByRole('heading', { name: PUBLIC_TIER, level: 3 })).toBeVisible();
+	});
+
+	test('a non-member sees the public tiers but not the members-only one', async ({ asUser }) => {
+		await asUser.goto(FUTURESTACK);
+		await waitForClientAuth(asUser);
+
+		// The list rendered (public tier present) — and the member tier is
+		// filtered out server-side, not just de-emphasized.
+		await expect(asUser.getByRole('heading', { name: PUBLIC_TIER, level: 3 })).toBeVisible();
+		await expect(asUser.getByRole('heading', { name: MEMBER_TIER, level: 3 })).toBeHidden();
+	});
+
+	test('an anonymous visitor does not see the members-only tier either', async ({ browser }) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		await page.goto(FUTURESTACK);
+
+		await expect(page.getByRole('heading', { name: PUBLIC_TIER, level: 3 })).toBeVisible();
+		await expect(page.getByRole('heading', { name: MEMBER_TIER, level: 3 })).toBeHidden();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/blacklist.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/blacklist.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser,
+	uniqueName
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J8 (USER_JOURNEYS.md) — org blacklist admin: add an entry by email (which
+// auto-links to the registered account and blocks them), add a name-only
+// entry, remove it again. The blocked user's side is asserted on a public
+// event of the org: the eligibility gate flips from the RSVP ask to the
+// blacklist message.
+//
+// Isolation: throwaway-owned org + throwaway blocked user; the name-only
+// entry uses a uniqueName() so fuzzy matching can never touch real personas.
+
+test.describe('J8 blacklist admin @p2', () => {
+	test('add by email blocks the user; name-only entry can be added and removed', async ({
+		browser
+	}) => {
+		test.setTimeout(150_000);
+
+		const org = await createOrganization();
+		const blocked = await createVerifiedUser('Blocked');
+		const event = await createTicketedEvent({
+			owner: org.owner,
+			orgSlug: org.slug,
+			freeTier: false,
+			event: { requires_ticket: false }
+		});
+
+		// Before: the user is an ordinary eligible visitor on the org's event.
+		const blockedContext = await browser.newContext();
+		await authenticateContext(blockedContext, blocked);
+		const blockedPage = await blockedContext.newPage();
+		await gotoHydrated(blockedPage, event.path);
+		await waitForClientAuth(blockedPage);
+		await expect(blockedPage.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+
+		// Admin adds them to the blacklist by email.
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+		await gotoHydrated(page, `/org/${org.slug}/admin/blacklist`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Blacklist Management' })).toBeVisible();
+
+		const modal = page.getByRole('dialog', { name: 'Add to Blacklist' });
+		await page.getByRole('button', { name: 'Add to Blacklist' }).click();
+		await expect(modal).toBeVisible();
+		await modal.getByLabel('Email Address').fill(blocked.email);
+		await modal.getByLabel('Reason for Blacklisting').fill('E2E blacklist journey');
+		await modal.getByRole('button', { name: 'Add to Blacklist' }).click();
+		await expect(modal).not.toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText(blocked.email).first()).toBeVisible();
+
+		// The blocked user loses event access outright — a hard-blacklisted user
+		// can't even SEE the org's events anymore: direct URL → 404.
+		const blockedResponse = await blockedPage.goto(event.path);
+		expect(blockedResponse?.status()).toBe(404);
+		await expect(blockedPage.getByRole('heading', { name: 'Page Not Found' })).toBeVisible();
+
+		// Name-only entry (no linked account) can be added…
+		const alias = uniqueName('Alias');
+		await page.getByRole('button', { name: 'Add to Blacklist' }).click();
+		await expect(modal).toBeVisible();
+		await modal.getByLabel('First Name').fill(alias);
+		await modal.getByLabel('Last Name').fill('Doe');
+		await modal.getByRole('button', { name: 'Add to Blacklist' }).click();
+		await expect(modal).not.toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText(alias).first()).toBeVisible();
+
+		// …and removed again through the entry's detail modal (Remove asks for an
+		// inline confirmation step).
+		await page.getByRole('button', { name: `Manage blacklist entry for ${alias} Doe` }).click();
+		const entryModal = page.getByRole('dialog', { name: /Blacklist Entry/ });
+		await expect(entryModal).toBeVisible();
+		await entryModal.getByRole('button', { name: 'Remove from Blacklist' }).click();
+		await entryModal.getByRole('button', { name: 'Confirm Remove' }).click();
+		await expect(entryModal).not.toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText(alias)).toBeHidden({ timeout: 15_000 });
+
+		await blockedContext.close();
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/membership-tiers.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/membership-tiers.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '../../support/fixtures';
+import { createOrganization } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J8 (USER_JOURNEYS.md) — membership tier CRUD + reorder (reorder shipped in
+// #622 / BE #690: optimistic up/down buttons calling the reorder endpoint).
+//
+// Isolation: throwaway-owned org. Every new org starts with its post-save
+// "General membership" tier, so the reorder buttons appear as soon as one
+// more tier exists.
+
+test.describe('J8 membership tiers @p2', () => {
+	test('create, edit, reorder, and delete tiers', async ({ browser }) => {
+		test.setTimeout(150_000);
+
+		const org = await createOrganization();
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(page);
+		await page.getByRole('tab', { name: /^Tiers/ }).click();
+		const panel = page.getByRole('tabpanel');
+		await expect(panel.getByRole('heading', { name: 'General membership' })).toBeVisible();
+
+		// Create two tiers through the form dialog.
+		const formDialog = page.getByRole('dialog', {
+			name: /Create Membership Tier|Edit Membership Tier/
+		});
+		for (const name of ['Gold', 'Silver']) {
+			await panel.getByRole('button', { name: 'Create Tier' }).click();
+			await expect(formDialog).toBeVisible();
+			await formDialog.getByLabel('Tier Name').fill(name);
+			await formDialog.getByRole('button', { name: 'Create Tier' }).click();
+			await expect(formDialog).not.toBeVisible({ timeout: 15_000 });
+			await expect(panel.getByRole('heading', { name, exact: true })).toBeVisible();
+		}
+
+		// Edit: rename Silver → Silver Plus.
+		await panel.getByRole('button', { name: 'Edit Silver' }).click();
+		await expect(formDialog).toBeVisible();
+		await formDialog.getByLabel('Tier Name').fill('Silver Plus');
+		await formDialog.getByRole('button', { name: 'Update Tier' }).click();
+		await expect(formDialog).not.toBeVisible({ timeout: 15_000 });
+		await expect(panel.getByRole('heading', { name: 'Silver Plus' })).toBeVisible();
+		await expect(panel.getByRole('heading', { name: 'Silver', exact: true })).toBeHidden();
+
+		// Reorder: Gold sits second (created after the default tier); move it to
+		// the top. The mutation is optimistic — reload to prove persistence.
+		// Order is read off the card headings, filtered to the known tier names
+		// (cards can contain other headings, e.g. per-tier plan sections).
+		const KNOWN = ['General membership', 'Gold', 'Silver Plus'];
+		const tierOrder = async () => {
+			const texts = await panel.getByRole('heading', { level: 3 }).allTextContents();
+			return texts.map((t) => t.trim()).filter((t) => KNOWN.includes(t));
+		};
+		await expect.poll(tierOrder).toEqual(['General membership', 'Gold', 'Silver Plus']);
+		await panel.getByRole('button', { name: 'Move Gold up' }).click();
+		await expect.poll(tierOrder).toEqual(['Gold', 'General membership', 'Silver Plus']);
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(page);
+		await page.getByRole('tab', { name: /^Tiers/ }).click();
+		await expect.poll(tierOrder).toEqual(['Gold', 'General membership', 'Silver Plus']);
+
+		// Delete Silver Plus through the confirmation dialog.
+		const deleteDialog = page.getByRole('dialog', { name: 'Delete Membership Tier' });
+		await panel.getByRole('button', { name: 'Delete Silver Plus' }).click();
+		await expect(deleteDialog).toBeVisible();
+		await deleteDialog.getByRole('button', { name: 'Delete Tier' }).click();
+		await expect(deleteDialog).not.toBeVisible({ timeout: 15_000 });
+		await expect(panel.getByRole('heading', { name: 'Silver Plus' })).toBeHidden();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/resources.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/resources.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	approveMembershipRequest,
+	createOrganization,
+	createVerifiedUser,
+	requestMembership,
+	uniqueName
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J8 (USER_JOURNEYS.md) — org resources: the owner creates a public link
+// resource and a members-only text resource through the admin UI (both
+// displayed on the org page), then the public resources page filters them
+// per viewer: a member sees both, an anonymous visitor only the public one.
+//
+// Isolation: throwaway-owned org + throwaway member.
+
+test.describe('J8 org resources @p2', () => {
+	test('create link/text resources; visibility filters per persona', async ({ browser }) => {
+		test.setTimeout(150_000);
+
+		const org = await createOrganization({ acceptMembershipRequests: true });
+		const member = await createVerifiedUser('ResourceReader');
+		const request = await requestMembership(member, org.slug);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+
+		const publicName = uniqueName('Public Link');
+		const membersName = uniqueName('Members Text');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/resources`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Resources', level: 1 })).toBeVisible();
+
+		const modal = page.getByRole('dialog', { name: /Add Resource/ });
+
+		// Public link resource, shown on the org page. (Header button +
+		// empty-state CTA both say "Add Resource" on a fresh org — .first().)
+		await page.getByRole('button', { name: 'Add Resource' }).first().click();
+		await expect(modal).toBeVisible();
+		await modal.getByRole('button', { name: 'Link', exact: true }).click();
+		await modal.getByLabel(/^Name/).fill(publicName);
+		await modal.getByLabel('URL').fill('https://example.com/e2e');
+		await modal.getByLabel('Visibility').selectOption({ label: 'Public - Anyone can view' });
+		await modal.getByLabel('Display on organization page').check();
+		await modal.getByRole('button', { name: 'Create Resource' }).click();
+		await expect(modal).not.toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText(publicName)).toBeVisible();
+
+		// Members-only text resource, also shown on the org page.
+		await page.getByRole('button', { name: 'Add Resource' }).click();
+		await expect(modal).toBeVisible();
+		await modal.getByRole('button', { name: 'Text', exact: true }).click();
+		await modal.getByLabel(/^Name/).fill(membersName);
+		await modal.getByLabel('Content').fill('Members-only content for the E2E journey.');
+		await modal
+			.getByLabel('Visibility')
+			.selectOption({ label: 'Members Only - Requires membership' });
+		await modal.getByLabel('Display on organization page').check();
+		await modal.getByRole('button', { name: 'Create Resource' }).click();
+		await expect(modal).not.toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText(membersName)).toBeVisible();
+
+		// A member sees both on the public resources page.
+		const memberContext = await browser.newContext();
+		await authenticateContext(memberContext, member);
+		const memberPage = await memberContext.newPage();
+		await memberPage.goto(`/org/${org.slug}/resources`);
+		await expect(memberPage.getByText(publicName)).toBeVisible();
+		await expect(memberPage.getByText(membersName)).toBeVisible();
+		await memberContext.close();
+
+		// An anonymous visitor only sees the public one.
+		const anonContext = await browser.newContext();
+		const anonPage = await anonContext.newPage();
+		await anonPage.goto(`/org/${org.slug}/resources`);
+		await expect(anonPage.getByText(publicName)).toBeVisible();
+		await expect(anonPage.getByText(membersName)).toBeHidden();
+		await anonContext.close();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/vat-billing.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/vat-billing.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '../../support/fixtures';
+import { createOrganization, uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { pickSelectOption } from '../../support/ui';
+
+// J8 (USER_JOURNEYS.md) — billing & VAT:
+// - the billing-info form persists (throwaway org, so the seeded Org Alpha
+//   billing setup — which the seeded platform invoice was generated from —
+//   is never mutated);
+// - the platform invoices page renders the invoice `make bootstrap` seeds
+//   for Org Alpha (read-only assertions, PDF download not exercised).
+
+test.describe('J8 VAT & billing @p2', () => {
+	test('billing information form saves and persists', async ({ browser }) => {
+		test.setTimeout(120_000);
+
+		const org = await createOrganization();
+		const billingName = uniqueName('Billing');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/billing`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Billing & VAT' })).toBeVisible();
+
+		await pickSelectOption(page, page.getByLabel('Country'), 'IT - Italy');
+		await page.getByLabel('Default VAT Rate (%)').fill('22.00');
+		await page.getByLabel('Legal / Billing Name').fill(billingName);
+		await page.getByLabel('Billing Address').fill('Via Roma 1, 00100 Roma');
+		await page.getByLabel('Billing Email').fill(org.owner.email);
+		await page.getByRole('button', { name: 'Save Billing Info' }).click();
+		await expect(page.getByText('Billing information updated')).toBeVisible({ timeout: 15_000 });
+
+		// Reload — the form re-populates from the persisted billing info.
+		await gotoHydrated(page, `/org/${org.slug}/admin/billing`);
+		await waitForClientAuth(page);
+		await expect(page.getByLabel('Legal / Billing Name')).toHaveValue(billingName, {
+			timeout: 15_000
+		});
+		await expect(page.getByLabel('Default VAT Rate (%)')).toHaveValue('22.00');
+		await expect(page.getByLabel('Country')).toContainText('Italy');
+
+		await context.close();
+	});
+
+	test('platform invoices page renders the seeded invoice', async ({ asOwner }) => {
+		await gotoHydrated(asOwner, '/org/revel-events-collective/admin/billing/invoices');
+		await waitForClientAuth(asOwner);
+		await expect(asOwner.getByRole('heading', { name: 'Invoices', level: 1 })).toBeVisible();
+
+		// The seed generates one platform-fee invoice for last month's Stripe
+		// sales (numbering varies with DB resets — match the pattern).
+		const invoiceButton = asOwner.getByRole('button', { name: /RVL-\d{4}-\d+/ }).first();
+		await expect(invoiceButton).toBeVisible({ timeout: 15_000 });
+		await expect(asOwner.getByText('Issued').first()).toBeVisible();
+
+		// Open the detail panel.
+		await invoiceButton.click();
+		await expect(asOwner.getByRole('heading', { name: 'Invoice Details' })).toBeVisible();
+		await expect(asOwner.getByText('Fee Breakdown')).toBeVisible();
+		// Two Download PDF buttons exist (per-row icon + detail panel) — the
+		// detail panel's renders after the table.
+		await expect(asOwner.getByRole('button', { name: 'Download PDF' }).last()).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/venues.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/venues.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '../../support/fixtures';
+import { createOrganization, uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J8 (USER_JOURNEYS.md) — venue management, all through the UI: create a
+// venue, add a sector, bulk-create its seats in the grid editor, and prove
+// the layout persists.
+//
+// Isolation: throwaway-owned org — the seeded "Revel Concert Hall" (Org
+// Alpha) is never touched.
+
+test.describe('J8 venues @p2', () => {
+	test('create venue → sector → bulk seats in the grid editor', async ({ browser }) => {
+		test.setTimeout(150_000);
+
+		const org = await createOrganization();
+		const venueName = uniqueName('Venue');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		// Create the venue.
+		await gotoHydrated(page, `/org/${org.slug}/admin/venues`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Venues', level: 1 })).toBeVisible();
+		// Header button + empty-state CTA both say "Create Venue" on a fresh org.
+		await page.getByRole('button', { name: 'Create Venue' }).first().click();
+		const venueModal = page.getByRole('dialog', { name: 'Create Venue' });
+		await expect(venueModal).toBeVisible();
+		await venueModal.getByLabel('Venue Name').fill(venueName);
+		await venueModal.getByLabel('Total Capacity').fill('12');
+		await venueModal.getByRole('button', { name: 'Create Venue' }).click();
+		await expect(venueModal).not.toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText(venueName)).toBeVisible();
+
+		// Into the venue → create a sector.
+		await page.getByLabel('Manage sectors').first().click();
+		await expect(page.getByRole('heading', { name: `Sectors - ${venueName}` })).toBeVisible();
+		// Header button + empty-state CTA both say "Add Sector".
+		await page.getByRole('button', { name: 'Add Sector' }).first().click();
+		const sectorModal = page.getByRole('dialog', { name: 'Create Sector' });
+		await expect(sectorModal).toBeVisible();
+		await sectorModal.getByLabel('Sector Name').fill('Balcony');
+		await sectorModal.getByLabel('Sector Code').fill('BAL');
+		await sectorModal.getByRole('button', { name: 'Create Sector' }).click();
+		await expect(sectorModal).not.toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText('Balcony')).toBeVisible();
+
+		// Into the sector → bulk-create a 2×3 grid of seats.
+		await page.getByLabel('Manage seats').first().click();
+		await expect(page.getByRole('heading', { name: 'Seats - Balcony' })).toBeVisible();
+		await page.getByLabel('Rows').fill('2');
+		await page.getByLabel('Columns').fill('3');
+		await page.getByRole('button', { name: 'Fill All' }).click();
+		await expect(page.getByText('Total:')).toContainText('6');
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(page.getByText('Seats saved successfully')).toBeVisible({ timeout: 15_000 });
+
+		// Reload: the editor re-initializes from the persisted seats.
+		await gotoHydrated(page, page.url());
+		await expect(page.getByText('Total:')).toContainText('6', { timeout: 15_000 });
+
+		// Back on the sectors page the card counts the seats.
+		await page.getByRole('button', { name: 'Back to sectors' }).click();
+		await expect(page.getByText(/6 seats/)).toBeVisible({ timeout: 15_000 });
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j09-staff/permission-gating.spec.ts
+++ b/tests/e2e/journeys/j09-staff/permission-gating.spec.ts
@@ -1,0 +1,126 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+	addStaff,
+	approveMembershipRequest,
+	createOrganization,
+	createVerifiedUser,
+	requestMembership,
+	setStaffPermissions
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J9 (USER_JOURNEYS.md) — staff permission gating. A staff member with a
+// narrow permission map sees exactly the allowed admin surfaces:
+// - owner-only nav items (Billing, Financials) are hidden and their direct
+//   URLs render the 403 error page;
+// - permission-driven affordances (Create Event) appear only once the owner
+//   grants the underlying permission;
+// - non-staff users can't reach the admin area at all.
+//
+// Per-EVENT permission overrides exist in the backend PermissionsSchema but
+// have no frontend editing UI yet — tracked as a follow-up issue, not
+// asserted here.
+//
+// Isolation: throwaway-owned org; staff + outsider are throwaway users.
+
+/** The admin nav is a sidebar on desktop and behind a toggle on mobile. */
+async function openAdminNav(page: Page): Promise<ReturnType<Page['getByRole']>> {
+	const desktopNav = page.getByRole('navigation', { name: 'Admin navigation' });
+	if (await desktopNav.isVisible()) {
+		return desktopNav;
+	}
+	// Both the global header and the admin layout render a toggle with this
+	// label on mobile — the admin one lives inside <main>.
+	await page.getByRole('main').getByRole('button', { name: 'Toggle navigation menu' }).click();
+	const mobileNav = page.getByRole('navigation', { name: 'Mobile admin navigation' });
+	await expect(mobileNav).toBeVisible();
+	return mobileNav;
+}
+
+test.describe('J9 permission gating @p2', () => {
+	test('staff sees only permitted surfaces; owner grant unlocks them', async ({ browser }) => {
+		test.setTimeout(180_000);
+
+		const org = await createOrganization({ acceptMembershipRequests: true });
+		const [staffUser, outsider] = await Promise.all([
+			createVerifiedUser('NarrowStaff'),
+			createVerifiedUser('Outsider')
+		]);
+		const request = await requestMembership(staffUser, org.slug);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		// Narrow permission set: nothing beyond the default view permission.
+		const staffUserId = await addStaff(org.owner, org.slug, staffUser.email, {
+			create_event: false,
+			manage_event: false,
+			manage_members: false,
+			edit_organization: false
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, staffUser);
+		const page = await context.newPage();
+
+		// The staff member reaches the admin area…
+		await gotoHydrated(page, `/org/${org.slug}/admin`);
+		await waitForClientAuth(page);
+		await expect(page.getByText('Staff', { exact: true }).first()).toBeVisible();
+
+		// …but the owner-only nav items aren't offered.
+		const nav = await openAdminNav(page);
+		await expect(nav.getByRole('link', { name: 'Events', exact: true })).toBeVisible();
+		await expect(nav.getByRole('link', { name: 'Billing' })).toBeHidden();
+		await expect(nav.getByRole('link', { name: 'Financials' })).toBeHidden();
+
+		// Direct URLs to owner-only pages render the 403 error page.
+		for (const path of ['financials', 'billing', 'billing/invoices']) {
+			await page.goto(`/org/${org.slug}/admin/${path}`);
+			await expect(page.getByRole('heading', { name: 'Access Denied' })).toBeVisible();
+		}
+
+		// create_event=false: no Create Event button, and the wizard URL is
+		// server-blocked too.
+		await gotoHydrated(page, `/org/${org.slug}/admin/events`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Events', level: 1 })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Create Event' })).toBeHidden();
+		await page.goto(`/org/${org.slug}/admin/events/new`);
+		await expect(page.getByRole('heading', { name: 'Access Denied' })).toBeVisible();
+
+		// The owner grants create_event → the surface unlocks.
+		await setStaffPermissions(org.owner, org.slug, staffUserId, { create_event: true });
+		await gotoHydrated(page, `/org/${org.slug}/admin/events`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('button', { name: 'Create Event' }).first()).toBeVisible();
+		await page.goto(`/org/${org.slug}/admin/events/new`);
+		await expect(page.getByRole('heading', { name: 'Access Denied' })).toBeHidden();
+
+		await context.close();
+
+		// A non-staff user can't reach the admin area at all — the backend hides
+		// the admin org resource from outsiders, so the page 404s rather than 403s.
+		const outsiderContext = await browser.newContext();
+		await authenticateContext(outsiderContext, outsider);
+		const outsiderPage = await outsiderContext.newPage();
+		await outsiderPage.goto(`/org/${org.slug}/admin`);
+		await expect(outsiderPage.getByRole('heading', { name: 'Page Not Found' })).toBeVisible();
+		await outsiderContext.close();
+	});
+
+	test('the owner sees the owner-only nav items', async ({ browser }) => {
+		const org = await createOrganization();
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}/admin`);
+		await waitForClientAuth(page);
+		const nav = await openAdminNav(page);
+		await expect(nav.getByRole('link', { name: 'Billing' })).toBeVisible();
+		await expect(nav.getByRole('link', { name: 'Financials' })).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j13-blacklist-moderation/hard-blacklist.spec.ts
+++ b/tests/e2e/journeys/j13-blacklist-moderation/hard-blacklist.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	addStaff,
+	addToBlacklist,
+	approveMembershipRequest,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser,
+	requestMembership
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J13 (USER_JOURNEYS.md) — hard blacklist consequences. Blacklisting a user
+// who is an active STAFF MEMBER strips their staff role, flips their
+// membership to BANNED, and blocks their event access — all applied
+// atomically by the backend's post_save signal when the entry links to the
+// account (matching email).
+//
+// Isolation: throwaway-owned org, throwaway member-then-staff victim.
+
+test.describe('J13 hard blacklist @p2', () => {
+	test('blacklisted staff member is stripped, banned, and blocked from events', async ({
+		browser
+	}) => {
+		test.setTimeout(150_000);
+
+		const org = await createOrganization({ acceptMembershipRequests: true });
+		const victim = await createVerifiedUser('Banned');
+		const request = await requestMembership(victim, org.slug);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		await addStaff(org.owner, org.slug, victim.email);
+		const event = await createTicketedEvent({
+			owner: org.owner,
+			orgSlug: org.slug,
+			freeTier: false,
+			event: { requires_ticket: false }
+		});
+		const victimName = `${victim.firstName} ${victim.lastName}`;
+
+		// Sanity: as staff, the victim can access the org admin and the event.
+		const victimContext = await browser.newContext();
+		await authenticateContext(victimContext, victim);
+		const victimPage = await victimContext.newPage();
+		await gotoHydrated(victimPage, event.path);
+		await waitForClientAuth(victimPage);
+		await expect(victimPage.getByRole('heading', { name: 'Will you attend?' })).toBeVisible();
+
+		// The owner blacklists them by email (auto-links to the account).
+		await addToBlacklist(org.owner, org.slug, {
+			email: victim.email,
+			reason: 'E2E hard-blacklist journey'
+		});
+
+		// Owner's admin view: no staff left, membership shows Banned.
+		const ownerContext = await browser.newContext();
+		await authenticateContext(ownerContext, org.owner);
+		const ownerPage = await ownerContext.newPage();
+		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(ownerPage);
+		await ownerPage.getByRole('tab', { name: /^Staff/ }).click();
+		await expect(ownerPage.getByText('No staff members found')).toBeVisible({ timeout: 15_000 });
+		await ownerPage.getByRole('tab', { name: /^Members/ }).click();
+		const memberCard = ownerPage
+			.locator('article, li, div')
+			.filter({ hasText: victimName })
+			.filter({ hasText: /Banned/ })
+			.first();
+		await expect(memberCard).toBeVisible({ timeout: 15_000 });
+
+		// The banned user's event access is gone outright — hard-blacklisting
+		// hides the org's events entirely: direct URL → 404.
+		const bannedResponse = await victimPage.goto(event.path);
+		expect(bannedResponse?.status()).toBe(404);
+		await expect(victimPage.getByRole('heading', { name: 'Page Not Found' })).toBeVisible();
+
+		await victimContext.close();
+		await ownerContext.close();
+	});
+});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -415,6 +415,84 @@ export async function approveMembershipRequest(
 	});
 }
 
+/**
+ * Look up an org member's user id via the org-admin members list (the search
+ * param matches email). Factory emails contain `+`, so the query is always
+ * URI-encoded.
+ */
+async function findMemberUserId(api: ApiClient, orgSlug: string, email: string): Promise<string> {
+	const page = await api.get<{ results: Array<{ user: { id: string; email: string } }> }>(
+		`/api/organization-admin/${orgSlug}/members?search=${encodeURIComponent(email)}`
+	);
+	const member = page.results.find((m) => m.user.email === email) ?? page.results[0];
+	if (!member) {
+		throw new Error(`No member matching ${email} in org ${orgSlug}`);
+	}
+	return member.user.id;
+}
+
+/** Set an existing member's status (active/paused/cancelled/banned) as the org owner. */
+export async function setMemberStatus(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	memberEmail: string,
+	status: 'active' | 'paused' | 'cancelled' | 'banned'
+): Promise<void> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	const userId = await findMemberUserId(api, orgSlug, memberEmail);
+	await api.put(`/api/organization-admin/${orgSlug}/members/${userId}`, { status });
+}
+
+/**
+ * Promote an existing MEMBER to staff, optionally with a narrow permission
+ * map (unset keys keep the backend defaults — everything false except
+ * view_organization_details). Returns the promoted user's id for follow-up
+ * permission updates.
+ */
+export async function addStaff(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	memberEmail: string,
+	permissions?: Record<string, boolean>
+): Promise<string> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	const userId = await findMemberUserId(api, orgSlug, memberEmail);
+	await api.post(
+		`/api/organization-admin/${orgSlug}/staff/${userId}`,
+		permissions ? { default: permissions, event_overrides: {} } : undefined
+	);
+	return userId;
+}
+
+/** Replace a staff member's org-wide permission map (owner-only endpoint). */
+export async function setStaffPermissions(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	userId: string,
+	permissions: Record<string, boolean>
+): Promise<void> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	await api.put(`/api/organization-admin/${orgSlug}/staff/${userId}/permissions`, {
+		default: permissions,
+		event_overrides: {}
+	});
+}
+
+/**
+ * API-create a blacklist entry on a throwaway-owned org. Passing the email of
+ * a REGISTERED user auto-links the entry to that account, which immediately
+ * applies the consequences (staff stripped, membership set to BANNED, event
+ * access blocked) via the backend's post_save signal.
+ */
+export async function addToBlacklist(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	entry: Record<string, unknown>
+): Promise<{ id: string }> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	return api.post<{ id: string }>(`/api/organization-admin/${orgSlug}/blacklist`, entry);
+}
+
 export interface CreatedPoll {
 	id: string;
 	orgSlug: string;


### PR DESCRIPTION
Part of #591 (E2E v2 Phase 3, @p2 journey suites) — **group (d): org admin**. Groups (a), (b), (e) landed in #614/#615/#626; groups (c) and (f) remain, so #591 stays open.

## New suites (13 tests ×2 projects; full-run tally 269 → 295)

| Spec | Covers |
|---|---|
| `j04/tier-benefits` | Seeded FutureStack "Member Discount" tier (visibility=members-only + purchasable_by=members) visible to a Beta member, hidden from non-members and anonymous. Uses **karen**, not frank — frank's seeded ticket on that very tier replaces the tier list with his ticket card. |
| `j04/status-changes` | Pause a member (API) → members-only event flips to the "Your membership is not active." gate + org page shows the Paused pill; reactivate → access restored. |
| `j08/membership-tiers` | Tier CRUD + the #622/BE #690 up/down reorder, order persisted across reload. |
| `j08/blacklist` | Add-by-email auto-links a registered user and hard-blocks them — **the org's events 404 for them outright** (the "not allowed to participate" gate is only for soft/fuzzy matches); name-only entry added and removed via the entry modal. |
| `j08/venues` | Venue → sector → 2×3 bulk seat grid in the editor, persisted (seat count on the sector card). |
| `j08/resources` | Link (public) + text (members-only) resources created in admin; public resources page shows both to a member, only the public one to anonymous. |
| `j08/vat-billing` | Billing-info form persists on a throwaway org (seeded Alpha billing never mutated — the seeded platform invoice depends on it); Alpha's seeded `RVL-…` invoice page asserted read-only. |
| `j09/permission-gating` | Narrow-permission staff: Billing/Financials nav hidden + direct URLs 403; no Create Event until the owner grants `create_event` (then the wizard unlocks); outsiders 404 (backend hides the admin org resource). |
| `j13/hard-blacklist` | Blacklisting an active staff member strips staff, flips membership to Banned in admin, and 404s their event access. |

New factories: `setMemberStatus`, `addStaff`, `setStaffPermissions`, `addToBlacklist`.

## Product bugs surfaced by the gates (fixed in-PR, per-concern commits)

1. **TanStack tracked-properties freeze** (`fix(queries)`): the venue sectors page went permanently blank on ~50–70% of first navigations. TanStack Query only pushes updates for result properties a subscriber has actually read; `venueQuery.isLoading || sectorsQuery.isLoading` short-circuits past the second query, so when it resolved first its update was dropped and its snapshot froze in the loading state forever. Fixed with `$derived.by` reading every operand unconditionally. Repo sweep found and fixed the same shape in `DietaryPreferencesManager` and `CancelTicketDialog`.
2. **Missing admin route guards** (`fix(admin)`): `/admin/billing/*` had no owner guard (staff direct-URL rendered a broken shell with failing owner-only queries) — new billing `+layout.server.ts` 403s non-owners, mirroring financials. `/admin/events/new` now 403s staff without `create_event` instead of serving the wizard whose submit would fail.

## Follow-up filed

- #628 — PermissionsEditor has no per-event permission override UI (backend `PermissionsSchema.event_overrides` fully supported since BE #685); j09 covers org-wide gating only.

## Verification

- New specs: `--workers=4 --retries=0 --repeat-each=3` → 78/78.
- Full suite after `reset_events`: **293 passed, 2 skipped, 0 failed** (~2.7 min, gunicorn+PgBouncer backend, BE #688).
- `make check` green, unit tests 846/846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Control**
  - Billing administration is now restricted to organization owners.
  - Event creation and administrative areas respect staff permissions.
  - Unauthorized users receive appropriate access-denied or not-found responses.

- **Bug Fixes**
  - Improved loading and error-state updates across dietary preferences, ticket cancellation, and venue management pages.
  - Prevented pages from becoming stuck while multiple requests are loading.

- **Membership & Moderation**
  - Improved handling of paused, banned, and blacklisted members across event and organization access.

- **Quality Improvements**
  - Expanded end-to-end coverage for membership tiers, resources, venues, billing, blacklist moderation, and staff permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->