### PR TITLE
chore(release): v1.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.69.0] - 2026-07-16
+
+### Added
+
+- **Attendee notes on RSVPs**: organizers can opt in per event ("Accept a note with RSVPs" in the RSVP options, also available on recurring-series templates) to collect an optional note (up to 500 characters) with each RSVP, including guest RSVPs. Attendees see a note dialog when RSVPing and can edit or clear their note by RSVPing again. Organizers see notes in the attendees list, and can add or edit a note when creating or editing an RSVP on an attendee's behalf.
+
 ## [1.68.1] - 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "1.68.1",
+	"version": "1.69.0",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## [1.69.0] - 2026-07-16

### Added

- **Attendee notes on RSVPs**: organizers can opt in per event ("Accept a note with RSVPs" in the RSVP options, also available on recurring-series templates) to collect an optional note (up to 500 characters) with each RSVP, including guest RSVPs. Attendees see a note dialog when RSVPing and can edit or clear their note by RSVPing again. Organizers see notes in the attendees list, and can add or edit a note when creating or editing an RSVP on an attendee's behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event organizers can enable optional attendee notes with RSVPs, including guest RSVPs.
  * Attendees can view, edit, or clear their RSVP notes.
  * Organizers can view and manage attendee notes from the attendees list.

* **Release**
  * Updated the application to version 1.69.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->