### PR TITLE
test(e2e): Phase 3c — j06/j16/j20/j22 @p2 tickets & payments suites (#591)

### DIFF
--- a/tests/e2e/journeys/j06-tickets/door-pwyc.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/door-pwyc.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	deleteDefaultTier
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import type { Browser, Locator, Page } from '@playwright/test';
+
+// J6.4/J6.5 (USER_JOURNEYS.md) — at-the-door and pay-what-you-can tiers:
+// - at_the_door checkout creates an immediately ACTIVE ticket (payment is
+//   collected on arrival; no staff confirmation gate, unlike offline).
+// - PWYC enforces its min/max range in the confirmation dialog and carries
+//   the chosen amount; exercised on BOTH manual payment methods —
+//   at_the_door (→ ACTIVE) and offline (→ PENDING + instructions).
+//
+// Isolation: each test API-arranges its own event + tier + throwaway buyer.
+
+async function openBuyerPage(browser: Browser, path: string) {
+	const buyer = await createVerifiedUser('DoorPwyc');
+	const context = await browser.newContext();
+	await authenticateContext(context, buyer);
+	const page = await context.newPage();
+	await gotoHydrated(page, path);
+	await waitForClientAuth(page);
+	return { context, page };
+}
+
+// Reserve-flow idempotent loop (same shape as free-tier.spec.ts): clicks
+// during dialog re-renders are occasionally dropped, so retry from whatever
+// state the UI is in. `beforeConfirm` runs whenever the confirm dialog is
+// open (PWYC amount fill — re-runs harmlessly on retries).
+async function reserveTicket(page: Page, beforeConfirm?: (dialog: Locator) => Promise<void>) {
+	const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+	const confirmDialog = page.getByRole('dialog', { name: 'Reserve Ticket' });
+	const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+	await expect(async () => {
+		if (await success.isVisible()) return;
+		if (!(await confirmDialog.isVisible())) {
+			if (!(await tierDialog.isVisible())) {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+			}
+			await tierDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+		}
+		await beforeConfirm?.(confirmDialog);
+		await confirmDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+		await expect(success).toBeVisible({ timeout: 8_000 });
+	}).toPass({ timeout: 60_000 });
+	return success;
+}
+
+test.describe('J6 at-the-door & PWYC @p2', () => {
+	test('at-the-door fixed price → ticket is active immediately', async ({ browser }) => {
+		const event = await createTicketedEvent({ freeTier: false });
+		await deleteDefaultTier(event.id); // its card also says "Reserve Ticket"
+		await createTicketTier(event.id, {
+			name: 'At The Door',
+			payment_method: 'at_the_door',
+			price: '15.00'
+		});
+
+		const { context, page } = await openBuyerPage(browser, event.path);
+		const success = await reserveTicket(page);
+
+		// ACTIVE straight away — no pending-payment banner, no staff gate.
+		await expect(success.getByText('Active', { exact: true }).first()).toBeVisible();
+		await expect(success.getByText('Your ticket is pending payment')).not.toBeVisible();
+
+		const activeCard = page
+			.locator('article, li, div')
+			.filter({ hasText: event.name })
+			.filter({ hasText: /Active/i })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await expect(activeCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		await context.close();
+	});
+
+	test('PWYC at-the-door enforces min/max and activates at the chosen amount', async ({
+		browser
+	}) => {
+		const event = await createTicketedEvent({ freeTier: false });
+		await deleteDefaultTier(event.id); // its card also says "Reserve Ticket"
+		await createTicketTier(event.id, {
+			name: 'Door PWYC',
+			payment_method: 'at_the_door',
+			price_type: 'pwyc',
+			price: '10.00',
+			pwyc_min: '5.00',
+			pwyc_max: '50.00'
+		});
+
+		const { context, page } = await openBuyerPage(browser, event.path);
+
+		// Open the confirm dialog once to exercise the range validation before
+		// completing the reservation inside the idempotent loop.
+		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+		const confirmDialog = page.getByRole('dialog', { name: 'Reserve Ticket' });
+		await expect(async () => {
+			if (await confirmDialog.isVisible()) return;
+			if (!(await tierDialog.isVisible())) {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+			}
+			await tierDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+			await expect(confirmDialog).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+
+		const amount = confirmDialog.getByLabel('Payment Amount');
+		await amount.fill('2');
+		await expect(confirmDialog.getByText(/Amount must be at least EUR 5\.00/)).toBeVisible();
+		await amount.fill('100');
+		await expect(confirmDialog.getByText(/Amount cannot exceed EUR 50\.00/)).toBeVisible();
+
+		const success = await reserveTicket(page, async (dialog) => {
+			await dialog.getByLabel('Payment Amount').fill('12.50');
+		});
+		await expect(success.getByText('Active', { exact: true }).first()).toBeVisible();
+
+		await context.close();
+	});
+
+	test('PWYC offline reserves a pending ticket at the chosen amount', async ({ browser }) => {
+		const event = await createTicketedEvent({ freeTier: false });
+		await deleteDefaultTier(event.id); // its card also says "Reserve Ticket"
+		await createTicketTier(event.id, {
+			name: 'Transfer PWYC',
+			payment_method: 'offline',
+			price_type: 'pwyc',
+			price: '10.00',
+			pwyc_min: '5.00',
+			pwyc_max: '50.00',
+			manual_payment_instructions: 'Send your chosen amount to IBAN AT98 7654.'
+		});
+
+		const { context, page } = await openBuyerPage(browser, event.path);
+		const success = await reserveTicket(page, async (dialog) => {
+			await dialog.getByLabel('Payment Amount').fill('7.50');
+		});
+
+		// Offline stays PENDING until staff confirm, and surfaces the
+		// organizer's payment instructions.
+		await expect(success.getByText('Your ticket is pending payment')).toBeVisible();
+		await expect(success.getByText('Send your chosen amount to IBAN AT98 7654.')).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j06-tickets/offline.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/offline.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	deleteDefaultTier
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J6.5 (USER_JOURNEYS.md) — offline-payment tier: reserve → ticket is PENDING
+// with the organizer's manual payment instructions → staff confirms the
+// payment in the event admin → ticket flips ACTIVE for the buyer.
+//
+// Isolation: API-arranged event + offline tier + throwaway buyer; the seeded
+// offline tiers (Workshop Seat, Standing Room) stay untouched.
+
+const INSTRUCTIONS = 'Wire the amount to IBAN AT12 3456 7890 within 5 days.';
+
+test.describe('J6 offline payment @p2', () => {
+	test('reserve → pending with instructions → staff confirms → active', async ({
+		browser,
+		asOwner
+	}) => {
+		const [event, buyer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('Offline')
+		]);
+		// The auto-created General Admission tier also renders "Reserve Ticket".
+		await deleteDefaultTier(event.id);
+		await createTicketTier(event.id, {
+			name: 'Bank Transfer',
+			payment_method: 'offline',
+			price: '20.00',
+			manual_payment_instructions: INSTRUCTIONS
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, buyer);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		// CTA → tier dialog → "Reserve Ticket" card button → confirm dialog →
+		// "Reserve Ticket" confirm. Same idempotent-loop shape as
+		// free-tier.spec.ts (clicks during dialog re-renders are occasionally
+		// dropped); success signal is the auto-opened "Your Ticket" modal. The
+		// card button and the confirm button share the name "Reserve Ticket" —
+		// they're distinguished by their containing dialog.
+		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+		const confirmDialog = page.getByRole('dialog', { name: 'Reserve Ticket' });
+		const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+		await expect(async () => {
+			if (await success.isVisible()) return;
+			if (await confirmDialog.isVisible()) {
+				await confirmDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+			} else if (await tierDialog.isVisible()) {
+				await tierDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+				await confirmDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+			} else {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+				await tierDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+				await confirmDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+			}
+			await expect(success).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+
+		// The ticket modal shows the pending-payment banner with the organizer's
+		// manual instructions.
+		await expect(success.getByText('Your ticket is pending payment')).toBeVisible();
+		await expect(success.getByText('Payment Instructions:')).toBeVisible();
+		await expect(success.getByText(INSTRUCTIONS)).toBeVisible();
+
+		// Staff side: the pending ticket has an inline "Confirm Payment" action.
+		await gotoHydrated(asOwner, `/org/${event.orgSlug}/admin/events/${event.id}/tickets`);
+		await waitForClientAuth(asOwner);
+		const buyerRow = asOwner
+			.locator('tr, article, li, div')
+			.filter({ hasText: `${buyer.firstName} ${buyer.lastName}` })
+			.filter({ hasText: /Pending/i })
+			.first();
+		await expect(buyerRow).toBeVisible({ timeout: 15_000 });
+		await buyerRow.getByRole('button', { name: 'Confirm Payment' }).click();
+
+		const confirmPayment = asOwner.getByRole('dialog', { name: 'Confirm Payment' });
+		await expect(confirmPayment).toBeVisible({ timeout: 15_000 });
+		await confirmPayment.getByRole('button', { name: 'Confirm Payment' }).click();
+		await expect(confirmPayment).not.toBeVisible({ timeout: 15_000 });
+
+		const activeRow = asOwner
+			.locator('tr, article, li, div')
+			.filter({ hasText: `${buyer.firstName} ${buyer.lastName}` })
+			.filter({ hasText: /Active/i })
+			.first();
+		await expect(activeRow).toBeVisible({ timeout: 15_000 });
+
+		// Buyer side: the dashboard ticket flipped to Active.
+		const activeCard = page
+			.locator('article, li, div')
+			.filter({ hasText: event.name })
+			.filter({ hasText: /Active/i })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await expect(activeCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j06-tickets/seat-selection.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/seat-selection.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	claimTicketViaApi,
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	deleteDefaultTier,
+	getSeededConcertHall,
+	listAvailableSeats
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J19→J6 (USER_JOURNEYS.md) — USER_CHOICE seat selection at checkout: the
+// confirmation dialog renders the sector's seat map, an already-taken seat is
+// unavailable, and the chosen seat lands on the ticket.
+//
+// Isolation: own event on Org Alpha with an OFFLINE user-choice tier attached
+// to the seeded "Revel Concert Hall" 10×10 grid — seat availability is per
+// event, so the seeded classical-music-evening's seats are untouched, and
+// offline avoids Stripe entirely (seat resolution is payment-method agnostic,
+// see batch_ticket_service._resolve_seats_user_choice). Row A is seeded
+// accessible (aria "…, accessible"), so the spec works in row B where seat
+// names are bare.
+
+test.describe('J6 seat selection @p2', () => {
+	test('seat map at checkout → taken seat blocked → chosen seat on ticket', async ({ browser }) => {
+		const hall = await getSeededConcertHall();
+		const [event, buyer, otherBuyer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('SeatBuyer'),
+			createVerifiedUser('SeatTaker')
+		]);
+		await deleteDefaultTier(event.id); // its card also says "Reserve Ticket"
+		const tier = await createTicketTier(event.id, {
+			name: 'Choose Your Seat',
+			payment_method: 'offline',
+			price: '25.00',
+			seat_assignment_mode: 'user_choice',
+			venue_id: hall.venueId,
+			sector_id: hall.sectorId
+		});
+
+		// Another attendee takes B1 via the API so the map shows it unavailable.
+		const seats = await listAvailableSeats(buyer, event.id, tier.id);
+		const seatB1 = seats.find((s) => s.label === 'B1');
+		if (!seatB1) throw new Error('Seeded seat B1 missing from Revel Concert Hall');
+		await claimTicketViaApi(otherBuyer, event.id, tier.id, { seatId: seatB1.id });
+
+		const context = await browser.newContext();
+		await authenticateContext(context, buyer);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		// Open the confirmation dialog (idempotent loop, see free-tier.spec.ts).
+		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+		const confirmDialog = page.getByRole('dialog', { name: 'Reserve Ticket' });
+		await expect(async () => {
+			if (await confirmDialog.isVisible()) return;
+			if (!(await tierDialog.isVisible())) {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+			}
+			await tierDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+			await expect(confirmDialog).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+
+		// Seat map: stage marker, the taken seat disabled, a free seat clickable.
+		await expect(confirmDialog.getByText('Select Your Seats')).toBeVisible();
+		await expect(confirmDialog.getByText('STAGE')).toBeVisible({ timeout: 15_000 });
+		await expect(
+			confirmDialog.getByRole('button', { name: 'Seat B1, unavailable' })
+		).toBeDisabled();
+
+		// Choose B3, then reserve. Re-render-dropped clicks retry: only click the
+		// seat when it isn't already selected (a second click would DESELECT it).
+		const seatB3 = confirmDialog.getByRole('button', { name: 'Seat B3', exact: true });
+		const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+		await expect(async () => {
+			if (await success.isVisible()) return;
+			if ((await seatB3.getAttribute('aria-pressed')) !== 'true') {
+				await seatB3.click();
+			}
+			await expect(confirmDialog.getByText('1 / 1 selected')).toBeVisible({ timeout: 5_000 });
+			await confirmDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+			await expect(success).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+
+		// The ticket carries the chosen seat ("Venue • Sector • Row B, Seat 3").
+		await expect(success.getByText(/Row B, Seat 3/)).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j06-tickets/self-cancel.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/self-cancel.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	startOnlineCheckout
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { completeStripeCheckout } from '../../support/stripe';
+
+// J6.7 (USER_JOURNEYS.md) — attendee self-cancellation on an online ticket:
+// the cancel dialog quotes the refund from the tier's policy before anything
+// happens, confirming cancels the ticket and issues the Stripe refund.
+//
+// Requires the full Stripe test-mode setup (tests/e2e/README.md): the ticket
+// must be PAID for a refund quote to exist, so the arrange drives the hosted
+// checkout with the API-returned session URL.
+//
+// Isolation: own event + online tier with allow_user_cancellation and a
+// 100%-until-start refund policy; throwaway buyer.
+
+test.describe('J6 self-cancel @p2', () => {
+	test('refund preview → confirm → ticket cancelled with refund toast', async ({ browser }) => {
+		// Stripe hosted checkout + webhook + refund round-trips.
+		test.setTimeout(240_000);
+
+		const [event, buyer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('SelfCancel')
+		]);
+		const tier = await createTicketTier(event.id, {
+			name: 'Refundable Entry',
+			payment_method: 'online',
+			price: '10.00',
+			allow_user_cancellation: true,
+			refund_policy: {
+				tiers: [{ hours_before_event: 0, refund_percentage: '100' }],
+				flat_fee: '0'
+			}
+		});
+
+		const checkoutUrl = await startOnlineCheckout(buyer, event.id, tier.id);
+
+		const context = await browser.newContext();
+		await authenticateContext(context, buyer);
+		const page = await context.newPage();
+		await page.goto(checkoutUrl);
+		await completeStripeCheckout(page);
+
+		// Activation arrives via the webhook — poll the dashboard.
+		const activeCard = page
+			.locator('article, li, div')
+			.filter({ hasText: event.name })
+			.filter({ hasText: /Active/i })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await expect(activeCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 90_000 });
+		await waitForClientAuth(page);
+
+		// Open the ticket modal → "Cancel ticket" (rendered only for active
+		// tickets on allow_user_cancellation tiers before event start).
+		await activeCard.getByRole('button', { name: 'View Ticket' }).click();
+		const ticketModal = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+		await expect(ticketModal).toBeVisible({ timeout: 15_000 });
+		await ticketModal.getByRole('button', { name: 'Cancel ticket' }).click();
+
+		// The dialog quotes the full refund (100% window, no flat fee) before
+		// any mutation happens.
+		const cancelDialog = page.getByRole('dialog', { name: 'Cancel your ticket' });
+		await expect(cancelDialog).toBeVisible({ timeout: 15_000 });
+		const summary = cancelDialog.getByTestId('refund-summary');
+		await expect(summary.getByText("You'll receive")).toBeVisible({ timeout: 15_000 });
+		await expect(summary.getByText(/10[.,]00/)).toBeVisible();
+		await expect(cancelDialog.getByText('Refund schedule')).toBeVisible();
+
+		await cancelDialog.getByLabel('Reason (optional)').fill('E2E self-cancel journey');
+		await cancelDialog.getByRole('button', { name: 'Confirm cancellation' }).click();
+
+		// Success toast announces the refund; the dashboard card flips to
+		// Cancelled once the list refetches.
+		await expect(page.getByText('Ticket cancelled')).toBeVisible({ timeout: 30_000 });
+		const cancelledCard = page
+			.locator('article, li, div')
+			.filter({ hasText: event.name })
+			.filter({ hasText: /Cancelled/i })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await expect(cancelledCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j16-billing/vat-preview.spec.ts
+++ b/tests/e2e/journeys/j16-billing/vat-preview.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '../../support/fixtures';
+import { ApiClient } from '../../support/api';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	setOrgInvoicingMode
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J16 (USER_JOURNEYS.md) — buyer-facing VAT preview in the checkout billing
+// form: a domestic (same-country) B2B buyer still pays the org's VAT, an EU
+// cross-border buyer with a VIES-valid VAT ID gets the reverse charge (no
+// VAT). The VAT math itself is backend-tested — this asserts the breakdown
+// UI reacts to the billing fields.
+//
+// The billing section only renders when the org has attendee invoicing
+// enabled AND the tier is online — the arrange flips Org Alpha (AT, 20%) to
+// 'auto' (idempotent, deliberately not reverted; see setOrgInvoicingMode).
+//
+// VAT IDs are validated against the LIVE EU VIES service (no backend stub),
+// so the spec uses two real, stable registrations — Red Bull GmbH (AT,
+// domestic) and Ferrari S.p.A. (IT, cross-border) — and skips itself when
+// VIES is down instead of failing the run.
+
+const DOMESTIC_VAT_ID = 'ATU33864707'; // Red Bull GmbH — same country as Org Alpha
+const CROSS_BORDER_VAT_ID = 'IT00159560366'; // Ferrari S.p.A. — EU B2B reverse charge
+
+test.describe('J16 VAT preview @p2', () => {
+	test('domestic B2B pays VAT; EU B2B with valid VAT ID gets reverse charge', async ({
+		browser
+	}) => {
+		await setOrgInvoicingMode('auto');
+		const [event, buyer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('VatPreview')
+		]);
+		// €10.00 gross at AT 20% VAT → net 8.33 + VAT 1.67.
+		const tier = await createTicketTier(event.id, { name: 'Invoiced Entry', price: '10.00' });
+
+		// Probe VIES through the backend preview endpoint — skip (not fail)
+		// when the external service is unavailable or won't validate the IDs.
+		const api = await ApiClient.login(buyer.email, buyer.password);
+		for (const vatId of [DOMESTIC_VAT_ID, CROSS_BORDER_VAT_ID]) {
+			const probe = await api.post<{ vat_id_valid: boolean | null }>(
+				`/api/events/${event.id}/tickets/vat-preview`,
+				{
+					billing_info: { billing_name: 'Probe', vat_id: vatId },
+					items: [{ tier_id: tier.id, count: 1 }]
+				}
+			);
+			test.skip(
+				probe.vat_id_valid !== true,
+				`VIES did not validate ${vatId} (service down or registration changed)`
+			);
+		}
+
+		const context = await browser.newContext();
+		await authenticateContext(context, buyer);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		// Open the purchase confirmation dialog (fixed-price online tier).
+		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+		const confirmDialog = page.getByRole('dialog', { name: 'Confirm Purchase' });
+		await expect(async () => {
+			if (await confirmDialog.isVisible()) return;
+			if (!(await tierDialog.isVisible())) {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+			}
+			await tierDialog.getByRole('button', { name: 'Buy Ticket' }).click();
+			await expect(confirmDialog).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+
+		// Expand the billing form and fill the domestic B2B case. The preview
+		// fetch fires on VAT-ID blur.
+		await confirmDialog.getByRole('checkbox', { name: 'Request Invoice' }).click();
+		await confirmDialog.getByLabel('Legal Name').fill('E2E Buyer GmbH');
+		await confirmDialog.getByLabel('Country Code').fill('AT');
+		const vatInput = confirmDialog.getByLabel('VAT ID (optional)');
+		await vatInput.fill(DOMESTIC_VAT_ID);
+		await vatInput.blur();
+
+		const preview = confirmDialog.locator('[aria-label="VAT Preview"]');
+		await expect(preview.getByText('VAT ID valid')).toBeVisible({ timeout: 30_000 });
+		await expect(preview.getByText('Total VAT')).toBeVisible();
+		// EUR 1.67 renders twice (line VAT column + Total VAT).
+		await expect(preview.getByText(/1[.,]67/).first()).toBeVisible();
+		await expect(preview.getByText('Reverse charge applies — no VAT charged')).not.toBeVisible();
+
+		// Switch to the EU cross-border B2B case → reverse charge, zero VAT.
+		await confirmDialog.getByLabel('Country Code').fill('IT');
+		await vatInput.fill(CROSS_BORDER_VAT_ID);
+		await vatInput.blur();
+
+		await expect(preview.getByText('Reverse charge applies — no VAT charged')).toBeVisible({
+			timeout: 30_000
+		});
+		await expect(preview.getByText(/1[.,]67/).first()).not.toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j20-discounts/discount-lifecycle.spec.ts
+++ b/tests/e2e/journeys/j20-discounts/discount-lifecycle.spec.ts
@@ -1,0 +1,137 @@
+import crypto from 'node:crypto';
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	deleteDefaultTier
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J20 (USER_JOURNEYS.md) — discount code lifecycle: admin creates a
+// percentage code → buyer applies it at checkout (invalid codes rejected
+// inline) → the discounted price shows and the reservation records the
+// usage → duplicate code creation 409s → deleting a USED code deactivates
+// it instead (redemption history preserved).
+//
+// The buyer side uses an OFFLINE tier: usage is recorded at ticket creation
+// (batch_ticket_service.apply_discount), so no Stripe round-trip is needed.
+//
+// Isolation: own event + tier + throwaway buyer on Org Alpha; the code name
+// is run-unique so re-runs never collide with previous (deactivated) codes.
+
+const CODE = `E2E${crypto.randomBytes(4).toString('hex').toUpperCase()}`;
+const ADMIN_LIST = '/org/revel-events-collective/admin/discount-codes';
+
+/**
+ * The admin list renders the code twice (desktop table + mobile cards, one
+ * hidden per viewport) — the deepest VISIBLE container holding both the code
+ * and the expected text is the real row/card (ancestors precede descendants
+ * in locator order, so .last() is the deepest).
+ */
+function codeRowWith(page: import('@playwright/test').Page, text: string) {
+	return page
+		.locator('tr, article, li, div')
+		.filter({ hasText: CODE })
+		.filter({ hasText: text })
+		.filter({ visible: true })
+		.last();
+}
+
+test.describe('J20 discount lifecycle @p2', () => {
+	test('create → apply at checkout → usage tracked → duplicate 409 → used delete deactivates', async ({
+		asOwner,
+		browser
+	}) => {
+		const [event, buyer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('Discount')
+		]);
+		await deleteDefaultTier(event.id); // its card also says "Reserve Ticket"
+		await createTicketTier(event.id, {
+			name: 'Discountable Entry',
+			payment_method: 'offline',
+			price: '20.00'
+		});
+
+		// Admin creates a 50% org-wide code through the form.
+		await gotoHydrated(asOwner, `${ADMIN_LIST}/new`);
+		await waitForClientAuth(asOwner);
+		await asOwner.getByLabel('Code', { exact: true }).fill(CODE);
+		await asOwner.getByRole('radio', { name: /Percentage/ }).check();
+		await asOwner.getByLabel('Discount Value').fill('50');
+		await asOwner.getByRole('button', { name: 'Create Discount Code' }).click();
+		await asOwner.waitForURL(/admin\/discount-codes(?:\?|$)/, { timeout: 15_000 });
+
+		await expect(codeRowWith(asOwner, '0 / ∞')).toBeVisible({ timeout: 15_000 });
+
+		// Buyer: invalid code rejected inline, real code halves the price.
+		const context = await browser.newContext();
+		await authenticateContext(context, buyer);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+		const confirmDialog = page.getByRole('dialog', { name: 'Reserve Ticket' });
+		await expect(async () => {
+			if (await confirmDialog.isVisible()) return;
+			if (!(await tierDialog.isVisible())) {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+			}
+			await tierDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+			await expect(confirmDialog).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+
+		await confirmDialog.getByRole('button', { name: 'Have a discount code?' }).click();
+		const codeInput = confirmDialog.getByLabel('Discount code');
+		await codeInput.fill('E2ENOSUCHCODE');
+		await confirmDialog.getByRole('button', { name: 'Apply' }).click();
+		await expect(confirmDialog.getByRole('alert')).toBeVisible({ timeout: 15_000 });
+
+		await codeInput.fill(CODE);
+		await confirmDialog.getByRole('button', { name: 'Apply' }).click();
+		// Applied state: -50.00% badge and the discounted €10.00 per-ticket price.
+		await expect(confirmDialog.getByText(/-50(\.00)?%/)).toBeVisible({ timeout: 15_000 });
+		await expect(confirmDialog.getByText(/10[.,]00/).first()).toBeVisible();
+
+		// Reserve — usage is recorded as soon as the (pending) ticket exists.
+		const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+		await expect(async () => {
+			if (await success.isVisible()) return;
+			await confirmDialog.getByRole('button', { name: 'Reserve Ticket' }).click();
+			await expect(success).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+		await context.close();
+
+		await expect(async () => {
+			await gotoHydrated(asOwner, ADMIN_LIST);
+			await expect(codeRowWith(asOwner, '1 / ∞')).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		// Duplicate code → backend 409 rendered in the form's error alert.
+		await gotoHydrated(asOwner, `${ADMIN_LIST}/new`);
+		await waitForClientAuth(asOwner);
+		await asOwner.getByLabel('Code', { exact: true }).fill(CODE);
+		await asOwner.getByRole('radio', { name: /Percentage/ }).check();
+		await asOwner.getByLabel('Discount Value').fill('25');
+		await asOwner.getByRole('button', { name: 'Create Discount Code' }).click();
+		await expect(asOwner.getByText('A discount code with this code already exists.')).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Deleting the used code deactivates it instead (native confirm()).
+		await gotoHydrated(asOwner, ADMIN_LIST);
+		await waitForClientAuth(asOwner);
+		asOwner.once('dialog', (dialog) => dialog.accept());
+		await asOwner
+			.getByRole('button', { name: `Deactivate discount code ${CODE}` })
+			.filter({ visible: true })
+			.click();
+		await expect(
+			asOwner.getByText("Discount code deactivated (it has been used, so it can't be deleted).")
+		).toBeVisible({ timeout: 15_000 });
+		await expect(codeRowWith(asOwner, 'Inactive')).toBeVisible({ timeout: 15_000 });
+	});
+});

--- a/tests/e2e/journeys/j22-attendee-invoicing/buyer-invoices.spec.ts
+++ b/tests/e2e/journeys/j22-attendee-invoicing/buyer-invoices.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '../../support/fixtures';
+import { getBackendUrl } from '../../support/api';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	setOrgInvoicingMode,
+	startOnlineCheckout
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { completeStripeCheckout } from '../../support/stripe';
+
+// J22 (USER_JOURNEYS.md) — buyer-side attendee invoicing: with the org in
+// AUTO invoicing mode, a paid online purchase generates an ISSUED invoice
+// that the buyer finds under /account/invoices, with the PDF served from a
+// signed URL in a new tab.
+//
+// Requires the full Stripe test-mode setup (tests/e2e/README.md) — the
+// invoice is generated from the webhook's payment record. No org in the
+// seed has invoicing enabled, so the arrange flips Org Alpha to 'auto'
+// (idempotent, deliberately not reverted; see setOrgInvoicingMode).
+
+test.describe('J22 buyer invoices @p2', () => {
+	test('auto-invoiced purchase → issued invoice in /account/invoices → PDF', async ({
+		browser
+	}) => {
+		// Stripe hosted checkout + webhook + invoice generation.
+		test.setTimeout(240_000);
+
+		await setOrgInvoicingMode('auto');
+		const [event, buyer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('Invoiced')
+		]);
+		const tier = await createTicketTier(event.id, { name: 'Invoiced Entry', price: '10.00' });
+		// Billing info at checkout is what opts the buyer into an invoice.
+		const checkoutUrl = await startOnlineCheckout(buyer, event.id, tier.id, {
+			billingInfo: {
+				billing_name: `${buyer.firstName} ${buyer.lastName}`,
+				billing_address: 'Musterstraße 1, 1010 Wien',
+				vat_country_code: 'AT',
+				billing_email: buyer.email
+			}
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, buyer);
+		const page = await context.newPage();
+		await page.goto(checkoutUrl);
+		await completeStripeCheckout(page);
+
+		// The invoice is generated when the webhook lands (inline Celery) — a
+		// fresh buyer has exactly one, so poll for its Issued table row.
+		const invoiceRow = page.getByRole('row').filter({ hasText: 'Issued' });
+		await expect(async () => {
+			await gotoHydrated(page, '/account/invoices');
+			await expect(invoiceRow).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 90_000 });
+		await waitForClientAuth(page);
+
+		// Gross amount (€10.00) renders in the row.
+		await expect(invoiceRow.getByText(/10[.,]00/).first()).toBeVisible();
+
+		// Detail dialog opens from the invoice-number button; Escape closes it
+		// (the footer Close and the X share the same accessible name).
+		await invoiceRow.getByRole('button', { name: /View details/ }).click();
+		const detail = page.getByRole('dialog', { name: 'Invoice Details' });
+		await expect(detail).toBeVisible({ timeout: 15_000 });
+		await page.keyboard.press('Escape');
+		await expect(detail).not.toBeVisible({ timeout: 15_000 });
+
+		// "Download PDF" resolves a signed URL from the API and window.open()s
+		// it — Chromium turns the PDF into a download, so the popup never
+		// commits a URL. Assert the journey at the network layer instead:
+		// capture the resolved download_url and fetch the PDF from it (a 404
+		// means the PDF is still rendering — the loop clicks again).
+		await expect(async () => {
+			const responsePromise = page.waitForResponse(
+				(r) => /\/api\/dashboard\/invoices\/[^/]+\/download/.test(r.url()),
+				{ timeout: 10_000 }
+			);
+			await invoiceRow.getByRole('button', { name: /Download PDF/ }).click();
+			const response = await responsePromise;
+			expect(response.status()).toBe(200);
+			const { download_url } = (await response.json()) as { download_url: string };
+			const pdf = await page.request.get(getBackendUrl(download_url));
+			expect(pdf.status()).toBe(200);
+			expect(pdf.headers()['content-type'] ?? '').toContain('pdf');
+		}).toPass({ timeout: 60_000 });
+
+		await context.close();
+	});
+});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -577,20 +577,132 @@ export async function rsvpViaApi(
  * checkout API — the ARRANGE step for specs whose journey starts from an
  * already-held ticket (check-in, ticket management). Free/offline tiers only:
  * an online tier answers with a Stripe checkout URL instead of tickets.
+ * Pass `seatId` on USER_CHOICE tiers (ids come from `listAvailableSeats`).
  */
 export async function claimTicketViaApi(
 	user: ThrowawayUser,
 	eventId: string,
-	tierId: string
+	tierId: string,
+	options: { seatId?: string } = {}
 ): Promise<{ id: string; status: string }> {
 	const api = await ApiClient.login(user.email, user.password);
 	const response = await api.post<{ tickets?: Array<{ id: string; status: string }> }>(
 		`/api/events/${eventId}/tickets/${tierId}/checkout`,
-		{ tickets: [{ guest_name: `${user.firstName} ${user.lastName}` }] }
+		{
+			tickets: [{ guest_name: `${user.firstName} ${user.lastName}`, seat_id: options.seatId }]
+		}
 	);
 	const ticket = response.tickets?.[0];
 	if (!ticket) {
 		throw new Error(`Checkout for tier ${tierId} returned no tickets (online tier?)`);
 	}
 	return ticket;
+}
+
+/**
+ * Delete the "General Admission" tier that a backend post-save signal
+ * auto-creates on every ticketed event. Specs arranging offline/at-the-door
+ * tiers must drop it: its card renders the same "Reserve Ticket" button as
+ * theirs and trips Playwright's strict mode in the tier dialog.
+ */
+export async function deleteDefaultTier(
+	eventId: string,
+	owner: PersonaName = 'owner'
+): Promise<void> {
+	const persona = PERSONAS[owner];
+	const api = await ApiClient.login(persona.email, persona.password);
+	const tiers = await api.get<{ results: Array<{ id: string; name: string }> }>(
+		`/api/event-admin/${eventId}/ticket-tiers`
+	);
+	const defaultTier = tiers.results.find((t) => t.name === 'General Admission');
+	if (defaultTier) {
+		await api.delete(`/api/event-admin/${eventId}/ticket-tier/${defaultTier.id}`);
+	}
+}
+
+/**
+ * Start an ONLINE (Stripe) checkout via the public API and return the hosted
+ * checkout URL — the ARRANGE step for specs that need a PAID ticket but whose
+ * journey under test starts after the purchase (self-cancel, buyer invoices).
+ * The caller drives the returned URL with completeStripeCheckout(); ticket
+ * activation still arrives via the `stripe listen` webhook.
+ */
+export async function startOnlineCheckout(
+	user: ThrowawayUser,
+	eventId: string,
+	tierId: string,
+	options: { billingInfo?: Record<string, unknown> } = {}
+): Promise<string> {
+	const api = await ApiClient.login(user.email, user.password);
+	const response = await api.post<{ checkout_url?: string }>(
+		`/api/events/${eventId}/tickets/${tierId}/checkout`,
+		{
+			tickets: [{ guest_name: `${user.firstName} ${user.lastName}` }],
+			// An attendee invoice is only generated when the buyer supplied
+			// billing info at checkout (payment.buyer_billing_snapshot).
+			billing_info: options.billingInfo
+		}
+	);
+	if (!response.checkout_url) {
+		throw new Error(`Checkout for tier ${tierId} returned no checkout_url (not an online tier?)`);
+	}
+	return response.checkout_url;
+}
+
+/**
+ * Set a seeded org's attendee invoicing mode (dedicated endpoint — the
+ * billing-info PATCH silently ignores the field). Specs that need
+ * `tier.invoicing_available` (checkout billing form, buyer invoices) flip Org
+ * Alpha to 'auto' and deliberately DON'T revert: a finally-revert would race
+ * parallel workers running the other invoicing spec, and 'auto' is harmless to
+ * every other suite (it only reveals the optional "Request Invoice" checkbox).
+ */
+export async function setOrgInvoicingMode(
+	mode: 'none' | 'hybrid' | 'auto',
+	orgSlug = 'revel-events-collective',
+	owner: PersonaName = 'owner'
+): Promise<void> {
+	const persona = PERSONAS[owner];
+	const api = await ApiClient.login(persona.email, persona.password);
+	await api.patch(`/api/organization-admin/${orgSlug}/invoicing`, { mode });
+}
+
+/**
+ * Look up the bootstrap-seeded "Revel Concert Hall" (10×10 seat grid, rows
+ * A–J) on Org Alpha — specs attach it to their OWN arranged tiers via
+ * venue_id/sector_id so seat availability never collides with the seeded
+ * classical-music-evening event (availability is per event, not per venue).
+ */
+export async function getSeededConcertHall(): Promise<{ venueId: string; sectorId: string }> {
+	const persona = PERSONAS.owner;
+	const api = await ApiClient.login(persona.email, persona.password);
+	const venues = await api.get<{ results: Array<{ id: string; name: string }> }>(
+		`/api/organization-admin/revel-events-collective/venues?page_size=50`
+	);
+	const hall = venues.results.find((v) => v.name === 'Revel Concert Hall');
+	if (!hall) {
+		throw new Error('Seeded "Revel Concert Hall" venue not found — re-run make bootstrap-tests');
+	}
+	// Plain array (not paginated), unlike the venues list.
+	const sectors = await api.get<Array<{ id: string; name: string }>>(
+		`/api/organization-admin/revel-events-collective/venues/${hall.id}/sectors`
+	);
+	const floor = sectors.find((s) => s.name === 'Main Floor');
+	if (!floor) {
+		throw new Error('Seeded "Main Floor" sector not found on Revel Concert Hall');
+	}
+	return { venueId: hall.id, sectorId: floor.id };
+}
+
+/** List a tier's seats with availability (public checkout endpoint). */
+export async function listAvailableSeats(
+	user: ThrowawayUser,
+	eventId: string,
+	tierId: string
+): Promise<Array<{ id: string; label: string; available: boolean }>> {
+	const api = await ApiClient.login(user.email, user.password);
+	const sector = await api.get<{
+		seats: Array<{ id: string; label: string; available: boolean }>;
+	}>(`/api/events/${eventId}/tickets/${tierId}/seats`);
+	return sector.seats;
 }


### PR DESCRIPTION
## Summary

**#591 group (c) — tickets & payments.** Seven new @p2 journey specs (9 tests ×2 projects), taking the suite tally **295 → 313**. Groups a/b/d/e landed in #614/#615/#626/#629; group (f) remains, so #591 stays open.

| Spec | Journey |
|---|---|
| `j06/offline` | Reserve → **PENDING** + manual payment instructions → staff **Confirm Payment** → ACTIVE for the buyer |
| `j06/door-pwyc` | `at_the_door` is **ACTIVE immediately** (no staff gate); PWYC min/max enforcement on both manual methods (door → ACTIVE, offline → PENDING + instructions) |
| `j06/seat-selection` | USER_CHOICE seat map at checkout; taken seat disabled; chosen seat renders on the ticket (`Row B, Seat 3`) |
| `j06/self-cancel` | Full Stripe purchase → refund preview quote → confirm → cancelled + refund toast (100%-until-start policy) |
| `j16/vat-preview` | Checkout billing form: domestic AT B2B keeps 20% VAT; EU B2B with VIES-valid VAT ID → reverse charge, zero VAT |
| `j20/discount-lifecycle` | Create 50% code → invalid code rejected → discounted price at checkout → usage tracked → duplicate 409 → deleting a used code deactivates it |
| `j22/buyer-invoices` | `invoicing_mode=auto` + billing info at checkout → Stripe purchase → **Issued** invoice in `/account/invoices` → detail dialog + PDF via signed URL |

## Design notes (backend-verified)

- **Ticket status by payment method** (`batch_ticket_service`): online/offline → PENDING, `at_the_door`/free → ACTIVE. The design doc's "immediate ACTIVE" for at-the-door is correct; offline needs the staff confirm.
- **Discount usage increments at ticket creation** (even PENDING), so `j20` runs on an offline tier with **no Stripe round-trip**; seat resolution is payment-method agnostic, so `j06/seat-selection` does too (reusing the seeded Revel Concert Hall grid — seat availability is per event).
- **VIES is a live external call** (no stub). `j16` uses two real, stable registrations (Red Bull GmbH / Ferrari S.p.A.), probes the backend vat-preview first, and **skips instead of failing** when VIES is down.
- **Attendee invoices** require billing info at checkout (`buyer_billing_snapshot`) AND org `invoicing_mode ∈ {hybrid, auto}` — set via the dedicated `PATCH …/invoicing` endpoint (the billing-info PATCH silently ignores the field). `j16`/`j22` flip Org Alpha to `auto` idempotently and deliberately don't revert (a finally-revert would race the other spec's parallel worker; 'auto' only reveals the optional "Request Invoice" checkbox).
- **Invoice PDF asserted at the network layer**: Chromium turns the signed-URL PDF into a download, so the popup never commits a URL — the spec captures the `download_url` response and fetches it (200 + `content-type: pdf`).

## New factories

`deleteDefaultTier` (the signal-created "General Admission" tier collides with "Reserve Ticket" buttons), `startOnlineCheckout` (optional `billing_info`), `setOrgInvoicingMode`, `getSeededConcertHall`, `listAvailableSeats`, `seatId` support on `claimTicketViaApi`.

## Test plan

- [x] New specs at `--workers=4 --retries=0`: 18/18 passed (46s)
- [x] Full suite after `reset_events` + `bootstrap-tests`: **311 passed / 2 skipped / 0 failed** in 3.6m (skip count normal — no BE #693 wedge)
- [x] `make check` green (lint 0/0, types, i18n, file-length)

Part of #591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for at-the-door, pay-what-you-want, and offline ticket reservations, including payment instructions and activation states.
  - Added seat-selection coverage, including unavailable seats and confirmation of the selected seat.
  - Added attendee self-cancellation coverage with refund previews and cancellation status updates.
  - Added VAT preview coverage for domestic and cross-border billing scenarios.
  - Added discount-code lifecycle coverage, including validation, usage, duplicate prevention, and deactivation.
  - Added buyer invoice coverage, including issued invoices and PDF downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->