### PR TITLE
chore(release): v1.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.68.0] - 2026-07-14
+
+### Changed
+
+- **Two-step online checkout**: online (Stripe) purchases — tickets, guest checkout, pay-what-you-can, and season passes — now reserve your spot first and then start payment as a separate step. Interrupted checkouts can be resumed via the existing **Resume Payment** action, expired reservations fall back to a fresh reservation automatically, and a failure to start payment shows a clear, retryable error message in every UI language.
+
+### Fixed
+
+- The membership subscription drawer no longer gets permanently stuck on a loading spinner.
+- The season-pass purchase button is now disabled when the price quote fails to load, instead of remaining clickable.
+- The discount-code edit page shows an error message instead of a blank page when the code fails to load.
+
 ## [1.67.0] - 2026-07-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.67.0",
+	"version": "1.68.0",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## [1.68.0] - 2026-07-14

### Changed

- **Two-step online checkout**: online (Stripe) purchases — tickets, guest checkout, pay-what-you-can, and season passes — now reserve your spot first and then start payment as a separate step. Interrupted checkouts can be resumed via the existing **Resume Payment** action, expired reservations fall back to a fresh reservation automatically, and a failure to start payment shows a clear, retryable error message in every UI language.

### Fixed

- The membership subscription drawer no longer gets permanently stuck on a loading spinner.
- The season-pass purchase button is now disabled when the price quote fails to load, instead of remaining clickable.
- The discount-code edit page shows an error message instead of a blank page when the code fails to load.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a two-step Stripe checkout flow that reserves purchases before payment.
  * Interrupted checkouts can now be resumed, with automatic fallback when reservations expire.
  * Added clear, retryable errors when payment cannot be started.

* **Bug Fixes**
  * Fixed a stuck loading spinner in the membership subscription drawer.
  * Disabled season-pass purchases when price quotes fail to load.
  * Added an error message when discount-code details cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->