### PR TITLE
test(e2e): Phase 3f — j11/j18/j23/j25 @p2 questionnaires, series, subscriptions & financials suites (#591)

### DIFF
--- a/tests/e2e/journeys/j11-questionnaires/conditional-branching.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/conditional-branching.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	attachQuestionnaire,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J11 (USER_JOURNEYS.md) — conditional branching in the questionnaire fill
+// flow: a dependent question appears only while its triggering option is
+// selected (and gates submission while visible + mandatory), and the
+// per-user option shuffle is STABLE across reloads (seeded server-side from
+// questionnaire id + user pk).
+//
+// Arranged from scratch: the seeded questionnaire with conditional content
+// (Org Beta's membership application) is org-level with no FE fill route, so
+// an own event + admission questionnaire is the only way to drive this UI.
+// Everything lives in a THROWAWAY org: questionnaires land on the org's
+// admin index, and piling E2E ones onto Org Alpha crowds the seeded
+// wine-tasting card that manual-review navigates by.
+
+const TRIGGER = 'Yes, I have restrictions';
+const OTHER = 'No restrictions';
+const CONDITIONAL_QUESTION = 'Please describe your restrictions';
+const SHUFFLED_OPTIONS = ['Workshops', 'Talks', 'Networking', 'Panels', 'Demos'];
+
+test.describe('J11 conditional branching @p2', () => {
+	test('dependent question toggles with its option, shuffle is reload-stable', async ({
+		browser
+	}) => {
+		const org = await createOrganization();
+		const event = await createTicketedEvent({ owner: org.owner, orgSlug: org.slug });
+		await attachQuestionnaire(
+			event,
+			{
+				multiplechoicequestion_questions: [
+					{
+						question: 'Do you have any dietary restrictions?',
+						is_mandatory: true,
+						order: 0,
+						shuffle_options: false,
+						options: [
+							{
+								option: TRIGGER,
+								order: 0,
+								conditional_ft_questions: [
+									{ question: CONDITIONAL_QUESTION, is_mandatory: true, order: 0 }
+								]
+							},
+							{ option: OTHER, order: 1 }
+						]
+					},
+					{
+						question: 'Which sessions interest you?',
+						is_mandatory: false,
+						order: 1,
+						shuffle_options: true,
+						options: SHUFFLED_OPTIONS.map((option, order) => ({ option, order }))
+					}
+				]
+			},
+			org.owner
+		);
+
+		const user = await createVerifiedUser('Branching');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		await page
+			.getByRole('button', { name: 'Complete Questionnaire' })
+			.filter({ visible: true })
+			.first()
+			.click();
+		await page.waitForURL(/\/questionnaire\//);
+		// Let the questionnaire queries settle — interactions during the
+		// settling re-renders are silently dropped (see fill-auto-eval).
+		await page.waitForLoadState('networkidle');
+
+		// The per-user option shuffle is deterministic: reloading renders the
+		// second question's options in the exact same order.
+		const shuffledGroup = page
+			.getByRole('radiogroup')
+			.filter({ has: page.getByRole('radio', { name: SHUFFLED_OPTIONS[0] }) });
+		const orderBefore = await shuffledGroup.ariaSnapshot();
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+		expect(await shuffledGroup.ariaSnapshot()).toBe(orderBefore);
+
+		// The dependent question is hidden until its trigger option is picked.
+		const conditional = page.getByText(CONDITIONAL_QUESTION);
+		const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
+		await expect(conditional).toBeHidden();
+
+		await expect(async () => {
+			await page.getByRole('radio', { name: OTHER }).check();
+			await expect(page.getByRole('radio', { name: OTHER })).toBeChecked();
+		}).toPass({ timeout: 30_000 });
+		await expect(conditional).toBeHidden();
+		// All visible mandatory questions answered → submittable.
+		await expect(submit).toBeEnabled();
+
+		// Switching to the trigger reveals the mandatory dependent question,
+		// which blocks submission until answered.
+		await page.getByRole('radio', { name: TRIGGER }).check();
+		await expect(conditional).toBeVisible();
+		await expect(submit).toBeDisabled();
+		await page.getByPlaceholder('Type your answer here...').fill('Vegetarian, no nuts.');
+		await expect(submit).toBeEnabled();
+
+		// Toggling away hides it again (and un-blocks submission without it).
+		await page.getByRole('radio', { name: OTHER }).check();
+		await expect(conditional).toBeHidden();
+		await expect(submit).toBeEnabled();
+
+		// Submit the branch WITH the conditional answer — the full journey.
+		// The event-page check must anchor at the END of the path: the fill
+		// route (/events/…/<slug>/questionnaire/<id>) CONTAINS the event slug.
+		const eventPageUrl = new RegExp(`/${event.slug}(?:\\?|$)`);
+		await page.getByRole('radio', { name: TRIGGER }).check();
+		await page.getByPlaceholder('Type your answer here...').fill('Vegetarian, no nuts.');
+		await expect(async () => {
+			if (eventPageUrl.test(page.url())) return;
+			await submit.click();
+			await page.waitForURL(eventPageUrl, { timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+
+		// Manual evaluation → the gate flips to "under review".
+		await expect(
+			page
+				.getByText(/being reviewed|under review/i)
+				.filter({ visible: true })
+				.first()
+		).toBeVisible({ timeout: 20_000 });
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j11-questionnaires/retake.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/retake.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	attachQuestionnaire,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J11 (USER_JOURNEYS.md) — max_attempts + cooldown: after a REJECTED
+// submission the messaging surfaces on the EVENT ELIGIBILITY GATE (not the
+// submit toast):
+// - cooldown pending  → "Questionnaire not passed" + retry countdown +
+//   disabled "Retry Available Soon" (next_step wait_to_retake_questionnaire),
+// - attempts exhausted → "Questionnaire not passed" + failed count and NO
+//   action at all (the backend omits next_step entirely),
+// - attempts remaining & no cooldown → the gate re-arms with "Complete
+//   Questionnaire" and a correct retake unlocks the event.
+//
+// Every path arranges its own NON-TICKETED event (the RSVP surface renders
+// the full IneligibilityMessage headers; the ticketed sidebar renders only
+// short next-step text), an AUTOMATIC MCQ-only questionnaire (deterministic
+// inline evaluation, no LLM: one fatal question, wrong option → REJECTED),
+// and its own throwaway user — submissions/attempts are per-user state.
+// Each event lives in a THROWAWAY org: questionnaires land on the org's
+// admin index, and piling E2E ones onto Org Alpha crowds the seeded
+// wine-tasting card that manual-review navigates by.
+
+const QUESTION = 'Do you agree to the community guidelines?';
+const CORRECT = 'Yes, I agree to the guidelines';
+const WRONG = 'No, I do not agree';
+
+async function arrangeGatedEvent(options: { maxAttempts: number; cooldownSeconds?: number }) {
+	const org = await createOrganization();
+	const event = await createTicketedEvent({
+		owner: org.owner,
+		orgSlug: org.slug,
+		freeTier: false,
+		event: { requires_ticket: false }
+	});
+	await attachQuestionnaire(
+		event,
+		{
+			evaluation_mode: 'automatic',
+			max_attempts: options.maxAttempts,
+			can_retake_after: options.cooldownSeconds ?? null,
+			multiplechoicequestion_questions: [
+				{
+					question: QUESTION,
+					is_mandatory: true,
+					is_fatal: true,
+					shuffle_options: false,
+					options: [
+						{ option: CORRECT, is_correct: true, order: 0 },
+						{ option: WRONG, order: 1 }
+					]
+				}
+			]
+		},
+		org.owner
+	);
+	return event;
+}
+
+async function openEventAs(
+	browser: import('@playwright/test').Browser,
+	label: string,
+	path: string
+) {
+	const user = await createVerifiedUser(label);
+	const context = await browser.newContext();
+	await authenticateContext(context, user);
+	const page = await context.newPage();
+	await gotoHydrated(page, path);
+	await waitForClientAuth(page);
+	return page;
+}
+
+/** Enter the questionnaire from the gate and submit the given answer. */
+async function submitAnswer(
+	page: import('@playwright/test').Page,
+	eventSlug: string,
+	answer: string
+): Promise<void> {
+	await page
+		.getByRole('button', { name: 'Complete Questionnaire' })
+		.filter({ visible: true })
+		.first()
+		.click();
+	await page.waitForURL(/\/questionnaire\//);
+	// Settle before answering: interactions during the initial re-renders are
+	// silently dropped, and an empty submission would burn an attempt.
+	await page.waitForLoadState('networkidle');
+
+	// The event-page check must anchor at the END of the path: the fill route
+	// (/events/…/<slug>/questionnaire/<id>) CONTAINS the event slug.
+	const eventPageUrl = new RegExp(`/${eventSlug}(?:\\?|$)`);
+	const radio = page.getByRole('radio', { name: answer });
+	const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
+	await expect(async () => {
+		if (eventPageUrl.test(page.url())) return; // already back on the event
+		await radio.check();
+		await expect(radio).toBeChecked();
+		await expect(submit).toBeEnabled();
+		await submit.click();
+		await page.waitForURL(eventPageUrl, { timeout: 8_000 });
+	}).toPass({ timeout: 40_000 });
+}
+
+/** Reload the event page until the (async-evaluated) gate shows `text`. */
+async function reloadUntilGateShows(
+	page: import('@playwright/test').Page,
+	path: string,
+	text: string
+): Promise<void> {
+	await expect(async () => {
+		await gotoHydrated(page, path);
+		await expect(page.getByText(text).filter({ visible: true }).first()).toBeVisible({
+			timeout: 3_000
+		});
+	}).toPass({ timeout: 30_000 });
+}
+
+test.describe('J11 questionnaire retake @p2', () => {
+	test('rejected with cooldown → retry countdown on the gate, retake locked', async ({
+		browser
+	}) => {
+		const event = await arrangeGatedEvent({ maxAttempts: 3, cooldownSeconds: 7200 });
+		const page = await openEventAs(browser, 'RetakeCooldown', event.path);
+
+		await submitAnswer(page, event.slug, WRONG);
+		await reloadUntilGateShows(page, event.path, 'Questionnaire not passed');
+
+		await expect(
+			page
+				.getByText("Your questionnaire didn't meet the requirements. You can try again.")
+				.filter({ visible: true })
+				.first()
+		).toBeVisible();
+		// retry_on is set → countdown renders and the action stays disabled.
+		await expect(
+			page
+				.getByText(/Available (on|in|soon|now)/)
+				.filter({ visible: true })
+				.first()
+		).toBeVisible();
+		const retryButton = page
+			.getByRole('button', { name: 'Retry Available Soon' })
+			.filter({ visible: true })
+			.first();
+		await expect(retryButton).toBeVisible();
+		await expect(retryButton).toBeDisabled();
+		await expect(page.getByRole('button', { name: 'Complete Questionnaire' })).toBeHidden();
+
+		await page.context().close();
+	});
+
+	test('attempts exhausted → failed gate with no action offered', async ({ browser }) => {
+		const event = await arrangeGatedEvent({ maxAttempts: 1 });
+		const page = await openEventAs(browser, 'RetakeExhausted', event.path);
+
+		await submitAnswer(page, event.slug, WRONG);
+		await reloadUntilGateShows(page, event.path, 'Questionnaire not passed');
+
+		// \s+: the count and the label are separate template chunks (raw
+		// newline + indentation between them — regexes skip whitespace folding).
+		await expect(
+			page
+				.getByText(/1\s+questionnaire failed/)
+				.filter({ visible: true })
+				.first()
+		).toBeVisible();
+		// The essential distinction vs the cooldown state: NO next step at all.
+		await expect(page.getByRole('button', { name: 'Complete Questionnaire' })).toBeHidden();
+		await expect(page.getByRole('button', { name: 'Retry Available Soon' })).toBeHidden();
+		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeHidden();
+
+		await page.context().close();
+	});
+
+	test('attempts remaining without cooldown → gate re-arms and a correct retake unlocks', async ({
+		browser
+	}) => {
+		const event = await arrangeGatedEvent({ maxAttempts: 2 });
+		const page = await openEventAs(browser, 'RetakeSecondTry', event.path);
+
+		await submitAnswer(page, event.slug, WRONG);
+		// No cooldown + one attempt left → the gate immediately re-offers the
+		// questionnaire ("Questionnaire required", not the failed dead-end).
+		await reloadUntilGateShows(page, event.path, 'Questionnaire required');
+		await expect(
+			page.getByRole('button', { name: 'Complete Questionnaire' }).filter({ visible: true }).first()
+		).toBeVisible();
+
+		await submitAnswer(page, event.slug, CORRECT);
+		// Approved → the RSVP card takes over from the gate.
+		await expect(async () => {
+			await gotoHydrated(page, event.path);
+			await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
+				timeout: 3_000
+			});
+		}).toPass({ timeout: 30_000 });
+		await expect(page.getByRole('button', { name: 'Complete Questionnaire' })).toBeHidden();
+
+		await page.context().close();
+	});
+});

--- a/tests/e2e/journeys/j18-series/follow-series.spec.ts
+++ b/tests/e2e/journeys/j18-series/follow-series.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '../../support/fixtures';
+import { createVerifiedUser } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J18 (USER_JOURNEYS.md) — following an event series: the Follow button on
+// the public series page, the followed series surfacing under
+// /dashboard/following → Event Series, and unfollowing from there.
+//
+// The round-trip test uses a THROWAWAY user so parallel projects never race
+// on the same follow row and a crashed run leaves no state behind. The
+// seeded-follow test reads hannah's bootstrap-seeded follow of
+// monthly-tech-talks and never mutates it.
+
+const SERIES_PATH = '/events/tech-innovators-network/series/monthly-tech-talks';
+const SERIES_NAME = 'Monthly Tech Talks';
+
+test.describe('J18 follow series @p2', () => {
+	test('follow on the series page → dashboard following → unfollow → empty state', async ({
+		browser
+	}) => {
+		const user = await createVerifiedUser('SeriesFollow');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, SERIES_PATH);
+		await waitForClientAuth(page);
+
+		await page.getByRole('button', { name: 'Follow', exact: true }).click();
+		await expect(page.getByText(`You are now following ${SERIES_NAME}`)).toBeVisible({
+			timeout: 15_000
+		});
+		// The button flips into the "Following" dropdown trigger.
+		await expect(page.getByRole('button', { name: 'Following', exact: true })).toBeVisible();
+
+		// The followed series shows up under /dashboard/following → Event Series.
+		await gotoHydrated(page, '/dashboard/following');
+		await waitForClientAuth(page);
+		await page.getByRole('button', { name: /Event Series/ }).click();
+		const seriesLink = page.getByRole('link', { name: SERIES_NAME });
+		await expect(seriesLink).toBeVisible({ timeout: 15_000 });
+
+		// Unfollow from the dashboard card → the list empties out.
+		await page.getByRole('button', { name: 'Unfollow' }).click();
+		await expect(page.getByText(`You have unfollowed ${SERIES_NAME}`)).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(page.getByText("You're not following any event series yet")).toBeVisible({
+			timeout: 15_000
+		});
+
+		await context.close();
+	});
+
+	test('a seeded follow lists the series and links back to its page', async ({ asUser }) => {
+		// hannah follows monthly-tech-talks via the bootstrap seed — read-only.
+		await gotoHydrated(asUser, '/dashboard/following');
+		await waitForClientAuth(asUser);
+
+		await expect(asUser.getByRole('heading', { name: 'Following', level: 1 })).toBeVisible();
+		await asUser.getByRole('button', { name: /Event Series/ }).click();
+
+		const seriesLink = asUser.getByRole('link', { name: SERIES_NAME });
+		await expect(seriesLink).toBeVisible({ timeout: 15_000 });
+		await seriesLink.click();
+		await asUser.waitForURL(/\/series\/monthly-tech-talks$/);
+		await expect(asUser.getByRole('heading', { name: SERIES_NAME, level: 1 })).toBeVisible();
+		// Her own follow renders as the "Following" state on the series page.
+		await expect(asUser.getByRole('button', { name: 'Following', exact: true })).toBeVisible();
+	});
+});

--- a/tests/e2e/journeys/j18-series/recurring-admin.spec.ts
+++ b/tests/e2e/journeys/j18-series/recurring-admin.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '../../support/fixtures';
+import { createOrganization, uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J18 (USER_JOURNEYS.md) — recurring-series authoring: the two-step wizard
+// (template event → weekly recurrence), the initial occurrence generation,
+// "Generate now" materialising further occurrences past the window, and
+// pause/resume of the recurrence.
+//
+// Runs in a THROWAWAY org: series accumulate on the org profile with no
+// cleanup, and repeated runs against a seeded org would eventually crowd its
+// "Event Series" section (the same pollution class as the org-list resets).
+// The wizard auto-derives the weekly weekday from the chosen start date, so
+// no weekday toggling is needed for a weekly rule.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** datetime-local inputs want the browser-local `YYYY-MM-DDTHH:mm` shape. */
+function toDatetimeLocal(date: Date): string {
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return (
+		`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+		`T${pad(date.getHours())}:${pad(date.getMinutes())}`
+	);
+}
+
+/**
+ * Fire a series-dashboard action: the desktop header renders the action row
+ * directly, mobile funnels everything through the "More actions" sheet — both
+ * carry the same data-testids, so pick whichever surface is visible.
+ */
+async function seriesAction(page: import('@playwright/test').Page, testId: string): Promise<void> {
+	const sheetTrigger = page.getByTestId('action-sheet-trigger').filter({ visible: true });
+	if ((await sheetTrigger.count()) > 0) {
+		await sheetTrigger.click();
+		await page.getByTestId('series-action-sheet').getByTestId(testId).click();
+	} else {
+		await page.getByTestId(testId).filter({ visible: true }).first().click();
+	}
+}
+
+test.describe('J18 recurring series admin @p2', () => {
+	test('wizard create → occurrences materialize → generate now → pause/resume', async ({
+		browser
+	}) => {
+		const org = await createOrganization();
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/event-series`);
+		await waitForClientAuth(page);
+
+		// New series → the picker offers grouping-only vs recurring.
+		await page.getByTestId('new-series-button').click();
+		await page.getByTestId('new-series-picker-recurring').click();
+		await page.waitForURL(/\/admin\/event-series\/new-recurring/);
+
+		// Step A: the template event (name, times, city via manual address).
+		const eventName = uniqueName('Occurrence');
+		const start = new Date(Date.now() + 7 * DAY_MS);
+		await page.locator('#event-name').fill(eventName);
+		await page.locator('#event-start').fill(toDatetimeLocal(start));
+		await page
+			.locator('#event-end')
+			.fill(toDatetimeLocal(new Date(start.getTime() + 2 * 3600_000)));
+		await page.getByRole('button', { name: 'Add Address' }).click();
+		await page.locator('#city-search').fill('Vienna');
+		await page
+			.getByRole('option', { name: /Vienna/ })
+			.first()
+			.click();
+
+		// (Role-scoped: the step indicator repeats the step title in a <p>.)
+		const stepB = page.getByRole('heading', { name: 'Recurrence & series settings' });
+		await expect(async () => {
+			if (!(await stepB.isVisible())) {
+				await page.getByRole('button', { name: 'Continue' }).click();
+			}
+			await expect(stepB).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+
+		// Step B: weekly (the default), with a small 2-week window so the
+		// initial generation stays cheap and "Generate now" has room to add more.
+		const seriesName = uniqueName('Series');
+		await page.locator('#series-name').fill(seriesName);
+		await page.getByRole('button', { name: 'Advanced' }).click();
+		await page.locator('#generation-window').fill('2');
+
+		await expect(async () => {
+			if (!/\/admin\/event-series\/[0-9a-f]{8}/.test(page.url())) {
+				await page.getByRole('button', { name: 'Create series' }).click();
+			}
+			await page.waitForURL(/\/admin\/event-series\/[0-9a-f]{8}[0-9a-f-]+$/, { timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+		await expect(page.getByText(`Series "${seriesName}" created.`)).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Creation already generated the first window of occurrences.
+		const rows = page.getByTestId('occurrence-row');
+		await expect(rows.first()).toBeVisible({ timeout: 20_000 });
+		const initialCount = await rows.count();
+
+		// Generate now, pushed past the 2-week window → new occurrences appear.
+		await seriesAction(page, 'action-generate-now');
+		const generateDialog = page.getByTestId('generate-now-dialog');
+		await expect(generateDialog).toBeVisible();
+		await generateDialog
+			.getByLabel('Generate up to (optional)')
+			.fill(toDatetimeLocal(new Date(Date.now() + 35 * DAY_MS)));
+		await generateDialog.getByTestId('generate-now-submit').click();
+		await expect(page.getByText(/new occurrences? scheduled through/)).toBeVisible({
+			timeout: 20_000
+		});
+		await expect.poll(async () => rows.count(), { timeout: 20_000 }).toBeGreaterThan(initialCount);
+
+		// Pause (confirm dialog) → status chip flips, then resume (immediate).
+		await seriesAction(page, 'action-pause-resume');
+		await page.getByTestId('pause-resume-confirm').click();
+		await expect(page.getByText('Series paused.')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByLabel('Paused').first()).toBeVisible();
+
+		await seriesAction(page, 'action-pause-resume');
+		await expect(page.getByText('Series resumed.')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByLabel('Active').first()).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j23-subscriptions/plans-admin.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/plans-admin.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '../../support/fixtures';
+import { createOrganization, createMembershipTier, uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J23 (USER_JOURNEYS.md) — subscription plans admin: plans are created PER
+// MEMBERSHIP TIER from the Tiers tab (each tier card embeds its own plans
+// list), archived in place, and deleted when unused (native confirm()).
+//
+// The design doc's "org policy fields" (membership_grace_period_days /
+// membership_refund_policy) have NO editing UI and aren't even exposed by the
+// backend API — deliberately not covered here. FE #631 / BE #695 track it.
+//
+// Runs in a throwaway org so tier/plan state never collides across
+// parallel projects or re-runs.
+
+/**
+ * The deepest container holding both the tier's name and its "Add plan"
+ * button is the tier card (ancestors precede descendants in locator order).
+ */
+function tierCard(page: import('@playwright/test').Page, tierName: string) {
+	return page
+		.locator('div')
+		.filter({ hasText: tierName })
+		.filter({ has: page.getByRole('button', { name: 'Add plan' }) })
+		.last();
+}
+
+/**
+ * A plan's row inside a tier card: the deepest container with the plan's
+ * name AND its action buttons (filtering on text alone would resolve to the
+ * name/price column, which excludes the buttons).
+ */
+function planRow(
+	page: import('@playwright/test').Page,
+	scope: ReturnType<typeof tierCard>,
+	planName: string
+) {
+	return scope
+		.locator('div')
+		.filter({ hasText: planName })
+		.filter({ has: page.getByRole('button', { name: 'Delete plan' }) })
+		.last();
+}
+
+test.describe('J23 subscription plans admin @p2', () => {
+	test('create a plan per tier → archive → delete unused', async ({ browser }) => {
+		const org = await createOrganization();
+		const secondTierName = uniqueName('Tier');
+		await createMembershipTier(org.owner, org.slug, secondTierName);
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+		await gotoHydrated(page, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(page);
+		await page.getByRole('tab', { name: /Tiers/ }).click();
+
+		const generalCard = tierCard(page, 'General membership');
+		const secondCard = tierCard(page, secondTierName);
+		await expect(generalCard.getByText('No plans yet.')).toBeVisible({ timeout: 15_000 });
+
+		// Monthly plan on the default tier.
+		const monthlyPlan = uniqueName('Monthly');
+		await generalCard.getByRole('button', { name: 'Add plan' }).click();
+		const dialog = page.getByRole('dialog', { name: 'Create plan' });
+		await dialog.locator('#plan-name').fill(monthlyPlan);
+		await dialog.locator('#plan-price').fill('15');
+		await dialog.getByRole('button', { name: 'Create plan' }).click();
+		await expect(dialog).toBeHidden({ timeout: 15_000 });
+		await expect(generalCard.getByText(monthlyPlan)).toBeVisible({ timeout: 15_000 });
+		await expect(generalCard.getByText('€15.00 / month')).toBeVisible();
+
+		// Yearly plan on the second tier — plans really are per tier.
+		const yearlyPlan = uniqueName('Yearly');
+		await secondCard.getByRole('button', { name: 'Add plan' }).click();
+		await dialog.locator('#plan-name').fill(yearlyPlan);
+		await dialog.locator('#plan-price').fill('100');
+		await dialog.locator('#plan-period-unit').selectOption('year');
+		await dialog.getByRole('button', { name: 'Create plan' }).click();
+		await expect(dialog).toBeHidden({ timeout: 15_000 });
+		await expect(secondCard.getByText(yearlyPlan)).toBeVisible({ timeout: 15_000 });
+		await expect(secondCard.getByText('€100.00 / year')).toBeVisible();
+		await expect(generalCard.getByText(yearlyPlan)).toBeHidden();
+
+		// Archive the monthly plan in place (no confirm dialog).
+		await planRow(page, generalCard, monthlyPlan).getByRole('button', { name: 'Archive' }).click();
+		await expect(generalCard.getByText('Archived')).toBeVisible({ timeout: 15_000 });
+
+		// Delete the unused yearly plan (native confirm()).
+		page.once('dialog', (d) => void d.accept());
+		await planRow(page, secondCard, yearlyPlan)
+			.getByRole('button', { name: 'Delete plan' })
+			.click();
+		await expect(secondCard.getByText(yearlyPlan)).toBeHidden({ timeout: 15_000 });
+		await expect(secondCard.getByText('No plans yet.')).toBeVisible();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	approveMembershipRequest,
+	createOrganization,
+	createSubscriptionPlan,
+	createVerifiedUser,
+	requestMembership,
+	uniqueName
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J23 (USER_JOURNEYS.md) — subscription lifecycle: staff creates a
+// subscription for an existing MEMBER and records the initial payment (the
+// succeeded payment is what flips it PENDING → ACTIVE), the member sees the
+// card under /account/memberships, then staff pause/resume/cancel and the
+// member-facing status follows. The member side is deliberately READ-ONLY —
+// pause/resume/cancel live only in the admin drawer.
+//
+// The subscribe target must already be an org member: the create-subscription
+// MemberCombobox searches org MEMBERS only (the same trap as manage-rsvps'
+// MemberCombobox), hence the requestMembership + approve arrange.
+
+test.describe('J23 subscription lifecycle @p2', () => {
+	test('create + record payment → member sees card → pause/resume/cancel', async ({ browser }) => {
+		const [org, member] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('SubLife')
+		]);
+		const request = await requestMembership(member, org.slug);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		const plan = await createSubscriptionPlan(org.owner, org.slug, org.defaultTierId, {
+			name: uniqueName('Plan'),
+			price: '15.00'
+		});
+
+		// Admin: create the subscription with an initial payment.
+		const adminContext = await browser.newContext();
+		await authenticateContext(adminContext, org.owner);
+		const admin = await adminContext.newPage();
+		await gotoHydrated(admin, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(admin);
+		await admin.getByRole('tab', { name: /Subs/ }).click();
+		await admin.getByRole('button', { name: 'Create subscription' }).click();
+
+		const createDialog = admin.getByRole('dialog', { name: 'Create subscription' });
+		// The member search input specifically — the native plan <select> also
+		// carries an implicit combobox role.
+		await createDialog.locator('input[role="combobox"]').fill('SubLife');
+		await createDialog
+			.getByRole('option', { name: /E2E SubLife/ })
+			.first()
+			.click();
+		await createDialog.locator('#sub-plan').selectOption(plan.id);
+		await createDialog.getByRole('checkbox', { name: 'Record initial payment' }).click();
+		await createDialog.locator('#sub-amt').fill('15');
+		await createDialog.getByRole('button', { name: 'Create', exact: true }).click();
+		await expect(createDialog).toBeHidden({ timeout: 15_000 });
+
+		// The drawer auto-opens on the fresh subscription; if that handoff is
+		// missed under load, open the row ourselves. The row's accessible name
+		// differs per layout: the desktop table row is aria-labelled "Open
+		// subscription details", the mobile card exposes its content text.
+		const drawer = admin.getByRole('dialog').filter({ hasText: 'E2E SubLife' });
+		try {
+			await expect(drawer).toBeVisible({ timeout: 10_000 });
+		} catch {
+			await admin
+				.getByRole('button', { name: 'Open subscription details' })
+				.or(admin.getByRole('button', { name: /E2E SubLife/ }))
+				.filter({ visible: true })
+				.first()
+				.click({ timeout: 5_000 });
+			await expect(drawer).toBeVisible({ timeout: 10_000 });
+		}
+
+		// Succeeded initial payment → ACTIVE, and the payment row is recorded.
+		await expect(drawer.getByLabel('Active')).toBeVisible({ timeout: 15_000 });
+		await expect(drawer.getByText('Payments')).toBeVisible();
+		await expect(drawer.getByText('15.00 EUR').first()).toBeVisible();
+
+		// Member: the subscription card renders under /account/memberships.
+		const memberContext = await browser.newContext();
+		await authenticateContext(memberContext, member);
+		const memberPage = await memberContext.newPage();
+		await gotoHydrated(memberPage, '/account/memberships');
+		await waitForClientAuth(memberPage);
+		const card = memberPage.getByRole('article', { name: org.name });
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		await expect(card.getByText(plan.name)).toBeVisible();
+		await expect(card.getByText('€15.00 / month')).toBeVisible();
+		await expect(card.getByLabel('Active')).toBeVisible();
+
+		// Admin pauses → the member-facing badge follows.
+		await drawer.getByRole('button', { name: 'Pause', exact: true }).click();
+		await expect(drawer.getByLabel('Paused')).toBeVisible({ timeout: 15_000 });
+		await gotoHydrated(memberPage, '/account/memberships');
+		await expect(
+			memberPage.getByRole('article', { name: org.name }).getByLabel('Paused')
+		).toBeVisible({ timeout: 15_000 });
+		await memberContext.close();
+
+		// Resume → ACTIVE again.
+		await drawer.getByRole('button', { name: 'Resume', exact: true }).click();
+		await expect(drawer.getByLabel('Active')).toBeVisible({ timeout: 15_000 });
+
+		// Immediate cancel needs the explicit acknowledgement.
+		await drawer.getByRole('button', { name: 'Cancel', exact: true }).click();
+		const cancelDialog = admin.getByRole('dialog', { name: 'Cancel subscription' });
+		await cancelDialog.getByRole('radio', { name: 'Immediately' }).click();
+		const confirmButton = cancelDialog.getByRole('button', { name: 'Confirm cancellation' });
+		await expect(confirmButton).toBeDisabled();
+		await cancelDialog
+			.getByRole('checkbox', { name: 'I understand access is revoked immediately.' })
+			.click();
+		await confirmButton.click();
+		await expect(cancelDialog).toBeHidden({ timeout: 15_000 });
+		await expect(drawer.getByLabel('Cancelled')).toBeVisible({ timeout: 15_000 });
+		// Terminal state: no lifecycle actions remain.
+		await expect(drawer.getByRole('button', { name: 'Pause', exact: true })).toBeHidden();
+
+		await adminContext.close();
+	});
+});

--- a/tests/e2e/journeys/j25-reporting/financials.spec.ts
+++ b/tests/e2e/journeys/j25-reporting/financials.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '../../support/fixtures';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J25 (USER_JOURNEYS.md) — the org Financials surface: seeded last-month
+// revenue renders in the Totals card, the per-event breakdown expands to the
+// full figures, and the year/period filters drive the range (an empty period
+// shows the empty state). Read-only on seeded data.
+//
+// Seed contract (bootstrap create_payments_and_invoice): 4 SUCCEEDED €75.00
+// payments on Org Alpha's "Classical Music Evening", back-dated across the
+// PREVIOUS calendar month relative to bootstrap time → €300.00 gross /
+// €250.00 net taxable / €50.00 VAT, EUR only. Because the period has a single
+// currency, the currency pill switcher deliberately doesn't render
+// (available_currencies.length > 1 gate) — so this spec covers the
+// year/period/sort filters, not currency switching.
+//
+// The page is owner-only (403 otherwise — covered by j09 permission-gating);
+// figures arrive via a client-side query after SSR, so every assertion waits
+// out the "Loading financials…" state implicitly through expect timeouts.
+
+const FINANCIALS_PATH = '/org/revel-events-collective/admin/financials';
+
+// Previous calendar month, assuming the DB was bootstrapped in the current
+// month (the standing suite assumption for all clock-relative seed data).
+const PREV = new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1);
+
+test.describe('J25 financials @p2', () => {
+	test('seeded last-month revenue, per-event breakdown, period filters', async ({ asOwner }) => {
+		await gotoHydrated(asOwner, FINANCIALS_PATH);
+		await waitForClientAuth(asOwner);
+
+		await expect(asOwner.getByRole('heading', { name: 'Financials', level: 1 })).toBeVisible();
+		await expect(asOwner.getByLabel('Sort by')).toBeVisible();
+
+		// Narrow to the seeded month (year select matters when Jan wraps to Dec).
+		await asOwner.getByLabel('Year').selectOption(String(PREV.getFullYear()));
+		await asOwner.getByLabel('Period').selectOption(`m${PREV.getMonth() + 1}`);
+
+		// Totals card: the deepest container holding the "Totals" heading is the
+		// card itself (ancestors precede descendants in locator order).
+		const totalsCard = asOwner
+			.locator('div')
+			.filter({ has: asOwner.getByRole('heading', { name: 'Totals' }) })
+			.last();
+		await expect(totalsCard.getByText('€300.00').first()).toBeVisible({ timeout: 15_000 });
+		await expect(totalsCard.getByText('€250.00').first()).toBeVisible();
+		await expect(totalsCard.getByText('Sold: 4')).toBeVisible();
+
+		// Per-event breakdown: the row is an aria-expanded button; expanding it
+		// reveals the event's own figures (Net taxable lives only in the
+		// expanded summary, scoped to the row's <li> to dodge the Totals card).
+		await expect(asOwner.getByRole('heading', { name: 'By event' })).toBeVisible();
+		const eventRow = asOwner.locator('li').filter({ hasText: 'Classical Music Evening' });
+		const rowToggle = eventRow.getByRole('button', { name: /Classical Music Evening/ });
+		await expect(rowToggle).toHaveAttribute('aria-expanded', 'false');
+		await rowToggle.click();
+		await expect(rowToggle).toHaveAttribute('aria-expanded', 'true');
+		await expect(eventRow.getByText('Net taxable')).toBeVisible();
+		await expect(eventRow.getByText('€250.00').first()).toBeVisible();
+
+		// A period with no sales shows the empty state (two years back is safely
+		// before both the seed's back-dated month and any e2e-run purchases).
+		await asOwner.getByLabel('Year').selectOption(String(new Date().getFullYear() - 2));
+		await expect(asOwner.getByText('No revenue in this period')).toBeVisible({ timeout: 15_000 });
+		await expect(
+			asOwner.getByText('There are no ticket sales for the selected period.')
+		).toBeVisible();
+	});
+});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -317,6 +317,40 @@ export async function attachAdmissionQuestionnaire(
 	return { id: questionnaire.id, name };
 }
 
+/**
+ * Create a PUBLISHED questionnaire with a caller-supplied question payload on
+ * the event's org and assign it to the event — the generalized sibling of
+ * attachAdmissionQuestionnaire for specs that need conditional questions,
+ * automatic evaluation, or attempt/cooldown settings. Same isolation rule:
+ * only ever attach to events the spec created itself — and prefer a
+ * THROWAWAY org: questionnaires accumulate on the org's admin index, and
+ * crowding Org Alpha's pushes the seeded wine-tasting card (which
+ * manual-review navigates by) off the page.
+ */
+export async function attachQuestionnaire(
+	event: CreatedEvent,
+	questionnaire: Record<string, unknown>,
+	owner: PersonaName | ThrowawayUser = 'owner'
+): Promise<{ id: string; name: string }> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+
+	const org = await api.get<{ id: string }>(`/api/organizations/${event.orgSlug}`);
+	const name = (questionnaire.name as string) ?? uniqueName('Questionnaire');
+	const created = await api.post<{ id: string }>(
+		`/api/questionnaires/${org.id}/create-questionnaire`,
+		{
+			name,
+			min_score: 0,
+			evaluation_mode: 'manual',
+			status: 'published',
+			...questionnaire
+		}
+	);
+	await api.post(`/api/questionnaires/${created.id}/events/${event.id}`);
+	return { id: created.id, name };
+}
+
 export interface GuestIdentity {
 	email: string;
 	firstName: string;
@@ -380,6 +414,26 @@ export async function createMembershipTier(
 ): Promise<{ id: string }> {
 	const api = await ApiClient.login(owner.email, owner.password);
 	return api.post<{ id: string }>(`/api/organization-admin/${orgSlug}/membership-tiers`, { name });
+}
+
+/**
+ * API-create a subscription plan on a membership tier of a throwaway-owned
+ * org (defaults: €15.00 monthly). ARRANGE step for the subscription-lifecycle
+ * journey — plan AUTHORING through the UI is j23 plans-admin.
+ */
+export async function createSubscriptionPlan(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	tierId: string,
+	plan: Record<string, unknown> = {}
+): Promise<{ id: string; name: string }> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	const name = (plan.name as string) ?? uniqueName('Plan');
+	const created = await api.post<{ id: string }>(
+		`/api/organization-admin/${orgSlug}/tiers/${tierId}/plans`,
+		{ name, price: '15.00', currency: 'EUR', ...plan }
+	);
+	return { id: created.id, name };
 }
 
 /**


### PR DESCRIPTION
## Summary

The **last #591 group (f)**: 7 specs / 10 tests ×2 projects → suite tally **313 → 333**. With this, all Phase 3 (@p2) groups are done.

Closes #591

| Spec | Journey | Data |
|---|---|---|
| `j11/conditional-branching` | dependent question toggles with its trigger option, gates submission while mandatory+visible; per-user option shuffle is reload-stable (`ariaSnapshot` equality) | api-arranged (throwaway org) |
| `j11/retake` | rejected-with-cooldown → gate countdown + disabled "Retry Available Soon"; attempts exhausted → failed count, **no** action; attempts remaining → gate re-arms, correct retake unlocks RSVP | api-arranged (throwaway org, automatic fatal MCQ) |
| `j18/recurring-admin` | wizard create (weekly RRULE, 2-week window) → initial occurrences → "Generate now" past the window materialises more → pause (confirm) / resume (immediate) | ui (throwaway org) |
| `j18/follow-series` | follow on public series page → `/dashboard/following` Event Series tab → unfollow → empty state; hannah's seeded follow read-only | ui + seed |
| `j23/plans-admin` | per-tier plan create (monthly + yearly), archive-in-place, native-confirm delete | ui (throwaway org) |
| `j23/subscription-lifecycle` | staff creates subscription + initial payment → ACTIVE → member card in `/account/memberships` → pause/resume/cancel (immediate + ack), member badge follows | api-arranged + ui |
| `j25/financials` | seeded last-month revenue (€300 / 4 sold, Classical Music Evening), expandable per-event breakdown, year/period filters, empty state | seed |

## Notes

- **Org subscription-policy fields** (`membership_grace_period_days`, `membership_refund_policy`) have no FE editing UI **and no API exposure** — filed #631 (FE) and letsrevel/revel-backend#695 (BE) instead of building; deliberately out of scope here.
- **New factories:** `attachQuestionnaire` (generalized payloads: conditional questions, automatic eval, attempts/cooldown) and `createSubscriptionPlan`.
- **New isolation rule encoded in specs + factory docs:** questionnaire arranges live in **throwaway orgs** — E2E questionnaires on Org Alpha crowd its admin questionnaires index and knock the seeded wine-tasting card (manual-review's navigation handle) off the page. Surfaced by the first full-suite run; cured with `reset_events --no-input` + `make bootstrap-tests` and prevented going forward.
- Selector traps found: the fill route `/events/…/<slug>/questionnaire/<id>` **contains** the event slug (URL guards must anchor at end-of-path); the failed-count gate row splits count/label across template chunks (regex needs `\s+`); native `<select>` carries an implicit `combobox` role (collides with the member-search input); mobile subscription cards expose content text as the accessible name while desktop rows are aria-labelled "Open subscription details".

## Verification

- Per-group gates + `--repeat-each=2` flake gate: **40/40** at `--workers=4 --retries=0`.
- Full suite on fresh seed: **331 passed, 2 skipped (mobile-viewport), 0 failed, 3.7m** at `--workers=4 --retries=0`.
- `make check` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for conditional questionnaires, including branching, validation, retakes, cooldowns, and review states.
  * Added coverage for following and unfollowing event series, recurring-series administration, and occurrence generation.
  * Added subscription plan and membership lifecycle coverage, including tier-specific plans, payments, pauses, resumes, and cancellations.
  * Added financial reporting checks for totals, event breakdowns, filtering, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->