### PR TITLE
fix(seo): robots.txt group-exemption bug + markdown leaking into meta descriptions

### DIFF
--- a/src/lib/seo/build.test.ts
+++ b/src/lib/seo/build.test.ts
@@ -66,6 +66,23 @@ describe('buildSeo', () => {
 		expect(cfg.og.logo).toBe('https://letsrevel.io/og-logo-v1.png');
 	});
 
+	it('event: strips markdown from the description (meta, og and twitter)', () => {
+		const cfg = buildSeo({
+			kind: 'event',
+			url: url('/events/acme/my-event'),
+			lang: 'en',
+			event: {
+				...fakeEvent,
+				description: '# Big Party\n## *A night to remember*\nCome join **all of us**!'
+			} as typeof fakeEvent,
+			indexable: true
+		});
+		const clean = 'Big Party A night to remember Come join all of us!';
+		expect(cfg.description).toBe(clean);
+		expect(cfg.og.description).toBe(clean);
+		expect(cfg.twitter.description).toBe(clean);
+	});
+
 	it('event non-indexable: emits noindex,follow', () => {
 		const cfg = buildSeo({
 			kind: 'event',

--- a/src/lib/seo/build.ts
+++ b/src/lib/seo/build.ts
@@ -15,7 +15,7 @@ import {
 	type Lang
 } from './constants';
 import type { SeoConfig } from './types';
-import { truncate, stripHtml } from './text';
+import { truncate, stripMarkup } from './text';
 import { sameUrlHreflang, landingPageHreflang } from './hreflang';
 import {
 	generateEventJsonLd,
@@ -259,7 +259,7 @@ function buildSeoConfig(input: BuildSeoInput): SeoConfig {
 
 		case 'event': {
 			const event = input.event;
-			const desc = stripHtml(event.description);
+			const desc = stripMarkup(event.description);
 			const truncated = truncate(desc, 155);
 			const image = getEventImage(event);
 			const title = `${event.name} | Revel`;
@@ -303,7 +303,7 @@ function buildSeoConfig(input: BuildSeoInput): SeoConfig {
 
 		case 'org': {
 			const org = input.org;
-			const desc = stripHtml(org.description);
+			const desc = stripMarkup(org.description);
 			const truncated = truncate(desc, 155);
 			const image = getOrgImage(org);
 			const title = `${org.name} | Revel`;
@@ -345,7 +345,7 @@ function buildSeoConfig(input: BuildSeoInput): SeoConfig {
 
 		case 'series': {
 			const series = input.series;
-			const desc = stripHtml(series.description);
+			const desc = stripMarkup(series.description);
 			const truncated = truncate(desc, 155);
 			const image = getSeriesImage(series);
 			const title = `${series.name} | ${series.organization.name} | Revel`;

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -3,4 +3,4 @@ export type { Lang } from './constants';
 export type { SeoConfig, Robots } from './types';
 export { buildSeo, type BuildSeoInput, type SeoPageSlug } from './build';
 export { default as SeoHead } from './SeoHead.svelte';
-export { stripMarkdown } from './text';
+export { stripMarkdown, stripMarkup } from './text';

--- a/src/lib/seo/text.test.ts
+++ b/src/lib/seo/text.test.ts
@@ -1,0 +1,48 @@
+// src/lib/seo/text.test.ts
+import { describe, it, expect } from 'vitest';
+import { stripHtml, stripMarkdown, stripMarkup, truncate } from './text';
+
+describe('truncate', () => {
+	it('returns short strings unchanged and ellipsizes overflow', () => {
+		expect(truncate('short', 10)).toBe('short');
+		expect(truncate('a'.repeat(20), 10)).toBe('a'.repeat(7) + '...');
+		expect(truncate('', 10)).toBe('');
+	});
+});
+
+describe('stripHtml', () => {
+	it('strips tags and collapses whitespace', () => {
+		expect(stripHtml('<p>Hello&nbsp;<b>world</b></p>\n<p>again</p>')).toBe('Hello world again');
+		expect(stripHtml(null)).toBe('');
+	});
+});
+
+describe('stripMarkup', () => {
+	it('strips markdown headings, emphasis and lists (event descriptions are markdown)', () => {
+		// Shape of real event descriptions that previously leaked "# … ## *…* **…**"
+		// into meta descriptions.
+		const md = [
+			'# RIGGOROS - Love Rope - Köln',
+			'## *Ein Fesseltreff für Einsteigys bis Alteingeseilte*',
+			'Wir treffen uns **jeden Monat** zum Fesseln.',
+			'- Anfänger willkommen',
+			'- [Anmeldung](https://example.com)'
+		].join('\n');
+		expect(stripMarkup(md)).toBe(
+			'RIGGOROS - Love Rope - Köln Ein Fesseltreff für Einsteigys bis Alteingeseilte ' +
+				'Wir treffen uns jeden Monat zum Fesseln. Anfänger willkommen Anmeldung'
+		);
+	});
+
+	it('also strips embedded HTML and handles empty input', () => {
+		expect(stripMarkup('**bold** and <em>html</em>')).toBe('bold and html');
+		expect(stripMarkup(null)).toBe('');
+		expect(stripMarkup(undefined)).toBe('');
+	});
+});
+
+describe('stripMarkdown', () => {
+	it('needs line structure — headings are only stripped at line starts', () => {
+		expect(stripMarkdown('# Title\nBody')).toBe('Title Body');
+	});
+});

--- a/src/lib/seo/text.ts
+++ b/src/lib/seo/text.ts
@@ -20,6 +20,15 @@ export function stripHtml(html: string | null | undefined): string {
 }
 
 /**
+ * Strip both Markdown and HTML markup for plain-text descriptions.
+ * Markdown must be stripped first: its rules are line-anchored (headings,
+ * lists, blockquotes) and stripHtml collapses the newlines they match on.
+ */
+export function stripMarkup(s: string | null | undefined): string {
+	return stripHtml(stripMarkdown(s));
+}
+
+/**
  * Strip markdown formatting from a string for plain text descriptions.
  * Handles common markdown syntax: headers, bold, italic, links, lists, code blocks, etc.
  */

--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -4,25 +4,24 @@ import type { RequestHandler } from './$types';
  * Generate robots.txt dynamically
  * https://www.robotstxt.org/
  * https://developers.google.com/search/docs/crawling-indexing/robots/intro
+ *
+ * IMPORTANT: a bot-specific `User-agent` group REPLACES the `*` group for that
+ * bot — it does not extend it. Any per-bot group must therefore repeat the
+ * private-area disallows, or the bot is silently exempted from all of them
+ * (this bug previously let Googlebot/Bingbot crawl /dashboard, /account, …).
+ *
+ * AI-crawler policy (search yes, training no): in production Cloudflare
+ * prepends a managed section that blocks AI-training crawlers (GPTBot,
+ * ClaudeBot, CCBot, Google-Extended, Bytespider, …) and declares
+ * `Content-Signal: search=yes, ai-train=no`. AI *search* crawlers
+ * (OAI-SearchBot, PerplexityBot) are covered by the `*` group and stay
+ * allowed. Do not add Allow groups for training bots here — they would
+ * contradict the managed block.
  */
-export const GET: RequestHandler = async ({ url }) => {
-	const baseUrl = url.origin;
 
-	const robotsTxt = `# Robots.txt for Revel - Community Event Platform
-# https://letsrevel.io
-# Allow all search engines to crawl public pages
-
-# Default rules for all bots
-User-agent: *
-Allow: /
-Allow: /events
-Allow: /events/
-Allow: /organizations
-Allow: /org/
-Allow: /legal/
-
-# Disallow private/authenticated areas
-Disallow: /api/
+// Private/authenticated areas and duplicate-content params, shared by every
+// user-agent group (see the group-replacement note above).
+const DISALLOW_RULES = `Disallow: /api/
 Disallow: /dashboard
 Disallow: /dashboard/
 Disallow: /account
@@ -34,44 +33,31 @@ Disallow: /join/
 Disallow: /verify
 Disallow: /reset-password
 Disallow: /confirm-action
-
-# Disallow URL parameters that create duplicate content
 Disallow: /*?viewMode=
 Disallow: /*?page=
-Disallow: /*&page=
+Disallow: /*&page=`;
 
-# Google-specific settings
-User-agent: Googlebot
+// SEO-tool crawlers that hammer small sites; keep them restricted and slow.
+const SLOW_BOTS = ['AhrefsBot', 'SemrushBot', 'MJ12bot'];
+
+export const GET: RequestHandler = async ({ url }) => {
+	const baseUrl = url.origin;
+
+	const slowBotGroups = SLOW_BOTS.map(
+		(bot) => `User-agent: ${bot}
+${DISALLOW_RULES}
+Crawl-delay: 10`
+	).join('\n\n');
+
+	const robotsTxt = `# Robots.txt for Revel - Community Event Platform
+# https://letsrevel.io
+# Search engines are welcome on all public pages.
+
+User-agent: *
 Allow: /
-Crawl-delay: 0
+${DISALLOW_RULES}
 
-# Bing-specific settings
-User-agent: Bingbot
-Allow: /
-Crawl-delay: 1
-
-# GPTBot (OpenAI) - Allow for AI training on public event data
-User-agent: GPTBot
-Allow: /events
-Allow: /org/
-Disallow: /api/
-Disallow: /dashboard
-Disallow: /account
-
-# CCBot (Common Crawl) - Allow for research purposes
-User-agent: CCBot
-Allow: /
-Crawl-delay: 2
-
-# Aggressive bots - slow them down
-User-agent: AhrefsBot
-Crawl-delay: 10
-
-User-agent: SemrushBot
-Crawl-delay: 10
-
-User-agent: MJ12bot
-Crawl-delay: 10
+${slowBotGroups}
 
 # Sitemap location
 Sitemap: ${baseUrl}/sitemap.xml
@@ -80,10 +66,6 @@ Sitemap: ${baseUrl}/sitemap-static.xml
 Sitemap: ${baseUrl}/sitemap-events-1.xml
 Sitemap: ${baseUrl}/sitemap-orgs-1.xml
 Sitemap: ${baseUrl}/sitemap-series-1.xml
-
-# RSS/Atom Feed for events
-# Note: This is informational - crawlers use <link rel="alternate"> in HTML
-# Feed: ${baseUrl}/feed.xml
 `;
 
 	return new Response(robotsTxt, {

--- a/src/routes/robots.txt/server.test.ts
+++ b/src/routes/robots.txt/server.test.ts
@@ -1,0 +1,53 @@
+// src/routes/robots.txt/server.test.ts
+import { describe, it, expect } from 'vitest';
+import { GET } from './+server';
+
+async function fetchRobots(): Promise<string> {
+	const response = await GET({
+		url: new URL('https://letsrevel.io/robots.txt')
+	} as unknown as Parameters<typeof GET>[0]);
+	return response.text();
+}
+
+// A user-agent group's rules apply INSTEAD of the `*` group's, not in addition
+// to them — so every group must carry the private-area disallows itself.
+function groupFor(body: string, agent: string): string | undefined {
+	return body.split(/\n\n+/).find((block) => block.includes(`User-agent: ${agent}`));
+}
+
+describe('GET /robots.txt', () => {
+	it('serves plain text with the sitemap index and all sub-sitemaps', async () => {
+		const body = await fetchRobots();
+		expect(body).toContain('Sitemap: https://letsrevel.io/sitemap.xml');
+		for (const sub of ['static', 'events-1', 'orgs-1', 'series-1']) {
+			expect(body).toContain(`Sitemap: https://letsrevel.io/sitemap-${sub}.xml`);
+		}
+	});
+
+	it('disallows private areas and duplicate-content params for all bots', async () => {
+		const star = groupFor(await fetchRobots(), '*');
+		expect(star).toBeDefined();
+		for (const path of ['/dashboard', '/account', '/api/', '/org/*/admin', '/*?page=']) {
+			expect(star).toContain(`Disallow: ${path}`);
+		}
+	});
+
+	it('has no per-bot Allow groups that would exempt search bots from the disallows', async () => {
+		const body = await fetchRobots();
+		// Googlebot/Bingbot groups with a bare `Allow: /` previously replaced the
+		// `*` group entirely, exempting them from every Disallow.
+		for (const agent of ['Googlebot', 'Bingbot', 'GPTBot', 'CCBot']) {
+			expect(groupFor(body, agent)).toBeUndefined();
+		}
+	});
+
+	it('keeps SEO-tool crawlers slowed down without exempting them from disallows', async () => {
+		const body = await fetchRobots();
+		for (const agent of ['AhrefsBot', 'SemrushBot', 'MJ12bot']) {
+			const group = groupFor(body, agent);
+			expect(group).toBeDefined();
+			expect(group).toContain('Crawl-delay: 10');
+			expect(group).toContain('Disallow: /dashboard');
+		}
+	});
+});


### PR DESCRIPTION
## Context

Follow-up to today's Search Console recovery (child sitemaps stuck on "Couldn't fetch" since May; only 2 pages indexed). While auditing the crawl surface, two on-site bugs surfaced.

## Fix 1: robots.txt exempted Googlebot/Bingbot from every Disallow

In robots.txt, a bot-specific `User-agent` group **replaces** the `*` group for that bot — it does not extend it. Our `User-agent: Googlebot` / `Allow: /` block (and the Bingbot, GPTBot, CCBot ones) therefore silently exempted those crawlers from all private-area disallows: `/dashboard`, `/account`, `/api/`, `/org/*/admin`, and the duplicate-content `?page=` params.

- Removed the per-bot Allow groups — search bots now inherit the `*` rules.
- SEO-tool throttle groups (Ahrefs/Semrush/MJ12) now repeat the disallow list, since they were exempted too.
- Removed the GPTBot/CCBot Allow sections that contradicted the Cloudflare-managed AI-training block. Policy is now coherent and documented in the route: search (incl. AI search crawlers) allowed, AI training blocked via the CF-managed section + `Content-Signal`.

## Fix 2: raw Markdown leaking into meta descriptions

Event/org/series descriptions are stored as Markdown, but the SEO builder only stripped HTML. Live event pages ship search snippets like:

> `# RIGGOROS - Love Rope - Köln ## *Ein Fesseltreff für Einsteigys bis Alteingeseilte* Wir treffen uns **jed...`

Added `stripMarkup()` in `src/lib/seo/text.ts` (Markdown stripped first while line structure is intact, then HTML + whitespace collapse) and switched the event/org/series description paths in `buildSeo` to it. The existing `stripMarkdown` helper was already in the module — it was just never wired into the SEO path.

## Tests

- `src/lib/seo/text.test.ts` (new): `stripMarkup` against a real-world markdown event description, plus `truncate`/`stripHtml` coverage.
- `src/lib/seo/build.test.ts`: event case asserting meta/og/twitter descriptions come out clean.
- `src/routes/robots.txt/server.test.ts` (new): asserts sitemaps are listed, `*` disallows hold, no per-bot group exempts search bots, and throttled bots keep the disallows.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO Improvements**
  * Event, organization, and series descriptions now remove Markdown and HTML before appearing in search and social metadata.
  * Added broader text-cleaning support for consistent plain-text descriptions.

* **Crawling & Indexing**
  * Updated `robots.txt` rules to better restrict private and duplicate-content paths.
  * Added crawl delays for selected SEO crawlers while preserving sitemap access.

* **Tests**
  * Added coverage for SEO description cleanup and crawler directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->