### PR TITLE
test(e2e): membership-subscriptions E2E suite (J23+J27) + #687 polish — PR⑤ of 5

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -6548,7 +6548,8 @@
 			"viewOrg": "Organisation ansehen",
 			"contactOrg": "Wende dich zum Verlängern an die Veranstalter*innen.",
 			"memberSince": "Mitglied seit {date}",
-			"managedBy": "Verwaltet von {org} — wende dich für Änderungen an sie."
+			"managedBy": "Verwaltet von {org} — wende dich für Änderungen an sie.",
+			"loadError": "Deine Mitgliedschaften konnten nicht geladen werden. Lade die Seite neu."
 		}
 	},
 	"orgPublic": {
@@ -7336,12 +7337,13 @@
 	"membershipRequestCard.questionnaire": "Fragebogen",
 	"membershipRequestCard.viewSubmission": "Antwortbogen ansehen",
 	"membershipRequestCard.submissionPendingReview": "Prüfung ausstehend",
+	"membershipRequestCard.tierPrefix": "Stufe:",
 	"membershipRequestCard.viewRequestAria": "Anfragedetails von {name} ansehen",
 	"membershipRequestCard.approveRequestAria": "Anfrage von {name} genehmigen",
 	"membershipRequestCard.rejectRequestAria": "Anfrage von {name} ablehnen",
 	"membershipRequestCard.dialogDescription": "Sieh dir die Anfragedetails an und genehmige oder lehne diesen Mitgliedschaftsantrag ab.",
 	"membershipRequestCard.close": "Schließen",
-	"membershipRequestsTab.approveFailedGeneric": "Der Antrag konnte nicht angenommen werden.",
+	"membershipRequestsTab.approveFailedGeneric": "Der Antrag konnte nicht genehmigt werden.",
 	"membershipRequestsTab.rejectFailedGeneric": "Der Antrag konnte nicht abgelehnt werden.",
 	"membershipRequestsTab.noTiersAvailable": "Anfrage kann nicht genehmigt werden: Keine Mitgliedschaftsstufen verfügbar",
 	"membershipRequestsTab.filterPending": "Ausstehend",
@@ -8613,7 +8615,7 @@
 		"inProgress": "In Bearbeitung",
 		"closed": "Beendet",
 		"empty": "Noch keine Bewerbungen. Wenn du dich bei einer Organisation bewirbst, kannst du sie hier verfolgen.",
-		"loadError": "Deine Anträge konnten nicht geladen werden. Lade die Seite neu.",
+		"loadError": "Deine Bewerbungen konnten nicht geladen werden. Lade die Seite neu.",
 		"appliedOn": "Beworben am {date}",
 		"tierLine": "Stufe: {tier}",
 		"status": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -6548,7 +6548,8 @@
 			"viewOrg": "View org",
 			"contactOrg": "Reach out to the organizer to renew.",
 			"memberSince": "Member since {date}",
-			"managedBy": "Managed by {org} — contact them to make changes."
+			"managedBy": "Managed by {org} — contact them to make changes.",
+			"loadError": "Could not load your memberships. Try reloading the page."
 		}
 	},
 	"orgPublic": {
@@ -7336,6 +7337,7 @@
 	"membershipRequestCard.questionnaire": "Questionnaire",
 	"membershipRequestCard.viewSubmission": "View questionnaire submission",
 	"membershipRequestCard.submissionPendingReview": "Review pending",
+	"membershipRequestCard.tierPrefix": "Tier:",
 	"membershipRequestCard.viewRequestAria": "View request details from {name}",
 	"membershipRequestCard.approveRequestAria": "Approve request from {name}",
 	"membershipRequestCard.rejectRequestAria": "Reject request from {name}",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -6519,7 +6519,8 @@
 			"viewOrg": "Voir l'organisation",
 			"contactOrg": "Contacte l'organisateur pour renouveler.",
 			"memberSince": "Membre depuis le {date}",
-			"managedBy": "Géré par {org} — contacte-les pour toute modification."
+			"managedBy": "Géré par {org} — contacte-les pour toute modification.",
+			"loadError": "Impossible de charger tes adhésions. Essaie de recharger la page."
 		}
 	},
 	"orgPublic": {
@@ -7307,6 +7308,7 @@
 	"membershipRequestCard.questionnaire": "Questionnaire",
 	"membershipRequestCard.viewSubmission": "Voir le questionnaire rempli",
 	"membershipRequestCard.submissionPendingReview": "Examen en attente",
+	"membershipRequestCard.tierPrefix": "Niveau :",
 	"membershipRequestCard.viewRequestAria": "Voir les détails de la demande de {name}",
 	"membershipRequestCard.approveRequestAria": "Approuver la demande de {name}",
 	"membershipRequestCard.rejectRequestAria": "Refuser la demande de {name}",

--- a/messages/it.json
+++ b/messages/it.json
@@ -6548,7 +6548,8 @@
 			"viewOrg": "Vedi l'organizzazione",
 			"contactOrg": "Contatta chi organizza per rinnovare.",
 			"memberSince": "Membro dal {date}",
-			"managedBy": "Gestito da {org} — contattali per apportare modifiche."
+			"managedBy": "Gestito da {org} — contattali per apportare modifiche.",
+			"loadError": "Non è stato possibile caricare i tuoi abbonamenti. Prova a ricaricare la pagina."
 		}
 	},
 	"orgPublic": {
@@ -7336,6 +7337,7 @@
 	"membershipRequestCard.questionnaire": "Questionario",
 	"membershipRequestCard.viewSubmission": "Vedi il questionario compilato",
 	"membershipRequestCard.submissionPendingReview": "Revisione in sospeso",
+	"membershipRequestCard.tierPrefix": "Livello:",
 	"membershipRequestCard.viewRequestAria": "Vedi i dettagli della richiesta di {name}",
 	"membershipRequestCard.approveRequestAria": "Approva la richiesta di {name}",
 	"membershipRequestCard.rejectRequestAria": "Rifiuta la richiesta di {name}",

--- a/src/lib/components/account/applications/ApplicationsSection.svelte
+++ b/src/lib/components/account/applications/ApplicationsSection.svelte
@@ -22,6 +22,10 @@
 		enabled: !!accessToken
 	}));
 
+	// TanStack keeps the last successful payload across a failed refetch, which
+	// is why the error branch below is gated on this being empty: a blipped
+	// background poll must not replace rows the member is reading with an error
+	// line. Only "we have nothing to show *and* the fetch failed" is an error.
 	const applications = $derived(applicationsQuery.data ?? []);
 
 	// PENDING and APPROVED are the two states the member is still waiting on —
@@ -50,10 +54,11 @@
 	<h2 id="applications-heading" class="text-lg font-semibold">{m['applications.title']()}</h2>
 
 	{#if isSectionPending}
-		<div role="status" aria-label={m['common.loading']()}>
+		<div role="status">
 			<Loader2 class="h-5 w-5 animate-spin" aria-hidden="true" />
+			<span class="sr-only">{m['common.loading']()}</span>
 		</div>
-	{:else if applicationsQuery.isError}
+	{:else if applicationsQuery.isError && applications.length === 0}
 		<p class="text-sm text-destructive">{m['applications.loadError']()}</p>
 	{:else if applications.length === 0}
 		<p class="text-sm text-muted-foreground">{m['applications.empty']()}</p>

--- a/src/lib/components/account/applications/ApplicationsSection.test.ts
+++ b/src/lib/components/account/applications/ApplicationsSection.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/svelte';
+import { render, screen, waitFor, within } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient } from '@tanstack/svelte-query';
 import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
@@ -119,6 +119,27 @@ describe('ApplicationsSection', () => {
 
 		expect(await screen.findByText(/could not load your applications/i)).toBeInTheDocument();
 		expect(screen.queryByText(/no applications yet/i)).toBeNull();
+	});
+
+	it('keeps the loaded rows when a background refetch fails', async () => {
+		// A refetch that fails must not throw away rows the member is already
+		// reading: the error state is for "nothing to show", not "the last poll
+		// blipped".
+		listMock.mockResolvedValueOnce({
+			data: { count: 1, next: null, previous: null, results: [makeApplication()] },
+			error: undefined
+		});
+		listMock.mockResolvedValue({ data: undefined, error: { detail: 'boom' } });
+		renderSection();
+
+		await screen.findByRole('list', { name: 'In progress' });
+		await queryClient.refetchQueries({ queryKey: ['me', 'applications'] });
+
+		await waitFor(() => {
+			expect(queryClient.getQueryState(['me', 'applications'])?.status).toBe('error');
+		});
+		expect(screen.getByRole('list', { name: 'In progress' })).toBeInTheDocument();
+		expect(screen.queryByText(/could not load your applications/i)).toBeNull();
 	});
 
 	it('requests a single generous page of applications', async () => {

--- a/src/lib/components/members/MembershipRequestCard.svelte
+++ b/src/lib/components/members/MembershipRequestCard.svelte
@@ -65,6 +65,12 @@
 	// Dialog state
 	let dialogOpen = $state(false);
 
+	// The card and its dialog each render the submission link + review hint, so
+	// the hint ids have to be distinct as well as unique across mounted cards.
+	const uid = $props.id();
+	const cardHintId = `${uid}-review-hint`;
+	const dialogHintId = `${uid}-dialog-review-hint`;
+
 	// Format created at date
 	const createdAt = $derived(formatRelativeTime(request.created_at));
 
@@ -131,7 +137,10 @@
 								<span
 									class="inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
 								>
-									{request.tier.name}
+									<!-- The chip reads as a bare word to a screen reader; the prefix
+									     supplies the "what is this" the visual grouping carries. -->
+									<span class="sr-only">{m['membershipRequestCard.tierPrefix']()}</span>
+									<span>{request.tier.name}</span>
 								</span>
 							{/if}
 						</div>
@@ -188,11 +197,14 @@
 								}
 							)}
 							class="font-medium text-primary underline underline-offset-2"
+							aria-describedby={submission.evaluation_status === 'pending review'
+								? cardHintId
+								: undefined}
 						>
 							{m['membershipRequestCard.viewSubmission']()}
 						</a>
 						{#if submission.evaluation_status === 'pending review'}
-							<span class="ml-2 text-xs text-muted-foreground">
+							<span id={cardHintId} class="ml-2 text-xs text-muted-foreground">
 								{m['membershipRequestCard.submissionPendingReview']()}
 							</span>
 						{/if}
@@ -374,11 +386,14 @@
 								}
 							)}
 							class="font-medium text-primary underline underline-offset-2"
+							aria-describedby={submission.evaluation_status === 'pending review'
+								? dialogHintId
+								: undefined}
 						>
 							{m['membershipRequestCard.viewSubmission']()}
 						</a>
 						{#if submission.evaluation_status === 'pending review'}
-							<span class="ml-2 text-xs text-muted-foreground">
+							<span id={dialogHintId} class="ml-2 text-xs text-muted-foreground">
 								{m['membershipRequestCard.submissionPendingReview']()}
 							</span>
 						{/if}

--- a/src/lib/components/members/MembershipRequestCard.test.ts
+++ b/src/lib/components/members/MembershipRequestCard.test.ts
@@ -45,6 +45,11 @@ describe('MembershipRequestCard tier chip', () => {
 		expect(screen.getByText('Gold')).toBeInTheDocument();
 	});
 
+	it('names the chip for a screen reader instead of reading a bare word', () => {
+		renderCard(makeRequest({ tier: { id: 't1', name: 'Gold' } as never }));
+		expect(screen.getByText('Gold').parentElement).toHaveTextContent('Tier: Gold');
+	});
+
 	it('renders no tier chip when the application has no tier', () => {
 		renderCard(makeRequest({ tier: null }));
 		expect(screen.queryByText('Gold')).not.toBeInTheDocument();
@@ -72,6 +77,25 @@ describe('MembershipRequestCard questionnaire submission', () => {
 		expect(screen.getAllByText('Review pending').length).toBeGreaterThan(0);
 	});
 
+	it('describes the submission link with the review-pending hint', () => {
+		renderCard(
+			makeRequest({
+				questionnaire_submission: {
+					id: 'sub-1',
+					org_questionnaire_id: 'oq-1',
+					evaluation_status: 'pending review'
+				}
+			})
+		);
+
+		// The hint sits beside the link visually; without the association a screen
+		// reader announces the link with no idea the review is still open.
+		const link = screen.getAllByRole('link', { name: 'View questionnaire submission' })[0];
+		const hintId = link.getAttribute('aria-describedby');
+		expect(hintId).toBeTruthy();
+		expect(document.getElementById(hintId as string)).toHaveTextContent('Review pending');
+	});
+
 	it('omits the review-pending hint once the submission is approved', () => {
 		renderCard(
 			makeRequest({
@@ -83,10 +107,11 @@ describe('MembershipRequestCard questionnaire submission', () => {
 			})
 		);
 
-		expect(
-			screen.getAllByRole('link', { name: 'View questionnaire submission' }).length
-		).toBeGreaterThan(0);
+		const links = screen.getAllByRole('link', { name: 'View questionnaire submission' });
+		expect(links.length).toBeGreaterThan(0);
 		expect(screen.queryByText('Review pending')).not.toBeInTheDocument();
+		// No hint to point at, so no dangling description either.
+		expect(links[0]).not.toHaveAttribute('aria-describedby');
 	});
 
 	it('renders no submission link when the application has none', () => {

--- a/src/lib/components/members/MembershipRequestsTab.test.ts
+++ b/src/lib/components/members/MembershipRequestsTab.test.ts
@@ -17,7 +17,8 @@ vi.mock('$lib/api/generated/sdk.gen', () => ({
 }));
 import {
 	organizationadminmembershiprequestsListMembershipRequests,
-	organizationadminmembershiprequestsApproveMembershipRequest
+	organizationadminmembershiprequestsApproveMembershipRequest,
+	organizationadminmembershiprequestsRejectMembershipRequest
 } from '$lib/api/generated/sdk.gen';
 
 vi.mock('svelte-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
@@ -50,9 +51,17 @@ const pendingRequest = {
 	}
 } as unknown as OrganizationMembershipRequestRetrieve;
 
-function listResponse(results: OrganizationMembershipRequestRetrieve[]) {
+/**
+ * One page of the list endpoint. `count` is the *total* across pages, not the
+ * length of `results` — a count above the page size is what makes the tab
+ * render its pager, so the page-reset test can actually reach page 2.
+ */
+function listResponse(
+	results: OrganizationMembershipRequestRetrieve[],
+	{ count = results.length, next = null as string | null } = {}
+) {
 	return {
-		data: { results, count: results.length, next: null, previous: null },
+		data: { results, count, next, previous: null },
 		error: undefined
 	};
 }
@@ -128,10 +137,32 @@ describe('MembershipRequestsTab filters', () => {
 		);
 	});
 
-	it('refetches with status=completed and resets to page 1 when Completed is clicked', async () => {
+	it('refetches with status=completed when Completed is clicked', async () => {
 		const user = userEvent.setup();
 		renderTab();
 		await screen.findByRole('button', { name: /^completed/i });
+
+		await user.click(screen.getByRole('button', { name: /^completed/i }));
+
+		await waitFor(() => {
+			expect(lastListQuery().status).toBe('completed');
+		});
+	});
+
+	it('resets to page 1 when a filter is clicked from a deeper page', async () => {
+		const user = userEvent.setup();
+		// A total above the page size (50) is what makes the pager render at all —
+		// with a single-row count the tab never leaves page 1 and the reset this
+		// test guards is unobservable.
+		vi.mocked(organizationadminmembershiprequestsListMembershipRequests).mockResolvedValue(
+			listResponse([pendingRequest], { count: 60, next: 'http://api/next' }) as never
+		);
+		renderTab();
+
+		await user.click(await screen.findByRole('button', { name: /^next/i }));
+		await waitFor(() => {
+			expect(lastListQuery().page).toBe(2);
+		});
 
 		await user.click(screen.getByRole('button', { name: /^completed/i }));
 
@@ -206,6 +237,49 @@ describe('MembershipRequestsTab approve errors', () => {
 
 		await waitFor(() => {
 			expect(toast.error).toHaveBeenCalledWith('Could not approve the application.');
+		});
+	});
+});
+
+describe('MembershipRequestsTab reject errors', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(organizationadminmembershiprequestsListMembershipRequests).mockResolvedValue(
+			listResponse([pendingRequest]) as never
+		);
+	});
+
+	it('surfaces the backend message in a toast when reject fails', async () => {
+		const user = userEvent.setup();
+		vi.mocked(organizationadminmembershiprequestsRejectMembershipRequest).mockResolvedValue({
+			data: undefined,
+			error: { message: 'Application already closed.' }
+		} as never);
+
+		renderTab();
+
+		const reject = await screen.findByRole('button', { name: /reject request from/i });
+		await user.click(reject);
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith('Application already closed.');
+		});
+	});
+
+	it('falls back to localized copy when the reject error has no backend message', async () => {
+		const user = userEvent.setup();
+		vi.mocked(organizationadminmembershiprequestsRejectMembershipRequest).mockResolvedValue({
+			data: undefined,
+			error: {}
+		} as never);
+
+		renderTab();
+
+		const reject = await screen.findByRole('button', { name: /reject request from/i });
+		await user.click(reject);
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith('Could not reject the application.');
 		});
 	});
 });

--- a/src/lib/components/members/PlanFormModal.svelte
+++ b/src/lib/components/members/PlanFormModal.svelte
@@ -127,7 +127,11 @@
 		if (!isOpen) onClose();
 	}}
 >
-	<DialogContent class="sm:max-w-md">
+	<!-- Scrollable: this form outgrew a phone viewport (payment method, capacity
+	     cap, sales pause), and the dialog is `position: fixed` — without its own
+	     scroll container the submit row sits below the fold with no way to reach
+	     it. -->
+	<DialogContent class="max-h-[90vh] overflow-y-auto sm:max-w-md">
 		<DialogHeader>
 			<DialogTitle>
 				{plan

--- a/src/lib/components/members/TierFormModal.svelte
+++ b/src/lib/components/members/TierFormModal.svelte
@@ -125,7 +125,11 @@
 		if (!isOpen) onClose();
 	}}
 >
-	<DialogContent class="sm:max-w-[425px]">
+	<!-- Scrollable: the form (name, rich-text description, questionnaire and
+	     approval selects) is taller than a phone viewport, and the dialog is
+	     `position: fixed` — without its own scroll container the submit row sits
+	     below the fold with no way to reach it. -->
+	<DialogContent class="max-h-[90vh] overflow-y-auto sm:max-w-[425px]">
 		<DialogHeader>
 			<DialogTitle>
 				{isEditing ? m['tierForm.editTitle']() : m['tierForm.createTitle']()}

--- a/src/routes/(auth)/account/memberships/+page.svelte
+++ b/src/routes/(auth)/account/memberships/+page.svelte
@@ -114,6 +114,21 @@
 		const subscriptionsPending = subscriptionsQuery.isPending;
 		return membershipsPending || subscriptionsPending;
 	});
+
+	// Either list failing makes the section unable to speak for the member:
+	// memberships carry the live cards, subscriptions carry the rejoin offers,
+	// so a missing half cannot honestly be reported as "you have none".
+	const hasSectionError = $derived.by(() => {
+		const membershipsFailed = membershipsQuery.isError;
+		const subscriptionsFailed = subscriptionsQuery.isError;
+		return membershipsFailed || subscriptionsFailed;
+	});
+
+	// TanStack keeps the last successful payload across a failed refetch, so the
+	// error state is gated on there being nothing left to show — a blipped
+	// background poll must not wipe cards the member is reading (same contract
+	// as ApplicationsSection).
+	const hasNoRows = $derived(displayedMemberships.length === 0 && rejoinSubs.length === 0);
 </script>
 
 <svelte:head>
