### PR TITLE
feat(seating): color designer canvas seats by price category (BE #734)

### DIFF
--- a/src/lib/components/venues/designer/DesignerLegend.svelte
+++ b/src/lib/components/venues/designer/DesignerLegend.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	/**
+	 * Passive price-category legend for the seat-map designer. Pure presentation:
+	 * lists the venue's price categories with their color swatch + name so the
+	 * canvas's category-colored seats are decodable (color is never the only
+	 * signal). Painting itself lives in the grid editor, not here.
+	 */
+	import * as m from '$lib/paraglide/messages.js';
+	import type { PriceCategorySchema } from '$lib/api/generated/types.gen';
+
+	interface Props {
+		categories: PriceCategorySchema[];
+	}
+
+	const { categories }: Props = $props();
+</script>
+
+{#if categories.length > 0}
+	<div class="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+		<span class="font-medium">
+			{m['seatDesigner.categoriesLegend']()}
+		</span>
+		{#each categories as category (category.id ?? category.name)}
+			<span class="inline-flex items-center gap-1.5">
+				<span
+					class="inline-block h-3 w-3 rounded-full border border-border"
+					style="background: {category.color}"
+					aria-hidden="true"
+				></span>
+				{category.name}
+			</span>
+		{/each}
+	</div>
+{/if}

--- a/src/lib/components/venues/designer/SeatMapDesigner.svelte
+++ b/src/lib/components/venues/designer/SeatMapDesigner.svelte
@@ -21,6 +21,8 @@
 	import { Minus, Plus, RotateCcw } from '@lucide/svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import DesignerToolbar from './DesignerToolbar.svelte';
+	import DesignerLegend from './DesignerLegend.svelte';
+	import { buildCategoryStyleMap, resolveSeatCategory } from './designer-colors';
 	import {
 		idsInRect,
 		nextSeatInDirection,
@@ -94,6 +96,8 @@
 	let saveIssues = $state<DesignerSavePlan | null>(null);
 
 	// --- derived --------------------------------------------------------------
+	// id → {color, name} for painted seats; drives fill accent + a11y suffix.
+	const categoryStyles = $derived(buildCategoryStyleMap(priceCategories));
 	const changedCount = $derived(countChangedSeats(model, seatPos, baselinePos));
 	const shapesDirty = $derived(anyShapeChanged(model.sectors, shapes, baselineShapes));
 	const dirty = $derived(changedCount > 0 || shapesDirty);
@@ -434,6 +438,9 @@
 		if (seat.isObstructedView) {
 			label += `, ${m['seatSelector.obstructedView']()}`;
 		}
+		// Category color is never the only signal: pair it with the name.
+		const category = resolveSeatCategory(seat.priceCategoryId, categoryStyles);
+		if (category) label += `, ${category.name}`;
 		return label;
 	}
 
@@ -592,12 +599,13 @@
 					</g>
 				{/each}
 
-				<!-- Seats -->
+				<!-- Seats (colored by painted price category; selection = halo on top) -->
 				{#each model.seats as seat (seat.id)}
 					{@const p = seatPos.get(seat.id) ?? seat}
 					{@const cx = px(p.x + 0.5)}
 					{@const cy = py(p.y + 0.5)}
 					{@const selected = selection.has(seat.id)}
+					{@const category = resolveSeatCategory(seat.priceCategoryId, categoryStyles)}
 					<g
 						data-seat-id={seat.id}
 						role="button"
@@ -612,15 +620,28 @@
 						onkeydown={(event) => onSeatKeydown(event, seat)}
 					>
 						<title>{seatLabel(seat)}</title>
+						<!-- Selection halo: theme-token ring outlined by the surface, so it
+						     stays unambiguous over ANY category color. Drawn behind the seat. -->
 						{#if selected}
 							<circle
 								{cx}
 								{cy}
-								r={SEAT_R + 3}
-								class="fill-none stroke-primary/40"
-								stroke-width="2"
+								r={SEAT_R + 4}
+								class="fill-none stroke-background"
+								stroke-width="4"
 							/>
-							<circle {cx} {cy} r={SEAT_R} class="fill-primary stroke-primary" />
+							<circle {cx} {cy} r={SEAT_R + 4} class="fill-none stroke-primary" stroke-width="2" />
+						{/if}
+						{#if category}
+							<circle
+								{cx}
+								{cy}
+								r={SEAT_R}
+								fill={category.color}
+								fill-opacity="0.22"
+								stroke={category.color}
+								stroke-width="2.5"
+							/>
 						{:else}
 							<circle {cx} {cy} r={SEAT_R} class="fill-background stroke-border" stroke-width="2" />
 						{/if}
@@ -629,9 +650,7 @@
 							y={cy}
 							text-anchor="middle"
 							dominant-baseline="central"
-							class="pointer-events-none text-[8px] {selected
-								? 'fill-primary-foreground'
-								: 'fill-muted-foreground'}"
+							class="pointer-events-none text-[8px] fill-muted-foreground"
 						>
 							{seat.label}
 						</text>
@@ -705,21 +724,5 @@
 	</div>
 
 	<!-- Price-category legend (painting lives in the grid editor) -->
-	{#if priceCategories.length > 0}
-		<div class="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-			<span class="font-medium">
-				{m['seatDesigner.categoriesLegend']()}
-			</span>
-			{#each priceCategories as category (category.id ?? category.name)}
-				<span class="inline-flex items-center gap-1.5">
-					<span
-						class="inline-block h-3 w-3 rounded-full border border-border"
-						style="background: {category.color}"
-						aria-hidden="true"
-					></span>
-					{category.name}
-				</span>
-			{/each}
-		</div>
-	{/if}
+	<DesignerLegend categories={priceCategories} />
 </div>

--- a/src/lib/components/venues/designer/designer-colors.test.ts
+++ b/src/lib/components/venues/designer/designer-colors.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import type { PriceCategorySchema } from '$lib/api/generated/types.gen';
+import { buildCategoryStyleMap, resolveSeatCategory } from './designer-colors';
+
+function category(overrides: Partial<PriceCategorySchema> = {}): PriceCategorySchema {
+	return { id: 'cat-1', name: 'Gold', color: '#d4af37', display_order: 0, ...overrides };
+}
+
+describe('buildCategoryStyleMap', () => {
+	it('maps each category id to its color and name', () => {
+		const map = buildCategoryStyleMap([
+			category({ id: 'gold', name: 'Gold', color: '#d4af37' }),
+			category({ id: 'silver', name: 'Silver', color: '#c0c0c0' })
+		]);
+		expect(map.get('gold')).toEqual({ color: '#d4af37', name: 'Gold' });
+		expect(map.get('silver')).toEqual({ color: '#c0c0c0', name: 'Silver' });
+		expect(map.size).toBe(2);
+	});
+
+	it('skips categories without a stable id', () => {
+		const map = buildCategoryStyleMap([
+			category({ id: null, name: 'No id', color: '#000000' }),
+			category({ id: '', name: 'Empty id', color: '#111111' }),
+			category({ id: 'ok', name: 'Ok', color: '#222222' })
+		]);
+		expect(map.size).toBe(1);
+		expect(map.has('ok')).toBe(true);
+	});
+});
+
+describe('resolveSeatCategory', () => {
+	const styles = buildCategoryStyleMap([category({ id: 'gold', name: 'Gold', color: '#d4af37' })]);
+
+	it('resolves a painted seat to its color + name (for the a11y pairing)', () => {
+		expect(resolveSeatCategory('gold', styles)).toEqual({ color: '#d4af37', name: 'Gold' });
+	});
+
+	it('treats an unpainted seat (null/undefined) as neutral', () => {
+		expect(resolveSeatCategory(null, styles)).toBeNull();
+		expect(resolveSeatCategory(undefined, styles)).toBeNull();
+	});
+
+	it('treats an unknown category id as neutral', () => {
+		expect(resolveSeatCategory('does-not-exist', styles)).toBeNull();
+	});
+});

--- a/src/lib/components/venues/designer/designer-colors.ts
+++ b/src/lib/components/venues/designer/designer-colors.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure price-category → seat-style resolution for the designer canvas.
+ *
+ * The designer only DISPLAYS the paint applied in the grid editor: each seat
+ * carries a `priceCategoryId` and the venue exposes its price categories
+ * (id → color + name). This builds the lookup map and resolves a seat's
+ * category style, mirroring SeatMap.svelte's "color is an accent that always
+ * pairs with the category name" rule — the returned `name` is what the seat's
+ * aria-label/title must include so color is never the only signal.
+ *
+ * Unpainted seats (null/undefined id) and seats pointing at an unknown category
+ * both resolve to `null` → the neutral (theme-token) seat style.
+ */
+import type { PriceCategorySchema } from '$lib/api/generated/types.gen';
+
+/** The two signals a painted seat needs: its accent color and category name. */
+export interface SeatCategoryStyle {
+	/** Org-defined hex color (raw, only ever applied paired with `name`). */
+	color: string;
+	/** Category name — required in the seat's accessible name/title. */
+	name: string;
+}
+
+/**
+ * Build an id → {color, name} lookup from the venue's price categories.
+ * Categories without a stable id are skipped (they can't tag a seat).
+ */
+export function buildCategoryStyleMap(
+	categories: PriceCategorySchema[]
+): Map<string, SeatCategoryStyle> {
+	const map = new Map<string, SeatCategoryStyle>();
+	for (const category of categories) {
+		if (typeof category.id === 'string' && category.id) {
+			map.set(category.id, { color: category.color, name: category.name });
+		}
+	}
+	return map;
+}
+
+/**
+ * Resolve a seat's painted category style, or `null` for the neutral style.
+ * Null/undefined id → unpainted; unknown id → treated as unpainted (neutral).
+ */
+export function resolveSeatCategory(
+	priceCategoryId: string | null | undefined,
+	styles: Map<string, SeatCategoryStyle>
+): SeatCategoryStyle | null {
+	if (!priceCategoryId) return null;
+	return styles.get(priceCategoryId) ?? null;
+}

--- a/src/lib/components/venues/designer/designer-model.test.ts
+++ b/src/lib/components/venues/designer/designer-model.test.ts
@@ -187,6 +187,22 @@ describe('buildDesignerModel', () => {
 		expect(model.sectors[0].width).toBe(EMPTY_SECTOR_WIDTH);
 	});
 
+	it('threads each seat painted price-category id (null when unpainted)', () => {
+		const sectors: VenueSectorWithSeatsSchema[] = [
+			{
+				id: 'sec-1',
+				name: 'Floor',
+				seats: [
+					seat('s1', 'A1', { position: { x: 0, y: 0 }, price_category_id: 'gold' }),
+					seat('s2', 'A2', { position: { x: 1, y: 0 } })
+				]
+			}
+		];
+		const model = buildDesignerModel(sectors);
+		expect(mustSeat(model, 's1').priceCategoryId).toBe('gold');
+		expect(mustSeat(model, 's2').priceCategoryId).toBeNull();
+	});
+
 	it('ignores stored shapes with fewer than 3 vertices', () => {
 		const sectors: VenueSectorWithSeatsSchema[] = [
 			{

--- a/src/lib/components/venues/designer/designer-model.ts
+++ b/src/lib/components/venues/designer/designer-model.ts
@@ -31,6 +31,8 @@ export interface DesignerSeat {
 	y: number;
 	isAccessible: boolean;
 	isObstructedView: boolean;
+	/** Painted price-category id (from the grid editor); null when unpainted. */
+	priceCategoryId: string | null;
 }
 
 export interface DesignerSector {
@@ -212,7 +214,8 @@ export function buildDesignerModel(rawSectors: VenueSectorWithSeatsSchema[]): De
 				x: global.x,
 				y: global.y,
 				isAccessible: seat.is_accessible ?? false,
-				isObstructedView: seat.is_obstructed_view ?? false
+				isObstructedView: seat.is_obstructed_view ?? false,
+				priceCategoryId: seat.price_category_id ?? null
 			});
 		}
 


### PR DESCRIPTION
## Summary

The venue **Layout Designer** now colors canvas seats by their painted price category — the enhancement backend #734 unblocked (the admin seat read now carries `price_category` (+id)). The designer already showed a passive category legend; now the seats themselves are colored, so admins can see the pricing layout while positioning seats. **Targets `feature/venue-seating`** (ships with the coordinated seating deploy).

- New pure `designer-colors.ts` — `buildCategoryStyleMap(categories)` (id→{color,name}) + `resolveSeatCategory(id, styles)` — with tests.
- `price_category_id` threaded through the designer seat model.
- Painted seats render a category tint fill + full-strength colored stroke (matching the public `SeatMap` idiom); unpainted seats keep neutral theme tokens.
- **Display-only** — painting still lives in the grid editor; the designer only shows it.
- Extracted `DesignerLegend.svelte`; `SeatMapDesigner.svelte` net **shrank to 722/750**.

### Accessibility
Color is never the only signal: the category **name is appended to each seat's `aria-label`/`title`** (e.g. "Seat A1, Main Floor, accessible, Gold"), and the legend stays. Selection is a theme-token halo drawn behind the seat (a background "moat" ring + a primary ring), so a selected seat reads unambiguously as both "selected" and its category color. Keyboard select / arrow-nudge / marquee / focus-visible are unchanged.

## Testing
- `make check`: **0 errors**; **1152 unit tests** (6 new in `designer-colors` + model); file caps OK; no new i18n (reused the legend key; category names are org data).
- **Browser check (Opus, live backend)**: painted seats show the exact category color (`#8c3cdd` verified in DOM), unpainted neutral, aria-label carries the name, selection ring clear over the color, arrow-nudge intact, **0 console errors** on the designer flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
