### PR TITLE
fix(org): stop cropping org cover art in the profile hero

### DIFF
--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -172,10 +172,18 @@
 		<!-- Cover Image or Gradient -->
 		<div class="relative h-48 w-full md:h-64 lg:h-80">
 			{#if coverUrl}
+				<!-- Blurred backdrop fills the ultra-wide strip; the real image is never cropped -->
+				<img
+					src={coverUrl}
+					alt=""
+					aria-hidden="true"
+					class="absolute inset-0 h-full w-full scale-110 object-cover blur-2xl brightness-75"
+					loading="eager"
+				/>
 				<img
 					src={coverUrl}
 					alt="{organization.name} cover"
-					class="h-full w-full object-cover"
+					class="relative h-full w-full object-contain"
 					loading="eager"
 				/>
 				<!-- Gradient overlay -->


### PR DESCRIPTION
## Summary

The org profile hero renders the cover as a fixed-height, full-viewport-width strip (`h-48 md:h-64 lg:h-80` + `object-cover`) — roughly **6:1** on wide screens. Any non-panoramic cover gets most of its height cropped away: the official Revel org's `1640×624` Facebook cover showed up as a giant zoomed-in center sliver of the R mark, wordmark gone. The org **card** preview was fine because it uses an `aspect-video` container with the 1200×630 social derivative — compatible geometry, nothing to crop.

## Fix

Standard "never crop" banner treatment, same fixed hero heights:

- foreground: the cover with `object-contain` — always fully visible, centered;
- backdrop: a blurred, darkened copy of the same image (`blur-2xl brightness-75 scale-110`, `aria-hidden`, empty alt) filling the strip, so the hero reads as intentional rather than letterboxed.

Fallback-gradient branch untouched.

## Verification

- Reproduced locally by uploading the Facebook cover to the demo org: full lockup now visible at 1440px and 390px viewports, blur fill blends with the Bubble theme in dark and light mode.
- `make check` green; `svelte-autofixer` reports no issues.

## Notes

The event detail hero uses the same fixed-height + `object-cover` pattern. Cropping is usually desirable for photographic event covers, so it's left as-is; if logo-style event covers become common, the same blur-fill treatment can be applied there as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)