@@ -129,10 +144,13 @@
 		</h2>
 
 		{#if isSectionPending}
-			<div role="status" aria-label={m['common.loading']()}>
+			<div role="status">
 				<Loader2 class="h-5 w-5 animate-spin" aria-hidden="true" />
+				<span class="sr-only">{m['common.loading']()}</span>
 			</div>
-		{:else if displayedMemberships.length === 0 && rejoinSubs.length === 0}
+		{:else if hasSectionError && hasNoRows}
+			<p class="text-sm text-destructive">{m['account.memberships.loadError']()}</p>
+		{:else if hasNoRows}
 			<div class="rounded-lg border p-6 text-center">
 				<!-- h3, not h2: this sits *inside* the memberships section, so an h2
 				     here would read as a third top-level section. -->

--- a/src/routes/(auth)/account/memberships/page.test.ts
+++ b/src/routes/(auth)/account/memberships/page.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/svelte';
+import { render, screen, waitFor, within } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient } from '@tanstack/svelte-query';
 import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
@@ -173,6 +173,48 @@ describe('Account memberships page', () => {
 			expect(screen.getByRole('heading', { level: 2, name: 'Applications' })).toBeVisible();
 			// The memberships half is still loading, so it must not have decided it is empty.
 			expect(screen.queryByText(/don't have any active memberships/i)).toBeNull();
+		});
+	});
+
+	describe('load failures', () => {
+		// The queryFns throw on `res.error`, so an errored response and a rejected
+		// call land in the same place — mirror the SDK's own `{ error }` shape.
+		const failure = { data: undefined, error: { detail: 'boom' } };
+
+		it('says the memberships list failed instead of claiming there are none', async () => {
+			listMembershipsMock.mockResolvedValue(failure);
+			listSubscriptionsMock.mockResolvedValue(page([]));
+			renderPage();
+
+			expect(await screen.findByText(/could not load your memberships/i)).toBeInTheDocument();
+			expect(screen.queryByText(/don't have any active memberships/i)).toBeNull();
+		});
+
+		it('says the list failed when the subscriptions query is the one that broke', async () => {
+			// Rejoin offers live in the subscriptions list, so losing it means the
+			// section cannot honestly claim the member has nothing.
+			listMembershipsMock.mockResolvedValue(page([]));
+			listSubscriptionsMock.mockResolvedValue(failure);
+			renderPage();
+
+			expect(await screen.findByText(/could not load your memberships/i)).toBeInTheDocument();
+			expect(screen.queryByText(/don't have any active memberships/i)).toBeNull();
+		});
+
+		it('keeps the loaded cards when a background refetch fails', async () => {
+			listMembershipsMock.mockResolvedValueOnce(page([makeMembership({ status: 'active' })]));
+			listMembershipsMock.mockResolvedValue(failure);
+			listSubscriptionsMock.mockResolvedValue(page([]));
+			renderPage();
+
+			await screen.findByRole('article', { name: 'Acme' });
+			await queryClient.refetchQueries({ queryKey: ['me', 'memberships'] });
+
+			await waitFor(() => {
+				expect(queryClient.getQueryState(['me', 'memberships'])?.status).toBe('error');
+			});
+			expect(screen.getByRole('article', { name: 'Acme' })).toBeInTheDocument();
+			expect(screen.queryByText(/could not load your memberships/i)).toBeNull();
 		});
 	});
 

--- a/tests/e2e/journeys/j01-guest/organizations.spec.ts
+++ b/tests/e2e/journeys/j01-guest/organizations.spec.ts
@@ -42,7 +42,16 @@ test.describe('J1 guest browses organizations @p0', () => {
 		).toBeVisible();
 		// Public org page exposes follow/membership CTAs and its events.
 		await expect(page.getByRole('button', { name: 'Follow' })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Request Membership' })).toBeVisible();
+		// The guest membership CTA is a real LINK into login carrying a returnUrl
+		// back to this org (MembershipCta's anonymous branch — it replaced the
+		// legacy "Request Membership" button), so it survives no-JS and
+		// middle-click.
+		const joinLink = page.getByRole('link', { name: 'Join Revel Events Collective' });
+		await expect(joinLink).toBeVisible();
+		await expect(joinLink).toHaveAttribute(
+			'href',
+			/\/login\?returnUrl=%2Forg%2Frevel-events-collective$/
+		);
 		await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
 	});
 });

--- a/tests/e2e/journeys/j03-account/follow-org.spec.ts
+++ b/tests/e2e/journeys/j03-account/follow-org.spec.ts
@@ -2,17 +2,23 @@ import { test, expect } from '../../support/fixtures';
 import { createOrganization, createVerifiedUser } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { closeDialog } from '../../support/ui';
 
 // J3.5 (USER_JOURNEYS.md) — follow an organization (with notification
-// preferences), request membership with a message, and see the request land
-// in the org admin's queue; unfollow at the end.
+// preferences), apply for membership with a message, and see the application
+// land in the org admin's queue; unfollow at the end.
+//
+// The join flow is the eligibility CTA + ApplyDialog (PR② of the membership
+// subscriptions work); the legacy "Request Membership" button is gone. A UI
+// apply carries no tier, so the backend leaves the application PENDING for
+// staff — hence the "Application received" outcome and the approve leg below.
 //
 // Isolation: throwaway-owned org (accepting requests) + throwaway follower —
 // seeded follow relationships (hannah→Alpha, ivan→Beta) stay untouched, and
 // parallel projects each build their own org/user pair.
 
 test.describe('J3 follow org & request membership @p1', () => {
-	test('follow with notify prefs, request membership → admin queue, unfollow', async ({
+	test('follow with notify prefs, apply for membership → admin approves, unfollow', async ({
 		browser
 	}) => {
 		test.setTimeout(180_000);
@@ -40,18 +46,32 @@ test.describe('J3 follow org & request membership @p1', () => {
 		await page.getByRole('menuitemcheckbox', { name: 'Notify me about new events' }).click();
 		await expect(page.getByText('Preferences updated')).toBeVisible({ timeout: 15_000 });
 
-		// Request membership with a message.
-		await page.getByRole('button', { name: 'Request Membership' }).click();
-		const dialog = page.getByRole('dialog', { name: 'Request Membership' });
-		await expect(dialog).toBeVisible();
-		await dialog.getByLabel('Message (Optional)').fill('E2E: please let me in');
-		await dialog.getByRole('button', { name: 'Submit Request' }).click();
-		await expect(page.getByText('Request Submitted!')).toBeVisible({ timeout: 15_000 });
+		// Apply for membership with a message.
+		await page.getByRole('button', { name: `Join ${org.name}` }).click();
+		const applyDialog = page.getByRole('dialog', { name: `Join ${org.name}` });
+		await expect(applyDialog).toBeVisible();
+		await applyDialog.getByLabel('Message (optional)').fill('E2E: please let me in');
+		await applyDialog.getByRole('button', { name: 'Send application' }).click();
 
-		// Both are server-side: a fresh load still shows Following…
+		// The outcome replaces the form in place, so the dialog is RE-TITLED —
+		// a tier-less apply stays PENDING, hence "Application received" (an
+		// auto-granted membership would title it "You're in!").
+		const outcomeDialog = page.getByRole('dialog', { name: 'Application received' });
+		await expect(outcomeDialog).toBeVisible({ timeout: 15_000 });
+		await expect(outcomeDialog.getByRole('link', { name: 'Track your application' })).toBeVisible();
+		await closeDialog(page, outcomeDialog);
+
+		// The CTA follows the refreshed eligibility verdict.
+		await expect(page.getByRole('button', { name: 'Application pending' })).toBeDisabled();
+
+		// Both are server-side: a fresh load still shows Following + the pending
+		// application…
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
 		await expect(page.getByRole('button', { name: 'Following' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Application pending' })).toBeVisible({
+			timeout: 15_000
+		});
 
 		// …and the org admin's request queue lists the applicant + message.
 		const ownerContext = await browser.newContext();
@@ -71,7 +91,25 @@ test.describe('J3 follow org & request membership @p1', () => {
 		await expect(
 			ownerPage.getByText('E2E: please let me in').filter({ visible: true }).first()
 		).toBeVisible();
+		await closeDialog(
+			ownerPage,
+			ownerPage.getByRole('dialog', { name: `Membership Request from ${followerName}` })
+		);
+
+		// Approve it. The throwaway org has exactly one tier, so the tier picker
+		// is skipped and the application completes straight away.
+		await ownerPage.getByRole('button', { name: `Approve request from ${followerName}` }).click();
+		await expect(
+			ownerPage.getByRole('button', { name: `Approve request from ${followerName}` })
+		).toBeHidden({ timeout: 15_000 });
 		await ownerContext.close();
+
+		// The member-side CTA is now the membership badge, tier and all.
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByLabel('Membership tier: General membership')).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Application pending' })).toBeHidden();
 
 		// Unfollow via the dropdown; the plain Follow button returns.
 		await page.getByRole('button', { name: 'Following' }).click();

--- a/tests/e2e/journeys/j23-subscriptions/manage-subscription.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/manage-subscription.spec.ts
@@ -1,0 +1,370 @@
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+	createMembershipTier,
+	createSubscriptionPlan,
+	createVerifiedUser,
+	getOrganizationId,
+	subscribeViaApi,
+	uniqueName,
+	type ThrowawayUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { completeStripeCheckout } from '../../support/stripe';
+
+// J23.5 (USER_JOURNEYS.md) — member SELF-SERVICE on a live Stripe subscription:
+// change plan (both directions), cancel (both modes) and the billing portal
+// hand-off. Everything here is driven from /account/memberships, the only
+// surface that offers these controls (MembershipCard + its two dialogs).
+//
+// Sibling coverage: subscribe-online.spec.ts owns the org-page → hosted
+// checkout → webhook journey; this spec compresses that arrange to
+// subscribeViaApi + page.goto(checkout_url) and only re-asserts what it needs
+// (an ACTIVE card) before exercising management.
+//
+// Requires the full Stripe test-mode setup from tests/e2e/README.md (backend
+// bootstrapped with CONNECTED_TEST_STRIPE_ID + the `stripe listen` forwarder).
+//
+// Isolation / retry-safety: Org Alpha is the only Stripe-connected org, so the
+// plans live there — but every test arranges its OWN uniqueName()-d tier +
+// plans and its OWN throwaway subscriber inside the test body. A retry
+// therefore never inherits the subscription of the attempt before it (the
+// backend refuses a second non-terminal subscription per user per org), and
+// the change-plan catalogue — which is org-wide — is still navigated by unique
+// plan name, so concurrent workers' plans cannot be picked by accident.
+
+const ORG_SLUG = 'revel-events-collective';
+const ORG_NAME = 'Revel Events Collective';
+const ORG_PATH = `/org/${ORG_SLUG}`;
+
+/**
+ * Dates render through `date.ts`, which always uses a TEXTUAL month (the
+ * house rule that keeps DD/MM vs MM/DD ambiguity out of the UI) — `formatDate`
+ * picks the SHORT form, e.g. "Aug 27, 2026". Asserting the presence of a month
+ * name proves a real formatted date without recomputing the backend's period
+ * boundary (or its timezone) here.
+ */
+const MONTH = 'Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec';
+
+function escapeRe(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** The org's card in the account hub's Memberships section. */
+function membershipCard(page: Page): Locator {
+	return page.getByRole('region', { name: 'Memberships' }).getByRole('article', { name: ORG_NAME });
+}
+
+/**
+ * Re-open the account hub until the card settles into the asserted shape.
+ *
+ * Every management action here ends in a Stripe round trip whose confirmation
+ * webhooks land AFTER the HTTP response the dialog already succeeded on, and
+ * they do not land in order. PROBED on the live stack (cancel-at-period-end
+ * after a downgrade): the POST returned `cancel_at_period_end: true` at
+ * T+0.507s, the `subscription_schedule.released` webhook (raised by the cancel
+ * releasing the queued downgrade) was applied at T+0.543s and mirrored Stripe's
+ * pre-modify snapshot back onto the row — `cancel_at_period_end: false` — and
+ * the `customer.subscription.updated` webhook for the modify itself only
+ * corrected it at T+0.850s. The dialog's one-shot `invalidateQueries` refetch
+ * fired inside that ~300ms window and latched the wrong value: with nothing
+ * polling afterwards, the card keeps showing "Next renewal" until the member
+ * reloads. Reloading here asserts the state the member actually converges on
+ * instead of that transient. (Reported as a finding of this task — the fix,
+ * seeding the cache from the mutation's own response or briefly re-polling,
+ * belongs in src, not in the spec.)
+ */
+async function reloadUntil(
+	page: Page,
+	assertions: (card: Locator) => Promise<void>,
+	timeout = 90_000
+): Promise<void> {
+	await expect(async () => {
+		await gotoHydrated(page, '/account/memberships');
+		await waitForClientAuth(page);
+		await assertions(membershipCard(page));
+	}).toPass({ timeout });
+}
+
+/**
+ * Two ONLINE plans on one fresh tier of Org Alpha (€15 "Standard" and €10
+ * "Lite", same currency so both are change-plan candidates for the other),
+ * plus the throwaway subscriber and the org id the member endpoints are keyed
+ * by.
+ */
+async function arrangeTwoPlans(label: string): Promise<{
+	user: ThrowawayUser;
+	orgId: string;
+	standard: { id: string; name: string };
+	lite: { id: string; name: string };
+}> {
+	const [tier, user, orgId] = await Promise.all([
+		createMembershipTier('owner', ORG_SLUG, uniqueName(`${label} Tier`)),
+		createVerifiedUser(label),
+		getOrganizationId(ORG_SLUG)
+	]);
+	const [standard, lite] = await Promise.all([
+		createSubscriptionPlan('owner', ORG_SLUG, tier.id, {
+			name: uniqueName(`${label} Standard`),
+			payment_method: 'online',
+			price: '15.00',
+			currency: 'EUR'
+		}),
+		createSubscriptionPlan('owner', ORG_SLUG, tier.id, {
+			name: uniqueName(`${label} Lite`),
+			payment_method: 'online',
+			price: '10.00',
+			currency: 'EUR'
+		})
+	]);
+	return { user, orgId, standard, lite };
+}
+
+/**
+ * Get to ACTIVE the cheap way: mint the subscription + hosted session over the
+ * API, pay it on Stripe, then poll the account hub until the `stripe listen`
+ * webhook has flipped the row ACTIVE. The org-page UI around this is
+ * subscribe-online.spec.ts's job, not ours.
+ */
+async function subscribeAndPay(
+	page: Page,
+	user: ThrowawayUser,
+	orgId: string,
+	plan: { id: string; name: string }
+): Promise<void> {
+	const { checkoutUrl } = await subscribeViaApi(user, orgId, plan.id);
+	expect(checkoutUrl, 'an ONLINE subscribe must mint a hosted checkout URL').toBeTruthy();
+	await page.goto(checkoutUrl as string);
+	await completeStripeCheckout(page);
+
+	// Activation arrives via the webhook, never the redirect. Each pass is a
+	// fresh navigation so the account queries refetch rather than serve cache.
+	await reloadUntil(
+		page,
+		async (card) => {
+			await expect(card).toBeVisible({ timeout: 15_000 });
+			await expect(card.getByLabel('Active')).toBeVisible({ timeout: 10_000 });
+			await expect(card.getByText(plan.name)).toBeVisible({ timeout: 5_000 });
+		},
+		150_000
+	);
+}
+
+/** Open ChangePlanDialog from the card and switch to `target`. */
+async function switchPlan(
+	page: Page,
+	current: { name: string },
+	target: { name: string },
+	explainer: RegExp
+): Promise<void> {
+	await membershipCard(page).getByRole('button', { name: 'Change plan' }).click();
+	const dialog = page.getByRole('dialog', { name: 'Change plan' });
+	await expect(dialog).toBeVisible({ timeout: 15_000 });
+	await expect(dialog.getByText(`Your ${ORG_NAME} membership`)).toBeVisible();
+	await expect(dialog.getByText(`Current plan: ${current.name}`)).toBeVisible();
+
+	// The catalogue is org-wide (other workers' plans are in this list too), so
+	// the option is addressed by its unique name. The radio's accessible name
+	// comes from its wrapping <label>: "<plan name> <price>".
+	await dialog.getByRole('radio', { name: target.name }).check();
+	// Direction explainer lives in a shared pre-mounted live region — it only
+	// appears once a radio is picked, and it is the member's only warning about
+	// WHEN the switch happens.
+	await expect(dialog.getByText(explainer)).toBeVisible();
+
+	await dialog.getByRole('button', { name: 'Switch plan' }).click();
+	await expect(dialog).toBeHidden({ timeout: 30_000 });
+}
+
+test.describe('J23 manage subscription @p2', () => {
+	test('downgrade queues at renewal, then cancel-at-period-end dates the card', async ({
+		browser
+	}) => {
+		// One hosted checkout plus two Stripe round trips on top.
+		test.setTimeout(300_000);
+
+		const { user, orgId, standard, lite } = await arrangeTwoPlans('SubDowngrade');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await subscribeAndPay(page, user, orgId, standard);
+		const card = membershipCard(page);
+		await expect(card.getByText('€15.00 / month')).toBeVisible();
+		await expect(card.getByText(new RegExp(`^Next renewal: .*(${MONTH})`))).toBeVisible();
+
+		// --- Downgrade: scheduled, not immediate -------------------------------
+		await switchPlan(page, standard, lite, /Takes effect at your next renewal/);
+
+		// The queued switch is the whole point of a downgrade: the card must say
+		// so, naming the target plan and the date it lands on.
+		await reloadUntil(page, async (settled) => {
+			await expect(
+				settled.getByText(new RegExp(`^Switching to ${escapeRe(lite.name)} on .*(${MONTH})`))
+			).toBeVisible({ timeout: 10_000 });
+		});
+		// …while the paid plan keeps billing until then.
+		await expect(card.getByText(standard.name)).toBeVisible();
+		await expect(card.getByLabel('Active')).toBeVisible();
+		// A second change would only 400 while one is pending (getMemberActions).
+		await expect(card.getByRole('button', { name: 'Change plan' })).toBeHidden();
+
+		// --- Cancel at period end ----------------------------------------------
+		await card.getByRole('button', { name: 'Cancel membership' }).click();
+		const cancelDialog = page.getByRole('dialog', { name: 'Cancel membership' });
+		await expect(cancelDialog).toBeVisible({ timeout: 15_000 });
+		await expect(cancelDialog.getByText(`${standard.name} · ${ORG_NAME}`)).toBeVisible();
+
+		// Period-end is the default: no acknowledgement, no destructive surprise.
+		await expect(
+			cancelDialog.getByRole('radio', { name: 'At the end of the current period' })
+		).toBeChecked();
+		await expect(
+			cancelDialog.getByText(new RegExp(`You keep access until .*(${MONTH})`))
+		).toBeVisible();
+		const confirm = cancelDialog.getByRole('button', { name: 'Cancel membership' });
+		await expect(confirm).toBeEnabled();
+		await confirm.click();
+		await expect(cancelDialog).toBeHidden({ timeout: 30_000 });
+
+		// Still a member until the period closes — the date line flips from
+		// "Next renewal" to "Cancels on", and every action but billing is gone.
+		await reloadUntil(page, async (settled) => {
+			await expect(settled.getByText(new RegExp(`^Cancels on .*(${MONTH})`))).toBeVisible({
+				timeout: 10_000
+			});
+		});
+		await expect(
+			card.getByText('Renewal is off. To keep your membership, contact the organization.')
+		).toBeVisible();
+		await expect(card.getByLabel('Active')).toBeVisible();
+		await expect(card.getByRole('button', { name: 'Cancel membership' })).toBeHidden();
+		await expect(card.getByRole('button', { name: 'Change plan' })).toBeHidden();
+		await expect(card.getByRole('button', { name: 'Manage billing' })).toBeVisible();
+
+		await context.close();
+	});
+
+	test('upgrade applies immediately, then an immediate cancel strips the subscription', async ({
+		browser
+	}) => {
+		test.setTimeout(300_000);
+
+		const { user, orgId, standard, lite } = await arrangeTwoPlans('SubUpgrade');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await subscribeAndPay(page, user, orgId, lite);
+		const card = membershipCard(page);
+		await expect(card.getByText('€10.00 / month')).toBeVisible();
+
+		// --- Upgrade: prorated and immediate -----------------------------------
+		await switchPlan(
+			page,
+			lite,
+			standard,
+			/You'll be charged the difference now \(prorated\) and switch immediately\./
+		);
+
+		// Immediate means the card names the new plan without waiting for a
+		// renewal — and never grows a pending-switch line.
+		await reloadUntil(page, async (settled) => {
+			await expect(settled.getByText(standard.name)).toBeVisible({ timeout: 10_000 });
+			await expect(settled.getByText('€15.00 / month')).toBeVisible({ timeout: 5_000 });
+		});
+		await expect(card.getByText(/^Switching to /)).toBeHidden();
+		await expect(card.getByLabel('Active')).toBeVisible();
+
+		// --- Immediate cancel ---------------------------------------------------
+		await card.getByRole('button', { name: 'Cancel membership' }).click();
+		const cancelDialog = page.getByRole('dialog', { name: 'Cancel membership' });
+		await expect(cancelDialog).toBeVisible({ timeout: 15_000 });
+		await cancelDialog.getByRole('radio', { name: 'Immediately' }).check();
+		await expect(cancelDialog.getByText('Your membership ends right away.')).toBeVisible();
+
+		// The acknowledgement gates the destructive button — it is the only
+		// thing standing between a click and irreversible loss of access.
+		const confirm = cancelDialog.getByRole('button', { name: 'Cancel membership' });
+		await expect(confirm).toBeDisabled();
+		await cancelDialog
+			.getByRole('checkbox', { name: 'I understand my membership ends immediately.' })
+			.click();
+		await expect(confirm).toBeEnabled();
+		await confirm.click();
+		await expect(cancelDialog).toBeHidden({ timeout: 30_000 });
+
+		// PROBED: the OrganizationMember row survives an immediate cancel (the
+		// backend's subscription signal maps CANCELLED → member CANCELLED rather
+		// than deleting the row), and `list_my_memberships` inlines only
+		// NON-terminal subscriptions. So the card stays but is stripped bare: no
+		// plan, no price, no date line, no management actions — the discriminator
+		// against the at-period-end mode, which keeps all of them plus a date.
+		await reloadUntil(page, async (settled) => {
+			await expect(settled).toBeVisible({ timeout: 10_000 });
+			await expect(settled.getByText(standard.name)).toBeHidden({ timeout: 5_000 });
+		});
+		await expect(card.getByText('cancelled', { exact: true })).toBeVisible();
+		await expect(card.getByText(new RegExp(`Member since .*(${MONTH})`))).toBeVisible();
+		await expect(card.getByRole('button', { name: 'Manage billing' })).toBeHidden();
+		await expect(card.getByRole('button', { name: 'Change plan' })).toBeHidden();
+		await expect(card.getByRole('button', { name: 'Cancel membership' })).toBeHidden();
+
+		// The org page tells the same story: the member row is still there, so
+		// the CTA slot renders the cancelled member badge (NOT a fresh Join
+		// button — the server load reports `isMember` from the permissions
+		// memberships dict, which keeps cancelled rows).
+		await gotoHydrated(page, ORG_PATH);
+		await waitForClientAuth(page);
+		await expect(page.getByLabel('Membership status: Cancelled')).toBeVisible({ timeout: 20_000 });
+
+		await context.close();
+	});
+
+	test('Manage billing mints a Stripe portal session and hands the browser over', async ({
+		browser
+	}) => {
+		test.setTimeout(300_000);
+
+		const { user, orgId, standard } = await arrangeTwoPlans('SubPortal');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+
+		await subscribeAndPay(page, user, orgId, standard);
+
+		// Network-layer: the portal lives on another origin, so the contract the
+		// app owns is "POST returns 201 with a Stripe URL, then the browser
+		// leaves". Asserted on the response, not on Stripe's page.
+		//
+		// The body is captured through a route handler rather than
+		// `waitForResponse(...).json()`: onSuccess assigns `window.location.href`
+		// the instant the promise resolves, and the document navigation tears down
+		// the network resource before Playwright can read its body ("No resource
+		// with given identifier found" — observed every run).
+		let portal: { status: number; body: string } | null = null;
+		await page.route(/\/billing-portal(\?|$)/, async (route) => {
+			const fetched = await route.fetch();
+			portal = { status: fetched.status(), body: await fetched.text() };
+			await route.fulfill({ response: fetched });
+		});
+
+		await membershipCard(page).getByRole('button', { name: 'Manage billing' }).click();
+
+		// onSuccess assigns window.location.href — a real document navigation.
+		await page.waitForURL(/billing\.stripe\.com/, { timeout: 30_000 });
+
+		expect(portal, 'the Manage billing click must POST /billing-portal').not.toBeNull();
+		const captured = portal as unknown as { status: number; body: string };
+		expect(captured.status).toBe(201);
+		expect((JSON.parse(captured.body) as { url?: string }).url).toMatch(
+			/^https:\/\/billing\.stripe\.com\//
+		);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j23-subscriptions/metrics.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/metrics.spec.ts
@@ -1,0 +1,100 @@
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+	approveMembershipRequest,
+	createOrganization,
+	createSubscriptionPlan,
+	createVerifiedUser,
+	getUserId,
+	requestMembership,
+	staffCreateOfflineSubscription,
+	uniqueName
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J23 (USER_JOURNEYS.md) — the subscription metrics header on the org admin
+// Subs tab (MRR / active subscribers / new in 30 days / churn).
+//
+// Metrics are an aggregate, so they are only assertable against an org whose
+// entire subscription population this test created. Hence a throwaway org with
+// exactly ONE subscription, on an OFFLINE plan (no Stripe in the loop), priced
+// €15.00/month with the initial payment recorded — the recorded payment is what
+// flips the subscription PENDING → ACTIVE, and only ACTIVE subscriptions count
+// toward MRR. That makes every figure on the header exact rather than
+// "greater than zero": MRR €15.00, active 1, new 1.
+//
+// The subscribe target must already be an org member (the same constraint
+// subscription-lifecycle.spec.ts documents), hence the requestMembership +
+// approve arrange.
+
+/**
+ * The value line of a metric card. Layout is
+ * `<CardContent><p>{label}</p><p>{value}</p></CardContent>`, and the deepest
+ * div carrying the label IS that CardContent (ancestors precede descendants in
+ * locator order), so the card's own two <p>s are the only ones in scope.
+ */
+function metricValue(page: Page, label: string): Locator {
+	return page
+		.locator('div')
+		.filter({ has: page.getByText(label, { exact: true }) })
+		.last()
+		.locator('p')
+		.nth(1);
+}
+
+test.describe('J23 subscription metrics @p2', () => {
+	test('a single paid offline subscription yields exact MRR, active and new counts', async ({
+		browser
+	}) => {
+		test.setTimeout(150_000);
+		const [org, member] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Metrics')
+		]);
+		const request = await requestMembership(member, org.slug);
+		await approveMembershipRequest(org.owner, org.slug, request.id, org.defaultTierId);
+		const plan = await createSubscriptionPlan(org.owner, org.slug, org.defaultTierId, {
+			name: uniqueName('Plan'),
+			price: '15.00',
+			currency: 'EUR',
+			period_unit: 'month',
+			payment_method: 'offline'
+		});
+		await staffCreateOfflineSubscription(org.owner, org.slug, {
+			planId: plan.id,
+			userId: await getUserId(member),
+			amount: '15.00'
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+		await gotoHydrated(page, `/org/${org.slug}/admin/members`);
+		await waitForClientAuth(page);
+		await page.getByRole('tab', { name: /Subs/ }).click();
+
+		// Exact strings, not substrings: '€15.00' would also match a '€15.00 / month'
+		// plan line, and '1' would match any digit on the page.
+		await expect(metricValue(page, 'Monthly recurring revenue')).toHaveText('€15.00', {
+			timeout: 15_000
+		});
+		await expect(metricValue(page, 'Active subscribers')).toHaveText('1');
+		await expect(metricValue(page, 'New (30 days)')).toHaveText('1');
+
+		// The one row behind those figures. StatusBadge exposes the status as its
+		// accessible name, so this is the ACTIVE state the MRR was computed from.
+		//
+		// Scoped twice over. To the open tab panel, because the Members tab stays
+		// mounted behind it and its membership rows carry an "Active" badge of
+		// their own; and to VISIBLE nodes, because each subscription renders both a
+		// desktop table row and a mobile card (one of which is always display:none)
+		// — so an unfiltered count is 2 per subscription and layout-dependent.
+		const subsPanel = page.getByRole('tabpanel');
+		const activeBadges = subsPanel.getByLabel('Active').filter({ visible: true });
+		await expect(activeBadges).toHaveCount(1);
+		await expect(subsPanel.getByText(member.email).filter({ visible: true })).toHaveCount(1);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j23-subscriptions/org-policy.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/org-policy.spec.ts
@@ -10,10 +10,11 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 // revenue_report_cadence).
 //
 // Built out once FE #631 / BE #695 landed the editing UI + writable schema.
-// Because OrganizationEditSchema gives BOTH fields defaults (7 / ""), any PUT
-// that omits them silently resets them — the telegram_url data-loss class from
-// #491. The second test is that regression guard: editing an UNRELATED field
-// must not wipe the policy.
+// The regression class guarded here is FE-side (the telegram_url class from
+// #491, which the settings form's `formData.has()` guards defend): a control
+// that repopulates wrong, or posts its schema default instead of the saved
+// value, clobbers the field on an unrelated save. The second test is that
+// guard: editing an UNRELATED field must not wipe the policy.
 //
 // Throwaway org per test so state never collides across parallel projects/re-runs.
 
@@ -175,8 +176,8 @@ test.describe('J23 org subscription policy fields @p2', () => {
 
 		// No-clobber: a save that only touched the address must leave the policy
 		// exactly as it was. The failure this guards is FE-side (the #491 class) —
-		// a control whose value is dropped or reset on its way back into the
-		// payload would land the schema defaults (30 / none / off) here instead.
+		// a control that repopulates wrong and posts the schema default
+		// (30 / none / off) instead of what was saved would land it here.
 		const newAddress = `E2E Address ${org.slug}`;
 		await page.locator('#address').fill(newAddress);
 		await page.getByRole('button', { name: 'Save Changes' }).click();

--- a/tests/e2e/journeys/j23-subscriptions/org-policy.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/org-policy.spec.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 import { test, expect } from '../../support/fixtures';
-import { createOrganization } from '../../support/factories';
+import { createMembershipQuestionnaire, createOrganization } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 
@@ -115,6 +115,81 @@ test.describe('J23 org subscription policy fields @p2', () => {
 		await expect(page.locator('#address')).toHaveValue(newAddress);
 		await expect(page.locator('#membership_grace_period_days')).toHaveValue('30');
 		await expect(policySection(page).locator('[contenteditable="true"]')).toContainText(refundText);
+
+		await context.close();
+	});
+
+	// The membership-eligibility defaults (BE #777) that landed alongside the
+	// revival window: the tier form's "inherit" options resolve against these, so
+	// they have to survive an ordinary Settings save unchanged. Every one of them
+	// posts on EVERY save (the whole form is one POST), so this pins the
+	// round-trip — form → PUT → retrieve → repopulated control — for the three
+	// controls at once, then re-checks them after a save that touched only an
+	// unrelated field.
+	test('revival window, default questionnaire and approval default round-trip; an unrelated save keeps them', async ({
+		browser
+	}) => {
+		test.setTimeout(150_000);
+		// Arranged BEFORE the first page load: the picker's options come from the
+		// settings load function, so a questionnaire created later would not be
+		// selectable without another reload.
+		const org = await createOrganization();
+		const questionnaire = await createMembershipQuestionnaire(org.owner, org.slug, {
+			evaluationMode: 'automatic'
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Organization Settings' })).toBeVisible();
+
+		const revivalInput = page.getByLabel('Revival window (days)');
+		const questionnairePicker = page.getByLabel('Default membership questionnaire');
+		const approvalToggle = page.getByRole('checkbox', {
+			name: 'Require manual approval for new members'
+		});
+
+		// Fresh-org defaults: 30-day revival, no questionnaire, no approval gate.
+		await expect(revivalInput).toHaveValue('30');
+		await expect(questionnairePicker).toHaveValue('');
+		await expect(approvalToggle).not.toBeChecked();
+
+		await revivalInput.fill('14');
+		await questionnairePicker.selectOption(questionnaire.id);
+		await approvalToggle.check();
+
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(page.getByText(SAVED)).toBeVisible({ timeout: 15_000 });
+
+		// Server-side persistence: a fresh load renders all three saved values.
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await waitForClientAuth(page);
+		await expect(page.getByLabel('Revival window (days)')).toHaveValue('14');
+		await expect(page.getByLabel('Default membership questionnaire')).toHaveValue(questionnaire.id);
+		await expect(
+			page.getByRole('checkbox', { name: 'Require manual approval for new members' })
+		).toBeChecked();
+
+		// No-clobber: a save that only touched the address must leave the policy
+		// exactly as it was. The failure this guards is FE-side (the #491 class) —
+		// a control whose value is dropped or reset on its way back into the
+		// payload would land the schema defaults (30 / none / off) here instead.
+		const newAddress = `E2E Address ${org.slug}`;
+		await page.locator('#address').fill(newAddress);
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(page.getByText(SAVED)).toBeVisible({ timeout: 15_000 });
+
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await waitForClientAuth(page);
+		await expect(page.locator('#address')).toHaveValue(newAddress);
+		await expect(page.getByLabel('Revival window (days)')).toHaveValue('14');
+		await expect(page.getByLabel('Default membership questionnaire')).toHaveValue(questionnaire.id);
+		await expect(
+			page.getByRole('checkbox', { name: 'Require manual approval for new members' })
+		).toBeChecked();
 
 		await context.close();
 	});

--- a/tests/e2e/journeys/j23-subscriptions/plan-states.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/plan-states.spec.ts
@@ -1,0 +1,145 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+	createMembershipTier,
+	createSubscriptionPlan,
+	createVerifiedUser,
+	getOrganizationId,
+	subscribeViaApi,
+	updateSubscriptionPlan,
+	uniqueName
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J23 (USER_JOURNEYS.md) — member-facing plan AVAILABILITY states on the public
+// org page: sold out (cap occupied), sales paused, offline (staff-managed) and
+// the guest CTA. No payment happens anywhere in this file.
+//
+// Everything is arranged on Org Alpha (`revel-events-collective`): it is the
+// only Stripe-connected seeded org, and ONLINE plans cannot exist anywhere
+// else. Isolation comes from uniqueName()-d tiers/plans (never from the org),
+// so a re-run — or a retry — never inherits a predecessor's occupancy.
+
+const ORG_SLUG = 'revel-events-collective';
+
+/**
+ * A plan's card on the public org page. Cards carry no role, so this matches
+ * the shadcn Card surface class and narrows by the (unique) plan name — the
+ * cards are siblings, never nested, so exactly one element resolves.
+ */
+function planCard(page: Page, planName: string) {
+	return page.locator('.bg-card').filter({ hasText: planName });
+}
+
+test.describe('J23 plan availability states @p2', () => {
+	test('sold out / paused / offline plans state their reason and offer no CTA', async ({
+		browser
+	}) => {
+		const tierName = uniqueName('States Tier');
+		const [tier, orgId, occupier, viewer] = await Promise.all([
+			createMembershipTier('owner', ORG_SLUG, tierName),
+			getOrganizationId(ORG_SLUG),
+			createVerifiedUser('CapFiller'),
+			createVerifiedUser('PlanViewer')
+		]);
+
+		// Four plans in one tier: the three unavailable shapes plus an open
+		// one, so an absent CTA is provably about THIS plan's state and not a
+		// broken page.
+		const [openPlan, soldOutPlan, pausedPlan, offlinePlan] = await Promise.all([
+			createSubscriptionPlan('owner', ORG_SLUG, tier.id, {
+				name: uniqueName('Open Plan'),
+				payment_method: 'online'
+			}),
+			createSubscriptionPlan('owner', ORG_SLUG, tier.id, {
+				name: uniqueName('Capped Plan'),
+				payment_method: 'online',
+				max_subscriptions: 1
+			}),
+			createSubscriptionPlan('owner', ORG_SLUG, tier.id, {
+				name: uniqueName('Paused Plan'),
+				payment_method: 'online'
+			}),
+			createSubscriptionPlan('owner', ORG_SLUG, tier.id, {
+				name: uniqueName('Offline Plan'),
+				payment_method: 'offline'
+			})
+		]);
+
+		// Occupy the single slot. A PENDING subscription (no payment made)
+		// counts: the backend's capacity check excludes only TERMINAL
+		// statuses, so an abandoned checkout still holds its card stock.
+		const { subscriptionId } = await subscribeViaApi(occupier, orgId, soldOutPlan.id);
+		expect(subscriptionId).toBeTruthy();
+
+		// Pausing through the PATCH endpoint rather than at creation: this is
+		// the transition an organizer actually performs.
+		await updateSubscriptionPlan('owner', ORG_SLUG, pausedPlan.id, { sales_status: 'paused' });
+
+		const context = await browser.newContext();
+		await authenticateContext(context, viewer);
+		const page = await context.newPage();
+		await gotoHydrated(page, `/org/${ORG_SLUG}`);
+		await waitForClientAuth(page);
+
+		// Control: an open ONLINE plan offers the CTA to this very user.
+		const open = planCard(page, openPlan.name);
+		await expect(open.getByRole('button', { name: 'Subscribe' })).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Sold out — badge + helper, and no CTA of any kind.
+		const soldOut = planCard(page, soldOutPlan.name);
+		await expect(soldOut.getByText('Sold out')).toBeVisible();
+		await expect(
+			soldOut.getByText('All spots are taken — one may free up if a membership ends.')
+		).toBeVisible();
+		await expect(soldOut.getByRole('button', { name: 'Subscribe' })).toHaveCount(0);
+		await expect(soldOut.getByRole('link', { name: 'Log in to subscribe' })).toHaveCount(0);
+
+		// Sales paused — a softer stop, same absence of a CTA.
+		const paused = planCard(page, pausedPlan.name);
+		await expect(paused.getByText('Sales paused')).toBeVisible();
+		await expect(
+			paused.getByText('The organization has temporarily closed sign-ups.')
+		).toBeVisible();
+		await expect(paused.getByRole('button', { name: 'Subscribe' })).toHaveCount(0);
+
+		// OFFLINE — displayed for information; joining is arranged with staff.
+		const offline = planCard(page, offlinePlan.name);
+		await expect(
+			offline.getByText('Managed by the organization — contact them to join this plan.')
+		).toBeVisible();
+		await expect(offline.getByRole('button', { name: 'Subscribe' })).toHaveCount(0);
+		await expect(offline.getByText('Sold out')).toHaveCount(0);
+
+		await context.close();
+	});
+
+	test('guest sees a login CTA instead of Subscribe', async ({ browser }) => {
+		const tier = await createMembershipTier('owner', ORG_SLUG, uniqueName('Guest Tier'));
+		const plan = await createSubscriptionPlan('owner', ORG_SLUG, tier.id, {
+			name: uniqueName('Guest Plan'),
+			payment_method: 'online'
+		});
+
+		// A context of its own: the `page` fixture would still be anonymous, but
+		// an explicit unauthenticated context says so.
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		await gotoHydrated(page, `/org/${ORG_SLUG}`);
+
+		const card = planCard(page, plan.name);
+		// A real link, not a scripted redirect — it carries the return trip.
+		const loginCta = card.getByRole('link', { name: 'Log in to subscribe' });
+		await expect(loginCta).toBeVisible({ timeout: 15_000 });
+		await expect(loginCta).toHaveAttribute(
+			'href',
+			`/login?returnUrl=${encodeURIComponent(`/org/${ORG_SLUG}`)}`
+		);
+		await expect(card.getByRole('button', { name: 'Subscribe' })).toHaveCount(0);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j23-subscriptions/revival.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/revival.spec.ts
@@ -1,0 +1,218 @@
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { authenticateContext, type Credentials } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J23.7 / J23.8 (USER_JOURNEYS.md) — the three states of a lapsed ONLINE
+// membership, all read from /account/memberships:
+//   * EXPIRED inside the revival window → RejoinCard, dated, with a live CTA;
+//   * EXPIRED past the deadline         → no offer, just the bare cancelled card;
+//   * PAST_DUE inside the grace period  → the `role=alert` payment-failed banner.
+//
+// These states cannot be arranged through the API: only the backend's billing
+// clock (Stripe webhooks + the `expire_subscriptions_past_grace` sweep) moves a
+// subscription to EXPIRED or PAST_DUE, and no member OR admin endpoint can
+// back-date `expired_at` (the org-admin subscription controller offers create /
+// record-payment / cancel / pause / resume / revive — no expire). They
+// therefore come from dedicated BACKEND FIXTURES (`bootstrap_test_events`,
+// BE #795): three fixed accounts on Org Alpha's "E2E Revival Plan"
+// (€10/month, tier "E2E Revival Tier").
+//
+// The fixtures are NOT personas — they back exactly one spec — so they are used
+// with raw credentials, the way the throwaway-user specs do it. Their dates are
+// derived from the seed instant, so every date below is asserted as a SHAPE.
+//
+// ─── SHARED-STATE CONTRACT: this spec is strictly READ-ONLY ──────────────────
+// All three fixtures are shared, single-copy backend state with no per-worker
+// isolation, and NOTHING here mutates them: no Rejoin click, no "Manage
+// billing", no "Cancel". That is what lets the file run on both projects, in
+// parallel, on every re-run, without a reseed.
+//
+// The Rejoin CTA is deliberately asserted but NOT clicked. PROBED on the live
+// stack (2026-07-27) — clicking it consumes the fixture permanently:
+// `POST …/subscription/revive` does not merely mint a Checkout Session, it
+// flips the SAME row EXPIRED → PENDING and clears `expired_at`'s window
+// (`create_revival_checkout` in subscription_stripe_service.py), so the account
+// hub immediately stops offering the rejoin and shows a "Pending / Awaiting
+// first payment" card instead. Abandoning the checkout does NOT restore it:
+// recovery runs in `_maybe_resume_pending_checkout`, which is only reached from
+// the SUBSCRIBE endpoint, and for a fixture row (no `MembershipPayment` ledger)
+// it DELETES the row rather than reverting it to EXPIRED. Repair needs a
+// backend reseed. A spec that clicks Rejoin therefore passes exactly once per
+// bootstrap and then fails — including for every later full-suite run.
+//
+// Coverage of the click itself lives where it can be exercised repeatably:
+// src/lib/components/account/RejoinCard.test.ts asserts the empty-body revive
+// call and the `window.location.href` hand-off against a mocked SDK, and the
+// backend owns the endpoint's own tests. The remaining E2E gap — a real
+// `/revive` reaching a real Stripe Checkout — needs either a fixture the suite
+// can mint itself or a backend that keeps the row EXPIRED until the session
+// completes; both are backend changes, tracked in this task's report.
+
+const ORG_NAME = 'Revel Events Collective';
+const PLAN_NAME = 'E2E Revival Plan';
+const PLAN_PRICE = '€10.00 / month';
+const TIER_NAME = 'E2E Revival Tier';
+
+const PASSWORD = 'password123';
+/** EXPIRED, revival deadline in the future. */
+const REVIVAL_IN: Credentials = { email: 'test.revival.in@example.com', password: PASSWORD };
+/** EXPIRED, revival deadline already passed. */
+const REVIVAL_OUT: Credentials = { email: 'test.revival.out@example.com', password: PASSWORD };
+/** PAST_DUE, grace deadline in the future. */
+const PAST_DUE: Credentials = { email: 'test.pastdue@example.com', password: PASSWORD };
+
+/**
+ * Dates render through `date.ts`, which always uses a TEXTUAL month (the house
+ * rule keeping DD/MM vs MM/DD ambiguity out of the UI); both surfaces here go
+ * through `formatDate`, the SHORT form — e.g. "Aug 21, 2026". Matching the
+ * shape rather than a literal survives a reseed (the fixture dates are relative
+ * to the seed instant) while still proving a real formatted date, and not a raw
+ * ISO string or the "—" both components fall back to when the stamp is missing.
+ */
+const DATE = '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \\d{1,2}, \\d{4}';
+
+/** The org's card in the account hub's Memberships section (either kind). */
+function orgCard(page: Page): Locator {
+	return page.getByRole('region', { name: 'Memberships' }).getByRole('article', { name: ORG_NAME });
+}
+
+/** Open the account hub with a settled client session. */
+async function openMemberships(page: Page): Promise<void> {
+	await gotoHydrated(page, '/account/memberships');
+	await waitForClientAuth(page);
+}
+
+test.describe('J23 revival window + past due @p2', () => {
+	test('inside the revival window the member is offered a dated Rejoin', async ({ browser }) => {
+		const context = await browser.newContext();
+		await authenticateContext(context, REVIVAL_IN);
+		const page = await context.newPage();
+
+		await openMemberships(page);
+		const card = orgCard(page);
+
+		await expect(
+			card.getByRole('heading', { name: `Your membership at ${ORG_NAME} has expired` })
+		).toBeVisible({ timeout: 20_000 });
+
+		// Both dates in one sentence, and the deadline is the actionable half:
+		// without it the member cannot tell whether rejoining is still possible.
+		await expect(
+			card.getByText(new RegExp(`^It expired on ${DATE}\\. You can rejoin until ${DATE}\\.$`))
+		).toBeVisible();
+
+		// What rejoining would cost — the offer is a purchase decision.
+		await expect(card.getByText(`${PLAN_NAME} · ${PLAN_PRICE}`)).toBeVisible();
+		await expect(
+			card.getByText("You'll pay securely with Stripe and return to the organization's page.")
+		).toBeVisible();
+		// Live, not a decorative badge. (Clicking it would consume the fixture —
+		// see the contract at the top of this file.)
+		await expect(card.getByRole('button', { name: 'Rejoin' })).toBeEnabled();
+
+		// The offer SUPERSEDES the org's own card. Expiry does not delete the
+		// member row (the backend signal maps EXPIRED → member CANCELLED), so
+		// `list_my_memberships` still returns this org — as a bare cancelled row.
+		// The page filters that row out in favour of the offer, which says
+		// strictly more; without the filter the org would render twice, a dead
+		// card up top and its rejoin offer far below.
+		await expect(
+			page.getByRole('region', { name: 'Memberships' }).getByRole('article', { name: ORG_NAME })
+		).toHaveCount(1);
+		await expect(page.getByText(new RegExp(`^Member since ${DATE}$`))).toBeHidden();
+
+		await context.close();
+	});
+
+	test('past the revival deadline there is no offer, only the bare cancelled card', async ({
+		browser
+	}) => {
+		const context = await browser.newContext();
+		await authenticateContext(context, REVIVAL_OUT);
+		const page = await context.newPage();
+
+		await openMemberships(page);
+		const card = orgCard(page);
+
+		// PROBED on the live stack: this user's `/api/me/membership-subscriptions`
+		// row is EXPIRED with `revival_deadline` in the PAST, and their membership
+		// row is `cancelled` with NO inlined subscription (only non-terminal subs
+		// are inlined). With no offer to supersede it, that bare cancelled row is
+		// what renders: org name, tier, a `cancelled` badge, "Member since", and
+		// no management actions at all.
+		await expect(card).toBeVisible({ timeout: 20_000 });
+		await expect(card.getByText('cancelled', { exact: true })).toBeVisible();
+		await expect(card.getByText(TIER_NAME)).toBeVisible();
+		await expect(card.getByText(new RegExp(`^Member since ${DATE}$`))).toBeVisible();
+
+		// The discriminators. Every one of these lights up if the deadline check
+		// (`isWithinRevivalWindow`) is dropped or inverted: an out-of-window row
+		// would then render a RejoinCard *and* suppress the cancelled card above,
+		// so this test fails on both counts rather than silently passing.
+		await expect(page.getByRole('button', { name: 'Rejoin' })).toBeHidden();
+		await expect(page.getByText(`Your membership at ${ORG_NAME} has expired`)).toBeHidden();
+		await expect(page.getByText(/You can rejoin until/)).toBeHidden();
+
+		// An expired subscription is not a live membership either: no plan, no
+		// price, no billing controls leak out of the terminal row.
+		await expect(card.getByText(PLAN_NAME)).toBeHidden();
+		await expect(card.getByText(PLAN_PRICE)).toBeHidden();
+		await expect(card.getByRole('button', { name: 'Manage billing' })).toBeHidden();
+		await expect(card.getByRole('button', { name: 'Change plan' })).toBeHidden();
+		await expect(card.getByRole('button', { name: 'Cancel membership' })).toBeHidden();
+		// …but the org stays reachable, which is the only thing left to do here.
+		await expect(card.getByRole('link', { name: 'View org' })).toBeVisible();
+
+		await context.close();
+	});
+
+	test('a past-due subscription alerts the member and keeps the fix within reach', async ({
+		browser
+	}) => {
+		const context = await browser.newContext();
+		await authenticateContext(context, PAST_DUE);
+		const page = await context.newPage();
+
+		await openMemberships(page);
+		const card = orgCard(page);
+		await expect(card).toBeVisible({ timeout: 20_000 });
+
+		// Grace semantics, PROBED: the member row stays ACTIVE and the past-due
+		// subscription is still inlined, so this is a full membership card
+		// carrying a warning — not a stripped terminal one.
+		await expect(card.getByLabel('Past due')).toBeVisible();
+		await expect(card.getByText(`${PLAN_NAME} · ${PLAN_PRICE}`)).toBeVisible();
+
+		// The banner is the failure's only announcement, so it must reach a screen
+		// reader on render (role=alert) and it must carry the grace deadline —
+		// "by when" is its entire actionable content, and the undated fallback
+		// (`subscriptions.pastDue.banner`) would be a silent regression here.
+		const banner = card.getByRole('alert');
+		await expect(banner).toBeVisible();
+		await expect(banner).toHaveText(
+			new RegExp(
+				`^Payment failed — update your payment method by ${DATE} to keep your membership\\.$`
+			)
+		);
+
+		// PROBED: `getMemberActions` narrows past_due to billing + cancel.
+		// "Manage billing" is the banner's remedy — an alert with no way to act on
+		// it would be the real failure — while "Change plan" is withheld until the
+		// failed payment is settled (deliberately stricter than the backend
+		// preflight, which would accept it).
+		//
+		// Neither button is CLICKED: the fixture is shared and read-only, and a
+		// portal hand-off or a cancel would consume it for every later run. The
+		// hand-off itself is covered against a throwaway subscriber in
+		// manage-subscription.spec.ts.
+		await expect(card.getByRole('button', { name: 'Manage billing' })).toBeEnabled();
+		await expect(card.getByRole('button', { name: 'Cancel membership' })).toBeVisible();
+		await expect(card.getByRole('button', { name: 'Change plan' })).toBeHidden();
+
+		// A past-due row is not an expired one: no rejoin offer anywhere on the page.
+		await expect(page.getByRole('button', { name: 'Rejoin' })).toBeHidden();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j23-subscriptions/revival.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/revival.spec.ts
@@ -31,10 +31,12 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 // The Rejoin CTA is deliberately asserted but NOT clicked. PROBED on the live
 // stack (2026-07-27) — clicking it consumes the fixture permanently:
 // `POST …/subscription/revive` does not merely mint a Checkout Session, it
-// flips the SAME row EXPIRED → PENDING and clears `expired_at`'s window
-// (`create_revival_checkout` in subscription_stripe_service.py), so the account
-// hub immediately stops offering the rejoin and shows a "Pending / Awaiting
-// first payment" card instead. Abandoning the checkout does NOT restore it:
+// flips the SAME row EXPIRED → PENDING (`create_revival_checkout` in
+// subscription_stripe_service.py), so `revival_deadline` stops being reported
+// — the deadline resolver gates on EXPIRED status, while `expired_at` itself
+// survives the revive — and the account hub immediately stops offering the
+// rejoin, showing a "Pending / Awaiting first payment" card instead.
+// Abandoning the checkout does NOT restore it:
 // recovery runs in `_maybe_resume_pending_checkout`, which is only reached from
 // the SUBSCRIBE endpoint, and for a fixture row (no `MembershipPayment` ledger)
 // it DELETES the row rather than reverting it to EXPIRED. Repair needs a

--- a/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
@@ -1,0 +1,200 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+	createMembershipTier,
+	createSubscriptionPlan,
+	createVerifiedUser,
+	uniqueName
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { completeStripeCheckout } from '../../support/stripe';
+
+// J23.3 / J23.4 (USER_JOURNEYS.md) — the member-initiated hosted-checkout
+// journey: Subscribe → SubscribeDialog → checkout.stripe.com → pay → back on
+// the org page, where CheckoutReturnCard polls until the `stripe listen`
+// webhook flips the subscription ACTIVE.
+//
+// MUST-COVER here and nowhere else: the `?membership_success=true` flag is
+// consumed in onMount with the RAW history API (see MembershipSection —
+// $app/navigation's replaceState throws during hydration). jsdom cannot
+// exercise that, so this spec is the only proof it happens.
+//
+// Requires the full Stripe test-mode setup from tests/e2e/README.md (backend
+// bootstrapped with CONNECTED_TEST_STRIPE_ID + the `stripe listen` forwarder).
+//
+// Isolation / retry-safety: Org Alpha is the only Stripe-connected org, so the
+// plans live there — but every test arranges its OWN uniqueName()-d tier + plan
+// and its OWN throwaway subscriber inside the test body. A retry therefore
+// never inherits the half-paid subscription of the attempt before it (the
+// backend refuses a second non-terminal subscription per user per org).
+
+const ORG_SLUG = 'revel-events-collective';
+const ORG_PATH = `/org/${ORG_SLUG}`;
+
+/**
+ * A plan's card on the public org page. Cards carry no role, so this matches
+ * the shadcn Card surface class and narrows by the (unique) plan name.
+ */
+function planCard(page: Page, planName: string) {
+	return page.locator('.bg-card').filter({ hasText: planName });
+}
+
+/** An online €15/month plan on a fresh tier of Org Alpha, plus its subscriber. */
+async function arrangeOnlinePlan(label: string) {
+	const [tier, user] = await Promise.all([
+		createMembershipTier('owner', ORG_SLUG, uniqueName(`${label} Tier`)),
+		createVerifiedUser(label)
+	]);
+	const plan = await createSubscriptionPlan('owner', ORG_SLUG, tier.id, {
+		name: uniqueName(`${label} Plan`),
+		payment_method: 'online',
+		price: '15.00',
+		currency: 'EUR'
+	});
+	return { plan, user };
+}
+
+/**
+ * Open the plan's SubscribeDialog, check its disclaimers, and hand off to
+ * Stripe. Idempotent-loop shaped like j06's stripe-online spec: clicks landing
+ * during a dialog re-render are occasionally dropped, so retry from whatever
+ * state the UI is in until the hosted page is reached. Re-clicking "Continue to
+ * payment" is safe — the backend resumes the pending checkout session it
+ * already minted instead of creating a second one.
+ */
+async function subscribeThroughDialog(page: Page, planName: string): Promise<void> {
+	const card = planCard(page, planName);
+	await card.getByRole('button', { name: 'Subscribe' }).click({ timeout: 15_000 });
+
+	const dialog = page.getByRole('dialog', { name: `Subscribe to ${planName}` });
+	await expect(dialog).toBeVisible({ timeout: 15_000 });
+	await expect(dialog.getByText('€15.00 / month')).toBeVisible();
+	await expect(
+		dialog.getByText("You'll be charged €15.00 now, then automatically each renewal.")
+	).toBeVisible();
+	await expect(dialog.getByText('Payments are processed securely by Stripe.')).toBeVisible();
+
+	await expect(async () => {
+		if (page.url().includes('checkout.stripe.com')) return;
+		if (await dialog.isVisible()) {
+			await dialog.getByRole('button', { name: 'Continue to payment' }).click();
+		} else {
+			await card.getByRole('button', { name: 'Subscribe' }).click();
+		}
+		await page.waitForURL(/checkout\.stripe\.com/, { timeout: 20_000 });
+	}).toPass({ timeout: 90_000 });
+}
+
+test.describe('J23 hosted-checkout subscribe @p2', () => {
+	test('subscribe → Stripe → webhook → Welcome card, stripped param, member CTA', async ({
+		browser
+	}) => {
+		// Stripe's hosted page + the webhook round trip don't fit the default budget.
+		test.setTimeout(240_000);
+
+		const { plan, user } = await arrangeOnlinePlan('SubOnline');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+		await gotoHydrated(page, ORG_PATH);
+		await waitForClientAuth(page);
+
+		await subscribeThroughDialog(page, plan.name);
+		await completeStripeCheckout(page);
+
+		// Back on the org page at the backend-built success URL. NOTE: no
+		// waitForClientAuth here — its stall fallback reloads, and a reload would
+		// drop the (already consumed) flag and unmount the card under us.
+		const confirming = page
+			.getByRole('status')
+			.filter({ hasText: 'Confirming your subscription…' });
+		const welcome = page.getByRole('heading', { name: 'Welcome, member!' });
+		// Either phase is a pass: locally the "Confirming…" copy is what shows
+		// first (probed — the webhook lands a second or two after the redirect),
+		// but asserting it alone would be a race against a fast webhook.
+		await expect(confirming.or(welcome)).toBeVisible({ timeout: 30_000 });
+
+		// Activation arrives via the webhook, never the redirect — the card polls.
+		await expect(welcome).toBeVisible({ timeout: 120_000 });
+		await expect(page.getByText('Your subscription is active.')).toBeVisible();
+
+		// MUST-COVER: the flag was consumed in onMount via the raw history API,
+		// so a reload or a back-navigation cannot replay the card.
+		await expect(page).toHaveURL(new RegExp(`${ORG_PATH}(?:$|[?#])`));
+		expect(page.url()).not.toContain('membership_success');
+
+		// The card invalidates the stale verdicts it invalidates precisely so the
+		// rest of the page agrees with it — no reload needed.
+		const inlineCard = page.locator('.bg-card').filter({ hasText: 'Your membership' });
+		await expect(inlineCard.getByText(plan.name)).toBeVisible({ timeout: 30_000 });
+		await expect(inlineCard.getByLabel('Active')).toBeVisible();
+		// …and the join CTA is replaced by the member status pill (this one rides
+		// on invalidateAll() re-running the server load).
+		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 30_000 });
+
+		// The account hub tells the same story.
+		await gotoHydrated(page, '/account/memberships');
+		await waitForClientAuth(page);
+		const membershipCard = page
+			.getByRole('region', { name: 'Memberships' })
+			.getByRole('article', { name: 'Revel Events Collective' });
+		await expect(membershipCard).toBeVisible({ timeout: 20_000 });
+		await expect(membershipCard.getByText(plan.name)).toBeVisible();
+		await expect(membershipCard.getByLabel('Active')).toBeVisible();
+
+		await context.close();
+	});
+
+	test('abandon checkout → cancelled card → resume payment → active', async ({ browser }) => {
+		test.setTimeout(240_000);
+
+		const { plan, user } = await arrangeOnlinePlan('SubAbandon');
+
+		const context = await browser.newContext();
+		await authenticateContext(context, user);
+		const page = await context.newPage();
+		await gotoHydrated(page, ORG_PATH);
+		await waitForClientAuth(page);
+
+		await subscribeThroughDialog(page, plan.name);
+
+		// Abandon: walk away from the hosted page onto the backend-built cancel
+		// URL instead of paying. The PENDING subscription (and its open Checkout
+		// session) survives.
+		await gotoHydrated(page, `${ORG_PATH}?membership_cancelled=true`);
+		await expect(page.getByRole('heading', { name: 'Checkout not completed' })).toBeVisible({
+			timeout: 20_000
+		});
+		await expect(
+			page.getByText("Your payment wasn't completed. You can resume it whenever you're ready.")
+		).toBeVisible();
+
+		// Pre-payment state elsewhere on the page: the member's own subscription
+		// card says the first payment is still outstanding.
+		//
+		// Deliberately asserted HERE and not on /account/memberships: that page
+		// lists OrganizationMember rows, and an ONLINE plan creates none until the
+		// first payment lands (subscription_service.create_subscription only
+		// syncs the member row for OFFLINE plans). Probed: `/api/me/memberships`
+		// answers `count: 0` at this point, while `/api/me/…/subscription` — what
+		// this card reads — already returns the PENDING row.
+		const inlineCard = page.locator('.bg-card').filter({ hasText: 'Your membership' });
+		await expect(inlineCard.getByLabel('Pending')).toBeVisible({ timeout: 20_000 });
+		await expect(inlineCard.getByText('Awaiting first payment')).toBeVisible();
+
+		// Resume: the backend hands back a payable session for the same pending
+		// subscription, and the browser leaves for Stripe again.
+		await page.getByRole('button', { name: 'Resume payment' }).click();
+		await page.waitForURL(/checkout\.stripe\.com/, { timeout: 30_000 });
+		await completeStripeCheckout(page);
+
+		await expect(page.getByRole('heading', { name: 'Welcome, member!' })).toBeVisible({
+			timeout: 120_000
+		});
+		expect(page.url()).not.toContain('membership_success');
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
@@ -85,7 +85,12 @@ test.describe('J23 subscription lifecycle @p2', () => {
 		const memberPage = await memberContext.newPage();
 		await gotoHydrated(memberPage, '/account/memberships');
 		await waitForClientAuth(memberPage);
-		const card = memberPage.getByRole('article', { name: org.name });
+		// Scoped to the memberships section: the page's Applications section
+		// renders its own <article aria-label="{org name}"> for the (now
+		// completed) application this test's arrange created, so an unscoped
+		// article lookup is ambiguous.
+		const membershipsSection = memberPage.getByRole('region', { name: 'Memberships' });
+		const card = membershipsSection.getByRole('article', { name: org.name });
 		await expect(card).toBeVisible({ timeout: 15_000 });
 		await expect(card.getByText(plan.name)).toBeVisible();
 		await expect(card.getByText('€15.00 / month')).toBeVisible();
@@ -95,9 +100,7 @@ test.describe('J23 subscription lifecycle @p2', () => {
 		await drawer.getByRole('button', { name: 'Pause', exact: true }).click();
 		await expect(drawer.getByLabel('Paused')).toBeVisible({ timeout: 15_000 });
 		await gotoHydrated(memberPage, '/account/memberships');
-		await expect(
-			memberPage.getByRole('article', { name: org.name }).getByLabel('Paused')
-		).toBeVisible({ timeout: 15_000 });
+		await expect(card.getByLabel('Paused')).toBeVisible({ timeout: 15_000 });
 		await memberContext.close();
 
 		// Resume → ACTIVE again.

--- a/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
@@ -100,6 +100,7 @@ test.describe('J23 subscription lifecycle @p2', () => {
 		await drawer.getByRole('button', { name: 'Pause', exact: true }).click();
 		await expect(drawer.getByLabel('Paused')).toBeVisible({ timeout: 15_000 });
 		await gotoHydrated(memberPage, '/account/memberships');
+		await waitForClientAuth(memberPage);
 		await expect(card.getByLabel('Paused')).toBeVisible({ timeout: 15_000 });
 		await memberContext.close();
 

--- a/tests/e2e/journeys/j23-subscriptions/tier-policy.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/tier-policy.spec.ts
@@ -1,0 +1,149 @@
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+	createMembershipQuestionnaire,
+	createOrganization,
+	setOrgMembershipPolicy
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J23 (USER_JOURNEYS.md) — the TIER half of the membership-eligibility policy
+// (FE PR④ / BE #777): each membership tier can override the organization's
+// default questionnaire and its manual-approval default, edited in the Tiers
+// tab's "Edit Membership Tier" dialog.
+//
+// Both overrides are TRI-STATE in the wire schema — `null` means "inherit",
+// which the backend keeps distinct from an explicit `false`. The form collapses
+// that onto a native <select> (`inherit` | `require` | `norequire`), so what
+// these tests pin is that the distinction survives the whole loop: select →
+// PUT → retrieve → repopulated select. A `false` that silently degraded to
+// `null` would still LOOK saved (the option would just read "Inherit …"), which
+// is exactly why the reopened control is asserted by option label as well as by
+// value.
+//
+// The pipeline consequence of those flags (a tier-level `true` gating an apply
+// to PENDING on a no-approval org) is covered end-to-end in j27; here it is the
+// FORM round-trip only.
+//
+// Throwaway org per test so tier state never collides across parallel projects
+// or re-runs.
+
+const EDIT_DIALOG = 'Edit Membership Tier';
+/** Every new org is created with this tier by a post-save signal. */
+const DEFAULT_TIER = 'General membership';
+
+/** Load the members page and switch to the Tiers tab. */
+async function openTiersTab(page: Page, slug: string): Promise<void> {
+	await gotoHydrated(page, `/org/${slug}/admin/members`);
+	await waitForClientAuth(page);
+	await page.getByRole('tab', { name: /^Tiers/ }).click();
+}
+
+/** Reload the members page and reopen the default tier's edit dialog. */
+async function reopenTierForm(page: Page, slug: string): Promise<Locator> {
+	await openTiersTab(page, slug);
+	await page.getByRole('button', { name: `Edit ${DEFAULT_TIER}` }).click();
+	const dialog = page.getByRole('dialog', { name: EDIT_DIALOG });
+	await expect(dialog).toBeVisible({ timeout: 15_000 });
+	return dialog;
+}
+
+/**
+ * The label text of a <select>'s currently selected option. Asserting the
+ * VALUE proves what will be posted; asserting the LABEL proves what the admin
+ * actually reads back — the two only differ when the tri-state collapses.
+ */
+function selectedOption(dialog: Locator, selectId: string): Locator {
+	return dialog.locator(`${selectId} option:checked`);
+}
+
+/** A specific option of a <select>, whose label may vary with org state. */
+function option(dialog: Locator, selectId: string, value: string): Locator {
+	return dialog.locator(`${selectId} option[value="${value}"]`);
+}
+
+test.describe('J23 tier eligibility overrides @p2', () => {
+	test('questionnaire and approval overrides round-trip; "no approval" persists as an explicit choice', async ({
+		browser
+	}) => {
+		test.setTimeout(150_000);
+		const org = await createOrganization();
+		// The picker's options come from the members page's questionnaire query,
+		// so this has to exist before the first load.
+		const questionnaire = await createMembershipQuestionnaire(org.owner, org.slug, {
+			evaluationMode: 'automatic'
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		let dialog = await reopenTierForm(page, org.slug);
+
+		// A fresh tier overrides nothing: both selects sit on their inherit sentinel.
+		await expect(dialog.locator('#tier-questionnaire')).toHaveValue('');
+		await expect(selectedOption(dialog, '#tier-questionnaire')).toHaveText(
+			'Inherit organization default'
+		);
+		await expect(dialog.locator('#tier-approval')).toHaveValue('inherit');
+
+		await dialog.locator('#tier-questionnaire').selectOption(questionnaire.id);
+		await dialog.locator('#tier-approval').selectOption('require');
+		await dialog.getByRole('button', { name: 'Update Tier' }).click();
+		await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+		// Reload, not just reopen: this has to be server state, not the form's
+		// own leftover $state.
+		dialog = await reopenTierForm(page, org.slug);
+		await expect(dialog.locator('#tier-questionnaire')).toHaveValue(questionnaire.id);
+		await expect(dialog.locator('#tier-approval')).toHaveValue('require');
+		await expect(selectedOption(dialog, '#tier-approval')).toHaveText('Require approval');
+
+		// The tri-state's sharp edge: switch to an explicit "don't require". If
+		// that were stored as `null` instead of `false`, the reopened select would
+		// fall back to the inherit sentinel.
+		await dialog.locator('#tier-approval').selectOption('norequire');
+		await dialog.getByRole('button', { name: 'Update Tier' }).click();
+		await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+		dialog = await reopenTierForm(page, org.slug);
+		await expect(dialog.locator('#tier-approval')).toHaveValue('norequire');
+		await expect(selectedOption(dialog, '#tier-approval')).toHaveText("Don't require approval");
+		// …and the untouched questionnaire override rode along unchanged.
+		await expect(dialog.locator('#tier-questionnaire')).toHaveValue(questionnaire.id);
+
+		await context.close();
+	});
+
+	test('the inherit option spells out the organization default it resolves to', async ({
+		browser
+	}) => {
+		test.setTimeout(150_000);
+		const org = await createOrganization();
+		await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: true });
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		let dialog = await reopenTierForm(page, org.slug);
+		await expect(dialog.locator('#tier-approval')).toHaveValue('inherit');
+		await expect(option(dialog, '#tier-approval', 'inherit')).toHaveText(
+			'Inherit organization default (approval required)'
+		);
+		// bits-ui dialogs close on Escape; leaving it open would block the reload.
+		await page.keyboard.press('Escape');
+		await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+		// Flip the ORG default (the tier itself is untouched) — the label follows.
+		await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: false });
+		dialog = await reopenTierForm(page, org.slug);
+		await expect(dialog.locator('#tier-approval')).toHaveValue('inherit');
+		await expect(option(dialog, '#tier-approval', 'inherit')).toHaveText(
+			'Inherit organization default (no approval required)'
+		);
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j27-applications/apply-flows.spec.ts
+++ b/tests/e2e/journeys/j27-applications/apply-flows.spec.ts
@@ -1,0 +1,251 @@
+import type { Browser, Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { ApiClient } from '../../support/api';
+import {
+	applyViaApi,
+	approveApplication,
+	createOrganization,
+	createVerifiedUser,
+	rejectApplication,
+	setOrgMembershipPolicy,
+	type ThrowawayUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { closeDialog } from '../../support/ui';
+
+// J27.2–27.4 (USER_JOURNEYS.md) — the four ways a membership application can
+// end: instant completion, staff approval, rejection → re-apply, and the
+// member withdrawing it.
+//
+// Isolation: every test arranges its OWN org (throwaway owner, one
+// auto-created "General membership" tier) and its own applicant, so parallel
+// projects/workers and a `retries: 1` re-run never share an application.
+//
+// Two backend behaviours the specs are built on, verified live against this
+// branch:
+//   * a TIER-BEARING apply on an ungated org completes on the spot — the
+//     membership exists before any UI is opened;
+//   * a TIER-LESS apply (all the UI ever sends, since ApplyDialog posts no
+//     tier) stays PENDING for staff, whatever the org's approval policy.
+// Approval alone does NOT create the membership: the state machine advances
+// when the MEMBER reads the application, which the account hub's Applications
+// section does on every mount.
+
+/** The account hub renders org-named <article>s in three different places
+ *  (membership cards, in-progress applications, closed applications), so every
+ *  lookup here is scoped to its list/region — an unscoped one trips strict
+ *  mode the moment a test has both a membership and an application. */
+function membershipCard(page: Page, orgName: string): Locator {
+	return page.getByRole('region', { name: 'Memberships' }).getByRole('article', { name: orgName });
+}
+
+function applicationRow(page: Page, list: 'In progress' | 'Closed', orgName: string): Locator {
+	return page.getByRole('list', { name: list }).getByRole('article', { name: orgName });
+}
+
+async function pageAs(browser: Browser, user: ThrowawayUser): Promise<Page> {
+	const context = await browser.newContext();
+	await authenticateContext(context, user);
+	return context.newPage();
+}
+
+/** The member's own application id, for admin-side arranges after a UI apply.
+ *  The LIST endpoint is a plain read — unlike GET /me/applications/{id}, which
+ *  advances the state machine and would do the very work under test. */
+async function findApplicationId(user: ThrowawayUser, orgSlug: string): Promise<string> {
+	const api = await ApiClient.login(user.email, user.password);
+	const page = await api.get<{ results: Array<{ id?: string | null; organization_slug: string }> }>(
+		'/api/me/applications'
+	);
+	const application = page.results.find((a) => a.organization_slug === orgSlug);
+	if (!application?.id) {
+		throw new Error(`No application for ${user.email} at ${orgSlug}`);
+	}
+	return application.id;
+}
+
+test.describe('j27 application flows @p2', () => {
+	test('tier-bearing apply completes instantly and shows up as a membership', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Applicant')
+		]);
+
+		// No approval requirement, no questionnaire, and a tier on the request →
+		// the backend has nothing left to gate on and grants membership outright.
+		const outcome = await applyViaApi(applicant, org.slug, { tierId: org.defaultTierId });
+		expect(outcome.status).toBe('completed');
+		expect(outcome.nextStep).toBeNull();
+
+		const page = await pageAs(browser, applicant);
+
+		// The org page reports it server-side: status + tier badges, not a CTA.
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByLabel('Membership tier: General membership')).toBeVisible();
+		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+
+		// …and the account hub lists both halves: the membership card, and the
+		// application itself already settled under "Closed".
+		await gotoHydrated(page, '/account/memberships');
+		await waitForClientAuth(page);
+		const card = membershipCard(page, org.name);
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		// The card's own status badge carries no aria-label — the text IS the
+		// message (CSS-capitalized, so the DOM string is lowercase).
+		await expect(card.getByText('active', { exact: true })).toBeVisible();
+		await expect(
+			applicationRow(page, 'Closed', org.name).getByLabel('Application status: Completed')
+		).toBeVisible();
+		await expect(page.getByRole('list', { name: 'In progress' })).toBeHidden();
+
+		await page.context().close();
+	});
+
+	test('approval-gated apply waits for staff, then completes on the next read', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Applicant')
+		]);
+		await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: true });
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+
+		await page.getByRole('button', { name: `Join ${org.name}` }).click();
+		const applyDialog = page.getByRole('dialog', { name: `Join ${org.name}` });
+		await expect(applyDialog).toBeVisible();
+		await applyDialog.getByLabel('Message (optional)').fill('E2E: approval pipeline');
+		await applyDialog.getByRole('button', { name: 'Send application' }).click();
+
+		// The outcome re-titles the dialog in place; "Application received" (not
+		// "You're in!") is the whole point — approval is still owed.
+		const outcomeDialog = page.getByRole('dialog', { name: 'Application received' });
+		await expect(outcomeDialog).toBeVisible({ timeout: 15_000 });
+		await expect(
+			outcomeDialog.getByText(
+				"Your application is with the organization for review. You'll hear back once they decide."
+			)
+		).toBeVisible();
+		await closeDialog(page, outcomeDialog);
+		await expect(page.getByRole('button', { name: 'Application pending' })).toBeDisabled();
+
+		// The account hub tracks it as in-progress.
+		await gotoHydrated(page, '/account/memberships');
+		await waitForClientAuth(page);
+		await expect(
+			applicationRow(page, 'In progress', org.name).getByLabel('Application status: Pending')
+		).toBeVisible({ timeout: 15_000 });
+		await expect(membershipCard(page, org.name)).toBeHidden();
+
+		// Staff approve. A UI apply carries no tier, so the approval must name one.
+		const applicationId = await findApplicationId(applicant, org.slug);
+		await approveApplication(org.owner, org.slug, applicationId, org.defaultTierId);
+
+		// Approval is not the membership: the row only completes when the member
+		// reads it, and each remount of the Applications section re-fires that
+		// state-advancing GET. Poll by reloading, not by waiting in place.
+		await expect(async () => {
+			await gotoHydrated(page, '/account/memberships');
+			await waitForClientAuth(page);
+			await expect(membershipCard(page, org.name)).toBeVisible({ timeout: 10_000 });
+			await expect(
+				applicationRow(page, 'Closed', org.name).getByLabel('Application status: Completed')
+			).toBeVisible({ timeout: 10_000 });
+		}).toPass({ timeout: 30_000 });
+
+		await page.context().close();
+	});
+
+	test('a rejected application can be re-applied for from the org page', async ({ browser }) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Applicant')
+		]);
+
+		// Tier-less (what the UI sends) so the application is staff's to decide.
+		const first = await applyViaApi(applicant, org.slug, { notes: 'E2E: first try' });
+		expect(first.status).toBe('pending');
+		await rejectApplication(org.owner, org.slug, first.applicationId);
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+
+		// The verdict turns the join CTA into a re-apply one — a rejection is not
+		// a dead end.
+		const reapplyButton = page.getByRole('button', { name: 'Re-apply for membership' });
+		await expect(reapplyButton).toBeVisible({ timeout: 15_000 });
+		await reapplyButton.click();
+
+		const reapplyDialog = page.getByRole('dialog', { name: `Re-apply to ${org.name}` });
+		await expect(reapplyDialog).toBeVisible();
+		await reapplyDialog.getByLabel('Message (optional)').fill('E2E: second try');
+		await reapplyDialog.getByRole('button', { name: 'Send application' }).click();
+
+		const outcomeDialog = page.getByRole('dialog', { name: 'Application received' });
+		await expect(outcomeDialog).toBeVisible({ timeout: 15_000 });
+		await closeDialog(page, outcomeDialog);
+
+		// Both rows coexist in the account hub — the settled one below, the new
+		// one above. (Both <article>s are named after the org; the lists are what
+		// tells them apart.)
+		await gotoHydrated(page, '/account/memberships');
+		await waitForClientAuth(page);
+		await expect(
+			applicationRow(page, 'Closed', org.name).getByLabel('Application status: Rejected')
+		).toBeVisible({ timeout: 15_000 });
+		await expect(
+			applicationRow(page, 'In progress', org.name).getByLabel('Application status: Pending')
+		).toBeVisible();
+
+		await page.context().close();
+	});
+
+	test('a member can cancel their own pending application', async ({ browser }) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Applicant')
+		]);
+		const application = await applyViaApi(applicant, org.slug, { notes: 'E2E: to withdraw' });
+		expect(application.status).toBe('pending');
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, '/account/memberships');
+		await waitForClientAuth(page);
+
+		const openRow = applicationRow(page, 'In progress', org.name);
+		await expect(openRow).toBeVisible({ timeout: 15_000 });
+		await openRow.getByRole('button', { name: 'Cancel application' }).click();
+
+		// A plain (non-bits-ui) confirm dialog: labelled by its title, confirmed
+		// by the shared "Confirm" button.
+		const confirmDialog = page.getByRole('dialog', { name: 'Cancel this application?' });
+		await expect(confirmDialog).toBeVisible();
+		await expect(
+			confirmDialog.getByText(`Your application to ${org.name} will be withdrawn.`)
+		).toBeVisible();
+		await confirmDialog.getByRole('button', { name: 'Confirm' }).click();
+
+		await expect(page.getByText('Application cancelled.')).toBeVisible({ timeout: 15_000 });
+
+		// The row settles into "Closed", and nothing is left in progress.
+		await expect(
+			applicationRow(page, 'Closed', org.name).getByLabel('Application status: Cancelled')
+		).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByRole('list', { name: 'In progress' })).toBeHidden();
+
+		await page.context().close();
+	});
+});

--- a/tests/e2e/journeys/j27-applications/eligibility-states.spec.ts
+++ b/tests/e2e/journeys/j27-applications/eligibility-states.spec.ts
@@ -1,0 +1,178 @@
+import type { Browser, Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+	applyViaApi,
+	createMembershipTier,
+	createOrganization,
+	createVerifiedUser,
+	patchTierPolicy,
+	setOrgMembershipPolicy,
+	type ThrowawayUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J27 eligibility states — the verdicts that are NOT an application in flight:
+// an org that has closed its doors, a user who is already in, and the tier
+// policy that outranks the org default.
+//
+// Live-verified behaviours these specs are built on:
+//   * `accept_membership_requests: false` renders NO membership CTA at all —
+//     the org page gates the whole <MembershipCta> block on that flag
+//     (src/routes/(public)/org/[slug]/+page.svelte), so the eligibility
+//     verdict's own copy ("not accepting new members" / "by invitation") never
+//     reaches the DOM. Test 1 asserts the absence, not the copy.
+//   * `requires_membership_approval` is TRI-STATE on a tier: `true`/`false`
+//     override the org default, `null` inherits it. Test 3 pins all three
+//     against both org defaults.
+
+function membershipCard(page: Page, orgName: string): Locator {
+	return page.getByRole('region', { name: 'Memberships' }).getByRole('article', { name: orgName });
+}
+
+function applicationRow(page: Page, list: 'In progress' | 'Closed', orgName: string): Locator {
+	return page.getByRole('list', { name: list }).getByRole('article', { name: orgName });
+}
+
+async function pageAs(browser: Browser, user: ThrowawayUser): Promise<Page> {
+	const context = await browser.newContext();
+	await authenticateContext(context, user);
+	return context.newPage();
+}
+
+test.describe('j27 membership eligibility states @p2', () => {
+	test('an org that is not accepting members offers no way in', async ({ browser }) => {
+		test.setTimeout(180_000);
+		// Public so an outsider can read the page at all, but closed to new
+		// members — the two flags are independent.
+		const [org, visitor] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: false, publicVisibility: true }),
+			createVerifiedUser('Visitor')
+		]);
+
+		const page = await pageAs(browser, visitor);
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+
+		// Positive control: the page itself rendered, so the absences below are
+		// the policy talking and not a broken/404 page.
+		await expect(page.getByRole('heading', { name: org.name, level: 1 })).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(page.getByRole('button', { name: 'Follow' })).toBeVisible();
+
+		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+		// The whole CTA block is gated away, so neither the reason copy nor the
+		// invite-only copy the verdict would map to is rendered.
+		await expect(
+			page.getByText("This organization isn't accepting new members right now.")
+		).toBeHidden();
+		await expect(
+			page.getByText('Joining is by invitation — ask the organization for an invite link.')
+		).toBeHidden();
+
+		await page.context().close();
+	});
+
+	test('an existing member sees their status and tier instead of a join CTA', async ({
+		asMember: page
+	}) => {
+		// Seed, read-only: charlie is a General-tier member of Org Alpha.
+		await gotoHydrated(page, '/org/revel-events-collective');
+		await waitForClientAuth(page);
+
+		// Both pills are labelled, so neither status nor tier is conveyed by
+		// colour alone.
+		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByLabel('Membership tier: General membership')).toBeVisible();
+		// A member has nothing to apply for — whatever the org's join policy is.
+		await expect(page.getByRole('button', { name: /^Join / })).toBeHidden();
+		await expect(page.getByRole('button', { name: 'Application pending' })).toBeHidden();
+		await expect(
+			page.getByRole('link', { name: 'Fill in the membership questionnaire' })
+		).toBeHidden();
+	});
+
+	test('a tier can override the org approval default in both directions', async ({ browser }) => {
+		test.setTimeout(240_000);
+		// Two orgs so both org defaults are represented; each gets one tier that
+		// INHERITS (the auto-created "General membership", left untouched) and one
+		// that OVERRIDES.
+		const [lax, strict, laxInherit, laxOverride, strictInherit, strictOverride] = await Promise.all(
+			[
+				createOrganization({ acceptMembershipRequests: true }),
+				createOrganization({ acceptMembershipRequests: true }),
+				createVerifiedUser('LaxInherit'),
+				createVerifiedUser('LaxOverride'),
+				createVerifiedUser('StrictInherit'),
+				createVerifiedUser('StrictOverride')
+			]
+		);
+
+		await Promise.all([
+			setOrgMembershipPolicy(lax.owner, lax.slug, { requiresApproval: false }),
+			setOrgMembershipPolicy(strict.owner, strict.slug, { requiresApproval: true })
+		]);
+		const [laxGatedTier, strictOpenTier] = await Promise.all([
+			createMembershipTier(lax.owner, lax.slug, 'Approval-gated tier'),
+			createMembershipTier(strict.owner, strict.slug, 'Open tier')
+		]);
+		await Promise.all([
+			// `true` on an org that asks for no approval…
+			patchTierPolicy(lax.owner, lax.slug, laxGatedTier.id, {
+				requires_membership_approval: true
+			}),
+			// …and `false` on an org that does.
+			patchTierPolicy(strict.owner, strict.slug, strictOpenTier.id, {
+				requires_membership_approval: false
+			})
+		]);
+
+		// Tier-bearing applies, so nothing but the resolved approval policy is
+		// left to gate on: `completed` means the tier said "no approval needed",
+		// `pending` means it said the opposite. Were the backend to ignore
+		// `requires_membership_approval` on the tier, both pairs would collapse
+		// onto their org's default and all four expectations below would flip.
+		const [inheritLax, overrideLax, inheritStrict, overrideStrict] = await Promise.all([
+			applyViaApi(laxInherit, lax.slug, { tierId: lax.defaultTierId }),
+			applyViaApi(laxOverride, lax.slug, { tierId: laxGatedTier.id }),
+			applyViaApi(strictInherit, strict.slug, { tierId: strict.defaultTierId }),
+			applyViaApi(strictOverride, strict.slug, { tierId: strictOpenTier.id })
+		]);
+
+		// null → inherit "no approval" → straight in.
+		expect(inheritLax.status).toBe('completed');
+		expect(inheritLax.nextStep).toBeNull();
+		// true → override "no approval" → held for staff.
+		expect(overrideLax.status).toBe('pending');
+		expect(overrideLax.nextStep).toBe('wait_for_approval');
+		// null → inherit "approval required" → held for staff.
+		expect(inheritStrict.status).toBe('pending');
+		expect(inheritStrict.nextStep).toBe('wait_for_approval');
+		// false → override "approval required" → straight in.
+		expect(overrideStrict.status).toBe('completed');
+		expect(overrideStrict.nextStep).toBeNull();
+
+		// The two halves of the lax org, as the members themselves see them: same
+		// org, same policy, different tier — one is in, the other is waiting.
+		const gatedPage = await pageAs(browser, laxOverride);
+		await gotoHydrated(gatedPage, '/account/memberships');
+		await waitForClientAuth(gatedPage);
+		await expect(
+			applicationRow(gatedPage, 'In progress', lax.name).getByLabel('Application status: Pending')
+		).toBeVisible({ timeout: 15_000 });
+		await expect(membershipCard(gatedPage, lax.name)).toBeHidden();
+		await gatedPage.context().close();
+
+		const openPage = await pageAs(browser, laxInherit);
+		await gotoHydrated(openPage, '/account/memberships');
+		await waitForClientAuth(openPage);
+		const card = membershipCard(openPage, lax.name);
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		await expect(card.getByText('active', { exact: true })).toBeVisible();
+		await expect(
+			applicationRow(openPage, 'Closed', lax.name).getByLabel('Application status: Completed')
+		).toBeVisible();
+		await openPage.context().close();
+	});
+});

--- a/tests/e2e/journeys/j27-applications/questionnaire-flow.spec.ts
+++ b/tests/e2e/journeys/j27-applications/questionnaire-flow.spec.ts
@@ -1,0 +1,205 @@
+import type { Browser, Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import {
+	applyViaApi,
+	createMembershipQuestionnaire,
+	createOrganization,
+	createVerifiedUser,
+	setOrgMembershipPolicy,
+	MEMBERSHIP_QUESTION,
+	type ThrowawayUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+
+// J27.1–27.3 (USER_JOURNEYS.md) — the membership QUESTIONNAIRE gate: the org
+// page's `submit_questionnaire` CTA, the org-scoped fill route it points at,
+// and the two evaluation modes' outcomes (auto-graded → gate clears; manual →
+// the member waits).
+//
+// Isolation: each test arranges its own org (throwaway owner), its own
+// questionnaire and its own applicant, so parallel projects/workers and a
+// `retries: 1` re-run never share a submission (which is one-shot per user).
+//
+// Live-verified behaviours these specs are built on:
+//   * the CTA's href — and `eligibility.questionnaire_id` — carry the INNER
+//     Questionnaire id, NOT the OrganizationQuestionnaire wrapper id that
+//     `createMembershipQuestionnaire` returns and that
+//     `default_membership_questionnaire_id` stores. Test 1 asserts the two
+//     apart explicitly.
+//   * submitting a membership questionnaire NEVER renders the page's
+//     "Questionnaire approved" panel, not even when the automatic grader
+//     passes it inline: the 200 says a review is owed, so the page toasts
+//     "Questionnaire submitted …" and returns to the org page either way. The
+//     modes diverge on what the org page says NEXT — join vs. still waiting.
+//   * clearing the questionnaire gate is not joining. It only turns the CTA
+//     back into a plain "Join" — the application is still owed.
+
+function membershipCard(page: Page, orgName: string): Locator {
+	return page.getByRole('region', { name: 'Memberships' }).getByRole('article', { name: orgName });
+}
+
+async function pageAs(browser: Browser, user: ThrowawayUser): Promise<Page> {
+	const context = await browser.newContext();
+	await authenticateContext(context, user);
+	return context.newPage();
+}
+
+test.describe('j27 membership questionnaire @p2', () => {
+	test('an auto-graded questionnaire clears the join gate and the applicant becomes a member', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Applicant')
+		]);
+		// Multiple choice with one correct option and `min_score: 0` — the house
+		// pattern for deterministic inline grading (no LLM anywhere near an E2E run).
+		const wrapper = await createMembershipQuestionnaire(org.owner, org.slug, {
+			evaluationMode: 'automatic'
+		});
+		await setOrgMembershipPolicy(org.owner, org.slug, { defaultQuestionnaireId: wrapper.id });
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+
+		// The gate replaces the join CTA outright: there is nothing to apply for
+		// until the questionnaire is on file.
+		const questionnaireCta = page.getByRole('link', {
+			name: 'Fill in the membership questionnaire'
+		});
+		await expect(questionnaireCta).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+
+		await questionnaireCta.click();
+		await page.waitForURL('**/questionnaire/**');
+
+		// The route takes the INNER questionnaire id. Linking the wrapper id here
+		// (the one the org policy stores) is the mistake this asserts against — it
+		// would 404 the fill page.
+		const routeId = new URL(page.url()).pathname.split('/').pop();
+		expect(routeId).toBeTruthy();
+		expect(routeId).not.toBe(wrapper.id);
+
+		await expect(page.getByRole('heading', { name: 'Membership questionnaire' })).toBeVisible();
+		await expect(page.getByText(`${org.name} asks new members to fill this in.`)).toBeVisible();
+		await expect(page.getByText(MEMBERSHIP_QUESTION.automatic.question)).toBeVisible();
+
+		// Submit stays disabled until every mandatory question is answered — an
+		// empty submission would score 0 and burn the attempt (#596).
+		const submit = page.getByRole('button', { name: 'Submit Questionnaire' });
+		await expect(submit).toBeDisabled();
+		await page
+			.getByRole('radio', { name: MEMBERSHIP_QUESTION.automatic.correct, exact: true })
+			.click();
+		await expect(submit).toBeEnabled();
+		await submit.click();
+
+		// Even a passing auto-graded submission takes the "under review" exit —
+		// see the file header. The confirmation is the toast plus the return trip.
+		await expect(
+			page.getByText('Questionnaire submitted — the organization will review it.')
+		).toBeVisible({ timeout: 15_000 });
+		await page.waitForURL(`**/org/${org.slug}`, { timeout: 15_000 });
+		await expect(page.getByText('Questionnaire approved')).toBeHidden();
+
+		// Grading is asynchronous, and the CTA is a cached client query: advance it
+		// by re-reading the page, not by waiting in place. "Join" reappearing IS
+		// the pass verdict — a failed one would leave a waiting/retry CTA.
+		await expect(async () => {
+			await gotoHydrated(page, `/org/${org.slug}`);
+			await waitForClientAuth(page);
+			await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeVisible({
+				timeout: 10_000
+			});
+		}).toPass({ timeout: 45_000 });
+
+		// Clearing the gate is not membership — the application is still owed, and
+		// the ApplyDialog sends no tier, so a UI apply can only ever park as
+		// pending (apply-flows.spec.ts owns that path). Here the apply is the
+		// arrange for the last leg: with the questionnaire passed and no approval
+		// requirement left, a tier-bearing apply completes on the spot.
+		const outcome = await applyViaApi(applicant, org.slug, { tierId: org.defaultTierId });
+		expect(outcome.status).toBe('completed');
+
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByLabel('Membership tier: General membership')).toBeVisible();
+		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+
+		await gotoHydrated(page, '/account/memberships');
+		await waitForClientAuth(page);
+		const card = membershipCard(page, org.name);
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		// The card's status badge carries no aria-label — the text IS the message
+		// (CSS-capitalized, so the DOM string is lowercase).
+		await expect(card.getByText('active', { exact: true })).toBeVisible();
+
+		await page.context().close();
+	});
+
+	test('a manually-graded questionnaire leaves the applicant waiting for review', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Applicant')
+		]);
+		// Free text, for a human to read — nothing grades itself here.
+		const wrapper = await createMembershipQuestionnaire(org.owner, org.slug, {
+			evaluationMode: 'manual'
+		});
+		await setOrgMembershipPolicy(org.owner, org.slug, { defaultQuestionnaireId: wrapper.id });
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+
+		await page.getByRole('link', { name: 'Fill in the membership questionnaire' }).click();
+		await page.waitForURL('**/questionnaire/**');
+		await expect(page.getByRole('heading', { name: 'Membership questionnaire' })).toBeVisible();
+
+		// The textarea is labelled by the question itself (plus the required "*").
+		await page.getByLabel(MEMBERSHIP_QUESTION.manual.question).fill('E2E: I like this org.');
+		await page.getByRole('button', { name: 'Submit Questionnaire' }).click();
+
+		await expect(
+			page.getByText('Questionnaire submitted — the organization will review it.')
+		).toBeVisible({ timeout: 15_000 });
+		await page.waitForURL(`**/org/${org.slug}`, { timeout: 15_000 });
+
+		// `wait_for_questionnaire_evaluation` → the disabled waiting CTA plus the
+		// account-hub link. No re-fill link: one submission is all the member gets
+		// until staff grade it.
+		await waitForClientAuth(page);
+		await expect(page.getByRole('button', { name: 'Application pending' })).toBeDisabled({
+			timeout: 15_000
+		});
+		await expect(page.getByRole('link', { name: 'Track your application' })).toBeVisible();
+		await expect(
+			page.getByRole('link', { name: 'Fill in the membership questionnaire' })
+		).toBeHidden();
+		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+
+		// …and yet there is nothing to track YET: a questionnaire submission is not
+		// an application, so the hub stays empty on both halves. (The waiting CTA
+		// above is the questionnaire's own state, not an application's.)
+		await gotoHydrated(page, '/account/memberships');
+		await waitForClientAuth(page);
+		await expect(
+			page
+				.getByRole('region', { name: 'Applications' })
+				.getByText(
+					'No applications yet. When you apply to join an organization, you can track it here.'
+				)
+		).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByRole('list', { name: 'In progress' })).toBeHidden();
+		await expect(membershipCard(page, org.name)).toBeHidden();
+
+		await page.context().close();
+	});
+});

--- a/tests/e2e/journeys/j27-applications/requests-admin.spec.ts
+++ b/tests/e2e/journeys/j27-applications/requests-admin.spec.ts
@@ -1,0 +1,408 @@
+import type { Browser, Locator, Page } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { ApiClient } from '../../support/api';
+import {
+	applyViaApi,
+	cancelApplicationViaApi,
+	createMembershipQuestionnaire,
+	createMembershipTier,
+	createOrganization,
+	createVerifiedUser,
+	rejectApplication,
+	setOrgMembershipPolicy,
+	MEMBERSHIP_QUESTION,
+	type CreatedOrg,
+	type ThrowawayUser
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { pickSelectOption } from '../../support/ui';
+
+// J27.5 (USER_JOURNEYS.md) — the org-admin side of membership applications:
+// the Members-area REQUESTS tab, which PR④ turned from a pending-only queue
+// into the whole application board (six status filters, tier-aware approval, a
+// link to the questionnaire submission that unlocked the application), plus the
+// permanent redirect off the retired standalone requests page.
+//
+// Isolation: every test arranges its OWN org (throwaway owner) and its own
+// applicants, so parallel projects/workers and a `retries: 1` re-run never
+// share a board — three of these tests approve rows, which is not undoable.
+//
+// Backend behaviours these specs are built on, verified live against this
+// branch (contradicting them means the backend moved, not the spec):
+//   * a TIER-BEARING apply parks as PENDING only while approval is required —
+//     on an ungated org it completes on the spot, so the board arrange flips
+//     the org's approval policy on BETWEEN the two applies;
+//   * admin approval of a free (plan-less) application goes straight to
+//     COMPLETED — "Approved" is the paid path's waiting room (Phase 2), so no
+//     row on a free board ever reaches it and the Approved filter is arranged
+//     to be legitimately empty;
+//   * a MANUAL-mode membership questionnaire queues no evaluation at all
+//     (`evaluation_status` stays null); HYBRID is the mode that files one as
+//     "pending review", which is what the card's review hint keys on.
+
+/** The card is a plain <div>, so its heading is the handle — the requester's
+ *  display name, which for throwaway users is "E2E <label>". */
+function card(page: Page, name: string): Locator {
+	return page.getByRole('heading', { name, exact: true });
+}
+
+/** A card's date+status row, anchored on its own "Requested …" line: the
+ *  status badge shares its wording with the FILTER BUTTONS ("Completed",
+ *  "Rejected", …), so an unscoped text lookup would match both. Every view this
+ *  is used in shows exactly one card. */
+function statusRow(page: Page): Locator {
+	return page.locator('p', { hasText: /^Requested/ }).locator('xpath=..');
+}
+
+/** The active filter button appends a count badge to its label ("Pending 2"),
+ *  so the name has to tolerate the suffix — and must NOT be a bare substring
+ *  match, which would make "Approved" ambiguous with nothing today but with
+ *  any future "Approved (paid)" filter tomorrow. */
+function filterButton(page: Page, label: string): Locator {
+	return page.getByRole('button', { name: new RegExp(`^${label}(\\s+\\d+)?$`) });
+}
+
+async function pageAs(browser: Browser, user: ThrowawayUser): Promise<Page> {
+	const context = await browser.newContext();
+	await authenticateContext(context, user);
+	return context.newPage();
+}
+
+/** Open the Members area straight on the Requests tab (the URL PR④'s redirect
+ *  now points at) and confirm the tab really is the selected one. */
+async function openRequestsTab(page: Page, orgSlug: string): Promise<void> {
+	await gotoHydrated(page, `/org/${orgSlug}/admin/members?tab=requests`);
+	await waitForClientAuth(page);
+	await expect(page.getByRole('tab', { name: 'Requests' })).toHaveAttribute(
+		'aria-selected',
+		'true'
+	);
+}
+
+/** Switch the board to one status filter and confirm the pressed state moved
+ *  (the filters are toggle BUTTONS with aria-pressed, not tabs). */
+async function selectFilter(page: Page, label: string): Promise<void> {
+	await filterButton(page, label).click();
+	await expect(filterButton(page, label)).toHaveAttribute('aria-pressed', 'true');
+}
+
+/** The applicant's submission, as the ORG sees it. Grading is asynchronous, so
+ *  this polls until the evaluation is on file — arranging the "Review pending"
+ *  hint means arranging the evaluation that renders it, not just a submission. */
+async function submissionPendingReview(
+	owner: ThrowawayUser,
+	wrapperId: string,
+	email: string
+): Promise<string> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	let submissionId = '';
+	await expect
+		.poll(
+			async () => {
+				const list = await api.get<{
+					results: Array<{
+						id: string;
+						user: { email: string };
+						evaluation_status?: string | null;
+					}>;
+				}>(`/api/questionnaires/${wrapperId}/submissions`);
+				const mine = list.results.find((s) => s.user.email === email);
+				submissionId = mine?.id ?? '';
+				return mine?.evaluation_status ?? null;
+			},
+			{ timeout: 45_000, message: 'submission never reached "pending review"' }
+		)
+		.toBe('pending review');
+	return submissionId;
+}
+
+/** One org whose board carries five applications in five different states. */
+interface Board {
+	org: CreatedOrg;
+	/** Display names, by the status their row sits in. */
+	names: Record<'tieredPending' | 'plainPending' | 'completed' | 'rejected' | 'cancelled', string>;
+}
+
+async function arrangeBoard(): Promise<Board> {
+	const [org, completed, tiered, plain, rejected, cancelled] = await Promise.all([
+		createOrganization({ acceptMembershipRequests: true }),
+		createVerifiedUser('Completed'),
+		createVerifiedUser('Tiered'),
+		createVerifiedUser('Plain'),
+		createVerifiedUser('Rejected'),
+		createVerifiedUser('Cancelled')
+	]);
+
+	// While nothing gates the org, a tier-bearing apply completes outright —
+	// that is the COMPLETED row, and it has to be taken before approval is
+	// switched on.
+	const done = await applyViaApi(completed, org.slug, { tierId: org.defaultTierId });
+	expect(done.status).toBe('completed');
+
+	// From here on staff decide, so the two PENDING rows survive: one carrying
+	// the tier it applied for, one tier-less (what the UI's ApplyDialog sends).
+	await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: true });
+	const tieredApplication = await applyViaApi(tiered, org.slug, { tierId: org.defaultTierId });
+	expect(tieredApplication.status).toBe('pending');
+	const plainApplication = await applyViaApi(plain, org.slug, { notes: 'E2E: tier-less' });
+	expect(plainApplication.status).toBe('pending');
+
+	// The two terminal rows, one decided by staff and one withdrawn by the member.
+	const toReject = await applyViaApi(rejected, org.slug);
+	await rejectApplication(org.owner, org.slug, toReject.applicationId);
+	const toCancel = await applyViaApi(cancelled, org.slug);
+	await cancelApplicationViaApi(cancelled, toCancel.applicationId);
+
+	const displayName = (user: ThrowawayUser) => `${user.firstName} ${user.lastName}`;
+	return {
+		org,
+		names: {
+			tieredPending: displayName(tiered),
+			plainPending: displayName(plain),
+			completed: displayName(completed),
+			rejected: displayName(rejected),
+			cancelled: displayName(cancelled)
+		}
+	};
+}
+
+test.describe('j27 requests admin @p2', () => {
+	test('the six status filters slice the application board', async ({ browser }) => {
+		test.setTimeout(180_000);
+		const { org, names } = await arrangeBoard();
+
+		const page = await pageAs(browser, org.owner);
+		await openRequestsTab(page, org.slug);
+
+		// PENDING is the tab's landing filter — no click needed, and both pending
+		// rows are there while the three settled ones are not.
+		await expect(filterButton(page, 'Pending')).toHaveAttribute('aria-pressed', 'true');
+		await expect(card(page, names.tieredPending)).toBeVisible({ timeout: 15_000 });
+		await expect(card(page, names.plainPending)).toBeVisible();
+		await expect(card(page, names.completed)).toBeHidden();
+		await expect(card(page, names.rejected)).toBeHidden();
+		await expect(card(page, names.cancelled)).toBeHidden();
+
+		// Each remaining status filter shows ITS row and drops the others — a
+		// filter that merely widened the list would pass a "visible" assert.
+		await selectFilter(page, 'Completed');
+		await expect(card(page, names.completed)).toBeVisible({ timeout: 15_000 });
+		await expect(statusRow(page)).toContainText('Completed');
+		await expect(card(page, names.tieredPending)).toBeHidden();
+		await expect(card(page, names.plainPending)).toBeHidden();
+
+		await selectFilter(page, 'Rejected');
+		await expect(card(page, names.rejected)).toBeVisible({ timeout: 15_000 });
+		await expect(statusRow(page)).toContainText('Rejected');
+		await expect(card(page, names.completed)).toBeHidden();
+		await expect(card(page, names.cancelled)).toBeHidden();
+
+		await selectFilter(page, 'Cancelled');
+		await expect(card(page, names.cancelled)).toBeVisible({ timeout: 15_000 });
+		await expect(statusRow(page)).toContainText('Cancelled');
+		await expect(card(page, names.rejected)).toBeHidden();
+		await expect(card(page, names.plainPending)).toBeHidden();
+
+		// APPROVED is the paid path's waiting room: a free board never reaches it,
+		// so the filter is expected to come back empty — the state exists in the
+		// UI ahead of the Phase-2 flow that fills it.
+		await selectFilter(page, 'Approved');
+		await expect(page.getByRole('heading', { name: 'No pending requests' })).toBeVisible({
+			timeout: 15_000
+		});
+		for (const name of Object.values(names)) {
+			await expect(card(page, name)).toBeHidden();
+		}
+
+		// ALL is the escape hatch: every row, whatever its state.
+		await selectFilter(page, 'All');
+		for (const name of Object.values(names)) {
+			await expect(card(page, name)).toBeVisible({ timeout: 15_000 });
+		}
+		await expect(page.getByRole('heading', { name: 'No pending requests' })).toBeHidden();
+
+		await page.context().close();
+	});
+
+	test('approving a tier-bearing application skips the tier picker and sends no tier_id', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Tiered')
+		]);
+		// A SECOND tier is what makes this test discriminate: with one tier the UI
+		// auto-picks it and no modal would open for any request. Approval is
+		// required so the tier-bearing apply parks as pending instead of
+		// completing on the spot.
+		await createMembershipTier(org.owner, org.slug, 'Premium');
+		await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: true });
+		const application = await applyViaApi(applicant, org.slug, { tierId: org.defaultTierId });
+		expect(application.status).toBe('pending');
+		const name = `${applicant.firstName} ${applicant.lastName}`;
+
+		const page = await pageAs(browser, org.owner);
+		await openRequestsTab(page, org.slug);
+
+		// The card advertises the tier the member applied for (the chip's screen
+		// reader prefix is what turns a bare word into a labelled fact).
+		await expect(card(page, name)).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText('Tier: General membership')).toBeVisible();
+
+		const approveModal = page.getByRole('dialog', { name: 'Approve Membership Request' });
+		const approveCall = page.waitForRequest(
+			(request) => request.url().includes('/approve') && request.method() === 'POST'
+		);
+		await page.getByRole('button', { name: `Approve request from ${name}` }).click();
+
+		// The contract: an EMPTY body. The application already carries its tier and
+		// the backend resolves it — sending a tier_id here would let the UI
+		// overrule the member's choice with tiers[0].
+		const request = await approveCall;
+		expect(request.postDataJSON()).toEqual({});
+
+		// No picker, at any point: not while the mutation was in flight, and not
+		// after it settled. (Two tiers exist — a tier-less row here WOULD open one.)
+		await expect(approveModal).toHaveCount(0);
+		await expect(card(page, name)).toBeHidden({ timeout: 15_000 });
+		await expect(approveModal).toHaveCount(0);
+
+		// The row moved to COMPLETED — and lost its action buttons with it.
+		await selectFilter(page, 'Completed');
+		await expect(card(page, name)).toBeVisible({ timeout: 15_000 });
+		await expect(statusRow(page)).toContainText('Completed');
+		await expect(page.getByRole('button', { name: `Approve request from ${name}` })).toHaveCount(0);
+
+		await page.context().close();
+	});
+
+	test('approving a tier-less application goes through the tier picker', async ({ browser }) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Plain')
+		]);
+		await createMembershipTier(org.owner, org.slug, 'Premium');
+		// Tier-less applications park as pending whatever the approval policy —
+		// the backend never resolves a default tier on the member's behalf.
+		const application = await applyViaApi(applicant, org.slug, { notes: 'E2E: pick a tier' });
+		expect(application.status).toBe('pending');
+		const name = `${applicant.firstName} ${applicant.lastName}`;
+
+		const page = await pageAs(browser, org.owner);
+		await openRequestsTab(page, org.slug);
+
+		await expect(card(page, name)).toBeVisible({ timeout: 15_000 });
+		// Nothing to advertise: no tier was applied for.
+		await expect(page.getByText('Tier: General membership')).toHaveCount(0);
+
+		await page.getByRole('button', { name: `Approve request from ${name}` }).click();
+		const approveModal = page.getByRole('dialog', { name: 'Approve Membership Request' });
+		await expect(approveModal).toBeVisible();
+		await expect(
+			approveModal.getByText(`Select a membership tier to assign to ${name}.`)
+		).toBeVisible();
+
+		// Staff pick, and their pick is what lands on the row.
+		await pickSelectOption(page, approveModal.getByLabel('Membership Tier'), 'Premium');
+		await approveModal.getByRole('button', { name: 'Approve Request' }).click();
+		await expect(approveModal).toBeHidden({ timeout: 15_000 });
+
+		await selectFilter(page, 'Completed');
+		await expect(card(page, name)).toBeVisible({ timeout: 15_000 });
+		await expect(statusRow(page)).toContainText('Completed');
+		await expect(page.getByText('Tier: Premium')).toBeVisible();
+
+		await page.context().close();
+	});
+
+	test('an application carrying a questionnaire submission links to it and flags the review', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('Filler')
+		]);
+		// HYBRID: auto-gradable multiple choice, filed for a human to confirm. It
+		// is the only mode that produces `evaluation_status: 'pending review'`,
+		// which is exactly what the card's hint renders off.
+		const wrapper = await createMembershipQuestionnaire(org.owner, org.slug, {
+			evaluationMode: 'hybrid'
+		});
+		await setOrgMembershipPolicy(org.owner, org.slug, { defaultQuestionnaireId: wrapper.id });
+		const name = `${applicant.firstName} ${applicant.lastName}`;
+
+		// The member fills the gate through the UI (the fill route's own coverage
+		// is questionnaire-flow.spec.ts; here it is the arrange that produces a
+		// real submission), then applies with it attached — the pointer the admin
+		// card turns into a link.
+		const memberPage = await pageAs(browser, applicant);
+		await gotoHydrated(memberPage, `/org/${org.slug}`);
+		await waitForClientAuth(memberPage);
+		await memberPage.getByRole('link', { name: 'Fill in the membership questionnaire' }).click();
+		await memberPage.waitForURL('**/questionnaire/**');
+		await memberPage
+			.getByRole('radio', { name: MEMBERSHIP_QUESTION.automatic.correct, exact: true })
+			.click();
+		await memberPage.getByRole('button', { name: 'Submit Questionnaire' }).click();
+		await memberPage.waitForURL(`**/org/${org.slug}`, { timeout: 20_000 });
+		await memberPage.context().close();
+
+		const submissionId = await submissionPendingReview(org.owner, wrapper.id, applicant.email);
+		const application = await applyViaApi(applicant, org.slug, { submissionId });
+		expect(application.status).toBe('pending');
+
+		const page = await pageAs(browser, org.owner);
+		await openRequestsTab(page, org.slug);
+		await expect(card(page, name)).toBeVisible({ timeout: 15_000 });
+
+		// The link points at the org-admin submission viewer — keyed by the
+		// WRAPPER questionnaire id, not the inner one the fill route takes.
+		const link = page.getByRole('link', { name: 'View questionnaire submission' });
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute(
+			'href',
+			`/org/${org.slug}/admin/questionnaires/${wrapper.id}/submissions/${submissionId}`
+		);
+		// …and it carries the reason it is worth clicking, as its accessible
+		// description (the hint is a sibling <span>, tied on by aria-describedby).
+		await expect(link).toHaveAccessibleDescription(/review pending/i);
+
+		await page.context().close();
+	});
+
+	test('the retired standalone requests page permanently redirects into the tab', async ({
+		browser
+	}) => {
+		test.setTimeout(120_000);
+		const org = await createOrganization({ acceptMembershipRequests: true });
+
+		const page = await pageAs(browser, org.owner);
+		const response = await page.goto(`/org/${org.slug}/admin/members/requests`);
+
+		// The redirect must be PERMANENT — a 302 would leave every old bookmark
+		// and notification link paying for the hop forever.
+		const redirected = response?.request().redirectedFrom() ?? null;
+		expect(redirected, 'no redirect happened at all').not.toBeNull();
+		expect((await redirected?.response())?.status()).toBe(301);
+
+		// …and it lands on the Requests tab, selected.
+		expect(new URL(page.url()).pathname + new URL(page.url()).search).toBe(
+			`/org/${org.slug}/admin/members?tab=requests`
+		);
+		await page.locator('body[data-hydrated="true"]').waitFor({ state: 'attached' });
+		await waitForClientAuth(page);
+		await expect(page.getByRole('tab', { name: 'Requests' })).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		await expect(page.getByRole('heading', { name: 'No pending requests' })).toBeVisible({
+			timeout: 15_000
+		});
+
+		await page.context().close();
+	});
+});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1346,14 +1346,16 @@ export async function rejectApplication(
  * Set an org's membership-eligibility policy (the org-level defaults every
  * tier inherits unless it overrides them).
  *
- * READ-THEN-PUT: the endpoint takes OrganizationEditSchema, whose unsent
- * optional fields fall back to their schema defaults — a naive PUT carrying
- * only the policy would silently flip `accept_membership_requests` back off,
- * the org back to private, and blank every social link and location field.
- * So the body echoes back EVERY writable field of OrganizationEditSchema as
- * the admin retrieve currently reports it, with only the caller's keys
- * overridden — nothing an earlier arrange (or a spec's own settings-UI edit)
- * put on the org is lost.
+ * READ-THEN-PUT, defensively: the endpoint takes OrganizationEditSchema, and
+ * the BE update path currently applies it with `model_dump(exclude_unset=True)`
+ * (organization_service/lifecycle.py), so omitted fields are simply left alone
+ * — a policy-only PUT would NOT lose data today (see `createOrganization`
+ * above, which does a harmless naive 2-field PUT). This factory still echoes
+ * back EVERY writable field of OrganizationEditSchema as the admin retrieve
+ * currently reports it, with only the caller's keys overridden: a full
+ * representation write stays correct even if those update semantics ever
+ * change, and makes each write self-documenting about the org state it leaves
+ * behind.
  *
  * Two fields are deliberately never sent: `contact_email` (excluded from the
  * edit schema — it has its own verification flow) and `tags` (not writable

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -526,34 +526,78 @@ export async function createGuestRsvp(eventId: string, label = 'Guest'): Promise
 	return { email, firstName, lastName };
 }
 
-/** Add a membership tier to a throwaway-owned org. */
+/**
+ * Add a membership tier to an org. `owner` accepts a persona name too, because
+ * ONLINE plans can only exist on the Stripe-connected seeded Org Alpha — every
+ * hosted-checkout spec arranges its tiers there as `'owner'` (alice).
+ */
 export async function createMembershipTier(
-	owner: ThrowawayUser,
+	owner: PersonaName | ThrowawayUser,
 	orgSlug: string,
 	name: string
 ): Promise<{ id: string }> {
-	const api = await ApiClient.login(owner.email, owner.password);
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
 	return api.post<{ id: string }>(`/api/organization-admin/${orgSlug}/membership-tiers`, { name });
 }
 
 /**
- * API-create a subscription plan on a membership tier of a throwaway-owned
- * org (defaults: €15.00 monthly). ARRANGE step for the subscription-lifecycle
- * journey — plan AUTHORING through the UI is j23 plans-admin.
+ * API-create a subscription plan on a membership tier (defaults: €15.00
+ * monthly, OFFLINE — the backend's own default payment method). ARRANGE step
+ * for the subscription journeys — plan AUTHORING through the UI is j23
+ * plans-admin. Extra plan fields (`payment_method: 'online'`,
+ * `max_subscriptions`, `sales_status`, `period_unit`, …) are spread onto the
+ * payload as given.
+ *
+ * `owner` accepts a persona name: ONLINE plans require Stripe Connect, which
+ * only the seeded Org Alpha has, so they are created as `'owner'` (alice).
  */
 export async function createSubscriptionPlan(
-	owner: ThrowawayUser,
+	owner: PersonaName | ThrowawayUser,
 	orgSlug: string,
 	tierId: string,
 	plan: Record<string, unknown> = {}
 ): Promise<{ id: string; name: string }> {
-	const api = await ApiClient.login(owner.email, owner.password);
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
 	const name = (plan.name as string) ?? uniqueName('Plan');
 	const created = await api.post<{ id: string }>(
 		`/api/organization-admin/${orgSlug}/tiers/${tierId}/plans`,
 		{ name, price: '15.00', currency: 'EUR', ...plan }
 	);
 	return { id: created.id, name };
+}
+
+/**
+ * PATCH a subscription plan (`sales_status`, `max_subscriptions`, price, …).
+ * `payment_method` is deliberately NOT patchable backend-side — archive the
+ * plan and create a new one instead.
+ */
+export async function updateSubscriptionPlan(
+	owner: PersonaName | ThrowawayUser,
+	orgSlug: string,
+	planId: string,
+	patch: Record<string, unknown>
+): Promise<void> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+	await api.patch(`/api/organization-admin/${orgSlug}/plans/${planId}`, patch);
+}
+
+/**
+ * The org's UUID, read from the PUBLIC retrieve endpoint (no auth needed).
+ * Member-facing subscription endpoints are keyed by org id, not slug.
+ */
+export async function getOrganizationId(slug: string): Promise<string> {
+	const response = await fetchWithRetry(`${API_URL}/api/organizations/${slug}`);
+	if (!response.ok) {
+		throw new ApiError(response.status, 'GET', `/api/organizations/${slug}`, await response.text());
+	}
+	const org = (await response.json()) as { id?: string };
+	if (!org.id) {
+		throw new Error(`Organization ${slug} has no id`);
+	}
+	return org.id;
 }
 
 /**

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1219,11 +1219,19 @@ export async function getSeededBestAvailableEvent(
  *
  * `nextStep` is the eligibility verdict's `next_step` (null once there is
  * nothing left to do) — the same field MembershipCta switches its CTA on.
+ *
+ * `submissionId` attaches the questionnaire submission that satisfied the
+ * gate — the audit pointer the org-admin request card turns into its
+ * "View questionnaire submission" link. The UI never sends it (ApplyDialog
+ * posts tier + notes only), so specs that need a submission-bearing row
+ * arrange it here. The backend validates it: it must be a READY submission
+ * owned by `user` for the questionnaire that actually gates this (org, tier),
+ * or the call 422s.
  */
 export async function applyViaApi(
 	user: ThrowawayUser,
 	orgSlug: string,
-	opts: { tierId?: string; notes?: string } = {}
+	opts: { tierId?: string; notes?: string; submissionId?: string } = {}
 ): Promise<{ applicationId: string; status: string; nextStep: string | null }> {
 	const api = await ApiClient.login(user.email, user.password);
 	const response = await api.post<{
@@ -1231,7 +1239,8 @@ export async function applyViaApi(
 		eligibility: { next_step?: string | null };
 	}>(`/api/me/organizations/${orgSlug}/apply`, {
 		tier_id: opts.tierId ?? null,
-		notes: opts.notes
+		notes: opts.notes,
+		questionnaire_submission_id: opts.submissionId ?? null
 	});
 	const applicationId = response.application.id;
 	if (!applicationId) {
@@ -1400,7 +1409,7 @@ export async function patchTierPolicy(
 /** The single question createMembershipQuestionnaire asks, per mode — exported
  *  so specs answer it by name instead of guessing at the wording. */
 export const MEMBERSHIP_QUESTION = {
-	/** Auto-graded multiple choice. */
+	/** Auto-graded multiple choice — asked in `'automatic'` AND `'hybrid'` mode. */
 	automatic: {
 		question: 'Do you agree to the code of conduct?',
 		correct: 'Yes, I agree',
@@ -1422,7 +1431,16 @@ export const MEMBERSHIP_QUESTION = {
  *     grading of prose needs an LLM, which no E2E run should depend on).
  *     With `min_score: 0` any answer passes, so the gate clears itself.
  *   * `'manual'` — one free-text question; the submission parks in the org's
- *     review queue until staff grade it.
+ *     review queue until staff grade it. NOTE: manual mode queues NO
+ *     evaluation at all (see `submit_membership_questionnaire`: only
+ *     automatic/hybrid enqueue the task), so the submission's
+ *     `evaluation_status` stays NULL forever — nothing renders a
+ *     "pending review" hint off a manual submission.
+ *   * `'hybrid'` — the same auto-gradable multiple choice as `'automatic'`
+ *     (free text would need LLM guidelines here too), but the grader files the
+ *     evaluation as PENDING REVIEW instead of finalizing it. This is the only
+ *     mode that yields `evaluation_status: 'pending review'` — what the
+ *     org-admin request card's "Review pending" hint keys on.
  *
  * The returned id is the ORGANIZATION-QUESTIONNAIRE WRAPPER's — what
  * `default_membership_questionnaire_id` / `membership_questionnaire_id` want.
@@ -1434,12 +1452,12 @@ export const MEMBERSHIP_QUESTION = {
 export async function createMembershipQuestionnaire(
 	owner: ThrowawayUser,
 	orgSlug: string,
-	opts: { evaluationMode: 'automatic' | 'manual' }
+	opts: { evaluationMode: 'automatic' | 'manual' | 'hybrid' }
 ): Promise<{ id: string }> {
 	const api = await ApiClient.login(owner.email, owner.password);
 	const org = await api.get<{ id: string }>(`/api/organizations/${orgSlug}`);
 	const questions =
-		opts.evaluationMode === 'automatic'
+		opts.evaluationMode !== 'manual'
 			? {
 					multiplechoicequestion_questions: [
 						{

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1295,8 +1295,17 @@ export async function rejectApplication(
  *
  * READ-THEN-PUT: the endpoint takes OrganizationEditSchema, whose unsent
  * optional fields fall back to their schema defaults — a naive PUT carrying
- * only the policy would silently flip `accept_membership_requests` back off
- * and the org back to private. Only the keys the caller passed change.
+ * only the policy would silently flip `accept_membership_requests` back off,
+ * the org back to private, and blank every social link and location field.
+ * So the body echoes back EVERY writable field of OrganizationEditSchema as
+ * the admin retrieve currently reports it, with only the caller's keys
+ * overridden — nothing an earlier arrange (or a spec's own settings-UI edit)
+ * put on the org is lost.
+ *
+ * Two fields are deliberately never sent: `contact_email` (excluded from the
+ * edit schema — it has its own verification flow) and `tags` (not writable
+ * here). `city` is the one shape mismatch: the retrieve nests the whole city
+ * object, the edit schema wants its id.
  */
 export async function setOrgMembershipPolicy(
 	owner: ThrowawayUser,
@@ -1312,7 +1321,16 @@ export async function setOrgMembershipPolicy(
 		visibility: string;
 		accept_membership_requests: boolean;
 		contact_method: string;
+		revenue_report_cadence: string;
 		description?: string | null;
+		instagram_url?: string | null;
+		facebook_url?: string | null;
+		bluesky_url?: string | null;
+		telegram_url?: string | null;
+		city?: { id?: number | null } | null;
+		address?: string | null;
+		location_maps_url?: string | null;
+		location_maps_embed?: string | null;
 		membership_grace_period_days: number;
 		membership_subscription_revival_window_days: number;
 		membership_refund_policy: string;
@@ -1320,12 +1338,23 @@ export async function setOrgMembershipPolicy(
 		default_requires_membership_approval: boolean;
 	}>(`/api/organization-admin/${orgSlug}`);
 	await api.put(`/api/organization-admin/${orgSlug}`, {
+		// Echoed back unchanged.
 		visibility: current.visibility,
 		accept_membership_requests: current.accept_membership_requests,
 		contact_method: current.contact_method,
+		revenue_report_cadence: current.revenue_report_cadence,
 		description: current.description ?? '',
+		instagram_url: current.instagram_url ?? null,
+		facebook_url: current.facebook_url ?? null,
+		bluesky_url: current.bluesky_url ?? null,
+		telegram_url: current.telegram_url ?? null,
+		city_id: current.city?.id ?? null,
+		address: current.address ?? null,
+		location_maps_url: current.location_maps_url ?? null,
+		location_maps_embed: current.location_maps_embed ?? null,
 		membership_grace_period_days: current.membership_grace_period_days,
 		membership_refund_policy: current.membership_refund_policy,
+		// Overridable.
 		membership_subscription_revival_window_days:
 			policy.revivalWindowDays ?? current.membership_subscription_revival_window_days,
 		// `undefined` means "leave alone"; an explicit `null` clears it.
@@ -1394,6 +1423,13 @@ export const MEMBERSHIP_QUESTION = {
  *     With `min_score: 0` any answer passes, so the gate clears itself.
  *   * `'manual'` — one free-text question; the submission parks in the org's
  *     review queue until staff grade it.
+ *
+ * The returned id is the ORGANIZATION-QUESTIONNAIRE WRAPPER's — what
+ * `default_membership_questionnaire_id` / `membership_questionnaire_id` want.
+ * It is NOT the id the join-eligibility verdict carries in
+ * `questionnaire_id` (the inner Questionnaire, which is what the
+ * /org/{slug}/questionnaire/{id} route takes), so specs must build that URL
+ * from the eligibility verdict or the CTA link, never from this return value.
  */
 export async function createMembershipQuestionnaire(
 	owner: ThrowawayUser,
@@ -1461,7 +1497,9 @@ export async function subscribeViaApi(
  * Staff-create a subscription on behalf of a member (OFFLINE plans only — the
  * backend refuses ONLINE ones here so the member can confirm their own first
  * payment). Recording an initial payment is what puts the subscription in an
- * ACTIVE, paid-up state; omit it to arrange a still-unpaid row.
+ * ACTIVE, paid-up state; omit it to arrange a still-unpaid row. `currency`
+ * defaults to 'EUR' whenever an `amount` is given (and is left unset without
+ * one, so no currency is recorded for a payment that never happened).
  */
 export async function staffCreateOfflineSubscription(
 	owner: ThrowawayUser | 'owner',

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1203,3 +1203,277 @@ export async function getSeededBestAvailableEvent(
 		tier: { id: tier.id, name: tier.name }
 	};
 }
+
+// ---- Membership applications & subscriptions (j23 / j27) ----
+
+/**
+ * Apply for membership straight through the member API
+ * (POST /me/organizations/{slug}/apply).
+ *
+ * The outcome depends entirely on the org/tier policy, so specs read the
+ * returned `status`: a TIER-BEARING apply against an org with no gate (no
+ * approval requirement, no questionnaire) comes back `completed` — the
+ * membership exists already. A TIER-LESS apply (what the UI's ApplyDialog
+ * sends) stays `pending` for staff, because the backend never resolves a
+ * default tier on the member's behalf.
+ *
+ * `nextStep` is the eligibility verdict's `next_step` (null once there is
+ * nothing left to do) — the same field MembershipCta switches its CTA on.
+ */
+export async function applyViaApi(
+	user: ThrowawayUser,
+	orgSlug: string,
+	opts: { tierId?: string; notes?: string } = {}
+): Promise<{ applicationId: string; status: string; nextStep: string | null }> {
+	const api = await ApiClient.login(user.email, user.password);
+	const response = await api.post<{
+		application: { id?: string | null; status: string };
+		eligibility: { next_step?: string | null };
+	}>(`/api/me/organizations/${orgSlug}/apply`, {
+		tier_id: opts.tierId ?? null,
+		notes: opts.notes
+	});
+	const applicationId = response.application.id;
+	if (!applicationId) {
+		throw new Error(`Apply to ${orgSlug} returned an application without an id`);
+	}
+	return {
+		applicationId,
+		status: response.application.status,
+		nextStep: response.eligibility.next_step ?? null
+	};
+}
+
+/** Withdraw one of the caller's own applications (idempotent server-side). */
+export async function cancelApplicationViaApi(
+	user: ThrowawayUser,
+	applicationId: string
+): Promise<void> {
+	const api = await ApiClient.login(user.email, user.password);
+	await api.post(`/api/me/applications/${applicationId}/cancel`);
+}
+
+/**
+ * Approve a membership application from the org-admin side. An application and
+ * the legacy membership request are the same row, so this is the same endpoint
+ * as approveMembershipRequest — but with `tier_id` OPTIONAL: an application
+ * that already carries a tier resolves its own, and only a tier-less
+ * (UI-created) one needs staff to pick.
+ *
+ * Approving does NOT create the membership — the state machine advances on the
+ * member's next read of the application (GET /me/applications/{id}), which the
+ * account hub's Applications section fires on every mount.
+ */
+export async function approveApplication(
+	owner: ThrowawayUser | 'owner',
+	orgSlug: string,
+	requestId: string,
+	tierId?: string
+): Promise<void> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+	await api.post(
+		`/api/organization-admin/${orgSlug}/membership-requests/${requestId}/approve`,
+		tierId ? { tier_id: tierId } : {}
+	);
+}
+
+/** Reject a membership application from the org-admin side. */
+export async function rejectApplication(
+	owner: ThrowawayUser | 'owner',
+	orgSlug: string,
+	requestId: string
+): Promise<void> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+	await api.post(`/api/organization-admin/${orgSlug}/membership-requests/${requestId}/reject`);
+}
+
+/**
+ * Set an org's membership-eligibility policy (the org-level defaults every
+ * tier inherits unless it overrides them).
+ *
+ * READ-THEN-PUT: the endpoint takes OrganizationEditSchema, whose unsent
+ * optional fields fall back to their schema defaults — a naive PUT carrying
+ * only the policy would silently flip `accept_membership_requests` back off
+ * and the org back to private. Only the keys the caller passed change.
+ */
+export async function setOrgMembershipPolicy(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	policy: {
+		requiresApproval?: boolean;
+		defaultQuestionnaireId?: string | null;
+		revivalWindowDays?: number;
+	}
+): Promise<void> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	const current = await api.get<{
+		visibility: string;
+		accept_membership_requests: boolean;
+		contact_method: string;
+		description?: string | null;
+		membership_grace_period_days: number;
+		membership_subscription_revival_window_days: number;
+		membership_refund_policy: string;
+		default_membership_questionnaire_id?: string | null;
+		default_requires_membership_approval: boolean;
+	}>(`/api/organization-admin/${orgSlug}`);
+	await api.put(`/api/organization-admin/${orgSlug}`, {
+		visibility: current.visibility,
+		accept_membership_requests: current.accept_membership_requests,
+		contact_method: current.contact_method,
+		description: current.description ?? '',
+		membership_grace_period_days: current.membership_grace_period_days,
+		membership_refund_policy: current.membership_refund_policy,
+		membership_subscription_revival_window_days:
+			policy.revivalWindowDays ?? current.membership_subscription_revival_window_days,
+		// `undefined` means "leave alone"; an explicit `null` clears it.
+		default_membership_questionnaire_id:
+			policy.defaultQuestionnaireId !== undefined
+				? policy.defaultQuestionnaireId
+				: (current.default_membership_questionnaire_id ?? null),
+		default_requires_membership_approval:
+			policy.requiresApproval ?? current.default_requires_membership_approval
+	});
+}
+
+/**
+ * Override a single TIER's eligibility policy (PUT membership-tiers/{id};
+ * MembershipTierUpdateSchema is fully partial, so unsent fields keep their
+ * value). `requires_membership_approval` is tri-state — `null` means "inherit
+ * the org default".
+ *
+ * The generated field is `membership_questionnaire_id`; the shorter
+ * `membership_questionnaire` key here is the spec-facing name, mapped on the
+ * way out.
+ */
+export async function patchTierPolicy(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	tierId: string,
+	patch: {
+		membership_questionnaire?: string | null;
+		requires_membership_approval?: boolean | null;
+	}
+): Promise<void> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	await api.put(`/api/organization-admin/${orgSlug}/membership-tiers/${tierId}`, {
+		...('membership_questionnaire' in patch
+			? { membership_questionnaire_id: patch.membership_questionnaire }
+			: {}),
+		...('requires_membership_approval' in patch
+			? { requires_membership_approval: patch.requires_membership_approval }
+			: {})
+	});
+}
+
+/** The single question createMembershipQuestionnaire asks, per mode — exported
+ *  so specs answer it by name instead of guessing at the wording. */
+export const MEMBERSHIP_QUESTION = {
+	/** Auto-graded multiple choice. */
+	automatic: {
+		question: 'Do you agree to the code of conduct?',
+		correct: 'Yes, I agree',
+		wrong: 'No, rules are not for me'
+	},
+	/** Free text, for a human to read. */
+	manual: { question: 'Why do you want to join?' }
+} as const;
+
+/**
+ * Create a PUBLISHED MEMBERSHIP questionnaire on a throwaway-owned org — the
+ * org-level or tier-level JOIN gate, never attached to an event (that is
+ * attachAdmissionQuestionnaire's job). Exactly one mandatory question, whose
+ * TYPE follows the evaluation mode (see MEMBERSHIP_QUESTION):
+ *
+ *   * `'automatic'` — one multiple-choice question with a correct option, the
+ *     house pattern for deterministic inline grading. A free-text question
+ *     here is rejected outright (422 `missing_llm_guidelines`: automatic
+ *     grading of prose needs an LLM, which no E2E run should depend on).
+ *     With `min_score: 0` any answer passes, so the gate clears itself.
+ *   * `'manual'` — one free-text question; the submission parks in the org's
+ *     review queue until staff grade it.
+ */
+export async function createMembershipQuestionnaire(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	opts: { evaluationMode: 'automatic' | 'manual' }
+): Promise<{ id: string }> {
+	const api = await ApiClient.login(owner.email, owner.password);
+	const org = await api.get<{ id: string }>(`/api/organizations/${orgSlug}`);
+	const questions =
+		opts.evaluationMode === 'automatic'
+			? {
+					multiplechoicequestion_questions: [
+						{
+							question: MEMBERSHIP_QUESTION.automatic.question,
+							is_mandatory: true,
+							is_fatal: true,
+							shuffle_options: false,
+							options: [
+								{ option: MEMBERSHIP_QUESTION.automatic.correct, is_correct: true, order: 0 },
+								{ option: MEMBERSHIP_QUESTION.automatic.wrong, order: 1 }
+							]
+						}
+					]
+				}
+			: {
+					freetextquestion_questions: [
+						{ question: MEMBERSHIP_QUESTION.manual.question, is_mandatory: true }
+					]
+				};
+	return api.post<{ id: string }>(`/api/questionnaires/${org.id}/create-questionnaire`, {
+		name: uniqueName('Membership Questionnaire'),
+		min_score: 0,
+		evaluation_mode: opts.evaluationMode,
+		status: 'published',
+		questionnaire_type: 'membership',
+		...questions
+	});
+}
+
+/**
+ * Member-initiated subscribe on an ONLINE plan (POST
+ * /me/organizations/{org_id}/subscribe) — returns the local subscription plus
+ * the hosted Stripe Checkout URL the spec then drives with
+ * completeStripeCheckout(). OFFLINE plans are refused here by design; use
+ * staffCreateOfflineSubscription for those.
+ */
+export async function subscribeViaApi(
+	user: ThrowawayUser,
+	orgId: string,
+	planId: string
+): Promise<{ subscriptionId: string; checkoutUrl: string | null }> {
+	const api = await ApiClient.login(user.email, user.password);
+	const response = await api.post<{
+		subscription: { id?: string | null };
+		checkout_url?: string | null;
+	}>(`/api/me/organizations/${orgId}/subscribe`, { plan_id: planId });
+	const subscriptionId = response.subscription.id;
+	if (!subscriptionId) {
+		throw new Error(`Subscribe to plan ${planId} returned a subscription without an id`);
+	}
+	return { subscriptionId, checkoutUrl: response.checkout_url ?? null };
+}
+
+/**
+ * Staff-create a subscription on behalf of a member (OFFLINE plans only — the
+ * backend refuses ONLINE ones here so the member can confirm their own first
+ * payment). Recording an initial payment is what puts the subscription in an
+ * ACTIVE, paid-up state; omit it to arrange a still-unpaid row.
+ */
+export async function staffCreateOfflineSubscription(
+	owner: ThrowawayUser | 'owner',
+	orgSlug: string,
+	opts: { planId: string; userId: string; amount?: string; currency?: string }
+): Promise<{ id: string }> {
+	const credentials = typeof owner === 'string' ? PERSONAS[owner] : owner;
+	const api = await ApiClient.login(credentials.email, credentials.password);
+	return api.post<{ id: string }>(`/api/organization-admin/${orgSlug}/subscriptions`, {
+		plan_id: opts.planId,
+		user_id: opts.userId,
+		initial_payment_amount: opts.amount,
+		initial_payment_currency: opts.currency ?? (opts.amount ? 'EUR' : undefined)
+	});
+}


### PR DESCRIPTION
## Summary

Final FE PR of the membership-subscriptions launch bundle (PR⑤ of 5). Adds the Playwright E2E suite mapping **USER_JOURNEYS J23 (subscriptions) + J27 (applications/eligibility)**, migrates the specs broken by the legacy-join retirement, and folds in the #687 polish batch.

**Suite tally: 433 → 489** (489 passed / 2 intentional skips / 0 failed, 8.2m full run on a fresh canonical reseed). Unit gate: 1574 passed / 1 todo; `make check` clean.

Closes #687

## What's in here

- **`j27-applications/`** (new journey dir, 14 tests): apply flows (instant tier-bearing completion, manual approval + advance-on-read, reject→re-apply, cancel), questionnaire pipeline (auto-eval gate-clear + manual waiting state, org-scoped fill route `/org/[slug]/questionnaire/[id]`), eligibility states (org not accepting, member badge, tier-level approval override 2×2 matrix), requests-admin (six filters, tier-bearing approve with **verified `{}` body**, tier-less picker, submission link + `aria-describedby` review hint, legacy-URL exact-301).
- **`j23-subscriptions/`** (6 new specs + 1 extended): hosted-Stripe subscribe journey incl. the launch's **zero-coverage MUST-COVER** — the `?membership_success` param-strip (raw `history.replaceState` in onMount, jsdom-untestable) and the CheckoutReturnCard webhook-driven `Welcome, member!` poll; abandon → `Checkout not completed` → Resume payment → paid; plan availability states (sold-out via PENDING-occupies-cap, paused, guest CTA, offline card); org-policy round-trips (revival window + default questionnaire + approval default, no-clobber guard); tier tri-state (`norequire` persists as explicit `false`, org-default-aware inherit label both directions); deterministic metrics (MRR €15.00 / active 1); change-plan up/down (pending-downgrade line) + both cancel modes + billing portal (201 + real `billing.stripe.com` navigation); revival window + past-due banner against the BE #795 fixtures.
- **j01/j03 migration**: `organizations` + `follow-org` rewritten from the deleted `RequestMembershipButton` flow to the eligibility CTA + ApplyDialog; j23 lifecycle locators disambiguated from the always-mounted Applications section.
- **#687 polish (src)**: sr-only "Tier:" chip prefix, `aria-describedby` review-pending hint, house spinner idiom (icon + sr-only), `account/memberships` error branch, ApplicationsSection refetch-discard guard, reject-toast + page-reset test hardening, de vocabulary alignment.
- **Shipped regression fixed in src** (found by the mobile baseline): `TierFormModal`/`PlanFormModal` dialogs measured 860px in a 752px viewport with no scroll container — submit row unreachable on mobile. Fixed with the house `max-h-[90vh] overflow-y-auto` (char-identical to ApplyDialog's).
- **Membership API factories** (`applyViaApi`, `approveApplication`, `subscribeViaApi`, `setOrgMembershipPolicy` full-field echo, `patchTierPolicy`, `createMembershipQuestionnaire`, `staffCreateOfflineSubscription`, …) for future suites.

## BE dependencies (already landed)

- **#794** — `reset_events` ProtectedError fix (tier-bearing applications blocked the org cascade; every reseed on the branch broke without it).
- **#795** — `bootstrap_test_events` revival/past-due fixtures (`test.revival.in/out@`, `test.pastdue@`). ⚠️ One contract note in #795 is now known-wrong: revive does NOT resume without consuming the fixture — `POST /revive` flips the row EXPIRED→PENDING pre-payment, so the revival spec is strictly read-only and the revive→Stripe click-leg is an acknowledged E2E gap (follow-up issue filed; `RejoinCard.test.ts` covers the hand-off unit-side).

## Notes for review / CI

- `requests-admin` test 4 polls up to 45s for a **hybrid**-mode questionnaire evaluation — it needs a live Celery worker; a CI env without one fails there first (manual-mode questionnaires never evaluate; that's a BE behavior, encoded in the factory doc).
- All online plans are arranged on Org Alpha (the only Stripe-connected org) with uniqueName tiers/plans; every mutating spec arranges in-body → parallel- and retries:1-safe. Revival/past-due specs only read seeded fixtures.
- Stripe specs need `stripe listen` (`make run-stripe`) and `CONNECTED_TEST_STRIPE_ID` at bootstrap, as with the ticket suite.
- Live findings during spec-writing, filed as follow-up issues rather than fixed here: stale `cancel_at_period_end` webhook write-back race (~40ms post-200, card shows "Next renewal" until reload — spec documents + reload-polls); abandoned-revival leaves a zero-action Pending card; `SubscriptionMetrics` fetches `status_breakdown` but never renders it.
- Nothing merges to `main` before the coordinated FE+BE deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)