### PR TITLE
test(e2e): Phase 4 — @p3 long-tail suites (#592)

### DIFF
--- a/tests/e2e/journeys/j05-rsvp/waitlist-offer.spec.ts
+++ b/tests/e2e/journeys/j05-rsvp/waitlist-offer.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '../../support/fixtures';
+import { createTicketedEvent, createVerifiedUser, rsvpViaApi } from '../../support/factories';
+import { ApiClient } from '../../support/api';
+import { PERSONAS } from '../../support/personas';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J5 (USER_JOURNEYS.md) — the advanced waitlist window, attendee side: a
+// waitlisted user with a PENDING offer sees the offer banner on the event
+// page and accepts it before expiry. There is NO dedicated accept endpoint —
+// the offer reserves the seat and is CLAIMED by registering normally (here:
+// RSVP Yes), which also removes the waitlist entry, so the banner disappears.
+//
+// Arrange mirrors j10 waitlist-admin: a 1-seat RSVP event fills up, the
+// waiter joins via the public API, the seat is freed (admin deletes the
+// filler's RSVP — BE #691 blocks self-downgrade on a full event), and the
+// offer is issued via the admin API with an explicit expiry (the event
+// carries no waitlist_time_window default).
+
+test.describe('J5 waitlist offer @p3', () => {
+	test('pending offer banner → claim by RSVPing before expiry', async ({ browser }) => {
+		test.setTimeout(150_000);
+
+		const [event, filler, waiter] = await Promise.all([
+			createTicketedEvent({
+				freeTier: false,
+				event: { requires_ticket: false, max_attendees: 1, waitlist_open: true }
+			}),
+			createVerifiedUser('OfferFiller'),
+			createVerifiedUser('OfferWaiter')
+		]);
+		await rsvpViaApi(filler, event.id, 'yes');
+		const waiterApi = await ApiClient.login(waiter.email, waiter.password);
+		await waiterApi.post(`/api/events/${event.id}/waitlist/join`, {});
+
+		// Free the seat, then issue the offer (would 409 while at capacity).
+		const ownerApi = await ApiClient.login(PERSONAS.owner.email, PERSONAS.owner.password);
+		const rsvps = await ownerApi.get<{ results: { id: string }[] }>(
+			`/api/event-admin/${event.id}/rsvps`
+		);
+		await ownerApi.delete(`/api/event-admin/${event.id}/rsvps/${rsvps.results[0].id}`);
+		const entries = await ownerApi.get<{ results: { id: string }[] }>(
+			`/api/event-admin/${event.id}/waitlist`
+		);
+		await ownerApi.post(`/api/event-admin/${event.id}/waitlist-offers`, {
+			waitlist_entry_id: entries.results[0].id,
+			expires_at: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString()
+		});
+
+		// The waiter sees the offer banner with the countdown.
+		const context = await browser.newContext();
+		await authenticateContext(context, waiter);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+		await expect(page.getByText("You've been selected!")).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText('Time remaining')).toBeVisible();
+
+		// "Claim spot" scrolls to the action sidebar — the RSVP card is the
+		// actual accept surface (the offer reserved the seat on a full event).
+		await page.getByRole('button', { name: 'Claim spot' }).click();
+		await expect(
+			page.getByRole('heading', { name: 'Will you attend?' }).filter({ visible: true }).first()
+		).toBeVisible();
+		await page
+			.getByRole('button', { name: /^RSVP Yes/ })
+			.filter({ visible: true })
+			.first()
+			.click();
+		await expect(page.getByRole('status').filter({ hasText: "You're attending" })).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Claiming consumed the offer and the waitlist entry — after a reload the
+		// banner is gone and the attending state persists (reload-retry: the
+		// status arrives via a client-side query and can lag a beat).
+		await expect(async () => {
+			await gotoHydrated(page, event.path);
+			await expect(page.getByRole('status').filter({ hasText: "You're attending" })).toBeVisible({
+				timeout: 5_000
+			});
+		}).toPass({ timeout: 45_000 });
+		await expect(page.getByText("You've been selected!")).toBeHidden();
+
+		// The offer is CLAIMED on the admin side (no pending offer left to revoke).
+		const offers = await ownerApi.get<{ results: Array<{ status: string }> }>(
+			`/api/event-admin/${event.id}/waitlist-offers`
+		);
+		expect(offers.results[0]?.status).toBe('claimed');
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j05-rsvp/waitlist-offer.spec.ts
+++ b/tests/e2e/journeys/j05-rsvp/waitlist-offer.spec.ts
@@ -51,43 +51,45 @@ test.describe('J5 waitlist offer @p3', () => {
 		const context = await browser.newContext();
 		await authenticateContext(context, waiter);
 		const page = await context.newPage();
-		await gotoHydrated(page, event.path);
-		await waitForClientAuth(page);
-		await expect(page.getByText("You've been selected!")).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByText('Time remaining')).toBeVisible();
-
-		// "Claim spot" scrolls to the action sidebar — the RSVP card is the
-		// actual accept surface (the offer reserved the seat on a full event).
-		await page.getByRole('button', { name: 'Claim spot' }).click();
-		await expect(
-			page.getByRole('heading', { name: 'Will you attend?' }).filter({ visible: true }).first()
-		).toBeVisible();
-		await page
-			.getByRole('button', { name: /^RSVP Yes/ })
-			.filter({ visible: true })
-			.first()
-			.click();
-		await expect(page.getByRole('status').filter({ hasText: "You're attending" })).toBeVisible({
-			timeout: 15_000
-		});
-
-		// Claiming consumed the offer and the waitlist entry — after a reload the
-		// banner is gone and the attending state persists (reload-retry: the
-		// status arrives via a client-side query and can lag a beat).
-		await expect(async () => {
+		try {
 			await gotoHydrated(page, event.path);
+			await waitForClientAuth(page);
+			await expect(page.getByText("You've been selected!")).toBeVisible({ timeout: 15_000 });
+			await expect(page.getByText('Time remaining')).toBeVisible();
+
+			// "Claim spot" scrolls to the action sidebar — the RSVP card is the
+			// actual accept surface (the offer reserved the seat on a full event).
+			await page.getByRole('button', { name: 'Claim spot' }).click();
+			await expect(
+				page.getByRole('heading', { name: 'Will you attend?' }).filter({ visible: true }).first()
+			).toBeVisible();
+			await page
+				.getByRole('button', { name: /^RSVP Yes/ })
+				.filter({ visible: true })
+				.first()
+				.click();
 			await expect(page.getByRole('status').filter({ hasText: "You're attending" })).toBeVisible({
-				timeout: 5_000
+				timeout: 15_000
 			});
-		}).toPass({ timeout: 45_000 });
-		await expect(page.getByText("You've been selected!")).toBeHidden();
 
-		// The offer is CLAIMED on the admin side (no pending offer left to revoke).
-		const offers = await ownerApi.get<{ results: Array<{ status: string }> }>(
-			`/api/event-admin/${event.id}/waitlist-offers`
-		);
-		expect(offers.results[0]?.status).toBe('claimed');
+			// Claiming consumed the offer and the waitlist entry — after a reload the
+			// banner is gone and the attending state persists (reload-retry: the
+			// status arrives via a client-side query and can lag a beat).
+			await expect(async () => {
+				await gotoHydrated(page, event.path);
+				await expect(page.getByRole('status').filter({ hasText: "You're attending" })).toBeVisible({
+					timeout: 5_000
+				});
+			}).toPass({ timeout: 45_000 });
+			await expect(page.getByText("You've been selected!")).toBeHidden();
 
-		await context.close();
+			// The offer is CLAIMED on the admin side (no pending offer left to revoke).
+			const offers = await ownerApi.get<{ results: Array<{ status: string }> }>(
+				`/api/event-admin/${event.id}/waitlist-offers`
+			);
+			expect(offers.results[0]?.status).toBe('claimed');
+		} finally {
+			await context.close();
+		}
 	});
 });

--- a/tests/e2e/journeys/j06-tickets/batch-purchase.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/batch-purchase.spec.ts
@@ -40,86 +40,88 @@ test.describe('J6 batch purchase @p3', () => {
 		const context = await browser.newContext();
 		await authenticateContext(context, buyer);
 		const page = await context.newPage();
-		await gotoHydrated(page, event.path);
-		await waitForClientAuth(page);
-
-		// Tier dialog → confirmation dialog with the quantity stepper capped at
-		// the per-user limit. The whole sequence runs as an idempotent loop
-		// (clicks during dialog re-renders are occasionally dropped).
-		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
-		const quantityLabel = page.getByText('Number of Tickets');
-		await expect(async () => {
-			if (await quantityLabel.isVisible()) return;
-			if (await tierDialog.isVisible()) {
-				await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
-			} else {
-				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
-				await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
-			}
-			await expect(quantityLabel).toBeVisible({ timeout: 8_000 });
-		}).toPass({ timeout: 60_000 });
-		await expect(page.getByText('(max 3)')).toBeVisible();
-
-		// Take 2 of the 3 allowed — a second guest-name input appears.
-		await page.getByRole('button', { name: 'Increase quantity' }).click();
-		await expect(page.getByText('Ticket Holders', { exact: true })).toBeVisible();
-		await page.getByPlaceholder('Guest 2 name').fill('E2E Guest Two');
-
-		const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
-		const claim = page.getByRole('button', { name: 'Claim Ticket', exact: true });
-		await expect(async () => {
-			if (await success.isVisible()) return;
-			await claim.click();
-			await expect(success).toBeVisible({ timeout: 8_000 });
-		}).toPass({ timeout: 40_000 });
-		await page.keyboard.press('Escape');
-
-		// Both tickets land as individual Active cards in the dashboard.
-		await expect(async () => {
-			await gotoHydrated(page, '/dashboard/tickets');
-			await expect(page.getByText('Showing 2 of 2')).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
-		await expect(
-			page
-				.locator('article, li, div')
-				.filter({ hasText: event.name })
-				.filter({ hasText: /Active/i })
-				.first()
-		).toBeVisible();
-
-		// Back on the event, the sidebar offers "Buy More Tickets" — but the
-		// remaining allowance is 1, so the confirmation dialog renders WITHOUT
-		// the quantity stepper this time.
-		await gotoHydrated(page, event.path);
-		await waitForClientAuth(page);
-		const claimAgain = page.getByRole('button', { name: 'Claim Ticket', exact: true });
-		await expect(async () => {
-			if (await claimAgain.isVisible()) return;
-			await page
-				.getByRole('button', { name: 'Buy More Tickets' })
-				.filter({ visible: true })
-				.first()
-				.click();
-			await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
-			await expect(claimAgain).toBeVisible({ timeout: 8_000 });
-		}).toPass({ timeout: 60_000 });
-		await expect(page.getByText('Number of Tickets')).toBeHidden();
-		await expect(async () => {
-			if (await success.isVisible()) return;
-			await claimAgain.click();
-			await expect(success).toBeVisible({ timeout: 8_000 });
-		}).toPass({ timeout: 40_000 });
-		await page.keyboard.press('Escape');
-
-		// Limit exhausted (3/3): the buy affordance is gone for good.
-		await expect(async () => {
+		try {
 			await gotoHydrated(page, event.path);
-			await expect(
-				page.getByRole('button', { name: 'Show Tickets (3)' }).filter({ visible: true }).first()
-			).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 30_000 });
-		await expect(page.getByRole('button', { name: 'Buy More Tickets' })).toBeHidden();
+			await waitForClientAuth(page);
 
-		await context.close();
+			// Tier dialog → confirmation dialog with the quantity stepper capped at
+			// the per-user limit. The whole sequence runs as an idempotent loop
+			// (clicks during dialog re-renders are occasionally dropped).
+			const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+			const quantityLabel = page.getByText('Number of Tickets');
+			await expect(async () => {
+				if (await quantityLabel.isVisible()) return;
+				if (await tierDialog.isVisible()) {
+					await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
+				} else {
+					await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+					await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
+				}
+				await expect(quantityLabel).toBeVisible({ timeout: 8_000 });
+			}).toPass({ timeout: 60_000 });
+			await expect(page.getByText('(max 3)')).toBeVisible();
+
+			// Take 2 of the 3 allowed — a second guest-name input appears.
+			await page.getByRole('button', { name: 'Increase quantity' }).click();
+			await expect(page.getByText('Ticket Holders', { exact: true })).toBeVisible();
+			await page.getByPlaceholder('Guest 2 name').fill('E2E Guest Two');
+
+			const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+			const claim = page.getByRole('button', { name: 'Claim Ticket', exact: true });
+			await expect(async () => {
+				if (await success.isVisible()) return;
+				await claim.click();
+				await expect(success).toBeVisible({ timeout: 8_000 });
+			}).toPass({ timeout: 40_000 });
+			await page.keyboard.press('Escape');
+
+			// Both tickets land as individual Active cards in the dashboard.
+			await expect(async () => {
+				await gotoHydrated(page, '/dashboard/tickets');
+				await expect(page.getByText('Showing 2 of 2')).toBeVisible({ timeout: 5_000 });
+			}).toPass({ timeout: 45_000 });
+			await expect(
+				page
+					.locator('article, li, div')
+					.filter({ hasText: event.name })
+					.filter({ hasText: /Active/i })
+					.first()
+			).toBeVisible();
+
+			// Back on the event, the sidebar offers "Buy More Tickets" — but the
+			// remaining allowance is 1, so the confirmation dialog renders WITHOUT
+			// the quantity stepper this time.
+			await gotoHydrated(page, event.path);
+			await waitForClientAuth(page);
+			const claimAgain = page.getByRole('button', { name: 'Claim Ticket', exact: true });
+			await expect(async () => {
+				if (await claimAgain.isVisible()) return;
+				await page
+					.getByRole('button', { name: 'Buy More Tickets' })
+					.filter({ visible: true })
+					.first()
+					.click();
+				await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
+				await expect(claimAgain).toBeVisible({ timeout: 8_000 });
+			}).toPass({ timeout: 60_000 });
+			await expect(page.getByText('Number of Tickets')).toBeHidden();
+			await expect(async () => {
+				if (await success.isVisible()) return;
+				await claimAgain.click();
+				await expect(success).toBeVisible({ timeout: 8_000 });
+			}).toPass({ timeout: 40_000 });
+			await page.keyboard.press('Escape');
+
+			// Limit exhausted (3/3): the buy affordance is gone for good.
+			await expect(async () => {
+				await gotoHydrated(page, event.path);
+				await expect(
+					page.getByRole('button', { name: 'Show Tickets (3)' }).filter({ visible: true }).first()
+				).toBeVisible({ timeout: 5_000 });
+			}).toPass({ timeout: 30_000 });
+			await expect(page.getByRole('button', { name: 'Buy More Tickets' })).toBeHidden();
+		} finally {
+			await context.close();
+		}
 	});
 });

--- a/tests/e2e/journeys/j06-tickets/batch-purchase.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/batch-purchase.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	deleteDefaultTier
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J6 (USER_JOURNEYS.md) — batch purchase: the checkout dialog's quantity
+// stepper (rendered only while more than one ticket is allowed) claims
+// several tickets in one go with a guest-name input per extra ticket, and the
+// per-user tier limit shrinks the allowance until the buy affordance
+// disappears entirely. Checkout is array-based server-side — one payload item
+// per ticket — and a free tier keeps Stripe out of the journey.
+//
+// Isolation: arranged event + throwaway buyer (the limit is per-user state);
+// the auto "General Admission" tier is dropped so the arranged tier is the
+// only claimable one.
+
+test.describe('J6 batch purchase @p3', () => {
+	test('stepper claims 2 of 3, remaining allowance is 1, then the limit locks', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+
+		const [event, buyer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('Batch')
+		]);
+		await deleteDefaultTier(event.id);
+		await createTicketTier(event.id, {
+			name: 'Group Entry',
+			payment_method: 'free',
+			price: '0.00',
+			max_tickets_per_user: 3
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, buyer);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		// Tier dialog → confirmation dialog with the quantity stepper capped at
+		// the per-user limit. The whole sequence runs as an idempotent loop
+		// (clicks during dialog re-renders are occasionally dropped).
+		const tierDialog = page.getByRole('dialog', { name: 'Select Your Ticket' });
+		const quantityLabel = page.getByText('Number of Tickets');
+		await expect(async () => {
+			if (await quantityLabel.isVisible()) return;
+			if (await tierDialog.isVisible()) {
+				await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
+			} else {
+				await page.getByRole('button', { name: 'Get Tickets', exact: true }).click();
+				await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
+			}
+			await expect(quantityLabel).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+		await expect(page.getByText('(max 3)')).toBeVisible();
+
+		// Take 2 of the 3 allowed — a second guest-name input appears.
+		await page.getByRole('button', { name: 'Increase quantity' }).click();
+		await expect(page.getByText('Ticket Holders', { exact: true })).toBeVisible();
+		await page.getByPlaceholder('Guest 2 name').fill('E2E Guest Two');
+
+		const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+		const claim = page.getByRole('button', { name: 'Claim Ticket', exact: true });
+		await expect(async () => {
+			if (await success.isVisible()) return;
+			await claim.click();
+			await expect(success).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+		await page.keyboard.press('Escape');
+
+		// Both tickets land as individual Active cards in the dashboard.
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/tickets');
+			await expect(page.getByText('Showing 2 of 2')).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+		await expect(
+			page
+				.locator('article, li, div')
+				.filter({ hasText: event.name })
+				.filter({ hasText: /Active/i })
+				.first()
+		).toBeVisible();
+
+		// Back on the event, the sidebar offers "Buy More Tickets" — but the
+		// remaining allowance is 1, so the confirmation dialog renders WITHOUT
+		// the quantity stepper this time.
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+		const claimAgain = page.getByRole('button', { name: 'Claim Ticket', exact: true });
+		await expect(async () => {
+			if (await claimAgain.isVisible()) return;
+			await page
+				.getByRole('button', { name: 'Buy More Tickets' })
+				.filter({ visible: true })
+				.first()
+				.click();
+			await tierDialog.getByRole('button', { name: 'Claim Free Ticket' }).click();
+			await expect(claimAgain).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+		await expect(page.getByText('Number of Tickets')).toBeHidden();
+		await expect(async () => {
+			if (await success.isVisible()) return;
+			await claimAgain.click();
+			await expect(success).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+		await page.keyboard.press('Escape');
+
+		// Limit exhausted (3/3): the buy affordance is gone for good.
+		await expect(async () => {
+			await gotoHydrated(page, event.path);
+			await expect(
+				page.getByRole('button', { name: 'Show Tickets (3)' }).filter({ visible: true }).first()
+			).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 30_000 });
+		await expect(page.getByRole('button', { name: 'Buy More Tickets' })).toBeHidden();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j08-org-owner/resources.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/resources.spec.ts
@@ -16,6 +16,21 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 //
 // Isolation: throwaway-owned org + throwaway member.
 
+/**
+ * Submit the Add-Resource dialog, outcome-keyed on it closing. The dialog's
+ * <form> intermittently keeps intercepting pointer events on the mobile
+ * viewport, hanging a positioned click in the actionability loop forever —
+ * dispatch the click straight to the button instead (re-dispatch only fires
+ * while the dialog is still open, so no duplicate resources).
+ */
+async function submitResource(modal: import('@playwright/test').Locator): Promise<void> {
+	await expect(async () => {
+		if (!(await modal.isVisible())) return;
+		await modal.getByRole('button', { name: 'Create Resource' }).dispatchEvent('click');
+		await expect(modal).not.toBeVisible({ timeout: 5_000 });
+	}).toPass({ timeout: 45_000 });
+}
+
 test.describe('J8 org resources @p2', () => {
 	test('create link/text resources; visibility filters per persona', async ({ browser }) => {
 		test.setTimeout(150_000);
@@ -47,8 +62,7 @@ test.describe('J8 org resources @p2', () => {
 		await modal.getByLabel('URL').fill('https://example.com/e2e');
 		await modal.getByLabel('Visibility').selectOption({ label: 'Public - Anyone can view' });
 		await modal.getByLabel('Display on organization page').check();
-		await modal.getByRole('button', { name: 'Create Resource' }).click();
-		await expect(modal).not.toBeVisible({ timeout: 15_000 });
+		await submitResource(modal);
 		await expect(page.getByText(publicName)).toBeVisible();
 
 		// Members-only text resource, also shown on the org page.
@@ -61,8 +75,7 @@ test.describe('J8 org resources @p2', () => {
 			.getByLabel('Visibility')
 			.selectOption({ label: 'Members Only - Requires membership' });
 		await modal.getByLabel('Display on organization page').check();
-		await modal.getByRole('button', { name: 'Create Resource' }).click();
-		await expect(modal).not.toBeVisible({ timeout: 15_000 });
+		await submitResource(modal);
 		await expect(page.getByText(membersName)).toBeVisible();
 
 		// A member sees both on the public resources page.

--- a/tests/e2e/journeys/j11-questionnaires/duplicate-export.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/duplicate-export.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	attachQuestionnaire,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser
+} from '../../support/factories';
+import { getBackendUrl } from '../../support/api';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J11 (USER_JOURNEYS.md) — questionnaire duplicate + submissions export.
+// Duplicating deep-copies sections/questions/options but never submissions,
+// always lands as an UNATTACHED DRAFT, and (like the poll clone) navigates to
+// the copy with no toast. The export is an async XLSX (not CSV) behind a
+// 202 + /api/exports/{id} poll; the spec observes the app's own traffic and
+// fetches the signed download_url at the network layer.
+//
+// Isolation: throwaway org (duplicates pile onto the SAME org's admin index —
+// exactly the pollution class that once knocked the seeded wine-tasting card
+// off Org Alpha's page) + throwaway submitter. The backend export throttle is
+// 1/min PER USER, and each project's run owns a fresh org owner, so parallel
+// projects never contend.
+
+const QUESTION = 'Do you agree to the house rules?';
+const CORRECT = 'Yes, I agree to the rules';
+
+test.describe('J11 questionnaire duplicate & export @p3', () => {
+	test('duplicate lands as draft copy; export delivers the submissions XLSX', async ({
+		browser
+	}) => {
+		test.setTimeout(240_000);
+
+		const org = await createOrganization();
+		const event = await createTicketedEvent({
+			owner: org.owner,
+			orgSlug: org.slug,
+			freeTier: false,
+			event: { requires_ticket: false }
+		});
+		const questionnaire = await attachQuestionnaire(
+			event,
+			{
+				evaluation_mode: 'automatic',
+				multiplechoicequestion_questions: [
+					{
+						question: QUESTION,
+						is_mandatory: true,
+						is_fatal: true,
+						shuffle_options: false,
+						options: [
+							{ option: CORRECT, is_correct: true, order: 0 },
+							{ option: 'No, I do not agree', order: 1 }
+						]
+					}
+				]
+			},
+			org.owner
+		);
+
+		// One real submission through the UI so the export has content.
+		const submitter = await createVerifiedUser('Exported');
+		const submitterContext = await browser.newContext();
+		await authenticateContext(submitterContext, submitter);
+		const submitterPage = await submitterContext.newPage();
+		await gotoHydrated(submitterPage, event.path);
+		await waitForClientAuth(submitterPage);
+		await submitterPage
+			.getByRole('button', { name: 'Complete Questionnaire' })
+			.filter({ visible: true })
+			.first()
+			.click();
+		await submitterPage.waitForURL(/\/questionnaire\//);
+		await submitterPage.waitForLoadState('networkidle');
+		const radio = submitterPage.getByRole('radio', { name: CORRECT });
+		const submit = submitterPage.getByRole('button', { name: 'Submit Questionnaire' });
+		const eventPageUrl = new RegExp(`/${event.slug}(?:\\?|$)`);
+		await expect(async () => {
+			if (eventPageUrl.test(submitterPage.url())) return;
+			await radio.check();
+			await expect(radio).toBeChecked();
+			await expect(submit).toBeEnabled();
+			await submit.click();
+			await submitterPage.waitForURL(eventPageUrl, { timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+		await submitterContext.close();
+
+		// Owner: duplicate from the questionnaire card on the admin index.
+		const ownerContext = await browser.newContext();
+		await authenticateContext(ownerContext, org.owner);
+		const page = await ownerContext.newPage();
+		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires`);
+		await waitForClientAuth(page);
+		const card = page
+			.locator('article, li, div')
+			.filter({ hasText: questionnaire.name })
+			.filter({ has: page.getByRole('button', { name: 'Duplicate' }) })
+			.last();
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		await card.getByRole('button', { name: 'Duplicate' }).click();
+
+		const modal = page.getByRole('dialog', { name: 'Duplicate Questionnaire' });
+		await expect(modal).toBeVisible();
+		const cloneName = `Copy of ${questionnaire.name}`;
+		await expect(modal.getByLabel('New Questionnaire Name')).toHaveValue(cloneName);
+		// Success = navigation to the copy's edit page (no toast), a different id.
+		await modal.getByRole('button', { name: 'Duplicate', exact: true }).click();
+		await page.waitForURL(
+			(url) =>
+				/\/admin\/questionnaires\/[0-9a-f-]{36}$/.test(url.pathname) &&
+				!url.pathname.includes(questionnaire.id),
+			{ timeout: 20_000 }
+		);
+		await expect(page.getByText(cloneName).first()).toBeVisible({ timeout: 15_000 });
+
+		// Back on the index the copy sits next to the original as a Draft.
+		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires`);
+		const cloneCard = page
+			.locator('article, li, div')
+			.filter({ hasText: cloneName })
+			.filter({ hasText: /Draft/ })
+			.filter({ has: page.getByRole('button', { name: 'Duplicate' }) })
+			.last();
+		await expect(cloneCard).toBeVisible({ timeout: 15_000 });
+
+		// Export the ORIGINAL's submissions from its summary page: capture the
+		// 202'd export id, let the app's poll surface the signed download_url,
+		// then fetch the XLSX directly.
+		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires/${questionnaire.id}/summary`);
+		await waitForClientAuth(page);
+		const exportCreated = page.waitForResponse(
+			(r) =>
+				/\/submissions\/export/.test(r.url()) &&
+				r.request().method() === 'POST' &&
+				r.status() < 300,
+			{ timeout: 30_000 }
+		);
+		await page.getByRole('button', { name: 'Export Submissions' }).click();
+		const exported = (await (await exportCreated).json()) as {
+			id: string;
+			download_url: string | null;
+		};
+
+		let downloadUrl = exported.download_url;
+		if (!downloadUrl) {
+			const readyPoll = await page.waitForResponse(
+				async (r) => {
+					if (!new RegExp(`/api/exports/${exported.id}`).test(r.url()) || !r.ok()) return false;
+					const body = (await r.json().catch(() => null)) as {
+						download_url?: string | null;
+					} | null;
+					return !!body?.download_url;
+				},
+				{ timeout: 130_000 }
+			);
+			downloadUrl = ((await readyPoll.json()) as { download_url: string }).download_url;
+		}
+		await expect(
+			page.getByText('Export ready! Your download should start automatically.')
+		).toBeVisible({ timeout: 130_000 });
+
+		const xlsx = await page.request.get(getBackendUrl(downloadUrl));
+		expect(xlsx.status()).toBe(200);
+		expect(xlsx.headers()['content-type'] ?? '').toMatch(/spreadsheet|excel|octet-stream/);
+
+		await ownerContext.close();
+	});
+});

--- a/tests/e2e/journeys/j11-questionnaires/duplicate-export.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/duplicate-export.spec.ts
@@ -63,106 +63,111 @@ test.describe('J11 questionnaire duplicate & export @p3', () => {
 		const submitterContext = await browser.newContext();
 		await authenticateContext(submitterContext, submitter);
 		const submitterPage = await submitterContext.newPage();
-		await gotoHydrated(submitterPage, event.path);
-		await waitForClientAuth(submitterPage);
-		await submitterPage
-			.getByRole('button', { name: 'Complete Questionnaire' })
-			.filter({ visible: true })
-			.first()
-			.click();
-		await submitterPage.waitForURL(/\/questionnaire\//);
-		await submitterPage.waitForLoadState('networkidle');
-		const radio = submitterPage.getByRole('radio', { name: CORRECT });
-		const submit = submitterPage.getByRole('button', { name: 'Submit Questionnaire' });
-		const eventPageUrl = new RegExp(`/${event.slug}(?:\\?|$)`);
-		await expect(async () => {
-			if (eventPageUrl.test(submitterPage.url())) return;
-			await radio.check();
-			await expect(radio).toBeChecked();
-			await expect(submit).toBeEnabled();
-			await submit.click();
-			await submitterPage.waitForURL(eventPageUrl, { timeout: 8_000 });
-		}).toPass({ timeout: 40_000 });
-		await submitterContext.close();
+		try {
+			await gotoHydrated(submitterPage, event.path);
+			await waitForClientAuth(submitterPage);
+			await submitterPage
+				.getByRole('button', { name: 'Complete Questionnaire' })
+				.filter({ visible: true })
+				.first()
+				.click();
+			await submitterPage.waitForURL(/\/questionnaire\//);
+			await submitterPage.waitForLoadState('networkidle');
+			const radio = submitterPage.getByRole('radio', { name: CORRECT });
+			const submit = submitterPage.getByRole('button', { name: 'Submit Questionnaire' });
+			const eventPageUrl = new RegExp(`/${event.slug}(?:\\?|$)`);
+			await expect(async () => {
+				if (eventPageUrl.test(submitterPage.url())) return;
+				await radio.check();
+				await expect(radio).toBeChecked();
+				await expect(submit).toBeEnabled();
+				await submit.click();
+				await submitterPage.waitForURL(eventPageUrl, { timeout: 8_000 });
+			}).toPass({ timeout: 40_000 });
+		} finally {
+			await submitterContext.close();
+		}
 
 		// Owner: duplicate from the questionnaire card on the admin index.
 		const ownerContext = await browser.newContext();
 		await authenticateContext(ownerContext, org.owner);
 		const page = await ownerContext.newPage();
-		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires`);
-		await waitForClientAuth(page);
-		const card = page
-			.locator('article, li, div')
-			.filter({ hasText: questionnaire.name })
-			.filter({ has: page.getByRole('button', { name: 'Duplicate' }) })
-			.last();
-		await expect(card).toBeVisible({ timeout: 15_000 });
-		await card.getByRole('button', { name: 'Duplicate' }).click();
+		try {
+			await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires`);
+			await waitForClientAuth(page);
+			const card = page
+				.locator('article, li, div')
+				.filter({ hasText: questionnaire.name })
+				.filter({ has: page.getByRole('button', { name: 'Duplicate' }) })
+				.last();
+			await expect(card).toBeVisible({ timeout: 15_000 });
+			await card.getByRole('button', { name: 'Duplicate' }).click();
 
-		const modal = page.getByRole('dialog', { name: 'Duplicate Questionnaire' });
-		await expect(modal).toBeVisible();
-		const cloneName = `Copy of ${questionnaire.name}`;
-		await expect(modal.getByLabel('New Questionnaire Name')).toHaveValue(cloneName);
-		// Success = navigation to the copy's edit page (no toast), a different id.
-		await modal.getByRole('button', { name: 'Duplicate', exact: true }).click();
-		await page.waitForURL(
-			(url) =>
-				/\/admin\/questionnaires\/[0-9a-f-]{36}$/.test(url.pathname) &&
-				!url.pathname.includes(questionnaire.id),
-			{ timeout: 20_000 }
-		);
-		await expect(page.getByText(cloneName).first()).toBeVisible({ timeout: 15_000 });
-
-		// Back on the index the copy sits next to the original as a Draft.
-		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires`);
-		const cloneCard = page
-			.locator('article, li, div')
-			.filter({ hasText: cloneName })
-			.filter({ hasText: /Draft/ })
-			.filter({ has: page.getByRole('button', { name: 'Duplicate' }) })
-			.last();
-		await expect(cloneCard).toBeVisible({ timeout: 15_000 });
-
-		// Export the ORIGINAL's submissions from its summary page: capture the
-		// 202'd export id, let the app's poll surface the signed download_url,
-		// then fetch the XLSX directly.
-		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires/${questionnaire.id}/summary`);
-		await waitForClientAuth(page);
-		const exportCreated = page.waitForResponse(
-			(r) =>
-				/\/submissions\/export/.test(r.url()) &&
-				r.request().method() === 'POST' &&
-				r.status() < 300,
-			{ timeout: 30_000 }
-		);
-		await page.getByRole('button', { name: 'Export Submissions' }).click();
-		const exported = (await (await exportCreated).json()) as {
-			id: string;
-			download_url: string | null;
-		};
-
-		let downloadUrl = exported.download_url;
-		if (!downloadUrl) {
-			const readyPoll = await page.waitForResponse(
-				async (r) => {
-					if (!new RegExp(`/api/exports/${exported.id}`).test(r.url()) || !r.ok()) return false;
-					const body = (await r.json().catch(() => null)) as {
-						download_url?: string | null;
-					} | null;
-					return !!body?.download_url;
-				},
-				{ timeout: 130_000 }
+			const modal = page.getByRole('dialog', { name: 'Duplicate Questionnaire' });
+			await expect(modal).toBeVisible();
+			const cloneName = `Copy of ${questionnaire.name}`;
+			await expect(modal.getByLabel('New Questionnaire Name')).toHaveValue(cloneName);
+			// Success = navigation to the copy's edit page (no toast), a different id.
+			await modal.getByRole('button', { name: 'Duplicate', exact: true }).click();
+			await page.waitForURL(
+				(url) =>
+					/\/admin\/questionnaires\/[0-9a-f-]{36}$/.test(url.pathname) &&
+					!url.pathname.includes(questionnaire.id),
+				{ timeout: 20_000 }
 			);
-			downloadUrl = ((await readyPoll.json()) as { download_url: string }).download_url;
+			await expect(page.getByText(cloneName).first()).toBeVisible({ timeout: 15_000 });
+
+			// Back on the index the copy sits next to the original as a Draft.
+			await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires`);
+			const cloneCard = page
+				.locator('article, li, div')
+				.filter({ hasText: cloneName })
+				.filter({ hasText: /Draft/ })
+				.filter({ has: page.getByRole('button', { name: 'Duplicate' }) })
+				.last();
+			await expect(cloneCard).toBeVisible({ timeout: 15_000 });
+
+			// Export the ORIGINAL's submissions from its summary page: capture the
+			// 202'd export id, let the app's poll surface the signed download_url,
+			// then fetch the XLSX directly.
+			await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires/${questionnaire.id}/summary`);
+			await waitForClientAuth(page);
+			const exportCreated = page.waitForResponse(
+				(r) =>
+					/\/submissions\/export/.test(r.url()) &&
+					r.request().method() === 'POST' &&
+					r.status() < 300,
+				{ timeout: 30_000 }
+			);
+			await page.getByRole('button', { name: 'Export Submissions' }).click();
+			const exported = (await (await exportCreated).json()) as {
+				id: string;
+				download_url: string | null;
+			};
+
+			let downloadUrl = exported.download_url;
+			if (!downloadUrl) {
+				const readyPoll = await page.waitForResponse(
+					async (r) => {
+						if (!new RegExp(`/api/exports/${exported.id}`).test(r.url()) || !r.ok()) return false;
+						const body = (await r.json().catch(() => null)) as {
+							download_url?: string | null;
+						} | null;
+						return !!body?.download_url;
+					},
+					{ timeout: 130_000 }
+				);
+				downloadUrl = ((await readyPoll.json()) as { download_url: string }).download_url;
+			}
+			await expect(
+				page.getByText('Export ready! Your download should start automatically.')
+			).toBeVisible({ timeout: 130_000 });
+
+			const xlsx = await page.request.get(getBackendUrl(downloadUrl));
+			expect(xlsx.status()).toBe(200);
+			expect(xlsx.headers()['content-type'] ?? '').toMatch(/spreadsheet|excel|octet-stream/);
+		} finally {
+			await ownerContext.close();
 		}
-		await expect(
-			page.getByText('Export ready! Your download should start automatically.')
-		).toBeVisible({ timeout: 130_000 });
-
-		const xlsx = await page.request.get(getBackendUrl(downloadUrl));
-		expect(xlsx.status()).toBe(200);
-		expect(xlsx.headers()['content-type'] ?? '').toMatch(/spreadsheet|excel|octet-stream/);
-
-		await ownerContext.close();
 	});
 });

--- a/tests/e2e/journeys/j11-questionnaires/feedback.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/feedback.spec.ts
@@ -67,43 +67,45 @@ test.describe('J11 feedback questionnaire @p3', () => {
 		const context = await browser.newContext();
 		await authenticateContext(context, attendee);
 		const page = await context.newPage();
-		await gotoHydrated(page, event.path);
-		await waitForClientAuth(page);
-
-		// The finished event greets the attendee with the feedback offer.
-		await expect(
-			page.getByText('Feedback Available').filter({ visible: true }).first()
-		).toBeVisible({ timeout: 15_000 });
-		await page
-			.getByRole('link', { name: 'Give Feedback' })
-			.or(page.getByRole('button', { name: 'Give Feedback' }))
-			.filter({ visible: true })
-			.first()
-			.click();
-		await page.waitForURL(/\/questionnaire\//);
-		await page.waitForLoadState('networkidle');
-
-		// Answer + submit (same drop-proof loop as the admission fills). Unlike
-		// admission questionnaires the page does NOT navigate back — with no
-		// evaluation to run it lands on the "You're all set!" completion status.
-		const radio = page.getByRole('radio', { name: ANSWER });
-		const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
-		const done = page.getByRole('status').filter({ hasText: "You're all set!" });
-		await expect(async () => {
-			if (await done.isVisible()) return;
-			await radio.check();
-			await expect(radio).toBeChecked();
-			await expect(submit).toBeEnabled();
-			await submit.click();
-			await expect(done).toBeVisible({ timeout: 8_000 });
-		}).toPass({ timeout: 40_000 });
-
-		// One-shot: with the submission recorded, the offer is gone for good.
-		await expect(async () => {
+		try {
 			await gotoHydrated(page, event.path);
-			await expect(page.getByText('Feedback Available')).toBeHidden({ timeout: 3_000 });
-		}).toPass({ timeout: 30_000 });
+			await waitForClientAuth(page);
 
-		await context.close();
+			// The finished event greets the attendee with the feedback offer.
+			await expect(
+				page.getByText('Feedback Available').filter({ visible: true }).first()
+			).toBeVisible({ timeout: 15_000 });
+			await page
+				.getByRole('link', { name: 'Give Feedback' })
+				.or(page.getByRole('button', { name: 'Give Feedback' }))
+				.filter({ visible: true })
+				.first()
+				.click();
+			await page.waitForURL(/\/questionnaire\//);
+			await page.waitForLoadState('networkidle');
+
+			// Answer + submit (same drop-proof loop as the admission fills). Unlike
+			// admission questionnaires the page does NOT navigate back — with no
+			// evaluation to run it lands on the "You're all set!" completion status.
+			const radio = page.getByRole('radio', { name: ANSWER });
+			const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
+			const done = page.getByRole('status').filter({ hasText: "You're all set!" });
+			await expect(async () => {
+				if (await done.isVisible()) return;
+				await radio.check();
+				await expect(radio).toBeChecked();
+				await expect(submit).toBeEnabled();
+				await submit.click();
+				await expect(done).toBeVisible({ timeout: 8_000 });
+			}).toPass({ timeout: 40_000 });
+
+			// One-shot: with the submission recorded, the offer is gone for good.
+			await expect(async () => {
+				await gotoHydrated(page, event.path);
+				await expect(page.getByText('Feedback Available')).toBeHidden({ timeout: 3_000 });
+			}).toPass({ timeout: 30_000 });
+		} finally {
+			await context.close();
+		}
 	});
 });

--- a/tests/e2e/journeys/j11-questionnaires/feedback.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/feedback.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	attachQuestionnaire,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser,
+	getUserId,
+	rsvpOnBehalf
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J11 (USER_JOURNEYS.md) — post-event feedback questionnaire: an attendee of
+// a FINISHED event gets the "Feedback Available" panel on the event page,
+// fills the feedback form once, and the offer disappears (one submission per
+// user/event, feedback is never evaluated).
+//
+// The seeded NYE-gala feedback fixture is deliberately NOT used: charlie's
+// one-shot submission would burn the seed for the sibling browser project and
+// every re-run. Instead the spec arranges its own already-finished event in a
+// throwaway org (the API accepts past dates) and creates the attendance
+// through the admin on-behalf RSVP endpoint, which skips the "event is over"
+// eligibility gates the public RSVP API enforces.
+
+const QUESTION = 'Did you enjoy the event?';
+const ANSWER = 'Yes, I loved it';
+
+test.describe('J11 feedback questionnaire @p3', () => {
+	test('past-event attendee gives feedback once', async ({ browser }) => {
+		test.setTimeout(180_000);
+
+		const org = await createOrganization();
+		const dayMs = 24 * 60 * 60 * 1000;
+		const start = new Date(Date.now() - 3 * dayMs);
+		const event = await createTicketedEvent({
+			owner: org.owner,
+			orgSlug: org.slug,
+			freeTier: false,
+			event: {
+				requires_ticket: false,
+				start: start.toISOString(),
+				end: new Date(start.getTime() + 3 * 60 * 60 * 1000).toISOString()
+			}
+		});
+		await attachQuestionnaire(
+			event,
+			{
+				questionnaire_type: 'feedback',
+				requires_evaluation: false,
+				multiplechoicequestion_questions: [
+					{
+						question: QUESTION,
+						is_mandatory: true,
+						shuffle_options: false,
+						options: [
+							{ option: ANSWER, order: 0 },
+							{ option: 'Not really', order: 1 }
+						]
+					}
+				]
+			},
+			org.owner
+		);
+		const attendee = await createVerifiedUser('Feedback');
+		await rsvpOnBehalf(org.owner, event.id, await getUserId(attendee), 'yes');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, attendee);
+		const page = await context.newPage();
+		await gotoHydrated(page, event.path);
+		await waitForClientAuth(page);
+
+		// The finished event greets the attendee with the feedback offer.
+		await expect(
+			page.getByText('Feedback Available').filter({ visible: true }).first()
+		).toBeVisible({ timeout: 15_000 });
+		await page
+			.getByRole('link', { name: 'Give Feedback' })
+			.or(page.getByRole('button', { name: 'Give Feedback' }))
+			.filter({ visible: true })
+			.first()
+			.click();
+		await page.waitForURL(/\/questionnaire\//);
+		await page.waitForLoadState('networkidle');
+
+		// Answer + submit (same drop-proof loop as the admission fills). Unlike
+		// admission questionnaires the page does NOT navigate back — with no
+		// evaluation to run it lands on the "You're all set!" completion status.
+		const radio = page.getByRole('radio', { name: ANSWER });
+		const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
+		const done = page.getByRole('status').filter({ hasText: "You're all set!" });
+		await expect(async () => {
+			if (await done.isVisible()) return;
+			await radio.check();
+			await expect(radio).toBeChecked();
+			await expect(submit).toBeEnabled();
+			await submit.click();
+			await expect(done).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+
+		// One-shot: with the submission recorded, the offer is gone for good.
+		await expect(async () => {
+			await gotoHydrated(page, event.path);
+			await expect(page.getByText('Feedback Available')).toBeHidden({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j13-blacklist-moderation/fuzzy-whitelist.spec.ts
+++ b/tests/e2e/journeys/j13-blacklist-moderation/fuzzy-whitelist.spec.ts
@@ -42,79 +42,84 @@ test.describe('J13 fuzzy whitelist @p3', () => {
 		const visitorContext = await browser.newContext();
 		await authenticateContext(visitorContext, visitor);
 		const visitorPage = await visitorContext.newPage();
-		await gotoHydrated(visitorPage, event.path);
-		await waitForClientAuth(visitorPage);
-		await expect(
-			visitorPage.getByText('Additional verification required.').filter({ visible: true }).first()
-		).toBeVisible({ timeout: 15_000 });
-		await expect(visitorPage.getByRole('heading', { name: 'Will you attend?' })).toBeHidden();
-
-		// Submit the whitelist request through the dialog.
-		await visitorPage
-			.getByRole('button', { name: 'Request Verification' })
-			.filter({ visible: true })
-			.first()
-			.click();
-		const requestDialog = visitorPage.getByRole('dialog', { name: 'Request Verification' });
-		await expect(requestDialog).toBeVisible();
-		await requestDialog
-			.getByLabel('Message (Optional)')
-			.fill('The organizers know me — this is a name collision.');
-		await requestDialog.getByRole('button', { name: 'Submit Request' }).click();
-		await expect(visitorPage.getByText('Verification Request Submitted').first()).toBeVisible({
-			timeout: 15_000
-		});
-
-		// Reloading, the gate now shows the pending state (disabled action).
-		await gotoHydrated(visitorPage, event.path);
-		const pendingButton = visitorPage
-			.getByRole('button', { name: 'Verification Pending' })
-			.filter({ visible: true })
-			.first();
-		await expect(pendingButton).toBeVisible({ timeout: 15_000 });
-		await expect(pendingButton).toBeDisabled();
-
-		// The owner approves it from the blacklist page's Verification Requests tab.
-		const ownerContext = await browser.newContext();
-		await authenticateContext(ownerContext, org.owner);
-		const ownerPage = await ownerContext.newPage();
-		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/blacklist`);
-		await waitForClientAuth(ownerPage);
-		await ownerPage.getByRole('tab', { name: /Verification Requests|Requests/ }).click();
-		// exact: true everywhere — role-name matching is SUBSTRING by default,
-		// and the tab's "Approved" FILTER button would match a bare 'Approve'
-		// (the tab switches itself to that filter after a decision, so the
-		// approved card + filter button otherwise keep the locator alive).
-		const requestCard = ownerPage
-			.locator('article, li, div')
-			.filter({ hasText: `${visitor.firstName} ${visitor.lastName}` })
-			.filter({ has: ownerPage.getByRole('button', { name: 'Approve', exact: true }) })
-			.last();
-		await expect(requestCard).toBeVisible({ timeout: 15_000 });
-		// Outcome-keyed approve with a DISPATCHED click — on the mobile project
-		// the card button intermittently never settles for Playwright's
-		// actionability check and a positioned click hangs (same class as the
-		// invoice-detail dialog). Approval removes the card from the "Pending"
-		// filter, so the card locator — which requires an exact Approve button —
-		// resolving to nothing IS the success state; re-dispatch is harmless
-		// (the endpoint 400s only after the request already left pending).
-		const approveButton = requestCard.getByRole('button', { name: 'Approve', exact: true });
-		await expect(async () => {
-			if (await approveButton.isHidden()) return;
-			await approveButton.dispatchEvent('click');
-			await expect(approveButton).toBeHidden({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
-
-		// Approval unblocks immediately: the gate is gone, the RSVP card renders.
-		await expect(async () => {
+		try {
 			await gotoHydrated(visitorPage, event.path);
-			await expect(visitorPage.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
-				timeout: 3_000
-			});
-		}).toPass({ timeout: 30_000 });
-		await expect(visitorPage.getByText('Additional verification required.')).toBeHidden();
+			await waitForClientAuth(visitorPage);
+			await expect(
+				visitorPage.getByText('Additional verification required.').filter({ visible: true }).first()
+			).toBeVisible({ timeout: 15_000 });
+			await expect(visitorPage.getByRole('heading', { name: 'Will you attend?' })).toBeHidden();
 
-		await visitorContext.close();
-		await ownerContext.close();
+			// Submit the whitelist request through the dialog.
+			await visitorPage
+				.getByRole('button', { name: 'Request Verification' })
+				.filter({ visible: true })
+				.first()
+				.click();
+			const requestDialog = visitorPage.getByRole('dialog', { name: 'Request Verification' });
+			await expect(requestDialog).toBeVisible();
+			await requestDialog
+				.getByLabel('Message (Optional)')
+				.fill('The organizers know me — this is a name collision.');
+			await requestDialog.getByRole('button', { name: 'Submit Request' }).click();
+			await expect(visitorPage.getByText('Verification Request Submitted').first()).toBeVisible({
+				timeout: 15_000
+			});
+
+			// Reloading, the gate now shows the pending state (disabled action).
+			await gotoHydrated(visitorPage, event.path);
+			const pendingButton = visitorPage
+				.getByRole('button', { name: 'Verification Pending' })
+				.filter({ visible: true })
+				.first();
+			await expect(pendingButton).toBeVisible({ timeout: 15_000 });
+			await expect(pendingButton).toBeDisabled();
+
+			// The owner approves it from the blacklist page's Verification Requests tab.
+			const ownerContext = await browser.newContext();
+			await authenticateContext(ownerContext, org.owner);
+			const ownerPage = await ownerContext.newPage();
+			try {
+				await gotoHydrated(ownerPage, `/org/${org.slug}/admin/blacklist`);
+				await waitForClientAuth(ownerPage);
+				await ownerPage.getByRole('tab', { name: /Verification Requests|Requests/ }).click();
+				// exact: true everywhere — role-name matching is SUBSTRING by default,
+				// and the tab's "Approved" FILTER button would match a bare 'Approve'
+				// (the tab switches itself to that filter after a decision, so the
+				// approved card + filter button otherwise keep the locator alive).
+				const requestCard = ownerPage
+					.locator('article, li, div')
+					.filter({ hasText: `${visitor.firstName} ${visitor.lastName}` })
+					.filter({ has: ownerPage.getByRole('button', { name: 'Approve', exact: true }) })
+					.last();
+				await expect(requestCard).toBeVisible({ timeout: 15_000 });
+				// Outcome-keyed approve with a DISPATCHED click — on the mobile project
+				// the card button intermittently never settles for Playwright's
+				// actionability check and a positioned click hangs (same class as the
+				// invoice-detail dialog). Approval removes the card from the "Pending"
+				// filter, so the card locator — which requires an exact Approve button —
+				// resolving to nothing IS the success state; re-dispatch is harmless
+				// (the endpoint 400s only after the request already left pending).
+				const approveButton = requestCard.getByRole('button', { name: 'Approve', exact: true });
+				await expect(async () => {
+					if (await approveButton.isHidden()) return;
+					await approveButton.dispatchEvent('click');
+					await expect(approveButton).toBeHidden({ timeout: 5_000 });
+				}).toPass({ timeout: 45_000 });
+			} finally {
+				await ownerContext.close();
+			}
+
+			// Approval unblocks immediately: the gate is gone, the RSVP card renders.
+			await expect(async () => {
+				await gotoHydrated(visitorPage, event.path);
+				await expect(visitorPage.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
+					timeout: 3_000
+				});
+			}).toPass({ timeout: 30_000 });
+			await expect(visitorPage.getByText('Additional verification required.')).toBeHidden();
+		} finally {
+			await visitorContext.close();
+		}
 	});
 });

--- a/tests/e2e/journeys/j13-blacklist-moderation/fuzzy-whitelist.spec.ts
+++ b/tests/e2e/journeys/j13-blacklist-moderation/fuzzy-whitelist.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	addToBlacklist,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J13 (USER_JOURNEYS.md) — fuzzy blacklist match → whitelist request →
+// approval → unblocked. A NAME-ONLY (unlinked) blacklist entry soft-matches
+// users by rapidfuzz name similarity: unlike a hard match (which 404s the
+// org's events outright), the fuzzy-matched user still reaches the event and
+// gets the "Additional verification required." gate with a Request
+// Verification action. Approving the request on the admin's Verification
+// Requests tab unblocks them immediately.
+//
+// Isolation: throwaway org + throwaway user; the entry carries only the
+// user's name (adding their email would auto-link it into a HARD block).
+
+test.describe('J13 fuzzy whitelist @p3', () => {
+	test('name-match gate → request verification → approve → unblocked', async ({ browser }) => {
+		test.setTimeout(180_000);
+
+		const org = await createOrganization();
+		const visitor = await createVerifiedUser('Fuzzy');
+		// Name-only entry, identical to the visitor's name (fuzzy threshold 85).
+		await addToBlacklist(org.owner, org.slug, {
+			first_name: visitor.firstName,
+			last_name: visitor.lastName,
+			reason: 'E2E fuzzy-whitelist journey'
+		});
+		const event = await createTicketedEvent({
+			owner: org.owner,
+			orgSlug: org.slug,
+			freeTier: false,
+			event: { requires_ticket: false }
+		});
+
+		// The fuzzy-matched visitor sees the verification gate, not a 404.
+		const visitorContext = await browser.newContext();
+		await authenticateContext(visitorContext, visitor);
+		const visitorPage = await visitorContext.newPage();
+		await gotoHydrated(visitorPage, event.path);
+		await waitForClientAuth(visitorPage);
+		await expect(
+			visitorPage.getByText('Additional verification required.').filter({ visible: true }).first()
+		).toBeVisible({ timeout: 15_000 });
+		await expect(visitorPage.getByRole('heading', { name: 'Will you attend?' })).toBeHidden();
+
+		// Submit the whitelist request through the dialog.
+		await visitorPage
+			.getByRole('button', { name: 'Request Verification' })
+			.filter({ visible: true })
+			.first()
+			.click();
+		const requestDialog = visitorPage.getByRole('dialog', { name: 'Request Verification' });
+		await expect(requestDialog).toBeVisible();
+		await requestDialog
+			.getByLabel('Message (Optional)')
+			.fill('The organizers know me — this is a name collision.');
+		await requestDialog.getByRole('button', { name: 'Submit Request' }).click();
+		await expect(visitorPage.getByText('Verification Request Submitted').first()).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Reloading, the gate now shows the pending state (disabled action).
+		await gotoHydrated(visitorPage, event.path);
+		const pendingButton = visitorPage
+			.getByRole('button', { name: 'Verification Pending' })
+			.filter({ visible: true })
+			.first();
+		await expect(pendingButton).toBeVisible({ timeout: 15_000 });
+		await expect(pendingButton).toBeDisabled();
+
+		// The owner approves it from the blacklist page's Verification Requests tab.
+		const ownerContext = await browser.newContext();
+		await authenticateContext(ownerContext, org.owner);
+		const ownerPage = await ownerContext.newPage();
+		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/blacklist`);
+		await waitForClientAuth(ownerPage);
+		await ownerPage.getByRole('tab', { name: /Verification Requests|Requests/ }).click();
+		// exact: true everywhere — role-name matching is SUBSTRING by default,
+		// and the tab's "Approved" FILTER button would match a bare 'Approve'
+		// (the tab switches itself to that filter after a decision, so the
+		// approved card + filter button otherwise keep the locator alive).
+		const requestCard = ownerPage
+			.locator('article, li, div')
+			.filter({ hasText: `${visitor.firstName} ${visitor.lastName}` })
+			.filter({ has: ownerPage.getByRole('button', { name: 'Approve', exact: true }) })
+			.last();
+		await expect(requestCard).toBeVisible({ timeout: 15_000 });
+		// Outcome-keyed approve with a DISPATCHED click — on the mobile project
+		// the card button intermittently never settles for Playwright's
+		// actionability check and a positioned click hangs (same class as the
+		// invoice-detail dialog). Approval removes the card from the "Pending"
+		// filter, so the card locator — which requires an exact Approve button —
+		// resolving to nothing IS the success state; re-dispatch is harmless
+		// (the endpoint 400s only after the request already left pending).
+		const approveButton = requestCard.getByRole('button', { name: 'Approve', exact: true });
+		await expect(async () => {
+			if (await approveButton.isHidden()) return;
+			await approveButton.dispatchEvent('click');
+			await expect(approveButton).toBeHidden({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		// Approval unblocks immediately: the gate is gone, the RSVP card renders.
+		await expect(async () => {
+			await gotoHydrated(visitorPage, event.path);
+			await expect(visitorPage.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
+				timeout: 3_000
+			});
+		}).toPass({ timeout: 30_000 });
+		await expect(visitorPage.getByText('Additional verification required.')).toBeHidden();
+
+		await visitorContext.close();
+		await ownerContext.close();
+	});
+});

--- a/tests/e2e/journeys/j13-blacklist-moderation/unban.spec.ts
+++ b/tests/e2e/journeys/j13-blacklist-moderation/unban.spec.ts
@@ -44,51 +44,58 @@ test.describe('J13 unban @p3', () => {
 		const victimContext = await browser.newContext();
 		await authenticateContext(victimContext, victim);
 		const victimPage = await victimContext.newPage();
-		const bannedResponse = await victimPage.goto(`/org/${org.slug}`);
-		expect(bannedResponse?.status()).toBe(404);
+		try {
+			const bannedResponse = await victimPage.goto(`/org/${org.slug}`);
+			expect(bannedResponse?.status()).toBe(404);
 
-		// The owner removes the entry through the blacklist page's detail modal.
-		const ownerContext = await browser.newContext();
-		await authenticateContext(ownerContext, org.owner);
-		const ownerPage = await ownerContext.newPage();
-		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/blacklist`);
-		await waitForClientAuth(ownerPage);
-		// The org has exactly one entry — the victim's (linked by email).
-		await ownerPage
-			.getByRole('button', { name: /^Manage blacklist entry for / })
-			.first()
-			.click();
-		const entryModal = ownerPage.getByRole('dialog', { name: /Blacklist Entry/ });
-		await expect(entryModal).toBeVisible();
-		await entryModal.getByRole('button', { name: 'Remove from Blacklist' }).click();
-		await entryModal.getByRole('button', { name: 'Confirm Remove' }).click();
-		await expect(entryModal).not.toBeVisible({ timeout: 15_000 });
-		await expect(ownerPage.getByText('Removed from blacklist')).toBeVisible({ timeout: 15_000 });
+			// The owner removes the entry through the blacklist page's detail modal.
+			const ownerContext = await browser.newContext();
+			await authenticateContext(ownerContext, org.owner);
+			const ownerPage = await ownerContext.newPage();
+			try {
+				await gotoHydrated(ownerPage, `/org/${org.slug}/admin/blacklist`);
+				await waitForClientAuth(ownerPage);
+				// The org has exactly one entry — the victim's (linked by email).
+				await ownerPage
+					.getByRole('button', { name: /^Manage blacklist entry for / })
+					.first()
+					.click();
+				const entryModal = ownerPage.getByRole('dialog', { name: /Blacklist Entry/ });
+				await expect(entryModal).toBeVisible();
+				await entryModal.getByRole('button', { name: 'Remove from Blacklist' }).click();
+				await entryModal.getByRole('button', { name: 'Confirm Remove' }).click();
+				await expect(entryModal).not.toBeVisible({ timeout: 15_000 });
+				await expect(ownerPage.getByText('Removed from blacklist')).toBeVisible({
+					timeout: 15_000
+				});
 
-		// Membership lands on CANCELLED — explicitly not reactivated (a member's
-		// status is single-valued, so Cancelled on the card rules out Active).
-		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/members`);
-		await waitForClientAuth(ownerPage);
-		const memberCard = ownerPage
-			.locator('article, li, div')
-			.filter({ hasText: victimName })
-			.filter({ hasText: /Cancelled/ })
-			.first();
-		await expect(memberCard).toBeVisible({ timeout: 15_000 });
+				// Membership lands on CANCELLED — explicitly not reactivated (a member's
+				// status is single-valued, so Cancelled on the card rules out Active).
+				await gotoHydrated(ownerPage, `/org/${org.slug}/admin/members`);
+				await waitForClientAuth(ownerPage);
+				const memberCard = ownerPage
+					.locator('article, li, div')
+					.filter({ hasText: victimName })
+					.filter({ hasText: /Cancelled/ })
+					.first();
+				await expect(memberCard).toBeVisible({ timeout: 15_000 });
+			} finally {
+				await ownerContext.close();
+			}
 
-		// Visibility returns for the victim: org page and event page load again
-		// (the event greets them as an ordinary eligible visitor).
-		await expect(async () => {
-			const response = await victimPage.goto(`/org/${org.slug}`);
-			expect(response?.status()).toBe(200);
-		}).toPass({ timeout: 30_000 });
-		await gotoHydrated(victimPage, event.path);
-		await waitForClientAuth(victimPage);
-		await expect(victimPage.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
-			timeout: 15_000
-		});
-
-		await victimContext.close();
-		await ownerContext.close();
+			// Visibility returns for the victim: org page and event page load again
+			// (the event greets them as an ordinary eligible visitor).
+			await expect(async () => {
+				const response = await victimPage.goto(`/org/${org.slug}`);
+				expect(response?.status()).toBe(200);
+			}).toPass({ timeout: 30_000 });
+			await gotoHydrated(victimPage, event.path);
+			await waitForClientAuth(victimPage);
+			await expect(victimPage.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
+				timeout: 15_000
+			});
+		} finally {
+			await victimContext.close();
+		}
 	});
 });

--- a/tests/e2e/journeys/j13-blacklist-moderation/unban.spec.ts
+++ b/tests/e2e/journeys/j13-blacklist-moderation/unban.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	addToBlacklist,
+	approveMembershipRequest,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser,
+	requestMembership
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J13 (USER_JOURNEYS.md) — unban: removing a hard blacklist entry restores
+// the user's VISIBILITY of the org, but deliberately not their privileges —
+// the backend flips the BANNED membership to CANCELLED (never back to
+// ACTIVE), so re-joining takes a fresh membership request.
+//
+// Isolation: throwaway org, throwaway member-victim blacklisted by email
+// (auto-links → membership BANNED → org/events 404 for them).
+
+test.describe('J13 unban @p3', () => {
+	test('remove blacklist entry → org visible again, membership Cancelled not Active', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+
+		const org = await createOrganization({ acceptMembershipRequests: true });
+		const victim = await createVerifiedUser('Unban');
+		const request = await requestMembership(victim, org.slug);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		const event = await createTicketedEvent({
+			owner: org.owner,
+			orgSlug: org.slug,
+			freeTier: false,
+			event: { requires_ticket: false }
+		});
+		await addToBlacklist(org.owner, org.slug, {
+			email: victim.email,
+			reason: 'E2E unban journey'
+		});
+		const victimName = `${victim.firstName} ${victim.lastName}`;
+
+		// While banned: the org page is a 404 for the victim.
+		const victimContext = await browser.newContext();
+		await authenticateContext(victimContext, victim);
+		const victimPage = await victimContext.newPage();
+		const bannedResponse = await victimPage.goto(`/org/${org.slug}`);
+		expect(bannedResponse?.status()).toBe(404);
+
+		// The owner removes the entry through the blacklist page's detail modal.
+		const ownerContext = await browser.newContext();
+		await authenticateContext(ownerContext, org.owner);
+		const ownerPage = await ownerContext.newPage();
+		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/blacklist`);
+		await waitForClientAuth(ownerPage);
+		// The org has exactly one entry — the victim's (linked by email).
+		await ownerPage
+			.getByRole('button', { name: /^Manage blacklist entry for / })
+			.first()
+			.click();
+		const entryModal = ownerPage.getByRole('dialog', { name: /Blacklist Entry/ });
+		await expect(entryModal).toBeVisible();
+		await entryModal.getByRole('button', { name: 'Remove from Blacklist' }).click();
+		await entryModal.getByRole('button', { name: 'Confirm Remove' }).click();
+		await expect(entryModal).not.toBeVisible({ timeout: 15_000 });
+		await expect(ownerPage.getByText('Removed from blacklist')).toBeVisible({ timeout: 15_000 });
+
+		// Membership lands on CANCELLED — explicitly not reactivated (a member's
+		// status is single-valued, so Cancelled on the card rules out Active).
+		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(ownerPage);
+		const memberCard = ownerPage
+			.locator('article, li, div')
+			.filter({ hasText: victimName })
+			.filter({ hasText: /Cancelled/ })
+			.first();
+		await expect(memberCard).toBeVisible({ timeout: 15_000 });
+
+		// Visibility returns for the victim: org page and event page load again
+		// (the event greets them as an ordinary eligible visitor).
+		await expect(async () => {
+			const response = await victimPage.goto(`/org/${org.slug}`);
+			expect(response?.status()).toBe(200);
+		}).toPass({ timeout: 30_000 });
+		await gotoHydrated(victimPage, event.path);
+		await waitForClientAuth(victimPage);
+		await expect(victimPage.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
+			timeout: 15_000
+		});
+
+		await victimContext.close();
+		await ownerContext.close();
+	});
+});

--- a/tests/e2e/journeys/j16-billing/vat-preview.spec.ts
+++ b/tests/e2e/journeys/j16-billing/vat-preview.spec.ts
@@ -16,8 +16,8 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 // UI reacts to the billing fields.
 //
 // The billing section only renders when the org has attendee invoicing
-// enabled AND the tier is online — the arrange flips Org Alpha (AT, 20%) to
-// 'auto' (idempotent, deliberately not reverted; see setOrgInvoicingMode).
+// enabled AND the tier is online — the arrange pins Org Alpha (AT, 20%) to
+// 'hybrid', the suite-wide invoicing mode (see setOrgInvoicingMode).
 //
 // VAT IDs are validated against the LIVE EU VIES service (no backend stub),
 // so the spec uses two real, stable registrations — Red Bull GmbH (AT,
@@ -31,7 +31,7 @@ test.describe('J16 VAT preview @p2', () => {
 	test('domestic B2B pays VAT; EU B2B with valid VAT ID gets reverse charge', async ({
 		browser
 	}) => {
-		await setOrgInvoicingMode('auto');
+		await setOrgInvoicingMode('hybrid');
 		const [event, buyer] = await Promise.all([
 			createTicketedEvent({ freeTier: false }),
 			createVerifiedUser('VatPreview')

--- a/tests/e2e/journeys/j18-series/series-questionnaire.spec.ts
+++ b/tests/e2e/journeys/j18-series/series-questionnaire.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	attachQuestionnaireToSeries,
+	createEventSeries,
+	createOrganization,
+	createTicketedEvent,
+	createVerifiedUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J18 (USER_JOURNEYS.md) — series-level questionnaire: a questionnaire
+// attached to the EVENT SERIES gates every event in it, and one approved
+// submission (per_event stays false, the default) unlocks them ALL — the
+// user passes on event A and event B opens without ever re-prompting.
+//
+// Isolation: throwaway org (questionnaires pollute the org's admin index),
+// automatic MCQ evaluation (inline, deterministic), throwaway user.
+
+const QUESTION = 'Will you follow the series code of conduct?';
+const CORRECT = 'Yes, I will follow it';
+
+test.describe('J18 series questionnaire @p3', () => {
+	test('pass once on one event → every series event unlocked', async ({ browser }) => {
+		test.setTimeout(180_000);
+
+		const org = await createOrganization();
+		const series = await createEventSeries(org.owner, org.slug);
+		const seriesEvent = {
+			owner: org.owner,
+			orgSlug: org.slug,
+			freeTier: false,
+			event: { requires_ticket: false, event_series_id: series.id }
+		};
+		const [eventA, eventB] = await Promise.all([
+			createTicketedEvent(seriesEvent),
+			createTicketedEvent(seriesEvent)
+		]);
+		await attachQuestionnaireToSeries(
+			series,
+			{
+				evaluation_mode: 'automatic',
+				multiplechoicequestion_questions: [
+					{
+						question: QUESTION,
+						is_mandatory: true,
+						is_fatal: true,
+						shuffle_options: false,
+						options: [
+							{ option: CORRECT, is_correct: true, order: 0 },
+							{ option: 'No, rules are not for me', order: 1 }
+						]
+					}
+				]
+			},
+			org.owner
+		);
+
+		const user = await createVerifiedUser('SeriesPass');
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		// Both events start gated by the series questionnaire.
+		await gotoHydrated(page, eventB.path);
+		await waitForClientAuth(page);
+		await expect(
+			page.getByRole('button', { name: 'Complete Questionnaire' }).filter({ visible: true }).first()
+		).toBeVisible({ timeout: 15_000 });
+
+		// Pass it from event A.
+		await gotoHydrated(page, eventA.path);
+		await page
+			.getByRole('button', { name: 'Complete Questionnaire' })
+			.filter({ visible: true })
+			.first()
+			.click();
+		await page.waitForURL(/\/questionnaire\//);
+		await page.waitForLoadState('networkidle');
+		const radio = page.getByRole('radio', { name: CORRECT });
+		const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
+		const eventAUrl = new RegExp(`/${eventA.slug}(?:\\?|$)`);
+		await expect(async () => {
+			if (eventAUrl.test(page.url())) return;
+			await radio.check();
+			await expect(radio).toBeChecked();
+			await expect(submit).toBeEnabled();
+			await submit.click();
+			await page.waitForURL(eventAUrl, { timeout: 8_000 });
+		}).toPass({ timeout: 40_000 });
+
+		// Approved (inline auto-eval) → event A's gate yields to the RSVP card…
+		await expect(async () => {
+			await gotoHydrated(page, eventA.path);
+			await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
+				timeout: 3_000
+			});
+		}).toPass({ timeout: 30_000 });
+
+		// …and event B is unlocked WITHOUT a second submission.
+		await gotoHydrated(page, eventB.path);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(page.getByRole('button', { name: 'Complete Questionnaire' })).toBeHidden();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j18-series/series-questionnaire.spec.ts
+++ b/tests/e2e/journeys/j18-series/series-questionnaire.spec.ts
@@ -60,51 +60,55 @@ test.describe('J18 series questionnaire @p3', () => {
 		const context = await browser.newContext();
 		await authenticateContext(context, user);
 		const page = await context.newPage();
+		try {
+			// Both events start gated by the series questionnaire.
+			await gotoHydrated(page, eventB.path);
+			await waitForClientAuth(page);
+			await expect(
+				page
+					.getByRole('button', { name: 'Complete Questionnaire' })
+					.filter({ visible: true })
+					.first()
+			).toBeVisible({ timeout: 15_000 });
 
-		// Both events start gated by the series questionnaire.
-		await gotoHydrated(page, eventB.path);
-		await waitForClientAuth(page);
-		await expect(
-			page.getByRole('button', { name: 'Complete Questionnaire' }).filter({ visible: true }).first()
-		).toBeVisible({ timeout: 15_000 });
-
-		// Pass it from event A.
-		await gotoHydrated(page, eventA.path);
-		await page
-			.getByRole('button', { name: 'Complete Questionnaire' })
-			.filter({ visible: true })
-			.first()
-			.click();
-		await page.waitForURL(/\/questionnaire\//);
-		await page.waitForLoadState('networkidle');
-		const radio = page.getByRole('radio', { name: CORRECT });
-		const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
-		const eventAUrl = new RegExp(`/${eventA.slug}(?:\\?|$)`);
-		await expect(async () => {
-			if (eventAUrl.test(page.url())) return;
-			await radio.check();
-			await expect(radio).toBeChecked();
-			await expect(submit).toBeEnabled();
-			await submit.click();
-			await page.waitForURL(eventAUrl, { timeout: 8_000 });
-		}).toPass({ timeout: 40_000 });
-
-		// Approved (inline auto-eval) → event A's gate yields to the RSVP card…
-		await expect(async () => {
+			// Pass it from event A.
 			await gotoHydrated(page, eventA.path);
+			await page
+				.getByRole('button', { name: 'Complete Questionnaire' })
+				.filter({ visible: true })
+				.first()
+				.click();
+			await page.waitForURL(/\/questionnaire\//);
+			await page.waitForLoadState('networkidle');
+			const radio = page.getByRole('radio', { name: CORRECT });
+			const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
+			const eventAUrl = new RegExp(`/${eventA.slug}(?:\\?|$)`);
+			await expect(async () => {
+				if (eventAUrl.test(page.url())) return;
+				await radio.check();
+				await expect(radio).toBeChecked();
+				await expect(submit).toBeEnabled();
+				await submit.click();
+				await page.waitForURL(eventAUrl, { timeout: 8_000 });
+			}).toPass({ timeout: 40_000 });
+
+			// Approved (inline auto-eval) → event A's gate yields to the RSVP card…
+			await expect(async () => {
+				await gotoHydrated(page, eventA.path);
+				await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
+					timeout: 3_000
+				});
+			}).toPass({ timeout: 30_000 });
+
+			// …and event B is unlocked WITHOUT a second submission.
+			await gotoHydrated(page, eventB.path);
+			await waitForClientAuth(page);
 			await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
-				timeout: 3_000
+				timeout: 15_000
 			});
-		}).toPass({ timeout: 30_000 });
-
-		// …and event B is unlocked WITHOUT a second submission.
-		await gotoHydrated(page, eventB.path);
-		await waitForClientAuth(page);
-		await expect(page.getByRole('heading', { name: 'Will you attend?' })).toBeVisible({
-			timeout: 15_000
-		});
-		await expect(page.getByRole('button', { name: 'Complete Questionnaire' })).toBeHidden();
-
-		await context.close();
+			await expect(page.getByRole('button', { name: 'Complete Questionnaire' })).toBeHidden();
+		} finally {
+			await context.close();
+		}
 	});
 });

--- a/tests/e2e/journeys/j22-attendee-invoicing/buyer-invoices.spec.ts
+++ b/tests/e2e/journeys/j22-attendee-invoicing/buyer-invoices.spec.ts
@@ -47,51 +47,53 @@ test.describe('J22 buyer invoices @p2', () => {
 		const context = await browser.newContext();
 		await authenticateContext(context, buyer);
 		const page = await context.newPage();
-		await page.goto(checkoutUrl);
-		await completeStripeCheckout(page);
+		try {
+			await page.goto(checkoutUrl);
+			await completeStripeCheckout(page);
 
-		// Hybrid mode leaves the generated invoice as a draft — wait for it and
-		// issue it as the org owner (API arrange; the UI journey is hybrid-flow).
-		await issueDraftInvoiceFor(buyer.email);
+			// Hybrid mode leaves the generated invoice as a draft — wait for it and
+			// issue it as the org owner (API arrange; the UI journey is hybrid-flow).
+			await issueDraftInvoiceFor(buyer.email);
 
-		// A fresh buyer has exactly one invoice — poll for its Issued table row.
-		const invoiceRow = page.getByRole('row').filter({ hasText: 'Issued' });
-		await expect(async () => {
-			await gotoHydrated(page, '/account/invoices');
-			await expect(invoiceRow).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 90_000 });
-		await waitForClientAuth(page);
+			// A fresh buyer has exactly one invoice — poll for its Issued table row.
+			const invoiceRow = page.getByRole('row').filter({ hasText: 'Issued' });
+			await expect(async () => {
+				await gotoHydrated(page, '/account/invoices');
+				await expect(invoiceRow).toBeVisible({ timeout: 5_000 });
+			}).toPass({ timeout: 90_000 });
+			await waitForClientAuth(page);
 
-		// Gross amount (€10.00) renders in the row.
-		await expect(invoiceRow.getByText(/10[.,]00/).first()).toBeVisible();
+			// Gross amount (€10.00) renders in the row.
+			await expect(invoiceRow.getByText(/10[.,]00/).first()).toBeVisible();
 
-		// Detail dialog opens from the invoice-number button; Escape closes it
-		// (the footer Close and the X share the same accessible name).
-		await invoiceRow.getByRole('button', { name: /View details/ }).click();
-		const detail = page.getByRole('dialog', { name: 'Invoice Details' });
-		await expect(detail).toBeVisible({ timeout: 15_000 });
-		await page.keyboard.press('Escape');
-		await expect(detail).not.toBeVisible({ timeout: 15_000 });
+			// Detail dialog opens from the invoice-number button; Escape closes it
+			// (the footer Close and the X share the same accessible name).
+			await invoiceRow.getByRole('button', { name: /View details/ }).click();
+			const detail = page.getByRole('dialog', { name: 'Invoice Details' });
+			await expect(detail).toBeVisible({ timeout: 15_000 });
+			await page.keyboard.press('Escape');
+			await expect(detail).not.toBeVisible({ timeout: 15_000 });
 
-		// "Download PDF" resolves a signed URL from the API and window.open()s
-		// it — Chromium turns the PDF into a download, so the popup never
-		// commits a URL. Assert the journey at the network layer instead:
-		// capture the resolved download_url and fetch the PDF from it (a 404
-		// means the PDF is still rendering — the loop clicks again).
-		await expect(async () => {
-			const responsePromise = page.waitForResponse(
-				(r) => /\/api\/dashboard\/invoices\/[^/]+\/download/.test(r.url()),
-				{ timeout: 10_000 }
-			);
-			await invoiceRow.getByRole('button', { name: /Download PDF/ }).click();
-			const response = await responsePromise;
-			expect(response.status()).toBe(200);
-			const { download_url } = (await response.json()) as { download_url: string };
-			const pdf = await page.request.get(getBackendUrl(download_url));
-			expect(pdf.status()).toBe(200);
-			expect(pdf.headers()['content-type'] ?? '').toContain('pdf');
-		}).toPass({ timeout: 60_000 });
-
-		await context.close();
+			// "Download PDF" resolves a signed URL from the API and window.open()s
+			// it — Chromium turns the PDF into a download, so the popup never
+			// commits a URL. Assert the journey at the network layer instead:
+			// capture the resolved download_url and fetch the PDF from it (a 404
+			// means the PDF is still rendering — the loop clicks again).
+			await expect(async () => {
+				const responsePromise = page.waitForResponse(
+					(r) => /\/api\/dashboard\/invoices\/[^/]+\/download/.test(r.url()),
+					{ timeout: 10_000 }
+				);
+				await invoiceRow.getByRole('button', { name: /Download PDF/ }).click();
+				const response = await responsePromise;
+				expect(response.status()).toBe(200);
+				const { download_url } = (await response.json()) as { download_url: string };
+				const pdf = await page.request.get(getBackendUrl(download_url));
+				expect(pdf.status()).toBe(200);
+				expect(pdf.headers()['content-type'] ?? '').toContain('pdf');
+			}).toPass({ timeout: 60_000 });
+		} finally {
+			await context.close();
+		}
 	});
 });

--- a/tests/e2e/journeys/j22-attendee-invoicing/buyer-invoices.spec.ts
+++ b/tests/e2e/journeys/j22-attendee-invoicing/buyer-invoices.spec.ts
@@ -4,6 +4,7 @@ import {
 	createTicketedEvent,
 	createTicketTier,
 	createVerifiedUser,
+	issueDraftInvoiceFor,
 	setOrgInvoicingMode,
 	startOnlineCheckout
 } from '../../support/factories';
@@ -11,24 +12,23 @@ import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 import { completeStripeCheckout } from '../../support/stripe';
 
-// J22 (USER_JOURNEYS.md) — buyer-side attendee invoicing: with the org in
-// AUTO invoicing mode, a paid online purchase generates an ISSUED invoice
-// that the buyer finds under /account/invoices, with the PDF served from a
-// signed URL in a new tab.
+// J22 (USER_JOURNEYS.md) — buyer-side attendee invoicing: a paid online
+// purchase with billing info generates an invoice that, once issued, the
+// buyer finds under /account/invoices with the PDF served from a signed URL.
 //
 // Requires the full Stripe test-mode setup (tests/e2e/README.md) — the
-// invoice is generated from the webhook's payment record. No org in the
-// seed has invoicing enabled, so the arrange flips Org Alpha to 'auto'
-// (idempotent, deliberately not reverted; see setOrgInvoicingMode).
+// invoice is generated from the webhook's payment record. The suite pins Org
+// Alpha (the only Stripe-connected org) to HYBRID invoicing — the mode is
+// read at webhook time and mixed modes would race parallel workers' checkouts
+// (see setOrgInvoicingMode) — so the arrange issues the draft via the admin
+// API; the organizer-side draft→issue UI journey is j22 hybrid-flow.
 
 test.describe('J22 buyer invoices @p2', () => {
-	test('auto-invoiced purchase → issued invoice in /account/invoices → PDF', async ({
-		browser
-	}) => {
+	test('invoiced purchase → issued invoice in /account/invoices → PDF', async ({ browser }) => {
 		// Stripe hosted checkout + webhook + invoice generation.
 		test.setTimeout(240_000);
 
-		await setOrgInvoicingMode('auto');
+		await setOrgInvoicingMode('hybrid');
 		const [event, buyer] = await Promise.all([
 			createTicketedEvent({ freeTier: false }),
 			createVerifiedUser('Invoiced')
@@ -50,8 +50,11 @@ test.describe('J22 buyer invoices @p2', () => {
 		await page.goto(checkoutUrl);
 		await completeStripeCheckout(page);
 
-		// The invoice is generated when the webhook lands (inline Celery) — a
-		// fresh buyer has exactly one, so poll for its Issued table row.
+		// Hybrid mode leaves the generated invoice as a draft — wait for it and
+		// issue it as the org owner (API arrange; the UI journey is hybrid-flow).
+		await issueDraftInvoiceFor(buyer.email);
+
+		// A fresh buyer has exactly one invoice — poll for its Issued table row.
 		const invoiceRow = page.getByRole('row').filter({ hasText: 'Issued' });
 		await expect(async () => {
 			await gotoHydrated(page, '/account/invoices');

--- a/tests/e2e/journeys/j22-attendee-invoicing/hybrid-flow.spec.ts
+++ b/tests/e2e/journeys/j22-attendee-invoicing/hybrid-flow.spec.ts
@@ -50,85 +50,87 @@ test.describe('J22 hybrid invoicing @p3', () => {
 		const buyerContext = await browser.newContext();
 		await authenticateContext(buyerContext, buyer);
 		const buyerPage = await buyerContext.newPage();
-		await buyerPage.goto(checkoutUrl);
-		await completeStripeCheckout(buyerPage);
+		try {
+			await buyerPage.goto(checkoutUrl);
+			await completeStripeCheckout(buyerPage);
 
-		// Organizer: the draft appears on the Attendee Invoices page (webhook +
-		// inline generation → poll by reload, scoped through the search box).
-		await gotoHydrated(asOwner, INVOICES_PATH);
-		await waitForClientAuth(asOwner);
-		const draftRow = asOwner
-			.getByRole('row')
-			.filter({ hasText: buyer.email })
-			.filter({ hasText: 'Draft' });
-		await expect(async () => {
+			// Organizer: the draft appears on the Attendee Invoices page (webhook +
+			// inline generation → poll by reload, scoped through the search box).
 			await gotoHydrated(asOwner, INVOICES_PATH);
-			await asOwner.getByPlaceholder('Search invoices...').fill(buyer.email);
-			await expect(draftRow).toBeVisible({ timeout: 8_000 });
-		}).toPass({ timeout: 120_000 });
+			await waitForClientAuth(asOwner);
+			const draftRow = asOwner
+				.getByRole('row')
+				.filter({ hasText: buyer.email })
+				.filter({ hasText: 'Draft' });
+			await expect(async () => {
+				await gotoHydrated(asOwner, INVOICES_PATH);
+				await asOwner.getByPlaceholder('Search invoices...').fill(buyer.email);
+				await expect(draftRow).toBeVisible({ timeout: 8_000 });
+			}).toPass({ timeout: 120_000 });
 
-		// While it's a draft, the buyer sees NOTHING under /account/invoices —
-		// the dashboard endpoint serves issued invoices only.
-		const buyerRow = buyerPage.getByRole('row').filter({ hasText: 'Issued' });
-		await gotoHydrated(buyerPage, '/account/invoices');
-		await waitForClientAuth(buyerPage);
-		await expect(buyerRow).toBeHidden();
-		await expect(buyerPage.getByText('No invoices yet')).toBeVisible({ timeout: 15_000 });
-
-		// Detail dialog → edit the buyer fields on the draft. In-dialog buttons
-		// get dispatchEvent clicks: on the mobile viewport the long scrollable
-		// dialog keeps them "unstable" for Playwright's actionability check and
-		// a normal click waits forever — every step is outcome-keyed instead.
-		await draftRow.getByRole('button').first().click();
-		const detail = asOwner.getByRole('dialog', { name: 'Invoice Detail' });
-		await expect(detail).toBeVisible();
-		const nameField = detail.getByLabel('Name', { exact: true });
-		await expect(async () => {
-			if (await nameField.isVisible()) return;
-			await detail.getByRole('button', { name: 'Edit' }).dispatchEvent('click');
-			await expect(nameField).toBeVisible({ timeout: 3_000 });
-		}).toPass({ timeout: 30_000 });
-
-		// Outcome-keyed save: success = the view mode renders the edited buyer
-		// name as TEXT (while editing it only exists as an input value, which
-		// getByText ignores). The VAT ID deliberately stays EMPTY — the form
-		// posts cleared fields as null, which used to 500 on the backend's
-		// NOT NULL buyer columns (BE #700, fixed by revel-backend#701); this
-		// save doubles as the FE-side regression for it.
-		const editedName = `${buyer.firstName} ${buyer.lastName} GmbH`;
-		const savedName = detail.getByText(editedName);
-		await expect(async () => {
-			if (await savedName.isVisible()) return;
-			await nameField.fill(editedName);
-			await detail.getByRole('button', { name: 'Save Changes' }).dispatchEvent('click');
-			await expect(savedName).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
-
-		// Issue it (confirm dialog) — sent to the buyer, no longer editable.
-		const confirm = asOwner.getByRole('dialog', { name: 'Issue this invoice?' });
-		await expect(async () => {
-			if (await confirm.isVisible()) return;
-			await detail.getByRole('button', { name: 'Issue Invoice' }).dispatchEvent('click');
-			await expect(confirm).toBeVisible({ timeout: 3_000 });
-		}).toPass({ timeout: 30_000 });
-		await expect(async () => {
-			if (await confirm.isHidden()) return;
-			await confirm.getByRole('button', { name: 'Yes, Issue' }).dispatchEvent('click');
-			await expect(confirm).toBeHidden({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
-
-		// The buyer receives the org-branded invoice email (PDF attached).
-		const email = await waitForEmail({ to: buyer.email, subject: 'Invoice' }, 30_000);
-		expect(email.Subject).toMatch(/^Invoice .+ — /);
-		expect(email.Subject).toContain(event.name);
-
-		// …and the invoice now shows under /account/invoices as Issued.
-		await expect(async () => {
+			// While it's a draft, the buyer sees NOTHING under /account/invoices —
+			// the dashboard endpoint serves issued invoices only.
+			const buyerRow = buyerPage.getByRole('row').filter({ hasText: 'Issued' });
 			await gotoHydrated(buyerPage, '/account/invoices');
-			await expect(buyerRow).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
-		await expect(buyerRow.getByText(/10[.,]00/).first()).toBeVisible();
+			await waitForClientAuth(buyerPage);
+			await expect(buyerRow).toBeHidden();
+			await expect(buyerPage.getByText('No invoices yet')).toBeVisible({ timeout: 15_000 });
 
-		await buyerContext.close();
+			// Detail dialog → edit the buyer fields on the draft. In-dialog buttons
+			// get dispatchEvent clicks: on the mobile viewport the long scrollable
+			// dialog keeps them "unstable" for Playwright's actionability check and
+			// a normal click waits forever — every step is outcome-keyed instead.
+			await draftRow.getByRole('button').first().click();
+			const detail = asOwner.getByRole('dialog', { name: 'Invoice Detail' });
+			await expect(detail).toBeVisible();
+			const nameField = detail.getByLabel('Name', { exact: true });
+			await expect(async () => {
+				if (await nameField.isVisible()) return;
+				await detail.getByRole('button', { name: 'Edit' }).dispatchEvent('click');
+				await expect(nameField).toBeVisible({ timeout: 3_000 });
+			}).toPass({ timeout: 30_000 });
+
+			// Outcome-keyed save: success = the view mode renders the edited buyer
+			// name as TEXT (while editing it only exists as an input value, which
+			// getByText ignores). The VAT ID deliberately stays EMPTY — the form
+			// posts cleared fields as null, which used to 500 on the backend's
+			// NOT NULL buyer columns (BE #700, fixed by revel-backend#701); this
+			// save doubles as the FE-side regression for it.
+			const editedName = `${buyer.firstName} ${buyer.lastName} GmbH`;
+			const savedName = detail.getByText(editedName);
+			await expect(async () => {
+				if (await savedName.isVisible()) return;
+				await nameField.fill(editedName);
+				await detail.getByRole('button', { name: 'Save Changes' }).dispatchEvent('click');
+				await expect(savedName).toBeVisible({ timeout: 5_000 });
+			}).toPass({ timeout: 45_000 });
+
+			// Issue it (confirm dialog) — sent to the buyer, no longer editable.
+			const confirm = asOwner.getByRole('dialog', { name: 'Issue this invoice?' });
+			await expect(async () => {
+				if (await confirm.isVisible()) return;
+				await detail.getByRole('button', { name: 'Issue Invoice' }).dispatchEvent('click');
+				await expect(confirm).toBeVisible({ timeout: 3_000 });
+			}).toPass({ timeout: 30_000 });
+			await expect(async () => {
+				if (await confirm.isHidden()) return;
+				await confirm.getByRole('button', { name: 'Yes, Issue' }).dispatchEvent('click');
+				await expect(confirm).toBeHidden({ timeout: 5_000 });
+			}).toPass({ timeout: 45_000 });
+
+			// The buyer receives the org-branded invoice email (PDF attached).
+			const email = await waitForEmail({ to: buyer.email, subject: 'Invoice' }, 30_000);
+			expect(email.Subject).toMatch(/^Invoice .+ — /);
+			expect(email.Subject).toContain(event.name);
+
+			// …and the invoice now shows under /account/invoices as Issued.
+			await expect(async () => {
+				await gotoHydrated(buyerPage, '/account/invoices');
+				await expect(buyerRow).toBeVisible({ timeout: 5_000 });
+			}).toPass({ timeout: 45_000 });
+			await expect(buyerRow.getByText(/10[.,]00/).first()).toBeVisible();
+		} finally {
+			await buyerContext.close();
+		}
 	});
 });

--- a/tests/e2e/journeys/j22-attendee-invoicing/hybrid-flow.spec.ts
+++ b/tests/e2e/journeys/j22-attendee-invoicing/hybrid-flow.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	setOrgInvoicingMode,
+	startOnlineCheckout
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { completeStripeCheckout } from '../../support/stripe';
+import { waitForEmail } from '../../support/mailpit';
+
+// J22 (USER_JOURNEYS.md) — HYBRID attendee invoicing, organizer side: in
+// hybrid mode a paid checkout (with billing info) generates a DRAFT invoice
+// that the buyer cannot see yet; the organizer reviews it on the Attendee
+// Invoices page, edits the buyer fields, and ISSUES it — which emails the
+// buyer (PDF attached, subject "Invoice {number} — {event}") and finally
+// surfaces it under the buyer's /account/invoices.
+//
+// Org Alpha is the only Stripe-connected org, so the org-level invoicing mode
+// is shared suite state: every invoicing spec pins it to 'hybrid' (see
+// setOrgInvoicingMode) — the mode is read at WEBHOOK time and mixed modes
+// would race each other's checkouts across parallel workers.
+
+const INVOICES_PATH = '/org/revel-events-collective/admin/billing/attendee-invoices';
+
+test.describe('J22 hybrid invoicing @p3', () => {
+	test('draft after purchase → edit buyer → issue → buyer email + visible invoice', async ({
+		browser,
+		asOwner
+	}) => {
+		test.setTimeout(300_000);
+
+		await setOrgInvoicingMode('hybrid');
+		const [event, buyer] = await Promise.all([
+			createTicketedEvent({ freeTier: false }),
+			createVerifiedUser('Hybrid')
+		]);
+		const tier = await createTicketTier(event.id, { name: 'Hybrid Entry', price: '10.00' });
+		const checkoutUrl = await startOnlineCheckout(buyer, event.id, tier.id, {
+			billingInfo: {
+				billing_name: `${buyer.firstName} ${buyer.lastName}`,
+				billing_address: 'Musterstraße 1, 1010 Wien',
+				vat_country_code: 'AT',
+				billing_email: buyer.email
+			}
+		});
+
+		const buyerContext = await browser.newContext();
+		await authenticateContext(buyerContext, buyer);
+		const buyerPage = await buyerContext.newPage();
+		await buyerPage.goto(checkoutUrl);
+		await completeStripeCheckout(buyerPage);
+
+		// Organizer: the draft appears on the Attendee Invoices page (webhook +
+		// inline generation → poll by reload, scoped through the search box).
+		await gotoHydrated(asOwner, INVOICES_PATH);
+		await waitForClientAuth(asOwner);
+		const draftRow = asOwner
+			.getByRole('row')
+			.filter({ hasText: buyer.email })
+			.filter({ hasText: 'Draft' });
+		await expect(async () => {
+			await gotoHydrated(asOwner, INVOICES_PATH);
+			await asOwner.getByPlaceholder('Search invoices...').fill(buyer.email);
+			await expect(draftRow).toBeVisible({ timeout: 8_000 });
+		}).toPass({ timeout: 120_000 });
+
+		// While it's a draft, the buyer sees NOTHING under /account/invoices —
+		// the dashboard endpoint serves issued invoices only.
+		const buyerRow = buyerPage.getByRole('row').filter({ hasText: 'Issued' });
+		await gotoHydrated(buyerPage, '/account/invoices');
+		await waitForClientAuth(buyerPage);
+		await expect(buyerRow).toBeHidden();
+		await expect(buyerPage.getByText('No invoices yet')).toBeVisible({ timeout: 15_000 });
+
+		// Detail dialog → edit the buyer fields on the draft. In-dialog buttons
+		// get dispatchEvent clicks: on the mobile viewport the long scrollable
+		// dialog keeps them "unstable" for Playwright's actionability check and
+		// a normal click waits forever — every step is outcome-keyed instead.
+		await draftRow.getByRole('button').first().click();
+		const detail = asOwner.getByRole('dialog', { name: 'Invoice Detail' });
+		await expect(detail).toBeVisible();
+		const nameField = detail.getByLabel('Name', { exact: true });
+		await expect(async () => {
+			if (await nameField.isVisible()) return;
+			await detail.getByRole('button', { name: 'Edit' }).dispatchEvent('click');
+			await expect(nameField).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+
+		// Outcome-keyed save: success = the view mode renders the edited buyer
+		// name as TEXT (while editing it only exists as an input value, which
+		// getByText ignores). The VAT ID deliberately stays EMPTY — the form
+		// posts cleared fields as null, which used to 500 on the backend's
+		// NOT NULL buyer columns (BE #700, fixed by revel-backend#701); this
+		// save doubles as the FE-side regression for it.
+		const editedName = `${buyer.firstName} ${buyer.lastName} GmbH`;
+		const savedName = detail.getByText(editedName);
+		await expect(async () => {
+			if (await savedName.isVisible()) return;
+			await nameField.fill(editedName);
+			await detail.getByRole('button', { name: 'Save Changes' }).dispatchEvent('click');
+			await expect(savedName).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		// Issue it (confirm dialog) — sent to the buyer, no longer editable.
+		const confirm = asOwner.getByRole('dialog', { name: 'Issue this invoice?' });
+		await expect(async () => {
+			if (await confirm.isVisible()) return;
+			await detail.getByRole('button', { name: 'Issue Invoice' }).dispatchEvent('click');
+			await expect(confirm).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+		await expect(async () => {
+			if (await confirm.isHidden()) return;
+			await confirm.getByRole('button', { name: 'Yes, Issue' }).dispatchEvent('click');
+			await expect(confirm).toBeHidden({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		// The buyer receives the org-branded invoice email (PDF attached).
+		const email = await waitForEmail({ to: buyer.email, subject: 'Invoice' }, 30_000);
+		expect(email.Subject).toMatch(/^Invoice .+ — /);
+		expect(email.Subject).toContain(event.name);
+
+		// …and the invoice now shows under /account/invoices as Issued.
+		await expect(async () => {
+			await gotoHydrated(buyerPage, '/account/invoices');
+			await expect(buyerRow).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+		await expect(buyerRow.getByText(/10[.,]00/).first()).toBeVisible();
+
+		await buyerContext.close();
+	});
+});

--- a/tests/e2e/journeys/j24-polls/poll-duplicate.spec.ts
+++ b/tests/e2e/journeys/j24-polls/poll-duplicate.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '../../support/fixtures';
+import { createPoll } from '../../support/factories';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J24 (USER_JOURNEYS.md) — poll duplication: cloning an OPEN poll from the
+// admin list produces a DRAFT copy with its lifecycle reset (open/close
+// timestamps cleared, votes not carried over), leaving the source untouched.
+//
+// The duplicate modal prefills "Copy of {name}" and — success has NO toast —
+// navigates straight to the clone's detail page; the test asserts the URL
+// flips to a different poll id and the clone offers "Open poll" (draft) while
+// the source still shows as Open on the list.
+
+const ORG_SLUG = 'revel-events-collective';
+
+test.describe('J24 poll duplicate @p3', () => {
+	test('duplicate an open poll → draft clone with lifecycle reset', async ({ asOwner: page }) => {
+		const poll = await createPoll({ open: true });
+
+		await gotoHydrated(page, `/org/${ORG_SLUG}/admin/polls`);
+		await waitForClientAuth(page);
+
+		// The list accumulates polls across runs — scope to THIS poll's card via
+		// its unique name before reaching for its actions menu.
+		const card = page
+			.locator('article, li, div')
+			.filter({ hasText: poll.name })
+			.filter({ has: page.getByRole('button', { name: 'More actions' }) })
+			.last();
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		await card.getByRole('button', { name: 'More actions' }).click();
+		await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+
+		// Modal: the name field is prefilled with the FE default "Copy of {name}".
+		const modal = page.getByRole('dialog', { name: 'Duplicate Poll' });
+		await expect(modal).toBeVisible();
+		const cloneName = `Copy of ${poll.name}`;
+		await expect(modal.getByLabel('New Poll Name')).toHaveValue(cloneName);
+
+		// Success navigates to the clone's detail page (no toast) — a different
+		// poll id than the source.
+		await modal.getByRole('button', { name: 'Duplicate', exact: true }).click();
+		await page.waitForURL(
+			(url) =>
+				/\/admin\/polls\/[0-9a-f-]{36}$/.test(url.pathname) && !url.pathname.endsWith(poll.id),
+			{ timeout: 20_000 }
+		);
+
+		// The clone is a DRAFT with its lifecycle reset: it can be opened, and
+		// the questions came along (deep copy).
+		await expect(page.getByText(cloneName).first()).toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.getByText('Draft', { exact: true }).filter({ visible: true }).first()
+		).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Open poll' })).toBeVisible();
+		await expect(page.getByText('Are you in?').first()).toBeVisible();
+
+		// The source poll is untouched — still listed as Open.
+		await gotoHydrated(page, `/org/${ORG_SLUG}/admin/polls`);
+		const sourceCard = page
+			.locator('article, li, div')
+			.filter({ hasText: poll.name })
+			.filter({ hasText: /Open/ })
+			.filter({ has: page.getByRole('button', { name: 'More actions' }) })
+			.last();
+		await expect(sourceCard).toBeVisible({ timeout: 15_000 });
+	});
+});

--- a/tests/e2e/journeys/j25-reporting/revenue-report.spec.ts
+++ b/tests/e2e/journeys/j25-reporting/revenue-report.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '../../support/fixtures';
+import { getBackendUrl } from '../../support/api';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J25 (USER_JOURNEYS.md) — revenue report: "Download report" on the org
+// Financials page requests a ZIP export (XLSX + PDF bundle), polls the export
+// until READY, and downloads it via a synthetic <a download> click. The spec
+// observes the app's own network traffic instead of re-implementing the poll
+// (the status endpoint needs the app's bearer token; the final download_url
+// is a signed URL fetchable without auth).
+//
+// Identical requests are served from a cached READY export whose download_url
+// arrives directly on the POST — the second project's run usually takes that
+// path, so nothing here asserts on the transient "Generating…" toast or the
+// poll traffic being present. The "ready" toast fires on both paths.
+//
+// Read-only on seeded data: Org Alpha's back-dated previous-month sales exist
+// from bootstrap and the default report period (Jan 1 → today) covers them.
+
+const FINANCIALS_PATH = '/org/revel-events-collective/admin/financials';
+
+test.describe('J25 revenue report @p3', () => {
+	test('request ZIP report → ready toast → download resolves a ZIP', async ({ asOwner: page }) => {
+		test.setTimeout(180_000);
+
+		await gotoHydrated(page, FINANCIALS_PATH);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Financials', level: 1 })).toBeVisible();
+
+		const createResponse = page.waitForResponse(
+			(r) =>
+				/\/api\/organization-admin\/[^/]+\/revenue-report(\?|$)/.test(r.url()) &&
+				r.request().method() === 'POST' &&
+				r.status() < 300,
+			{ timeout: 30_000 }
+		);
+		await page.getByRole('button', { name: 'Download report' }).click();
+		const created = (await (await createResponse).json()) as {
+			id: string;
+			download_url: string | null;
+		};
+
+		// Cache hit → the URL is already on the POST; otherwise observe the
+		// button's own 2s polling until a poll answers with a download_url.
+		let downloadUrl = created.download_url;
+		if (!downloadUrl) {
+			const readyPoll = await page.waitForResponse(
+				async (r) => {
+					if (!/\/revenue-reports\//.test(r.url()) || !r.ok()) return false;
+					const body = (await r.json().catch(() => null)) as {
+						download_url?: string | null;
+					} | null;
+					return !!body?.download_url;
+				},
+				{ timeout: 130_000 }
+			);
+			downloadUrl = ((await readyPoll.json()) as { download_url: string }).download_url;
+		}
+
+		await expect(page.getByText('Your report is ready.')).toBeVisible({ timeout: 130_000 });
+
+		// The signed URL serves the actual ZIP bundle.
+		const zip = await page.request.get(getBackendUrl(downloadUrl));
+		expect(zip.status()).toBe(200);
+		expect(zip.headers()['content-type'] ?? '').toContain('zip');
+	});
+});

--- a/tests/e2e/journeys/j26-series-passes/pass-online-cancel.spec.ts
+++ b/tests/e2e/journeys/j26-series-passes/pass-online-cancel.spec.ts
@@ -45,83 +45,84 @@ test.describe('J26 season pass online cancel @p3', () => {
 		const buyerContext = await browser.newContext();
 		await authenticateContext(buyerContext, buyer);
 		const page = await buyerContext.newPage();
+		try {
+			// Purchase through the series page → hosted Stripe checkout.
+			await gotoHydrated(page, series.path);
+			await waitForClientAuth(page);
+			await page.getByRole('button', { name: 'Get season pass' }).click();
+			const dialog = page.getByRole('dialog', { name: new RegExp(pass.name) });
+			await expect(dialog).toBeVisible();
+			await dialog.getByRole('button', { name: 'Continue to payment' }).click();
+			await completeStripeCheckout(page);
 
-		// Purchase through the series page → hosted Stripe checkout.
-		await gotoHydrated(page, series.path);
-		await waitForClientAuth(page);
-		await page.getByRole('button', { name: 'Get season pass' }).click();
-		const dialog = page.getByRole('dialog', { name: new RegExp(pass.name) });
-		await expect(dialog).toBeVisible();
-		await dialog.getByRole('button', { name: 'Continue to payment' }).click();
-		await completeStripeCheckout(page);
+			// The webhook creates + activates the held pass — poll My passes for it.
+			const activeCard = page
+				.locator('article, li, div')
+				.filter({ hasText: pass.name })
+				.filter({ hasText: /Active/ })
+				.first();
+			await expect(async () => {
+				await gotoHydrated(page, '/dashboard/passes');
+				await expect(activeCard).toBeVisible({ timeout: 5_000 });
+			}).toPass({ timeout: 90_000 });
 
-		// The webhook creates + activates the held pass — poll My passes for it.
-		const activeCard = page
-			.locator('article, li, div')
-			.filter({ hasText: pass.name })
-			.filter({ hasText: /Active/ })
-			.first();
-		await expect(async () => {
-			await gotoHydrated(page, '/dashboard/passes');
-			await expect(activeCard).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 90_000 });
+			// Organizer cancels the held pass from the Holders dialog.
+			await gotoHydrated(asOwner, `/org/revel-events-collective/admin/event-series/${series.id}`);
+			await waitForClientAuth(asOwner);
+			// The dashboard's tab strip is plain buttons, not a WAI-ARIA tablist.
+			await asOwner.getByRole('button', { name: 'Passes', exact: true }).click();
+			await asOwner.getByRole('button', { name: 'Holders' }).click();
+			const holders = asOwner.getByRole('dialog', { name: new RegExp(`Holders — ${pass.name}`) });
+			await expect(holders).toBeVisible();
+			await expect(holders.getByText(`${buyer.firstName} ${buyer.lastName}`)).toBeVisible({
+				timeout: 15_000
+			});
+			await holders.getByRole('button', { name: 'Cancel pass' }).click();
+			// The cancel dialog stacks under the (still-open, aria-modal) holders
+			// dialog, whose overlay intercepts pointer events — dispatch the click
+			// straight to the button, outcome-keyed on the dialog closing (it stays
+			// open on failure; a just-mounted button can swallow the first dispatch
+			// under parallel-worker load). The optional reason stays empty. The
+			// backend cancel is idempotent, so a re-dispatch is always safe.
+			const cancelDialog = asOwner.getByRole('dialog', { name: 'Cancel held pass' });
+			await expect(cancelDialog).toBeVisible();
+			await expect(async () => {
+				if (await cancelDialog.isHidden()) return;
+				await cancelDialog.getByRole('button', { name: 'Cancel pass' }).dispatchEvent('click');
+				await expect(cancelDialog).toBeHidden({ timeout: 5_000 });
+			}).toPass({ timeout: 45_000 });
+			// The holder row re-renders with the Cancelled badge (its Cancel-pass
+			// action disappears with it).
+			await expect(holders.getByText('Cancelled').first()).toBeVisible({ timeout: 15_000 });
+			await expect(holders.getByRole('button', { name: 'Cancel pass' })).toBeHidden();
 
-		// Organizer cancels the held pass from the Holders dialog.
-		await gotoHydrated(asOwner, `/org/revel-events-collective/admin/event-series/${series.id}`);
-		await waitForClientAuth(asOwner);
-		// The dashboard's tab strip is plain buttons, not a WAI-ARIA tablist.
-		await asOwner.getByRole('button', { name: 'Passes', exact: true }).click();
-		await asOwner.getByRole('button', { name: 'Holders' }).click();
-		const holders = asOwner.getByRole('dialog', { name: new RegExp(`Holders — ${pass.name}`) });
-		await expect(holders).toBeVisible();
-		await expect(holders.getByText(`${buyer.firstName} ${buyer.lastName}`)).toBeVisible({
-			timeout: 15_000
-		});
-		await holders.getByRole('button', { name: 'Cancel pass' }).click();
-		// The cancel dialog stacks under the (still-open, aria-modal) holders
-		// dialog, whose overlay intercepts pointer events — dispatch the click
-		// straight to the button, outcome-keyed on the dialog closing (it stays
-		// open on failure; a just-mounted button can swallow the first dispatch
-		// under parallel-worker load). The optional reason stays empty. The
-		// backend cancel is idempotent, so a re-dispatch is always safe.
-		const cancelDialog = asOwner.getByRole('dialog', { name: 'Cancel held pass' });
-		await expect(cancelDialog).toBeVisible();
-		await expect(async () => {
-			if (await cancelDialog.isHidden()) return;
-			await cancelDialog.getByRole('button', { name: 'Cancel pass' }).dispatchEvent('click');
-			await expect(cancelDialog).toBeHidden({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
-		// The holder row re-renders with the Cancelled badge (its Cancel-pass
-		// action disappears with it).
-		await expect(holders.getByText('Cancelled').first()).toBeVisible({ timeout: 15_000 });
-		await expect(holders.getByRole('button', { name: 'Cancel pass' })).toBeHidden();
+			// Buyer side: the pass flips Cancelled and the View-pass action is gone;
+			// the materialized tickets are cancelled with it (none left Active).
+			await expect(async () => {
+				await gotoHydrated(page, '/dashboard/passes');
+				await expect(
+					page
+						.locator('article, li, div')
+						.filter({ hasText: pass.name })
+						.filter({ hasText: /Cancelled/ })
+						.first()
+				).toBeVisible({ timeout: 5_000 });
+			}).toPass({ timeout: 45_000 });
+			await expect(page.getByRole('button', { name: 'View pass' })).toBeHidden();
 
-		// Buyer side: the pass flips Cancelled and the View-pass action is gone;
-		// the materialized tickets are cancelled with it (none left Active).
-		await expect(async () => {
-			await gotoHydrated(page, '/dashboard/passes');
-			await expect(
-				page
-					.locator('article, li, div')
-					.filter({ hasText: pass.name })
-					.filter({ hasText: /Cancelled/ })
-					.first()
-			).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
-		await expect(page.getByRole('button', { name: 'View pass' })).toBeHidden();
-
-		// The materialized tickets went down with the pass (asserted at the API —
-		// a page-level absence check would false-positive on the status filter
-		// chips, which also read "Active").
-		const buyerApi = await ApiClient.login(buyer.email, buyer.password);
-		const tickets = await buyerApi.get<{ results: Array<{ status: string }> }>(
-			'/api/dashboard/tickets'
-		);
-		expect(tickets.results.length).toBeGreaterThan(0);
-		for (const ticket of tickets.results) {
-			expect(ticket.status).toBe('cancelled');
+			// The materialized tickets went down with the pass (asserted at the API —
+			// a page-level absence check would false-positive on the status filter
+			// chips, which also read "Active").
+			const buyerApi = await ApiClient.login(buyer.email, buyer.password);
+			const tickets = await buyerApi.get<{ results: Array<{ status: string }> }>(
+				'/api/dashboard/tickets'
+			);
+			expect(tickets.results.length).toBeGreaterThan(0);
+			for (const ticket of tickets.results) {
+				expect(ticket.status).toBe('cancelled');
+			}
+		} finally {
+			await buyerContext.close();
 		}
-
-		await buyerContext.close();
 	});
 });

--- a/tests/e2e/journeys/j26-series-passes/pass-online-cancel.spec.ts
+++ b/tests/e2e/journeys/j26-series-passes/pass-online-cancel.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '../../support/fixtures';
+import { ApiClient } from '../../support/api';
+import {
+	createEventSeries,
+	createSeriesPass,
+	createTicketedEvent,
+	createVerifiedUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { completeStripeCheckout } from '../../support/stripe';
+
+// J26 (USER_JOURNEYS.md) — season pass, online flavor: hosted-Stripe purchase
+// of a pass (the held pass only materializes when the webhook lands), then
+// the ORGANIZER cancels it from the Holders dialog — remaining tickets are
+// cancelled and the succeeded payment refunded backend-side; the buyer's pass
+// card flips to Cancelled and loses its View-pass action.
+//
+// Lives on Org Alpha (the only Stripe-connected org — CONNECTED_TEST_STRIPE_ID
+// at bootstrap) with the standard full Stripe test-mode setup
+// (tests/e2e/README.md); the series itself is arranged fresh per run.
+
+test.describe('J26 season pass online cancel @p3', () => {
+	test('Stripe pass purchase → organizer cancels → pass and tickets cancelled', async ({
+		browser,
+		asOwner
+	}) => {
+		test.setTimeout(300_000);
+
+		const series = await createEventSeries('owner', 'revel-events-collective');
+		const [eventA, eventB] = await Promise.all([
+			createTicketedEvent({ event: { event_series_id: series.id } }),
+			createTicketedEvent({ event: { event_series_id: series.id } })
+		]);
+		const pass = await createSeriesPass('owner', series.id, {
+			payment_method: 'online',
+			price: '10.00',
+			tier_links: [
+				{ event_id: eventA.id, tier_id: eventA.freeTierId as string },
+				{ event_id: eventB.id, tier_id: eventB.freeTierId as string }
+			]
+		});
+
+		const buyer = await createVerifiedUser('OnlinePass');
+		const buyerContext = await browser.newContext();
+		await authenticateContext(buyerContext, buyer);
+		const page = await buyerContext.newPage();
+
+		// Purchase through the series page → hosted Stripe checkout.
+		await gotoHydrated(page, series.path);
+		await waitForClientAuth(page);
+		await page.getByRole('button', { name: 'Get season pass' }).click();
+		const dialog = page.getByRole('dialog', { name: new RegExp(pass.name) });
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole('button', { name: 'Continue to payment' }).click();
+		await completeStripeCheckout(page);
+
+		// The webhook creates + activates the held pass — poll My passes for it.
+		const activeCard = page
+			.locator('article, li, div')
+			.filter({ hasText: pass.name })
+			.filter({ hasText: /Active/ })
+			.first();
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/passes');
+			await expect(activeCard).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 90_000 });
+
+		// Organizer cancels the held pass from the Holders dialog.
+		await gotoHydrated(asOwner, `/org/revel-events-collective/admin/event-series/${series.id}`);
+		await waitForClientAuth(asOwner);
+		// The dashboard's tab strip is plain buttons, not a WAI-ARIA tablist.
+		await asOwner.getByRole('button', { name: 'Passes', exact: true }).click();
+		await asOwner.getByRole('button', { name: 'Holders' }).click();
+		const holders = asOwner.getByRole('dialog', { name: new RegExp(`Holders — ${pass.name}`) });
+		await expect(holders).toBeVisible();
+		await expect(holders.getByText(`${buyer.firstName} ${buyer.lastName}`)).toBeVisible({
+			timeout: 15_000
+		});
+		await holders.getByRole('button', { name: 'Cancel pass' }).click();
+		// The cancel dialog stacks under the (still-open, aria-modal) holders
+		// dialog, whose overlay intercepts pointer events — dispatch the click
+		// straight to the button, outcome-keyed on the dialog closing (it stays
+		// open on failure; a just-mounted button can swallow the first dispatch
+		// under parallel-worker load). The optional reason stays empty. The
+		// backend cancel is idempotent, so a re-dispatch is always safe.
+		const cancelDialog = asOwner.getByRole('dialog', { name: 'Cancel held pass' });
+		await expect(cancelDialog).toBeVisible();
+		await expect(async () => {
+			if (await cancelDialog.isHidden()) return;
+			await cancelDialog.getByRole('button', { name: 'Cancel pass' }).dispatchEvent('click');
+			await expect(cancelDialog).toBeHidden({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+		// The holder row re-renders with the Cancelled badge (its Cancel-pass
+		// action disappears with it).
+		await expect(holders.getByText('Cancelled').first()).toBeVisible({ timeout: 15_000 });
+		await expect(holders.getByRole('button', { name: 'Cancel pass' })).toBeHidden();
+
+		// Buyer side: the pass flips Cancelled and the View-pass action is gone;
+		// the materialized tickets are cancelled with it (none left Active).
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/passes');
+			await expect(
+				page
+					.locator('article, li, div')
+					.filter({ hasText: pass.name })
+					.filter({ hasText: /Cancelled/ })
+					.first()
+			).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+		await expect(page.getByRole('button', { name: 'View pass' })).toBeHidden();
+
+		// The materialized tickets went down with the pass (asserted at the API —
+		// a page-level absence check would false-positive on the status filter
+		// chips, which also read "Active").
+		const buyerApi = await ApiClient.login(buyer.email, buyer.password);
+		const tickets = await buyerApi.get<{ results: Array<{ status: string }> }>(
+			'/api/dashboard/tickets'
+		);
+		expect(tickets.results.length).toBeGreaterThan(0);
+		for (const ticket of tickets.results) {
+			expect(ticket.status).toBe('cancelled');
+		}
+
+		await buyerContext.close();
+	});
+});

--- a/tests/e2e/journeys/j26-series-passes/pass-purchase.spec.ts
+++ b/tests/e2e/journeys/j26-series-passes/pass-purchase.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '../../support/fixtures';
+import { ApiClient, ApiError } from '../../support/api';
+import {
+	createEventSeries,
+	createOrganization,
+	createSeriesPass,
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J26 (USER_JOURNEYS.md) — season pass, offline flavor: the public series
+// page quotes the pass PRO-RATA (one covered event already happened → price
+// drops by one pro_rata_discount step), reserving holds it PENDING until the
+// organizer confirms payment from the Holders dialog, and activation
+// materializes one ticket per remaining event. Pass-derived tickets fold into
+// the pass card on /dashboard/tickets and refuse self-cancellation (400).
+//
+// Isolation: throwaway org — nothing here needs Stripe, and series/passes
+// have no cleanup. The past covered event is API-created with past dates.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+test.describe('J26 season pass purchase @p3', () => {
+	test('pro-rata quote → reserve offline → confirm → tickets materialized, not self-cancellable', async ({
+		browser
+	}) => {
+		test.setTimeout(240_000);
+
+		// Public visibility: the buyer browses the org's PUBLIC series page.
+		const org = await createOrganization({ publicVisibility: true });
+		const series = await createEventSeries(org.owner, org.slug);
+		const pastStart = new Date(Date.now() - 2 * DAY_MS);
+		const [pastEvent, upcomingA, upcomingB] = await Promise.all([
+			createTicketedEvent({
+				owner: org.owner,
+				orgSlug: org.slug,
+				// The factory's default tier opens sales yesterday, which the
+				// backend rejects on an event that started 2 days ago — this
+				// event gets its own tier with an earlier sales window below.
+				freeTier: false,
+				event: {
+					event_series_id: series.id,
+					start: pastStart.toISOString(),
+					end: new Date(pastStart.getTime() + 3 * 60 * 60 * 1000).toISOString()
+				}
+			}),
+			createTicketedEvent({
+				owner: org.owner,
+				orgSlug: org.slug,
+				event: { event_series_id: series.id }
+			}),
+			createTicketedEvent({
+				owner: org.owner,
+				orgSlug: org.slug,
+				event: { event_series_id: series.id }
+			})
+		]);
+		const pastTier = await createTicketTier(
+			pastEvent.id,
+			{
+				name: 'Free Entry',
+				payment_method: 'free',
+				price: '0.00',
+				total_quantity: 200,
+				sales_start_at: new Date(pastStart.getTime() - 7 * DAY_MS).toISOString(),
+				sales_end_at: pastStart.toISOString()
+			},
+			org.owner
+		);
+		const pass = await createSeriesPass(org.owner, series.id, {
+			payment_method: 'offline',
+			price: '10.00',
+			pro_rata_discount: '2.50',
+			tier_links: [
+				{ event_id: pastEvent.id, tier_id: pastTier.id },
+				{ event_id: upcomingA.id, tier_id: upcomingA.freeTierId as string },
+				{ event_id: upcomingB.id, tier_id: upcomingB.freeTierId as string }
+			]
+		});
+
+		const buyer = await createVerifiedUser('PassBuyer');
+		const buyerContext = await browser.newContext();
+		await authenticateContext(buyerContext, buyer);
+		const page = await buyerContext.newPage();
+
+		// Series page: the pass card quotes €7.50 (10.00 − 1 passed × 2.50).
+		await gotoHydrated(page, series.path);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: pass.name })).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText('2 of 3 events remaining')).toBeVisible({ timeout: 15_000 });
+		await page.getByRole('button', { name: 'Get season pass' }).click();
+
+		// Purchase dialog: pro-rata price + note, offline reserve CTA.
+		const dialog = page.getByRole('dialog', { name: new RegExp(pass.name) });
+		await expect(dialog).toBeVisible();
+		await expect(dialog.getByText('Price today')).toBeVisible();
+		await expect(dialog.getByText('€7.50')).toBeVisible();
+		await expect(dialog.getByText(/1 event\(s\) have already passed/)).toBeVisible();
+		await dialog.getByRole('button', { name: 'Reserve pass' }).click();
+
+		// Reserved → success toast → the app navigates to My passes (PENDING).
+		await expect(page.getByText('Season pass reserved!')).toBeVisible({ timeout: 20_000 });
+		await page.waitForURL(/\/dashboard\/passes/, { timeout: 20_000 });
+		const passCard = page
+			.locator('article, li, div')
+			.filter({ hasText: pass.name })
+			.filter({ hasText: /Pending/ })
+			.first();
+		await expect(passCard).toBeVisible({ timeout: 20_000 });
+
+		// Organizer confirms the offline payment from the Holders dialog.
+		const ownerContext = await browser.newContext();
+		await authenticateContext(ownerContext, org.owner);
+		const ownerPage = await ownerContext.newPage();
+		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/event-series/${series.id}`);
+		await waitForClientAuth(ownerPage);
+		// The dashboard's tab strip is plain buttons, not a WAI-ARIA tablist.
+		await ownerPage.getByRole('button', { name: 'Passes', exact: true }).click();
+		await expect(ownerPage.getByRole('heading', { name: 'Season passes' })).toBeVisible({
+			timeout: 15_000
+		});
+		await ownerPage.getByRole('button', { name: 'Holders' }).click();
+		const holders = ownerPage.getByRole('dialog', { name: new RegExp(`Holders — ${pass.name}`) });
+		await expect(holders).toBeVisible();
+		await expect(holders.getByText(`${buyer.firstName} ${buyer.lastName}`)).toBeVisible({
+			timeout: 15_000
+		});
+		// The confirmation dialog stacks under the (still-open, aria-modal)
+		// holders dialog, whose overlay intercepts pointer events — dispatch the
+		// click straight to the button, outcome-keyed on the row's
+		// Confirm-payment action disappearing (it only renders while the holder
+		// is still PENDING; a just-mounted dialog button can swallow the first
+		// dispatch under parallel-worker load).
+		const confirmRowButton = holders.getByRole('button', { name: 'Confirm payment' });
+		const confirmDialog = ownerPage.getByRole('dialog', { name: 'Confirm offline payment' });
+		await confirmRowButton.click();
+		await expect(confirmDialog).toBeVisible();
+		await expect(async () => {
+			if (await confirmRowButton.isHidden()) return;
+			if (await confirmDialog.isHidden()) {
+				await confirmRowButton.click();
+				await expect(confirmDialog).toBeVisible({ timeout: 3_000 });
+			}
+			await confirmDialog.getByRole('button', { name: 'Confirm payment' }).dispatchEvent('click');
+			await expect(confirmRowButton).toBeHidden({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+
+		// Buyer side: the pass flips ACTIVE, and the two upcoming events'
+		// materialized tickets fold into the pass card on the tickets page.
+		await expect(async () => {
+			await gotoHydrated(page, '/dashboard/passes');
+			await expect(
+				page
+					.locator('article, li, div')
+					.filter({ hasText: pass.name })
+					.filter({ hasText: /Active/ })
+					.first()
+			).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 45_000 });
+		// Coverage counts every covered event (3) with 2 still upcoming.
+		await expect(page.getByText('2 of 3 events remaining').first()).toBeVisible();
+
+		await gotoHydrated(page, '/dashboard/tickets');
+		await waitForClientAuth(page);
+		await expect(page.getByText(pass.name).first()).toBeVisible({ timeout: 20_000 });
+		await expect(page.getByRole('button', { name: 'View pass' }).first()).toBeVisible();
+
+		// Pass-derived tickets are not self-cancellable — the cancel endpoint
+		// blocks with 409 and the stable part_of_series_pass reason code.
+		const buyerApi = await ApiClient.login(buyer.email, buyer.password);
+		const tickets = await buyerApi.get<{ results: Array<{ id: string }> }>(
+			'/api/dashboard/tickets'
+		);
+		expect(tickets.results.length).toBeGreaterThan(0);
+		const attempt = buyerApi.post(`/api/events/tickets/${tickets.results[0].id}/cancel`, {});
+		await expect(attempt).rejects.toThrow(ApiError);
+		await attempt.catch((error: ApiError) => {
+			expect(error.status).toBe(409);
+			expect(error.body).toContain('part_of_series_pass');
+		});
+
+		await buyerContext.close();
+		await ownerContext.close();
+	});
+});

--- a/tests/e2e/journeys/j26-series-passes/pass-purchase.spec.ts
+++ b/tests/e2e/journeys/j26-series-passes/pass-purchase.spec.ts
@@ -85,104 +85,112 @@ test.describe('J26 season pass purchase @p3', () => {
 		const buyerContext = await browser.newContext();
 		await authenticateContext(buyerContext, buyer);
 		const page = await buyerContext.newPage();
+		try {
+			// Series page: the pass card quotes €7.50 (10.00 − 1 passed × 2.50).
+			await gotoHydrated(page, series.path);
+			await waitForClientAuth(page);
+			await expect(page.getByRole('heading', { name: pass.name })).toBeVisible({ timeout: 15_000 });
+			await expect(page.getByText('2 of 3 events remaining')).toBeVisible({ timeout: 15_000 });
+			await page.getByRole('button', { name: 'Get season pass' }).click();
 
-		// Series page: the pass card quotes €7.50 (10.00 − 1 passed × 2.50).
-		await gotoHydrated(page, series.path);
-		await waitForClientAuth(page);
-		await expect(page.getByRole('heading', { name: pass.name })).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByText('2 of 3 events remaining')).toBeVisible({ timeout: 15_000 });
-		await page.getByRole('button', { name: 'Get season pass' }).click();
+			// Purchase dialog: pro-rata price + note, offline reserve CTA.
+			const dialog = page.getByRole('dialog', { name: new RegExp(pass.name) });
+			await expect(dialog).toBeVisible();
+			await expect(dialog.getByText('Price today')).toBeVisible();
+			await expect(dialog.getByText('€7.50')).toBeVisible();
+			await expect(dialog.getByText(/1 event\(s\) have already passed/)).toBeVisible();
+			await dialog.getByRole('button', { name: 'Reserve pass' }).click();
 
-		// Purchase dialog: pro-rata price + note, offline reserve CTA.
-		const dialog = page.getByRole('dialog', { name: new RegExp(pass.name) });
-		await expect(dialog).toBeVisible();
-		await expect(dialog.getByText('Price today')).toBeVisible();
-		await expect(dialog.getByText('€7.50')).toBeVisible();
-		await expect(dialog.getByText(/1 event\(s\) have already passed/)).toBeVisible();
-		await dialog.getByRole('button', { name: 'Reserve pass' }).click();
+			// Reserved → success toast → the app navigates to My passes (PENDING).
+			await expect(page.getByText('Season pass reserved!')).toBeVisible({ timeout: 20_000 });
+			await page.waitForURL(/\/dashboard\/passes/, { timeout: 20_000 });
+			const passCard = page
+				.locator('article, li, div')
+				.filter({ hasText: pass.name })
+				.filter({ hasText: /Pending/ })
+				.first();
+			await expect(passCard).toBeVisible({ timeout: 20_000 });
 
-		// Reserved → success toast → the app navigates to My passes (PENDING).
-		await expect(page.getByText('Season pass reserved!')).toBeVisible({ timeout: 20_000 });
-		await page.waitForURL(/\/dashboard\/passes/, { timeout: 20_000 });
-		const passCard = page
-			.locator('article, li, div')
-			.filter({ hasText: pass.name })
-			.filter({ hasText: /Pending/ })
-			.first();
-		await expect(passCard).toBeVisible({ timeout: 20_000 });
-
-		// Organizer confirms the offline payment from the Holders dialog.
-		const ownerContext = await browser.newContext();
-		await authenticateContext(ownerContext, org.owner);
-		const ownerPage = await ownerContext.newPage();
-		await gotoHydrated(ownerPage, `/org/${org.slug}/admin/event-series/${series.id}`);
-		await waitForClientAuth(ownerPage);
-		// The dashboard's tab strip is plain buttons, not a WAI-ARIA tablist.
-		await ownerPage.getByRole('button', { name: 'Passes', exact: true }).click();
-		await expect(ownerPage.getByRole('heading', { name: 'Season passes' })).toBeVisible({
-			timeout: 15_000
-		});
-		await ownerPage.getByRole('button', { name: 'Holders' }).click();
-		const holders = ownerPage.getByRole('dialog', { name: new RegExp(`Holders — ${pass.name}`) });
-		await expect(holders).toBeVisible();
-		await expect(holders.getByText(`${buyer.firstName} ${buyer.lastName}`)).toBeVisible({
-			timeout: 15_000
-		});
-		// The confirmation dialog stacks under the (still-open, aria-modal)
-		// holders dialog, whose overlay intercepts pointer events — dispatch the
-		// click straight to the button, outcome-keyed on the row's
-		// Confirm-payment action disappearing (it only renders while the holder
-		// is still PENDING; a just-mounted dialog button can swallow the first
-		// dispatch under parallel-worker load).
-		const confirmRowButton = holders.getByRole('button', { name: 'Confirm payment' });
-		const confirmDialog = ownerPage.getByRole('dialog', { name: 'Confirm offline payment' });
-		await confirmRowButton.click();
-		await expect(confirmDialog).toBeVisible();
-		await expect(async () => {
-			if (await confirmRowButton.isHidden()) return;
-			if (await confirmDialog.isHidden()) {
+			// Organizer confirms the offline payment from the Holders dialog.
+			const ownerContext = await browser.newContext();
+			await authenticateContext(ownerContext, org.owner);
+			const ownerPage = await ownerContext.newPage();
+			try {
+				await gotoHydrated(ownerPage, `/org/${org.slug}/admin/event-series/${series.id}`);
+				await waitForClientAuth(ownerPage);
+				// The dashboard's tab strip is plain buttons, not a WAI-ARIA tablist.
+				await ownerPage.getByRole('button', { name: 'Passes', exact: true }).click();
+				await expect(ownerPage.getByRole('heading', { name: 'Season passes' })).toBeVisible({
+					timeout: 15_000
+				});
+				await ownerPage.getByRole('button', { name: 'Holders' }).click();
+				const holders = ownerPage.getByRole('dialog', {
+					name: new RegExp(`Holders — ${pass.name}`)
+				});
+				await expect(holders).toBeVisible();
+				await expect(holders.getByText(`${buyer.firstName} ${buyer.lastName}`)).toBeVisible({
+					timeout: 15_000
+				});
+				// The confirmation dialog stacks under the (still-open, aria-modal)
+				// holders dialog, whose overlay intercepts pointer events — dispatch the
+				// click straight to the button, outcome-keyed on the row's
+				// Confirm-payment action disappearing (it only renders while the holder
+				// is still PENDING; a just-mounted dialog button can swallow the first
+				// dispatch under parallel-worker load).
+				const confirmRowButton = holders.getByRole('button', { name: 'Confirm payment' });
+				const confirmDialog = ownerPage.getByRole('dialog', { name: 'Confirm offline payment' });
 				await confirmRowButton.click();
-				await expect(confirmDialog).toBeVisible({ timeout: 3_000 });
+				await expect(confirmDialog).toBeVisible();
+				await expect(async () => {
+					if (await confirmRowButton.isHidden()) return;
+					if (await confirmDialog.isHidden()) {
+						await confirmRowButton.click();
+						await expect(confirmDialog).toBeVisible({ timeout: 3_000 });
+					}
+					await confirmDialog
+						.getByRole('button', { name: 'Confirm payment' })
+						.dispatchEvent('click');
+					await expect(confirmRowButton).toBeHidden({ timeout: 5_000 });
+				}).toPass({ timeout: 45_000 });
+			} finally {
+				await ownerContext.close();
 			}
-			await confirmDialog.getByRole('button', { name: 'Confirm payment' }).dispatchEvent('click');
-			await expect(confirmRowButton).toBeHidden({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
 
-		// Buyer side: the pass flips ACTIVE, and the two upcoming events'
-		// materialized tickets fold into the pass card on the tickets page.
-		await expect(async () => {
-			await gotoHydrated(page, '/dashboard/passes');
-			await expect(
-				page
-					.locator('article, li, div')
-					.filter({ hasText: pass.name })
-					.filter({ hasText: /Active/ })
-					.first()
-			).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 45_000 });
-		// Coverage counts every covered event (3) with 2 still upcoming.
-		await expect(page.getByText('2 of 3 events remaining').first()).toBeVisible();
+			// Buyer side: the pass flips ACTIVE, and the two upcoming events'
+			// materialized tickets fold into the pass card on the tickets page.
+			await expect(async () => {
+				await gotoHydrated(page, '/dashboard/passes');
+				await expect(
+					page
+						.locator('article, li, div')
+						.filter({ hasText: pass.name })
+						.filter({ hasText: /Active/ })
+						.first()
+				).toBeVisible({ timeout: 5_000 });
+			}).toPass({ timeout: 45_000 });
+			// Coverage counts every covered event (3) with 2 still upcoming.
+			await expect(page.getByText('2 of 3 events remaining').first()).toBeVisible();
 
-		await gotoHydrated(page, '/dashboard/tickets');
-		await waitForClientAuth(page);
-		await expect(page.getByText(pass.name).first()).toBeVisible({ timeout: 20_000 });
-		await expect(page.getByRole('button', { name: 'View pass' }).first()).toBeVisible();
+			await gotoHydrated(page, '/dashboard/tickets');
+			await waitForClientAuth(page);
+			await expect(page.getByText(pass.name).first()).toBeVisible({ timeout: 20_000 });
+			await expect(page.getByRole('button', { name: 'View pass' }).first()).toBeVisible();
 
-		// Pass-derived tickets are not self-cancellable — the cancel endpoint
-		// blocks with 409 and the stable part_of_series_pass reason code.
-		const buyerApi = await ApiClient.login(buyer.email, buyer.password);
-		const tickets = await buyerApi.get<{ results: Array<{ id: string }> }>(
-			'/api/dashboard/tickets'
-		);
-		expect(tickets.results.length).toBeGreaterThan(0);
-		const attempt = buyerApi.post(`/api/events/tickets/${tickets.results[0].id}/cancel`, {});
-		await expect(attempt).rejects.toThrow(ApiError);
-		await attempt.catch((error: ApiError) => {
-			expect(error.status).toBe(409);
-			expect(error.body).toContain('part_of_series_pass');
-		});
-
-		await buyerContext.close();
-		await ownerContext.close();
+			// Pass-derived tickets are not self-cancellable — the cancel endpoint
+			// blocks with 409 and the stable part_of_series_pass reason code.
+			const buyerApi = await ApiClient.login(buyer.email, buyer.password);
+			const tickets = await buyerApi.get<{ results: Array<{ id: string }> }>(
+				'/api/dashboard/tickets'
+			);
+			expect(tickets.results.length).toBeGreaterThan(0);
+			const attempt = buyerApi.post(`/api/events/tickets/${tickets.results[0].id}/cancel`, {});
+			await expect(attempt).rejects.toThrow(ApiError);
+			await attempt.catch((error: ApiError) => {
+				expect(error.status).toBe(409);
+				expect(error.body).toContain('part_of_series_pass');
+			});
+		} finally {
+			await buyerContext.close();
+		}
 	});
 });

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -165,10 +165,10 @@ export async function createTicketedEvent(
 export async function createTicketTier(
 	eventId: string,
 	tier: Record<string, unknown> = {},
-	owner: PersonaName = 'owner'
+	owner: PersonaName | ThrowawayUser = 'owner'
 ): Promise<{ id: string; name: string }> {
-	const persona = PERSONAS[owner];
-	const api = await ApiClient.login(persona.email, persona.password);
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
 	const dayMs = 24 * 60 * 60 * 1000;
 	const name = (tier.name as string) ?? 'Online Tier';
 	const created = await api.post<{ id: string }>(`/api/event-admin/${eventId}/ticket-tier`, {
@@ -201,7 +201,14 @@ export interface CreatedOrg {
  * "General membership" tier; its id is returned for approve-with-tier flows.
  */
 export async function createOrganization(
-	options: { acceptMembershipRequests?: boolean; contactEmail?: string } = {}
+	options: {
+		acceptMembershipRequests?: boolean;
+		contactEmail?: string;
+		/** New orgs default to PRIVATE visibility, which also hides their public
+		 * series pages (series visibility derives from the org's) — set this for
+		 * specs that browse the org's public surfaces as an outsider. */
+		publicVisibility?: boolean;
+	} = {}
 ): Promise<CreatedOrg> {
 	const owner = await createVerifiedUser('OrgOwner');
 	const api = await ApiClient.login(owner.email, owner.password);
@@ -214,10 +221,10 @@ export async function createOrganization(
 		contact_email: options.contactEmail ?? owner.email
 	});
 
-	if (options.acceptMembershipRequests) {
+	if (options.acceptMembershipRequests || options.publicVisibility) {
 		await api.put(`/api/organization-admin/${org.slug}`, {
 			visibility: 'public',
-			accept_membership_requests: true
+			accept_membership_requests: options.acceptMembershipRequests ?? false
 		});
 	}
 
@@ -348,6 +355,119 @@ export async function attachQuestionnaire(
 		}
 	);
 	await api.post(`/api/questionnaires/${created.id}/events/${event.id}`);
+	return { id: created.id, name };
+}
+
+/** Look up a throwaway user's own id — admin on-behalf endpoints want a user_id. */
+export async function getUserId(user: ThrowawayUser): Promise<string> {
+	const api = await ApiClient.login(user.email, user.password);
+	const me = await api.get<{ id: string }>('/api/account/me');
+	return me.id;
+}
+
+/**
+ * Admin-create an RSVP on behalf of a registered user — the ARRANGE step for
+ * specs that need attendance state the public API refuses to create (e.g. a
+ * YES RSVP on an already-finished event for the feedback-questionnaire gate).
+ */
+export async function rsvpOnBehalf(
+	owner: PersonaName | ThrowawayUser,
+	eventId: string,
+	userId: string,
+	status: 'yes' | 'no' | 'maybe'
+): Promise<void> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+	await api.post(`/api/event-admin/${eventId}/rsvps`, { user_id: userId, status });
+}
+
+export interface CreatedSeries {
+	id: string;
+	slug: string;
+	orgSlug: string;
+	name: string;
+	/** Public series path, e.g. /events/<org>/series/<slug>. */
+	path: string;
+}
+
+/**
+ * API-create a plain (non-recurring, grouping-only) event series. Events join
+ * it by passing `event_series_id` to createTicketedEvent. Series accumulate on
+ * the org profile with no cleanup — prefer a THROWAWAY org unless the spec
+ * needs Org Alpha's Stripe connection.
+ */
+export async function createEventSeries(
+	owner: PersonaName | ThrowawayUser,
+	orgSlug: string
+): Promise<CreatedSeries> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+	const name = uniqueName('Series');
+	const series = await api.post<{ id: string; slug: string }>(
+		`/api/organization-admin/${orgSlug}/create-event-series`,
+		{ name }
+	);
+	return {
+		id: series.id,
+		slug: series.slug,
+		orgSlug,
+		name,
+		path: `/events/${orgSlug}/series/${series.slug}`
+	};
+}
+
+/**
+ * API-create a season pass on an event series. `tier_links` maps each covered
+ * event to the backing tier the materialized tickets will use. Coverage rules
+ * (backend validate_events_coverable): covered events must be OPEN, ticketed,
+ * in a NON-recurring series, not questionnaire-gated; backing tiers must not
+ * be seated or pay-what-you-can; the quote is only purchasable while at least
+ * 2 covered events are still upcoming.
+ */
+export async function createSeriesPass(
+	owner: PersonaName | ThrowawayUser,
+	seriesId: string,
+	pass: Record<string, unknown> & { tier_links: Array<{ event_id: string; tier_id: string }> }
+): Promise<{ id: string; name: string }> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+	const name = (pass.name as string) ?? uniqueName('Pass');
+	const created = await api.post<{ id: string }>(`/api/event-series-admin/${seriesId}/passes/`, {
+		name,
+		price: '10.00',
+		pro_rata_discount: '0.00',
+		currency: 'EUR',
+		payment_method: 'free',
+		...pass
+	});
+	return { id: created.id, name };
+}
+
+/**
+ * Create a PUBLISHED questionnaire on the org and attach it at the EVENT
+ * SERIES level — passing once then satisfies the gate for every event in the
+ * series (as long as the wrapper keeps per_event=false, the default). Same
+ * isolation rule as attachQuestionnaire: THROWAWAY orgs only.
+ */
+export async function attachQuestionnaireToSeries(
+	series: CreatedSeries,
+	questionnaire: Record<string, unknown>,
+	owner: ThrowawayUser
+): Promise<{ id: string; name: string }> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	const org = await api.get<{ id: string }>(`/api/organizations/${series.orgSlug}`);
+	const name = (questionnaire.name as string) ?? uniqueName('Questionnaire');
+	const created = await api.post<{ id: string }>(
+		`/api/questionnaires/${org.id}/create-questionnaire`,
+		{
+			name,
+			min_score: 0,
+			evaluation_mode: 'manual',
+			status: 'published',
+			...questionnaire
+		}
+	);
+	await api.post(`/api/questionnaires/${created.id}/event-series/${series.id}`);
 	return { id: created.id, name };
 }
 
@@ -705,11 +825,13 @@ export async function startOnlineCheckout(
 
 /**
  * Set a seeded org's attendee invoicing mode (dedicated endpoint — the
- * billing-info PATCH silently ignores the field). Specs that need
- * `tier.invoicing_available` (checkout billing form, buyer invoices) flip Org
- * Alpha to 'auto' and deliberately DON'T revert: a finally-revert would race
- * parallel workers running the other invoicing spec, and 'auto' is harmless to
- * every other suite (it only reveals the optional "Request Invoice" checkbox).
+ * billing-info PATCH silently ignores the field). The suite-wide convention is
+ * that every invoicing spec flips Org Alpha to 'hybrid' and DOESN'T revert:
+ * the mode is read at WEBHOOK time, so two specs standing on different modes
+ * would race each other's checkouts (an 'auto' flip mid-run turns another
+ * spec's expected draft into an issued invoice, and vice versa). 'hybrid' is
+ * harmless to non-invoicing suites — it only reveals the optional "Request
+ * Invoice" checkbox on online checkouts.
  */
 export async function setOrgInvoicingMode(
 	mode: 'none' | 'hybrid' | 'auto',
@@ -719,6 +841,39 @@ export async function setOrgInvoicingMode(
 	const persona = PERSONAS[owner];
 	const api = await ApiClient.login(persona.email, persona.password);
 	await api.patch(`/api/organization-admin/${orgSlug}/invoicing`, { mode });
+}
+
+/**
+ * Wait for the DRAFT attendee invoice a hybrid-mode checkout generated (the
+ * Stripe webhook + inline Celery make it eventually-consistent) and ISSUE it
+ * as the org owner — the ARRANGE step for buyer-side invoice specs now that
+ * the suite pins Org Alpha to 'hybrid' (auto-issue no longer happens; the
+ * organizer-side issue journey itself is j22 hybrid-flow).
+ */
+export async function issueDraftInvoiceFor(
+	buyerEmail: string,
+	orgSlug = 'revel-events-collective',
+	timeoutMs = 120_000
+): Promise<void> {
+	const persona = PERSONAS.owner;
+	const api = await ApiClient.login(persona.email, persona.password);
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		const page = await api.get<{ results: Array<{ id: string; status: string }> }>(
+			`/api/organization-admin/${orgSlug}/attendee-invoices?search=${encodeURIComponent(buyerEmail)}`
+		);
+		const invoice = page.results[0];
+		if (invoice) {
+			if (invoice.status === 'draft') {
+				await api.post(`/api/organization-admin/${orgSlug}/attendee-invoices/${invoice.id}/issue`);
+			}
+			return;
+		}
+		if (Date.now() > deadline) {
+			throw new Error(`No attendee invoice for ${buyerEmail} within ${timeoutMs}ms`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 2_000));
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 4 of the E2E suite v2 (umbrella #28): the **@p3 long-tail** — 12 new journey specs across 9 journeys. Suite tally: 333 → **359 passed + 2 skips**, full run ~4.6 min at `--workers=4 --retries=0`. Of the v2 phases, only #593 (CI wiring) remains.

Closes #592

### New specs
| Spec | Journey |
|---|---|
| `j05/waitlist-offer` | pending-offer banner → claim by RSVPing before expiry (no accept endpoint — registering claims the offer); admin-side offer flips to CLAIMED |
| `j06/batch-purchase` | quantity stepper capped by `max_tickets_per_user`, guest-name input per extra ticket, remaining allowance shrinks, limit removes the buy affordance |
| `j11/duplicate-export` | questionnaire deep-copy lands as unattached DRAFT; async XLSX submissions export asserted at the network layer |
| `j11/feedback` | past-event attendee gets "Feedback Available", one-shot fill; own past event + admin on-behalf RSVP (charlie's seeded NYE fixture is single-use and would break the 2nd project/re-runs) |
| `j13/fuzzy-whitelist` | name-only entry → "Additional verification required." gate → request → admin approve → unblocked |
| `j13/unban` | entry removal → org/event visibility returns, membership lands on **Cancelled** (never Active) |
| `j18/series-questionnaire` | series-attached questionnaire: pass once on event A → event B unlocked |
| `j22/hybrid-flow` | Stripe purchase w/ billing info → DRAFT invoice (invisible to buyer) → edit buyer fields → issue → org-branded email + `/account/invoices` |
| `j24/poll-duplicate` | clone → DRAFT with lifecycle reset, source stays open |
| `j25/revenue-report` | Financials "Download report" → export poll → signed ZIP fetched at the network layer |
| `j26/pass-purchase` | offline season pass: pro-rata quote (1 passed event → €7.50), reserve → organizer confirms payment → tickets materialize & fold into the pass card; self-cancel blocked with 409 `part_of_series_pass` |
| `j26/pass-online-cancel` | Stripe pass purchase (webhook materializes the held pass) → organizer cancels from Holders → pass + tickets cancelled, refund server-side |

### Suite-level decision: invoicing mode pinned to `hybrid`
Org Alpha is the only Stripe-connected org and `invoicing_mode` is read at **webhook time** — buyer-invoices standing on `auto` and hybrid-flow on `hybrid` would race each other's checkouts across parallel workers. All invoicing specs now pin `hybrid`; `buyer-invoices` issues its draft via the new `issueDraftInvoiceFor` factory (auto-issue semantics stay backend-tested; the draft→issue UI journey is `hybrid-flow`), `vat-preview` adapted (`invoicing_available` treats hybrid/auto identically).

### Bugs
- **BE #700 filed** (draft-invoice PATCH 500 on null buyer fields, hit by the FE edit form whenever VAT ID is empty) — fixed by **letsrevel/revel-backend#701**. `hybrid-flow` now deliberately saves the draft with an **empty VAT ID**, doubling as the FE-side regression test.
- Fixed inline: pre-existing mobile flake in `j08/resources` (dialog form intercepting pointer events — outcome-keyed dispatched click).

### ⚠️ Merge ordering
The suite needs a backend that includes **letsrevel/revel-backend#701** — against an older backend, `hybrid-flow` fails on the empty-VAT save.

### Support additions
`createEventSeries`, `createSeriesPass`, `attachQuestionnaireToSeries`, `getUserId`, `rsvpOnBehalf`, `issueDraftInvoiceFor`; `createOrganization({ publicVisibility })` (new orgs default PRIVATE, which 404s their public series pages); `createTicketTier` accepts a throwaway owner.

## Test plan
- [x] `make check` green (format, lint, types, i18n, file-length, ssr-token, image-alt)
- [x] Full suite green **3× consecutively** on the final code at `--workers=4 --retries=0` (359 passed / 2 mobile-viewport skips each), fresh `reset_events --no-input` + `make bootstrap-tests` before each run
- [x] Stripe specs run against real test-mode hosted checkout + `stripe listen` webhook forwarding
- [x] `hybrid-flow` verified against the revel-backend#701 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxmNyfoaDPenbP76Bx5frb