### PR TITLE
ci: label-triggered beta image publishing

### DIFF
--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -1,0 +1,84 @@
+name: Publish Beta
+
+# Label-triggered, single-slot beta publishing. See the backend repo's
+# docs/superpowers/specs/2026-07-20-beta-environment-design.md
+#
+# `pull_request` (NOT pull_request_target): PR-authored code must never run
+# with access to this repo's secrets. Fork PRs get a read-only token and the
+# push fails by design.
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-beta
+  cancel-in-progress: true
+
+jobs:
+  publish-beta:
+    if: contains(github.event.pull_request.labels.*.name, 'beta')
+    runs-on: ubuntu-latest
+    name: Publish Beta Image
+
+    steps:
+      - name: Enforce a single beta claimant
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          THIS_PR: ${{ github.event.pull_request.number }}
+        run: |
+          OTHERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --label beta \
+                     --state open --json number \
+                     --jq "[.[] | select(.number != $THIS_PR)] | length")
+          if [ "$OTHERS" -gt 0 ]; then
+            echo "::error::Another open PR already holds the 'beta' label. One slot, one claimant — remove it there first."
+            exit 1
+          fi
+          echo "✅ This PR is the sole beta claimant"
+
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=$(echo '${{ github.event.pull_request.head.sha }}' | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      # PUBLIC_API_URL / ORIGIN are RUNTIME env (#396) and deliberately absent
+      # here — one image targets any deployment. PUBLIC_VERSION is baked so the
+      # footer identifies exactly which commit a tester is looking at.
+      - name: Build and push image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          build-args: |
+            PUBLIC_VERSION=beta-${{ steps.sha.outputs.short }}
+          tags: |
+            ghcr.io/letsrevel/revel-frontend:beta
+            ghcr.io/letsrevel/revel-frontend:beta-${{ steps.sha.outputs.short }}
+
+      - name: Summary
+        run: |
+          {
+            echo "### 🧪 Beta image published"
+            echo ""
+            echo '`ghcr.io/letsrevel/revel-frontend:beta` → `beta-${{ steps.sha.outputs.short }}`'
+            echo ""
+            echo 'Deploy: `ssh personal "cd infra/revel-beta && ./deploy.sh"`'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -18,8 +18,15 @@ permissions:
   pull-requests: read
 
 concurrency:
+  # cancel-in-progress is deliberately FALSE. Concurrency is workflow-scoped,
+  # so any new trigger — including an unrelated label change while `beta`
+  # stays on — would cancel the whole in-progress run. Cancelling a docker
+  # push is harmless; cancelling the deploy job between `up -d` and `migrate`,
+  # or midway through reset.sh, leaves beta half-migrated or destroyed. A
+  # job-level concurrency block does NOT prevent workflow-level cancellation,
+  # so the guard has to live here. Runs queue instead; the last one wins.
   group: publish-beta
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   publish-beta:
@@ -96,5 +103,40 @@ jobs:
             echo ""
             echo '`ghcr.io/letsrevel/revel-frontend:beta` → `beta-${{ steps.sha.outputs.short }}`'
             echo ""
-            echo 'Deploy: `ssh personal "cd infra/revel-beta && ./deploy.sh"`'
+            echo 'Deploying automatically — see the **Deploy Beta** job.'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Separate job on purpose: a deploy failure must be distinguishable from a
+  # build failure in the checks list.
+  deploy-beta:
+    needs: publish-beta
+    runs-on: ubuntu-latest
+    name: Deploy Beta
+    steps:
+      # Handing a server SSH key to a `pull_request`-triggered workflow is a
+      # real escalation — a same-repo PR can edit this file and the edited
+      # version is what runs. Two things make it tolerable:
+      #
+      #   1. The key is pinned to a FORCED COMMAND in the server's
+      #      authorized_keys: it can only exec ci-deploy.sh, and ci-deploy.sh
+      #      only accepts backend|frontend|both. It cannot get a shell, read
+      #      .env, port-forward, or reach demo/nozze. Verified, not assumed.
+      #   2. It is a dedicated key used nowhere else, so revoking it costs
+      #      nothing.
+      #
+      # If you ever need this job to do more, add it to ci-deploy.sh on the
+      # server — never by loosening the forced command.
+      - name: Deploy over SSH
+        env:
+          SSH_KEY: ${{ secrets.BETA_SSH_KEY }}
+          SSH_HOST: ${{ secrets.BETA_SSH_HOST }}
+          SSH_USER: ${{ secrets.BETA_SSH_USER }}
+          SSH_PORT: ${{ secrets.BETA_SSH_PORT }}
+          KNOWN_HOSTS: ${{ secrets.BETA_SSH_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s' "$SSH_KEY" > ~/.ssh/beta_deploy
+          chmod 600 ~/.ssh/beta_deploy
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/beta_deploy -o IdentitiesOnly=yes -p "$SSH_PORT" \
+              "$SSH_USER@$SSH_HOST" frontend

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -35,9 +35,16 @@ jobs:
         run: |
           # $THIS_PR comes from github.event.pull_request.number, a
           # GitHub-controlled integer — safe to splice into the jq filter.
-          OTHERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --label beta \
-                     --state open --json number \
-                     --jq "[.[] | select(.number != $THIS_PR)] | length")
+          #
+          # Deliberately NOT `gh pr list --label beta`: that flag resolves
+          # through GitHub's issues search index, which is eventually
+          # consistent and was observed to keep returning a PR whose actual
+          # `labels` array was empty (survived even a delete+recreate of the
+          # label). Reading labels off the PR objects themselves is strongly
+          # consistent, so we filter client-side instead.
+          OTHERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+                     --json number,labels \
+                     --jq "[.[] | select(.number != $THIS_PR) | select(any(.labels[]; .name == \"beta\"))] | length")
           if ! [[ "$OTHERS" =~ ^[0-9]+$ ]]; then
             echo "::error::Could not determine the beta claimant count (got '$OTHERS')"
             exit 1

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -10,7 +10,7 @@ name: Publish Beta
 # push fails by design.
 on:
   pull_request:
-    types: [labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -18,14 +18,13 @@ permissions:
   pull-requests: read
 
 concurrency:
-  # cancel-in-progress is deliberately FALSE. Concurrency is workflow-scoped,
-  # so any new trigger — including an unrelated label change while `beta`
-  # stays on — would cancel the whole in-progress run. Cancelling a docker
-  # push is harmless; cancelling the deploy job between `up -d` and `migrate`,
-  # or midway through reset.sh, leaves beta half-migrated or destroyed. A
-  # job-level concurrency block does NOT prevent workflow-level cancellation,
-  # so the guard has to live here. Runs queue instead; the last one wins.
-  group: publish-beta
+  # Scoped to the PR: a static group would be shared by every pull_request event
+  # in the repo, and GitHub keeps only ONE pending run per group — so unrelated
+  # PR activity could silently cancel a QUEUED beta deploy.
+  # cancel-in-progress stays false: this workflow SSHes to the box and runs
+  # migrations, and cancelling mid-deploy can leave beta half-migrated or, if it
+  # lands inside reset.sh, destroyed and offline.
+  group: publish-beta-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
@@ -66,6 +65,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Compute short SHA
         id: sha
@@ -112,6 +112,7 @@ jobs:
     needs: publish-beta
     runs-on: ubuntu-latest
     name: Deploy Beta
+    timeout-minutes: 10
     steps:
       # Handing a server SSH key to a `pull_request`-triggered workflow is a
       # real escalation — a same-repo PR can edit this file and the edited
@@ -140,5 +141,10 @@ jobs:
           printf '%s\n' "$SSH_KEY" > ~/.ssh/beta_deploy
           chmod 600 ~/.ssh/beta_deploy
           printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
-          ssh -i ~/.ssh/beta_deploy -o IdentitiesOnly=yes -p "$SSH_PORT" \
+          # BatchMode=yes forbids interactive prompts (host-key confirmation,
+          # passphrase) so a hung prompt fails fast instead of burning the
+          # job timeout. Host-key verification still runs — BatchMode just
+          # stops it from falling back to a prompt.
+          ssh -i ~/.ssh/beta_deploy -o IdentitiesOnly=yes -o BatchMode=yes \
+              -o ConnectTimeout=15 -p "$SSH_PORT" \
               "$SSH_USER@$SSH_HOST" frontend

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -1,7 +1,9 @@
 name: Publish Beta
 
-# Label-triggered, single-slot beta publishing. See the backend repo's
-# docs/superpowers/specs/2026-07-20-beta-environment-design.md
+# Label-triggered, single-slot beta publishing: labelling a PR "beta" builds
+# its Docker image and pushes it to GHCR as a mutable :beta tag. Only one open
+# PR may hold the label at a time — a guard step enforces this, since two
+# claimants would silently overwrite each other's image.
 #
 # `pull_request` (NOT pull_request_target): PR-authored code must never run
 # with access to this repo's secrets. Fork PRs get a read-only token and the
@@ -13,6 +15,7 @@ on:
 permissions:
   contents: read
   packages: write
+  pull-requests: read
 
 concurrency:
   group: publish-beta
@@ -30,9 +33,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           THIS_PR: ${{ github.event.pull_request.number }}
         run: |
+          # $THIS_PR comes from github.event.pull_request.number, a
+          # GitHub-controlled integer — safe to splice into the jq filter.
           OTHERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --label beta \
                      --state open --json number \
                      --jq "[.[] | select(.number != $THIS_PR)] | length")
+          if ! [[ "$OTHERS" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not determine the beta claimant count (got '$OTHERS')"
+            exit 1
+          fi
           if [ "$OTHERS" -gt 0 ]; then
             echo "::error::Another open PR already holds the 'beta' label. One slot, one claimant — remove it there first."
             exit 1

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -135,7 +135,9 @@ jobs:
           KNOWN_HOSTS: ${{ secrets.BETA_SSH_KNOWN_HOSTS }}
         run: |
           mkdir -p ~/.ssh
-          printf '%s' "$SSH_KEY" > ~/.ssh/beta_deploy
+          # The trailing newline is load-bearing: OpenSSH rejects a private key
+          # whose final line is unterminated with "error in libcrypto".
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/beta_deploy
           chmod 600 ~/.ssh/beta_deploy
           printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/beta_deploy -o IdentitiesOnly=yes -p "$SSH_PORT" \


### PR DESCRIPTION
Implements Task 2 of the beta environment plan (spec lives in revel-backend).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of a beta Docker image when a pull request is labeled `beta`.
  * Beta images are available with both a moving `beta` tag and an immutable commit-based tag.
  * Added build summary details, including the command for deploying the beta image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->