### PR TITLE
fix(errors): narrow the backend's honest error unions instead of casting (#653)

### DIFF
--- a/src/lib/components/events/ClaimInvitationButton.svelte
+++ b/src/lib/components/events/ClaimInvitationButton.svelte
@@ -8,6 +8,7 @@
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import type { EventTokenSchema } from '$lib/api/generated/types.gen';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		tokenId: string;
@@ -42,11 +43,13 @@
 			});
 
 			if (response.error) {
-				const err: unknown = response.error;
-				const errorDetail =
-					typeof err === 'object' && err !== null && 'detail' in err ? err.detail : undefined;
+				// One of only two endpoints in the codebase that genuinely answer 400
+				// with `ResponseMessage` (`{message}`) — everywhere else that
+				// declaration was a lie and `.message` was undefined at runtime
+				// (backend #824). Its 404 is `{detail}`, so `backendMessage` probes
+				// both rather than picking one and dropping the other.
 				throw new Error(
-					typeof errorDetail === 'string' ? errorDetail : m['claimInvitationButton.failedToClaim']()
+					backendMessage(response.error) ?? m['claimInvitationButton.failedToClaim']()
 				);
 			}
 

--- a/src/lib/components/events/EventRSVP.svelte
+++ b/src/lib/components/events/EventRSVP.svelte
@@ -3,7 +3,14 @@
 	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
 	import { eventpublicattendanceRsvpEvent } from '$lib/api/generated/sdk.gen';
 	import type { UserEventStatus } from '$lib/utils/eligibility';
-	import { isRSVP, isEligibility, isUserStatusResponse } from '$lib/utils/eligibility';
+	import {
+		isRSVP,
+		isEligibility,
+		isUserStatusResponse,
+		isEligibilityRefusal,
+		getEligibilityRefusalMessage
+	} from '$lib/utils/eligibility';
+	import { extractApiErrorDetail, isErrorDetail } from '$lib/utils/api-error-detail';
 	import { cn } from '$lib/utils/cn';
 	import RSVPButtons from './RSVPButtons.svelte';
 	import RsvpNoteDialog from './RsvpNoteDialog.svelte';
@@ -90,26 +97,15 @@
 	});
 
 	/**
-	 * The RSVP endpoint has two 400 shapes: the EventUserEligibility object
-	 * (carries `allowed`) and a plain `{detail}` when a note is sent while the
-	 * event no longer accepts notes. Detect the latter by shape, not wording.
+	 * The RSVP endpoint declares `EventUserEligibility | ErrorDetail` at 400
+	 * (backend #824). The eligibility branch carries `allowed`/`reason_code`; the
+	 * `{detail}` branch is what a note sent to an event that no longer accepts
+	 * notes produces (alongside capacity and RSVP-note rejections). Detect the
+	 * latter by shape, not wording — and never mistake an eligibility refusal for
+	 * it, which would silently re-submit the RSVP the backend just refused.
 	 */
 	function isNoteRejection(error: unknown): boolean {
-		return (
-			typeof error === 'object' &&
-			error !== null &&
-			'detail' in error &&
-			typeof (error as { detail: unknown }).detail === 'string' &&
-			!('allowed' in error)
-		);
-	}
-
-	function extractErrorDetail(error: unknown): string | null {
-		if (typeof error === 'object' && error !== null && 'detail' in error) {
-			const detail = (error as { detail: unknown }).detail;
-			if (typeof detail === 'string') return detail;
-		}
-		return null;
+		return isErrorDetail(error) && !isEligibilityRefusal(error);
 	}
 
 	// Mutation: RSVP to event
@@ -131,7 +127,15 @@
 			}
 
 			if (response.error || !response.data) {
-				throw new Error(extractErrorDetail(response.error) ?? 'No data returned from RSVP');
+				// Narrow the 400 union before reading it. An eligibility refusal is
+				// kept as `cause` so onError can re-seat it into `userStatus` and let
+				// the ineligibility CTA re-render with the backend's next_step.
+				if (isEligibilityRefusal(response.error)) {
+					const reason =
+						getEligibilityRefusalMessage(response.error) ?? m['eventRSVP.submitFailed']();
+					throw new Error(reason, { cause: response.error });
+				}
+				throw new Error(extractApiErrorDetail(response.error) ?? m['eventRSVP.submitFailed']());
 			}
 
 			return response.data;
@@ -215,6 +219,15 @@
 			// Rollback optimistic update
 			if (context?.previousStatus !== undefined) {
 				userStatus = context.previousStatus;
+			}
+
+			// The backend refused on eligibility grounds and told us why: adopt the
+			// fresh eligibility payload so the ineligibility message and its CTA
+			// re-render against the *current* next_step instead of the stale one the
+			// page was loaded with.
+			const refusal: unknown = error.cause;
+			if (isEligibilityRefusal(refusal)) {
+				userStatus = refusal;
 			}
 
 			// Show error message

--- a/src/lib/components/events/EventRSVP.test.ts
+++ b/src/lib/components/events/EventRSVP.test.ts
@@ -297,4 +297,127 @@ describe('EventRSVP', () => {
 		const buttons = screen.getAllByRole('button');
 		expect(buttons.length).toBeGreaterThan(0);
 	});
+	// --- 400 union narrowing (issue #653) -----------------------------------
+	// The RSVP endpoint declares `EventUserEligibility | ErrorDetail` at 400
+	// (backend #824). Each branch has to be probed before it is read, and the
+	// eligibility branch is the one that must re-render the CTA.
+
+	it('adopts an EventUserEligibility 400 so the ineligibility CTA re-renders', async () => {
+		const user = userEvent.setup();
+		vi.mocked(eventpublicattendanceRsvpEvent).mockResolvedValue({
+			error: {
+				allowed: false,
+				event_id: 'event-123',
+				reason: 'This event now requires an invitation',
+				next_step: 'request_invitation'
+			}
+		});
+
+		renderRSVP({
+			eventId: 'event-123',
+			eventName: 'Test Event',
+			userStatus: { allowed: true, next_step: 'rsvp' } satisfies EventUserEligibility,
+			isAuthenticated: true,
+			requiresTicket: false,
+			event: mockEvent
+		});
+
+		await user.click(screen.getByRole('button', { name: /yes/i }));
+
+		await waitFor(() => {
+			// The refusal's own prose, not a generic "no data returned" string.
+			expect(screen.getByText(/This event now requires an invitation/i)).toBeInTheDocument();
+		});
+		// And the RSVP buttons are gone: the fresh eligibility payload replaced the
+		// stale allowed=true one the page was loaded with.
+		expect(screen.queryByRole('button', { name: /^yes$/i })).not.toBeInTheDocument();
+	});
+
+	it('surfaces an ErrorDetail 400 verbatim without faking an eligibility state', async () => {
+		const user = userEvent.setup();
+		vi.mocked(eventpublicattendanceRsvpEvent).mockResolvedValue({
+			error: { detail: 'This event is at capacity.' }
+		});
+
+		renderRSVP({
+			eventId: 'event-123',
+			eventName: 'Test Event',
+			userStatus: { allowed: true, next_step: 'rsvp' } satisfies EventUserEligibility,
+			isAuthenticated: true,
+			requiresTicket: false,
+			event: mockEvent
+		});
+
+		await user.click(screen.getByRole('button', { name: /yes/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/This event is at capacity\./i)).toBeInTheDocument();
+		});
+		// No `allowed: false` payload arrived, so the RSVP controls stay put and the
+		// user can retry.
+		expect(screen.getByRole('button', { name: /yes/i })).toBeInTheDocument();
+	});
+
+	it('reads a request-validation 422 detail LIST instead of stringifying it', async () => {
+		const user = userEvent.setup();
+		vi.mocked(eventpublicattendanceRsvpEvent).mockResolvedValue({
+			error: {
+				detail: [
+					{ type: 'string_too_long', loc: ['body', 'payload', 'note'], msg: 'Note is too long' }
+				]
+			}
+		});
+
+		renderRSVP({
+			eventId: 'event-123',
+			eventName: 'Test Event',
+			userStatus: { allowed: true, next_step: 'rsvp' } satisfies EventUserEligibility,
+			isAuthenticated: true,
+			requiresTicket: false,
+			event: mockEvent
+		});
+
+		await user.click(screen.getByRole('button', { name: /yes/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/Note is too long/i)).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument();
+	});
+
+	it('does not mistake an eligibility refusal for a note rejection and re-submit', async () => {
+		const user = userEvent.setup();
+		vi.mocked(eventpublicattendanceRsvpEvent).mockResolvedValue({
+			error: {
+				allowed: false,
+				event_id: 'event-123',
+				reason: 'RSVPs have closed for this event',
+				next_step: 'wait_for_event_to_open'
+			}
+		});
+
+		renderRSVP({
+			eventId: 'event-123',
+			eventName: 'Test Event',
+			userStatus: { allowed: true, next_step: 'rsvp' } satisfies EventUserEligibility,
+			isAuthenticated: true,
+			requiresTicket: false,
+			event: { ...mockEvent, accept_rsvp_notes: true } as unknown as EventDetailSchema
+		});
+
+		await user.click(screen.getByRole('button', { name: /yes/i }));
+		// The note dialog opens first; confirm it with an empty note.
+		const confirmNote = await screen.findByRole('button', { name: /^RSVP Yes$/i });
+		await user.click(confirmNote);
+
+		// The refusal's next_step drives the CTA (this one renders its own copy
+		// rather than the backend `reason`, which is the point: it is the
+		// eligibility branch that was adopted, not the `{detail}` one).
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: /notify me/i })).toBeInTheDocument();
+		});
+		// Exactly one call: the refusal must not trigger the note-dropped retry,
+		// which would silently re-submit an RSVP the backend just refused.
+		expect(vi.mocked(eventpublicattendanceRsvpEvent)).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/lib/components/events/IneligibilityActionButton.svelte
+++ b/src/lib/components/events/IneligibilityActionButton.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import type { NextStep, EventTokenSchema } from '$lib/api/generated/types.gen';
-	import { getActionButtonText, isActionDisabled } from '$lib/utils/eligibility';
+	import {
+		getActionButtonText,
+		isActionDisabled,
+		getEligibilityRefusalMessage
+	} from '$lib/utils/eligibility';
+	import { backendMessage, extractApiErrorDetail } from '$lib/utils/api-error-detail';
 	import { cn } from '$lib/utils/cn';
 	import { Button } from '$lib/components/ui/button';
 	import RequestInvitationButton from './RequestInvitationButton.svelte';
@@ -69,6 +74,9 @@
 	let showSuccess = $state(false);
 	let showError = $state(false);
 	let errorMessage = $state('');
+	// Backend's own success sentence when it carries one (join-waitlist is
+	// idempotent and says so); falls back to the generic localized copy.
+	let successMessage = $state('');
 
 	/**
 	 * Get the Lucide icon component for the current next_step
@@ -141,6 +149,7 @@
 		// Clear previous errors
 		showError = false;
 		errorMessage = '';
+		successMessage = '';
 
 		// Navigation actions
 		if (nextStep === 'become_member') {
@@ -235,17 +244,25 @@
 							}
 						});
 					} else {
+						// 400 is declared `EventUserEligibility | ErrorDetail` (backend
+						// #824): probe before reading. The eligibility branch carries the
+						// refusal reason, the ErrorDetail branch a plain sentence, and a
+						// request-validation 422 a list — none of which is a bare string.
 						showError = true;
-						const errorDetail =
-							typeof response.error === 'object' &&
-							response.error !== null &&
-							'detail' in response.error
-								? (response.error.detail as string)
-								: m['ineligibilityActionButton.waitlist_error']();
-						errorMessage = errorDetail;
+						errorMessage =
+							getEligibilityRefusalMessage(response.error) ??
+							extractApiErrorDetail(response.error) ??
+							m['ineligibilityActionButton.waitlist_error']();
 					}
 				} else {
+					// Idempotent since backend #824: a double-submit / lost race now
+					// answers 200 with "You are already on the waitlist for this event."
+					// rather than a 400, so prefer the backend's own sentence — it is the
+					// only thing that distinguishes "you just joined" from "you already
+					// had" — and fall back to the generic success copy.
 					showSuccess = true;
+					successMessage =
+						backendMessage(response.data) ?? m['ineligibilityActionButton.success']();
 					// Optionally refresh the page or update UI to reflect waitlist status
 					setTimeout(() => {
 						window.location.reload();
@@ -284,13 +301,9 @@
 
 			if (response.error) {
 				showError = true;
-				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['ineligibilityActionButton.leaveWaitlist_error']();
-				errorMessage = errorDetail;
+				errorMessage =
+					extractApiErrorDetail(response.error) ??
+					m['ineligibilityActionButton.leaveWaitlist_error']();
 			} else {
 				// Success - reload the page to update the status
 				window.location.reload();
@@ -420,7 +433,7 @@
 				role="status"
 				aria-live="polite"
 			>
-				{m['ineligibilityActionButton.success']()}
+				{successMessage || m['ineligibilityActionButton.success']()}
 			</div>
 		{/if}
 

--- a/src/lib/components/events/RequestInvitationButton.svelte
+++ b/src/lib/components/events/RequestInvitationButton.svelte
@@ -7,6 +7,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { escapeHtml } from '$lib/utils/sanitize';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		eventId: string;
@@ -53,9 +54,7 @@
 
 			if (response.error) {
 				throw new Error(
-					typeof response.error === 'object' && response.error && 'detail' in response.error
-						? String(response.error.detail)
-						: m['requestInvitationButton.failedToSubmit']()
+					extractApiErrorDetail(response.error) ?? m['requestInvitationButton.failedToSubmit']()
 				);
 			}
 

--- a/src/lib/components/events/RequestWhitelistButton.svelte
+++ b/src/lib/components/events/RequestWhitelistButton.svelte
@@ -7,6 +7,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { escapeHtml } from '$lib/utils/sanitize';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		organizationSlug: string;
@@ -55,9 +56,7 @@
 
 			if (response.error) {
 				throw new Error(
-					typeof response.error === 'object' && response.error && 'detail' in response.error
-						? String(response.error.detail)
-						: m['requestWhitelistButton.failedToSubmit']()
+					extractApiErrorDetail(response.error) ?? m['requestWhitelistButton.failedToSubmit']()
 				);
 			}
 

--- a/src/lib/components/events/admin/DuplicateEventModal.svelte
+++ b/src/lib/components/events/admin/DuplicateEventModal.svelte
@@ -10,6 +10,7 @@
 	import { Copy, Loader2 } from '@lucide/svelte';
 	import { cn } from '$lib/utils/cn';
 	import DateTimePicker from '$lib/components/forms/DateTimePicker.svelte';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		open: boolean;
@@ -102,11 +103,8 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['duplicateEventModal.error_failedToDuplicate']();
+					extractApiErrorDetail(response.error) ??
+					m['duplicateEventModal.error_failedToDuplicate']();
 				throw new Error(errorDetail);
 			}
 

--- a/src/lib/components/events/admin/EssentialsStepSlugEditor.svelte
+++ b/src/lib/components/events/admin/EssentialsStepSlugEditor.svelte
@@ -5,6 +5,7 @@
 	import { createMutation } from '@tanstack/svelte-query';
 	import { eventadmincoreEditSlug } from '$lib/api/generated/sdk.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		eventId?: string;
@@ -61,11 +62,7 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['essentialsStep.error_slugUpdateFailed']();
+					extractApiErrorDetail(response.error) ?? m['essentialsStep.error_slugUpdateFailed']();
 				throw new Error(errorDetail);
 			}
 

--- a/src/lib/components/events/event-checkout-controller.svelte.ts
+++ b/src/lib/components/events/event-checkout-controller.svelte.ts
@@ -15,6 +15,7 @@ import type {
 } from '$lib/api/generated/types.gen';
 import { seatingBodyFields, type SeatingCheckoutFields } from '$lib/types/tickets';
 import { getEligibilityRefusalMessage } from '$lib/utils/eligibility';
+import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 import type { EventTicketSchemaActual, UserEventStatus } from '$lib/utils/eligibility';
 import {
 	createReservationRetry,
@@ -27,20 +28,19 @@ import { toast } from 'svelte-sonner';
 /**
  * Turn a backend error envelope into a throwable Error.
  *
- * Two shapes arrive here: the (undeclared) runtime `detail` field most payloads
- * carry, and — since BE #807 — a refused purchase, which answers 400 with the
- * whole `EventUserEligibility` payload and has no `detail` at all, so it would
- * otherwise land on the generic fallback. The refusal is read first and kept as
- * `cause`, so the confirmation dialog can recognise it and offer its own CTA.
+ * The checkout endpoints declare `EventUserEligibility | ErrorDetail` at 400
+ * (backend #824), so the union must be probed before it is read. A refused
+ * purchase (BE #807) answers with the whole eligibility payload and has no
+ * `detail` at all; capacity, seat-resolution, discount-code, PWYC-bound and
+ * Stripe-config rejections answer with `{detail}`. The refusal is read first and
+ * kept as `cause`, so the confirmation dialog can recognise it and offer its own
+ * CTA. `extractApiErrorDetail` also covers the request-validation 422, whose
+ * `detail` is a list of objects rather than a string.
  */
 function checkoutError(error: unknown, fallback: string): Error {
 	const refusal = getEligibilityRefusalMessage(error);
 	if (refusal) return new Error(refusal, { cause: error });
-	if (typeof error === 'object' && error !== null && 'detail' in error) {
-		const { detail } = error;
-		if (typeof detail === 'string' && detail) return new Error(detail);
-	}
-	return new Error(fallback);
+	return new Error(extractApiErrorDetail(error) ?? fallback, { cause: error });
 }
 
 // Type for checkout parameters

--- a/src/lib/components/invitations/InvitationLinksTab.svelte
+++ b/src/lib/components/invitations/InvitationLinksTab.svelte
@@ -22,6 +22,7 @@
 	import EventTokenModal from '$lib/components/tokens/EventTokenModal.svelte';
 	import TokenShareDialog from '$lib/components/tokens/TokenShareDialog.svelte';
 	import { getEventTokenUrl } from '$lib/utils/tokens';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		eventId: string;
@@ -91,7 +92,13 @@
 			});
 
 			if (response.error) {
-				throw new Error('Failed to create token');
+				// Newly declared 404 (backend #824): a `ticket_tier_ids` entry that
+				// does not belong to this event. The body NAMES the offending ids, so
+				// show it — a generic "failed" leaves the organizer with no way to
+				// find the stale tier in their selection.
+				throw new Error(
+					extractApiErrorDetail(response.error) ?? m['invitationLinksTab.createFailed']()
+				);
 			}
 
 			return response.data;
@@ -103,8 +110,8 @@
 			isCreateTokenModalOpen = false;
 			toast.success(m['invitationLinksTab.linkCreated']());
 		},
-		onError: () => {
-			toast.error(m['invitationLinksTab.createFailed']());
+		onError: (error: Error) => {
+			toast.error(error.message || m['invitationLinksTab.createFailed']());
 		}
 	}));
 
@@ -124,7 +131,11 @@
 			});
 
 			if (response.error) {
-				throw new Error('Failed to update token');
+				// Same newly declared 404 as create: the body names the offending
+				// ticket-tier ids.
+				throw new Error(
+					extractApiErrorDetail(response.error) ?? m['invitationLinksTab.updateFailed']()
+				);
 			}
 
 			return response.data;
@@ -136,8 +147,8 @@
 			tokenToEdit = null;
 			toast.success(m['invitationLinksTab.linkUpdated']());
 		},
-		onError: () => {
-			toast.error(m['invitationLinksTab.updateFailed']());
+		onError: (error: Error) => {
+			toast.error(error.message || m['invitationLinksTab.updateFailed']());
 		}
 	}));
 

--- a/src/lib/components/members/StaffReviveModal.svelte
+++ b/src/lib/components/members/StaffReviveModal.svelte
@@ -22,7 +22,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Loader2 } from '@lucide/svelte';
 	import { CURRENCY_OPTIONS } from '$lib/utils/currencies';
-	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		sub: SubscriptionSchema;
@@ -64,12 +64,13 @@
 				headers: { Authorization: `Bearer ${accessToken}` }
 			});
 			if (res.error) {
-				// The backend's 400s (revival window closed, plan sold out, member
-				// banned) are the source of truth — surface them verbatim.
-				const fallback = (res.error as { message?: string }).message;
-				throw new Error(
-					extractApiErrorDetail(res.error) ?? (fallback || 'Failed to revive subscription')
-				);
+				// The backend's refusals (revival window closed, plan sold out, member
+				// banned) are the source of truth — surface them verbatim. The 400 is
+				// `ValidationErrorResponse | ErrorDetail` and a negative `amount` is a
+				// request-validation 422 whose `detail` is a LIST, so probe rather than
+				// read: the old `(res.error as {message?})` cast named a field that was
+				// already undefined at runtime (backend #824).
+				throw new Error(backendMessage(res.error) ?? 'Failed to revive subscription');
 			}
 			return res.data;
 		},

--- a/src/lib/components/members/SubscriptionsTab.svelte
+++ b/src/lib/components/members/SubscriptionsTab.svelte
@@ -21,6 +21,7 @@
 	import SubscriptionDrawer from './SubscriptionDrawer.svelte';
 	import SubscriptionMetrics from './SubscriptionMetrics.svelte';
 	import { onDestroy } from 'svelte';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	// Buffer matching the bits-ui Dialog close animation. Chaining a Dialog
 	// open inside another Dialog's close handler in the same tick leaves
@@ -99,8 +100,10 @@
 				headers: { Authorization: `Bearer ${accessToken}` }
 			});
 			if (res.error) {
-				const detail = (res.error as { detail?: string }).detail ?? 'Failed to create subscription';
-				throw new Error(detail);
+				// 400 is `ValidationErrorResponse | ErrorDetail` (backend #824): the old
+				// `{detail?: string}` cast silently dropped the `{errors}` branch and
+				// stringified a request-validation 422's `detail` LIST.
+				throw new Error(backendMessage(res.error) ?? 'Failed to create subscription');
 			}
 			return res.data as SubscriptionSchema;
 		},

--- a/src/lib/components/notifications/NotificationPreferencesForm.svelte
+++ b/src/lib/components/notifications/NotificationPreferencesForm.svelte
@@ -22,14 +22,13 @@
 		NotificationTypeSettings,
 		UpdateNotificationPreferenceSchema
 	} from '$lib/api/generated/types.gen.js';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
-	// Extract a human-readable message from an unknown API error shape
+	// Extract a human-readable message from an unknown API error shape.
+	// `backendMessage` probes detail (string OR the 422 list) → errors → message;
+	// `String(error.detail)` used to render `[object Object]` on a 422.
 	function extractErrorMessage(error: unknown): string {
-		if (error && typeof error === 'object') {
-			if ('detail' in error && error.detail) return String(error.detail);
-			if ('message' in error && error.message) return String(error.message);
-		}
-		return 'Failed to update preferences';
+		return backendMessage(error) ?? 'Failed to update preferences';
 	}
 
 	interface Props {

--- a/src/lib/components/organization/OrgContactEmailModal.svelte
+++ b/src/lib/components/organization/OrgContactEmailModal.svelte
@@ -7,6 +7,7 @@
 		organizationadmincoreGetOrganization
 	} from '$lib/api/generated/sdk.gen';
 	import type { ContactMethod } from '$lib/api/generated/types.gen';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		slug: string;
@@ -67,10 +68,7 @@
 			});
 
 			if (error || !orgData) {
-				emailUpdateError =
-					typeof error === 'object' && error && 'detail' in error
-						? (error as { detail?: string }).detail || m['orgContactEmailModal.failedToUpdate']()
-						: m['orgContactEmailModal.failedToUpdate']();
+				emailUpdateError = backendMessage(error) ?? m['orgContactEmailModal.failedToUpdate']();
 				return;
 			}
 

--- a/src/lib/components/organization/OrgImageUploader.svelte
+++ b/src/lib/components/organization/OrgImageUploader.svelte
@@ -10,6 +10,7 @@
 		organizationadmincoreDeleteLogo,
 		organizationadmincoreDeleteCoverArt
 	} from '$lib/api/generated/sdk.gen';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		slug: string;
@@ -59,10 +60,7 @@
 			});
 
 			if (response.error) {
-				const errorMsg =
-					typeof response.error === 'object' && response.error && 'detail' in response.error
-						? String(response.error.detail)
-						: JSON.stringify(response.error);
+				const errorMsg = backendMessage(response.error) ?? JSON.stringify(response.error);
 				throw new Error(`Upload failed: ${errorMsg}`);
 			}
 
@@ -93,10 +91,7 @@
 			});
 
 			if (response.error) {
-				const errorMsg =
-					typeof response.error === 'object' && response.error && 'detail' in response.error
-						? String(response.error.detail)
-						: JSON.stringify(response.error);
+				const errorMsg = backendMessage(response.error) ?? JSON.stringify(response.error);
 				throw new Error(`Upload failed: ${errorMsg}`);
 			}
 

--- a/src/lib/components/organization/StripeConnect.svelte
+++ b/src/lib/components/organization/StripeConnect.svelte
@@ -19,6 +19,7 @@
 		organizationadmincoreStripeAccountVerify
 	} from '$lib/api/generated/sdk.gen';
 	import StripeConnectModal from './StripeConnectModal.svelte';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		organizationSlug: string;
@@ -101,9 +102,7 @@
 
 					if (response.error) {
 						const errorMsg =
-							typeof response.error === 'object' && response.error && 'detail' in response.error
-								? String(response.error.detail)
-								: m['stripeConnect.failedToCreateLink']();
+							extractApiErrorDetail(response.error) ?? m['stripeConnect.failedToCreateLink']();
 						throw new Error(errorMsg);
 					}
 

--- a/src/lib/components/organizations/ClaimMembershipButton.svelte
+++ b/src/lib/components/organizations/ClaimMembershipButton.svelte
@@ -8,6 +8,7 @@
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import type { OrganizationTokenSchema } from '$lib/api/generated/types.gen';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		tokenId: string;
@@ -41,13 +42,13 @@
 			});
 
 			if (response.error) {
-				const error = response.error;
-				const errorDetail =
-					error && typeof error === 'object' && 'detail' in error ? error.detail : undefined;
+				// One of only two endpoints in the codebase that genuinely answer 400
+				// with `ResponseMessage` (`{message}`) — everywhere else that
+				// declaration was a lie and `.message` was undefined at runtime
+				// (backend #824). Its 404 is `{detail}`, so `backendMessage` probes
+				// both rather than picking one and dropping the other.
 				throw new Error(
-					typeof errorDetail === 'string'
-						? errorDetail
-						: m['claimMembershipButton.error_failedToClaim']()
+					backendMessage(response.error) ?? m['claimMembershipButton.error_failedToClaim']()
 				);
 			}
 

--- a/src/lib/components/polls/DuplicatePollModal.svelte
+++ b/src/lib/components/polls/DuplicatePollModal.svelte
@@ -11,6 +11,7 @@
 	import { cn } from '$lib/utils/cn';
 	import { resultVisibilityRequiresPublicAnonymous } from '$lib/utils/polls';
 	import type { ResourceVisibility } from '$lib/api/generated/types.gen';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		open: boolean;
@@ -94,11 +95,8 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['duplicatePollModal.error_failedToDuplicate']();
+					extractApiErrorDetail(response.error) ??
+					m['duplicatePollModal.error_failedToDuplicate']();
 				throw new Error(errorDetail);
 			}
 			if (!response.data) {

--- a/src/lib/components/polls/PollStatusBar.svelte
+++ b/src/lib/components/polls/PollStatusBar.svelte
@@ -14,6 +14,7 @@
 	} from '$lib/api/generated/sdk.gen';
 	import type { PollDetailSchema } from '$lib/api/generated/types.gen';
 	import { formatDateTime } from '$lib/utils/date';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		poll: PollDetailSchema;
@@ -70,9 +71,7 @@
 				// be in the future.") instead of a generic lifecycle toast — the
 				// reopen endpoint has user-actionable validation that the operator
 				// needs to see.
-				const detail =
-					(r.error as { detail?: string } | undefined)?.detail ?? JSON.stringify(r.error);
-				throw new Error(detail);
+				throw new Error(extractApiErrorDetail(r.error) ?? m['pollStatusBar.lifecycleError']());
 			}
 			reopenOpen = false;
 			await invalidateAll();

--- a/src/lib/components/questionnaires/DuplicateQuestionnaireModal.svelte
+++ b/src/lib/components/questionnaires/DuplicateQuestionnaireModal.svelte
@@ -9,6 +9,7 @@
 	import { resolve } from '$app/paths';
 	import { Copy, Loader2 } from '@lucide/svelte';
 	import { cn } from '$lib/utils/cn';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		open: boolean;
@@ -52,11 +53,8 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['duplicateQuestionnaireModal.error_failedToDuplicate']();
+					extractApiErrorDetail(response.error) ??
+					m['duplicateQuestionnaireModal.error_failedToDuplicate']();
 				throw new Error(errorDetail);
 			}
 			if (!response.data) {

--- a/src/lib/components/resources/ResourceModal.svelte
+++ b/src/lib/components/resources/ResourceModal.svelte
@@ -11,6 +11,7 @@
 	import { getApiUrl } from '$lib/config/api';
 	import { X } from '@lucide/svelte';
 	import ResourceForm from './ResourceForm.svelte';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	interface Props {
 		resource?: AdditionalResourceSchema | null;
@@ -181,11 +182,7 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['resourceModal.error_failedToUpdate']();
+					extractApiErrorDetail(response.error) ?? m['resourceModal.error_failedToUpdate']();
 				throw new Error(errorDetail);
 			}
 

--- a/src/lib/components/tickets/CancelTicketDialog.svelte
+++ b/src/lib/components/tickets/CancelTicketDialog.svelte
@@ -40,6 +40,27 @@
 
 	let { open = $bindable(), ticketId, onCancelled }: Props = $props();
 
+	const BLOCK_REASONS: readonly CancellationBlockReason[] = [
+		'already_cancelled',
+		'checked_in',
+		'event_started',
+		'not_permitted',
+		'past_deadline',
+		'not_owner',
+		'part_of_series_pass'
+	];
+
+	/**
+	 * Read the 409's stable `code` off an unknown error body. Validated against
+	 * the enum rather than cast, so an unrecognised code falls through to the
+	 * generic path instead of reaching `reasonLabel` as a bogus key.
+	 */
+	function readBlockReason(error: unknown): CancellationBlockReason | null {
+		if (!error || typeof error !== 'object' || !('code' in error)) return null;
+		const code = (error as { code: unknown }).code;
+		return BLOCK_REASONS.find((reason) => reason === code) ?? null;
+	}
+
 	const accessToken = $derived(authStore.accessToken);
 	const queryClient = useQueryClient();
 
@@ -79,10 +100,14 @@
 				body: trimmed ? { reason: trimmed } : null
 			});
 			if (response.error) {
-				const errorAny = response.error as { code?: CancellationBlockReason; detail?: string };
+				// This endpoint's 403/502 are among the TWELVE `ResponseMessage`
+				// declarations backend #824 did not audit (tracked in backend #826),
+				// so its declared type is not trustworthy — probe the body rather than
+				// casting it into a shape the spec merely claims.
+				const blockCode = readBlockReason(response.error);
 				// 409: stable block reason → re-render the dialog with the localized copy.
-				if (errorAny?.code) {
-					throw new Error(`code:${errorAny.code}`);
+				if (blockCode) {
+					throw new Error(`code:${blockCode}`);
 				}
 				// 502: Stripe refund couldn't be issued. Detect by HTTP status, not prose,
 				// so the toast is right even if the backend message changes/localizes.
@@ -142,7 +167,9 @@
 		if (preview && !preview.can_cancel && preview.reason) return preview.reason;
 		const err = cancelMutation.error;
 		if (err && err.message.startsWith('code:')) {
-			return err.message.slice(5) as CancellationBlockReason;
+			// Re-validate rather than cast: the `code:` prefix is our own encoding,
+			// but the suffix originates in an untyped error body.
+			return BLOCK_REASONS.find((reason) => reason === err.message.slice(5)) ?? null;
 		}
 		return null;
 	});

--- a/src/lib/components/tickets/ticket-member-admin.svelte.ts
+++ b/src/lib/components/tickets/ticket-member-admin.svelte.ts
@@ -9,6 +9,7 @@ import {
 	organizationadminblacklistCreateBlacklistEntry
 } from '$lib/api';
 import type { AdminTicketSchema, MembershipTierSchema } from '$lib/api/generated/types.gen';
+import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 interface MakeMemberUser {
 	id: string;
@@ -54,12 +55,7 @@ export function createTicketMemberAdmin(opts: Options) {
 			});
 
 			if (response.error) {
-				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? String(response.error.detail)
-						: m['makeMemberAction.error']();
+				const errorDetail = extractApiErrorDetail(response.error) ?? m['makeMemberAction.error']();
 				throw new Error(errorDetail);
 			}
 

--- a/src/lib/utils/api-error-detail.test.ts
+++ b/src/lib/utils/api-error-detail.test.ts
@@ -49,6 +49,15 @@ describe('isRequestValidationError', () => {
 		expect(isRequestValidationError({ detail: ['just-a-string'] })).toBe(false);
 		expect(isRequestValidationError(null)).toBe(false);
 	});
+
+	it('rejects a MIXED list — the predicate promises every entry is readable', () => {
+		expect(isRequestValidationError({ detail: [{ msg: 'Field required' }, 'not-an-object'] })).toBe(
+			false
+		);
+		expect(isRequestValidationError({ detail: [{ msg: 'Field required' }, { type: 'x' }] })).toBe(
+			false
+		);
+	});
 });
 
 describe('isValidationErrorResponse', () => {

--- a/src/lib/utils/api-error-detail.test.ts
+++ b/src/lib/utils/api-error-detail.test.ts
@@ -1,33 +1,145 @@
 import { describe, it, expect } from 'vitest';
-import { backendMessage, extractApiErrorDetail } from './api-error-detail';
+import {
+	backendMessage,
+	extractApiErrorDetail,
+	extractValidationErrors,
+	isErrorDetail,
+	isRequestValidationError,
+	isResponseMessage,
+	isValidationErrorResponse
+} from './api-error-detail';
+
+// django-ninja's request-validation 422: `detail` is a LIST of objects, not a
+// string. Typing it as ErrorDetail would be actively wrong (backend #826).
+const REQUEST_VALIDATION_422 = {
+	detail: [
+		{ type: 'greater_than_equal', loc: ['body', 'payload', 'amount'], msg: 'Input should be >= 0' },
+		{ type: 'missing', loc: ['body', 'payload', 'currency'], msg: 'Field required' }
+	]
+};
+
+describe('isErrorDetail', () => {
+	it('accepts the { detail: string } domain-refusal body', () => {
+		expect(isErrorDetail({ detail: 'Ticket tiers not found: abc, def' })).toBe(true);
+	});
+
+	it('rejects the 422 list shape, which is a different schema sharing the key', () => {
+		expect(isErrorDetail(REQUEST_VALIDATION_422)).toBe(false);
+	});
+
+	it('rejects blank details, other shapes, and non-objects', () => {
+		expect(isErrorDetail({ detail: '   ' })).toBe(false);
+		expect(isErrorDetail({ errors: { name: ['required'] } })).toBe(false);
+		expect(isErrorDetail({ message: 'nope' })).toBe(false);
+		expect(isErrorDetail('a string')).toBe(false);
+		expect(isErrorDetail(null)).toBe(false);
+		expect(isErrorDetail(undefined)).toBe(false);
+		expect(isErrorDetail([{ detail: 'x' }])).toBe(false);
+	});
+});
+
+describe('isRequestValidationError', () => {
+	it('accepts a 422 whose detail is a list of { msg } entries', () => {
+		expect(isRequestValidationError(REQUEST_VALIDATION_422)).toBe(true);
+	});
+
+	it('rejects a string detail and a list with no readable msg', () => {
+		expect(isRequestValidationError({ detail: 'plain string' })).toBe(false);
+		expect(isRequestValidationError({ detail: [] })).toBe(false);
+		expect(isRequestValidationError({ detail: ['just-a-string'] })).toBe(false);
+		expect(isRequestValidationError(null)).toBe(false);
+	});
+});
+
+describe('isValidationErrorResponse', () => {
+	it('accepts array-valued and string-valued field errors', () => {
+		expect(isValidationErrorResponse({ errors: { name: ['This field is required.'] } })).toBe(true);
+		expect(isValidationErrorResponse({ errors: { name: 'This field is required.' } })).toBe(true);
+	});
+
+	it('rejects empty error maps and the other shapes', () => {
+		expect(isValidationErrorResponse({ errors: {} })).toBe(false);
+		expect(isValidationErrorResponse({ errors: { name: [] } })).toBe(false);
+		expect(isValidationErrorResponse({ detail: 'boom' })).toBe(false);
+		expect(isValidationErrorResponse(undefined)).toBe(false);
+	});
+});
+
+describe('isResponseMessage', () => {
+	it('accepts { message: string } — genuine on the two claim-invitation endpoints', () => {
+		expect(isResponseMessage({ message: 'This invitation has already been claimed.' })).toBe(true);
+	});
+
+	it('rejects blanks, non-strings and the other shapes', () => {
+		expect(isResponseMessage({ message: '' })).toBe(false);
+		expect(isResponseMessage({ message: 42 })).toBe(false);
+		expect(isResponseMessage({ detail: 'boom' })).toBe(false);
+		expect(isResponseMessage(null)).toBe(false);
+	});
+});
+
+describe('extractApiErrorDetail', () => {
+	it('reads a plain string detail', () => {
+		expect(extractApiErrorDetail({ detail: 'boom' })).toBe('boom');
+	});
+
+	it('flattens the 422 detail LIST instead of stringifying it', () => {
+		expect(extractApiErrorDetail(REQUEST_VALIDATION_422)).toBe(
+			'Input should be >= 0, Field required'
+		);
+	});
+
+	it('returns null when nothing readable is present', () => {
+		expect(extractApiErrorDetail({ errors: { name: ['x'] } })).toBeNull();
+		expect(extractApiErrorDetail({ detail: '' })).toBeNull();
+		expect(extractApiErrorDetail(null)).toBeNull();
+	});
+});
+
+describe('extractValidationErrors', () => {
+	it('flattens array-valued and string-valued field errors', () => {
+		expect(
+			extractValidationErrors({ errors: { name: ['Too long.'], price: 'Must be positive.' } })
+		).toBe('Too long. Must be positive.');
+	});
+
+	it('returns null for the other shapes', () => {
+		expect(extractValidationErrors({ detail: 'boom' })).toBeNull();
+		expect(extractValidationErrors(null)).toBeNull();
+	});
+});
 
 describe('backendMessage', () => {
-	it('returns message when the body carries a Ninja hard-block message', () => {
+	it('prefers detail over message — `message` was the lying declaration (#824)', () => {
+		expect(backendMessage({ message: 'from-message', detail: 'from-detail' })).toBe('from-detail');
+	});
+
+	it('still reads message when it is the only shape present', () => {
 		expect(backendMessage({ message: 'Cannot cancel a completed application.' })).toBe(
 			'Cannot cancel a completed application.'
 		);
 	});
 
-	it('prefers message over detail when both are present', () => {
-		expect(backendMessage({ message: 'from-message', detail: 'from-detail' })).toBe('from-message');
+	it('reads a string detail', () => {
+		expect(backendMessage({ detail: 'Not found.' })).toBe('Not found.');
 	});
 
-	it('falls back to a DRF-style string detail', () => {
-		expect(backendMessage({ detail: 'Not found.' })).toBe('Not found.');
+	it('reads the 422 detail list rather than falling through to generic copy', () => {
+		expect(backendMessage(REQUEST_VALIDATION_422)).toBe('Input should be >= 0, Field required');
+	});
+
+	it('reads a ValidationErrorResponse when that is the union branch that arrived', () => {
+		expect(backendMessage({ errors: { amount: ['Ensure this value is greater than 0.'] } })).toBe(
+			'Ensure this value is greater than 0.'
+		);
 	});
 
 	it('returns null for empty strings, non-string fields, non-objects, and null', () => {
 		expect(backendMessage({ message: '' })).toBeNull();
 		expect(backendMessage({ message: 42 })).toBeNull();
-		expect(backendMessage({ detail: ['pydantic-list-shape-is-not-handled-here'] })).toBeNull();
+		expect(backendMessage({ detail: [] })).toBeNull();
 		expect(backendMessage('a string')).toBeNull();
 		expect(backendMessage(null)).toBeNull();
 		expect(backendMessage(undefined)).toBeNull();
-	});
-});
-
-describe('extractApiErrorDetail (existing behavior untouched)', () => {
-	it('still reads a plain string detail', () => {
-		expect(extractApiErrorDetail({ detail: 'boom' })).toBe('boom');
 	});
 });

--- a/src/lib/utils/api-error-detail.test.ts
+++ b/src/lib/utils/api-error-detail.test.ts
@@ -72,6 +72,14 @@ describe('isValidationErrorResponse', () => {
 		expect(isValidationErrorResponse({ detail: 'boom' })).toBe(false);
 		expect(isValidationErrorResponse(undefined)).toBe(false);
 	});
+
+	it('rejects a map with any value outside the declared `string | string[]`', () => {
+		expect(isValidationErrorResponse({ errors: { name: ['Too long.'], price: 42 } })).toBe(false);
+		expect(isValidationErrorResponse({ errors: { name: ['Too long.'], price: [42] } })).toBe(false);
+		expect(isValidationErrorResponse({ errors: { name: ['Too long.'], meta: { a: 1 } } })).toBe(
+			false
+		);
+	});
 });
 
 describe('isResponseMessage', () => {

--- a/src/lib/utils/api-error-detail.ts
+++ b/src/lib/utils/api-error-detail.ts
@@ -77,13 +77,26 @@ export function isRequestValidationError(
 	});
 }
 
-/** Is this the `{ errors: { field: [msg, …] } }` model-validation body? */
+/**
+ * Is this the `{ errors: { field: [msg, …] } }` model-validation body?
+ *
+ * EVERY value must match the declared `string | string[]`, not merely one of
+ * them — the predicate promises callers a `ValidationErrorResponse` they can
+ * iterate. At least one value must also be readable, so an all-blank map falls
+ * through to the caller's own copy instead of rendering as an empty string.
+ */
 export function isValidationErrorResponse(value: unknown): value is ValidationErrorResponse {
 	const body = asRecord(value);
 	const errors = body ? asRecord(body.errors) : null;
 	if (!errors) return false;
-	return Object.values(errors).some(
-		(v) => nonEmptyString(v) || (Array.isArray(v) && v.some(nonEmptyString))
+	const values = Object.values(errors);
+	if (values.length === 0) return false;
+	const wellFormed = values.every(
+		(v) => typeof v === 'string' || (Array.isArray(v) && v.every((e) => typeof e === 'string'))
+	);
+	return (
+		wellFormed &&
+		values.some((v) => nonEmptyString(v) || (Array.isArray(v) && v.some(nonEmptyString)))
 	);
 }
 

--- a/src/lib/utils/api-error-detail.ts
+++ b/src/lib/utils/api-error-detail.ts
@@ -1,23 +1,121 @@
+import type {
+	ErrorDetail,
+	ResponseMessage,
+	ValidationErrorResponse
+} from '$lib/api/generated/types.gen';
+
+/**
+ * Runtime narrowing for the backend's error bodies (issue #653).
+ *
+ * Since backend PR #824 the OpenAPI error declarations are honest, so most
+ * endpoints type their 4xx bodies as `ErrorDetail`, `ValidationErrorResponse`,
+ * or an `anyOf` union of the two. A union has to be *probed* before it is read —
+ * `err.detail` on a `ValidationErrorResponse` branch is `undefined`, and reading
+ * it unnarrowed is exactly the silent blank-error bug this module exists to
+ * prevent. Every guard here is a real predicate: no casts, no `any`.
+ *
+ * Three shapes arrive in practice:
+ *
+ * - `{ detail: string }` — `ErrorDetail`, django-ninja's domain refusals.
+ * - `{ errors: { field: [msg, …] } }` — `ValidationErrorResponse`, model-level
+ *   validation. Values are `string | string[]` per the generated schema.
+ * - `{ detail: [{ msg, loc, type }, …] }` — django-ninja's **request**-validation
+ *   422. `detail` is a LIST, not a string, and it is *not* `ErrorDetail`. Any
+ *   code doing `String(err.detail)` on one renders `[object Object]`; any code
+ *   doing `err.detail.toLowerCase()` throws. 422 is systemically under-declared
+ *   (backend #826), so it can arrive from an endpoint that does not declare it.
+ *
+ * A fourth, `{ message: string }` (`ResponseMessage`), is a genuine error body
+ * on exactly two endpoints — `POST /events/claim-invitation/{token}` and
+ * `POST /organizations/claim-invitation/{token}` — plus assorted 2xx bodies.
+ * Everywhere else its declaration was a lie and `.message` was already
+ * `undefined` at runtime, so it is probed last.
+ */
+
+/** One entry of django-ninja's request-validation 422 `detail` list. */
+export interface RequestValidationItem {
+	msg: string;
+	loc?: (string | number)[];
+	type?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === 'object' && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function nonEmptyString(value: unknown): value is string {
+	return typeof value === 'string' && value.trim() !== '';
+}
+
+/**
+ * Is this the `{ detail: string }` body? Rejects the 422 list shape, which is a
+ * different schema that happens to share the key.
+ */
+export function isErrorDetail(value: unknown): value is ErrorDetail {
+	const body = asRecord(value);
+	return body !== null && nonEmptyString(body.detail);
+}
+
+/**
+ * Is this django-ninja's request-validation 422, whose `detail` is a list of
+ * `{ msg, loc, type }` objects rather than a string?
+ */
+export function isRequestValidationError(
+	value: unknown
+): value is { detail: RequestValidationItem[] } {
+	const body = asRecord(value);
+	if (!body || !Array.isArray(body.detail)) return false;
+	return body.detail.some((item) => {
+		const entry = asRecord(item);
+		return entry !== null && nonEmptyString(entry.msg);
+	});
+}
+
+/** Is this the `{ errors: { field: [msg, …] } }` model-validation body? */
+export function isValidationErrorResponse(value: unknown): value is ValidationErrorResponse {
+	const body = asRecord(value);
+	const errors = body ? asRecord(body.errors) : null;
+	if (!errors) return false;
+	return Object.values(errors).some(
+		(v) => nonEmptyString(v) || (Array.isArray(v) && v.some(nonEmptyString))
+	);
+}
+
+/**
+ * Is this the `{ message: string }` body? Genuine only on the two
+ * claim-invitation endpoints (and on 2xx `ResponseMessage` payloads).
+ */
+export function isResponseMessage(value: unknown): value is ResponseMessage {
+	const body = asRecord(value);
+	return body !== null && nonEmptyString(body.message);
+}
+
+/** Flatten a `ValidationErrorResponse` into one readable sentence. */
+export function extractValidationErrors(error: unknown): string | null {
+	if (!isValidationErrorResponse(error)) return null;
+	const parts = Object.values(error.errors)
+		.flatMap((v) => (Array.isArray(v) ? v : [v]))
+		.filter(nonEmptyString);
+	return parts.length > 0 ? parts.join(' ') : null;
+}
+
 /**
  * Extract the backend's human-readable `detail` from an SDK error envelope
- * (`response.error`) or any raw error body. Handles the two shapes
- * django-ninja produces: a plain `{ detail: string }` body (e.g. the
- * price-category duplicate-name and tier-referenced delete guards) and a
- * pydantic-style `{ detail: [{ msg }] }` validation list. Returns `null` when
- * no readable detail is present so the caller can fall back to a localized
- * generic message.
+ * (`response.error`) or any raw error body. Handles both `detail` shapes: the
+ * plain `{ detail: string }` domain refusal and the request-validation 422
+ * `{ detail: [{ msg }, …] }` list. Returns `null` when no readable detail is
+ * present so the caller can fall back to a localized generic message.
  */
 export function extractApiErrorDetail(error: unknown): string | null {
-	if (!error || typeof error !== 'object') return null;
-	const detail = (error as Record<string, unknown>).detail;
-	if (typeof detail === 'string' && detail.trim() !== '') return detail;
-	if (Array.isArray(detail)) {
-		const messages = detail
-			.map((item) =>
-				item && typeof item === 'object' && typeof (item as { msg?: unknown }).msg === 'string'
-					? (item as { msg: string }).msg
-					: null
-			)
+	if (isErrorDetail(error)) return error.detail;
+	if (isRequestValidationError(error)) {
+		const messages = error.detail
+			.map((item) => {
+				const entry = asRecord(item);
+				return entry && nonEmptyString(entry.msg) ? entry.msg : null;
+			})
 			.filter((msg): msg is string => msg !== null);
 		if (messages.length > 0) return messages.join(', ');
 	}
@@ -25,17 +123,19 @@ export function extractApiErrorDetail(error: unknown): string | null {
 }
 
 /**
- * Extract a human-readable error string from a membership/subscription
- * endpoint's error envelope. hey-api types these endpoints' errors as
- * `unknown`, so the shape is probed: Ninja hard-blocks carry `message`,
- * DRF-style payloads carry a string `detail`. Returns null when neither is
- * present so callers can fall back to localized generic copy (house rule:
- * fall back with `||`).
+ * Best available human-readable text from any backend error body, probing the
+ * shapes in order of how likely they are to be the real one:
+ * `detail` (string or 422 list) → `errors` → `message`.
+ *
+ * `message` is probed last on purpose: it is genuine on only two endpoints, and
+ * before backend #824 dozens of endpoints declared it while emitting `detail`.
+ * Returns `null` when nothing readable is present so callers can fall back to
+ * their own localized copy (house rule: fall back with `||` / `??`).
  */
 export function backendMessage(error: unknown): string | null {
-	if (!error || typeof error !== 'object') return null;
-	const body = error as { message?: unknown; detail?: unknown };
-	if (typeof body.message === 'string' && body.message) return body.message;
-	if (typeof body.detail === 'string' && body.detail) return body.detail;
-	return null;
+	return (
+		extractApiErrorDetail(error) ??
+		extractValidationErrors(error) ??
+		(isResponseMessage(error) ? error.message : null)
+	);
 }

--- a/src/lib/utils/api-error-detail.ts
+++ b/src/lib/utils/api-error-detail.ts
@@ -66,8 +66,12 @@ export function isRequestValidationError(
 	value: unknown
 ): value is { detail: RequestValidationItem[] } {
 	const body = asRecord(value);
-	if (!body || !Array.isArray(body.detail)) return false;
-	return body.detail.some((item) => {
+	if (!body || !Array.isArray(body.detail) || body.detail.length === 0) return false;
+	// EVERY entry must be a readable item, not merely one of them: the predicate
+	// promises callers a `RequestValidationItem[]` they can iterate, so a mixed
+	// array would make the narrowing a lie — the exact failure mode this module
+	// exists to prevent.
+	return body.detail.every((item) => {
 		const entry = asRecord(item);
 		return entry !== null && nonEmptyString(entry.msg);
 	});
@@ -110,15 +114,7 @@ export function extractValidationErrors(error: unknown): string | null {
  */
 export function extractApiErrorDetail(error: unknown): string | null {
 	if (isErrorDetail(error)) return error.detail;
-	if (isRequestValidationError(error)) {
-		const messages = error.detail
-			.map((item) => {
-				const entry = asRecord(item);
-				return entry && nonEmptyString(entry.msg) ? entry.msg : null;
-			})
-			.filter((msg): msg is string => msg !== null);
-		if (messages.length > 0) return messages.join(', ');
-	}
+	if (isRequestValidationError(error)) return error.detail.map((item) => item.msg).join(', ');
 	return null;
 }
 

--- a/src/routes/(auth)/create-org/+page.server.ts
+++ b/src/routes/(auth)/create-org/+page.server.ts
@@ -86,29 +86,29 @@ export const actions: Actions = {
 				throw redirect(303, `/org/${orgData.slug}/admin/settings`);
 			}
 
-			// Handle errors
-			// Handle specific error cases
-			if (error && typeof error === 'object') {
-				const errorObj = error as { detail?: string; status?: number };
+			// Handle errors. The status lives on the Response, never on the parsed
+			// error BODY — the old `(error as { status?: number }).status` was always
+			// `undefined`, so both branches below were dead and every refusal was
+			// reported as a 500.
+			const status = response?.status;
 
-				if (errorObj.status === 400) {
-					const errorMessage = extractErrorMessage(error, 'You already own an organization');
-					return fail(400, {
-						errors: { form: errorMessage },
-						...data
-					});
-				}
+			if (status === 400) {
+				const errorMessage = extractErrorMessage(error, 'You already own an organization');
+				return fail(400, {
+					errors: { form: errorMessage },
+					...data
+				});
+			}
 
-				if (errorObj.status === 403) {
-					const errorMessage = extractErrorMessage(
-						error,
-						'Please verify your email before creating an organization'
-					);
-					return fail(403, {
-						errors: { form: errorMessage },
-						...data
-					});
-				}
+			if (status === 403) {
+				const errorMessage = extractErrorMessage(
+					error,
+					'Please verify your email before creating an organization'
+				);
+				return fail(403, {
+					errors: { form: errorMessage },
+					...data
+				});
 			}
 
 			const errorMessage = extractErrorMessage(

--- a/src/routes/(auth)/create-org/+page.server.ts
+++ b/src/routes/(auth)/create-org/+page.server.ts
@@ -111,11 +111,15 @@ export const actions: Actions = {
 				});
 			}
 
+			// Anything else 4xx is still the CLIENT's problem — this endpoint declares
+			// no error responses at all, so a runtime 422 (request validation, which
+			// is systemically under-declared per backend #826) is entirely plausible
+			// and must not be reported to the user as a server failure.
 			const errorMessage = extractErrorMessage(
 				error,
 				'Failed to create organization. Please try again.'
 			);
-			return fail(500, {
+			return fail(status && status >= 400 && status < 500 ? status : 500, {
 				errors: { form: errorMessage },
 				...data
 			});

--- a/src/routes/(auth)/org/[slug]/admin/event-series/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/new/+page.svelte
@@ -10,6 +10,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { organizationadmincoreCreateEventSeries } from '$lib/api/generated';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	const organization = $derived($page.data.organization);
 	const accessToken = $derived(authStore.accessToken);
@@ -58,11 +59,7 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['eventSeriesNewPage.error_createFailed']();
+					extractApiErrorDetail(response.error) ?? m['eventSeriesNewPage.error_createFailed']();
 				throw new Error(errorDetail);
 			}
 

--- a/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
@@ -30,6 +30,7 @@
 		Copy,
 		Edit
 	} from '@lucide/svelte';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	const { data }: { data: PageData } = $props();
 
@@ -54,12 +55,7 @@
 			});
 
 			if (response.error) {
-				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: 'Failed to update status';
+				const errorDetail = extractApiErrorDetail(response.error) ?? 'Failed to update status';
 				throw new Error(errorDetail);
 			}
 
@@ -90,12 +86,7 @@
 			});
 
 			if (response.error) {
-				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: 'Failed to delete event';
+				const errorDetail = extractApiErrorDetail(response.error) ?? 'Failed to delete event';
 				throw new Error(errorDetail);
 			}
 		},

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
@@ -29,6 +29,7 @@
 	import CreateRsvpDialog from '$lib/components/attendees/CreateRsvpDialog.svelte';
 	import type { RsvpDetailSchema, MembershipTierSchema } from '$lib/api/generated/types.gen';
 	import * as m from '$lib/paraglide/messages.js';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	const { data }: { data: PageData } = $props();
 
@@ -149,12 +150,7 @@
 			});
 
 			if (response.error) {
-				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? String(response.error.detail)
-						: m['makeMemberAction.error']();
+				const errorDetail = extractApiErrorDetail(response.error) ?? m['makeMemberAction.error']();
 				throw new Error(errorDetail);
 			}
 
@@ -225,11 +221,7 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? String(response.error.detail)
-						: m['attendeesAdmin.createError']();
+					extractApiErrorDetail(response.error) ?? m['attendeesAdmin.createError']();
 				throw new Error(errorDetail);
 			}
 

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
@@ -16,6 +16,7 @@
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { CheckCircle, XCircle, FileEdit, Trash2, Ban, MoreVertical, Copy } from '@lucide/svelte';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	const { data }: { data: PageData } = $props();
 
@@ -41,11 +42,7 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['eventEditPage.error_updateStatusFailed']();
+					extractApiErrorDetail(response.error) ?? m['eventEditPage.error_updateStatusFailed']();
 				throw new Error(errorDetail);
 			}
 
@@ -79,11 +76,7 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? (response.error.detail as string)
-						: m['eventEditPage.error_deleteFailed']();
+					extractApiErrorDetail(response.error) ?? m['eventEditPage.error_deleteFailed']();
 				throw new Error(errorDetail);
 			}
 		},

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.server.ts
@@ -19,6 +19,7 @@ import type {
 	TicketTierDetailSchema
 } from '$lib/api/generated/types.gen';
 import { extractErrorMessage } from '$lib/utils/errors';
+import { backendMessage } from '$lib/utils/api-error-detail';
 import { log } from '$lib/server/logger';
 import { computePagination, defaultPagination } from './pagination';
 import { parseInvitationOptions } from './invitation-form';
@@ -307,8 +308,18 @@ export const actions: Actions = {
 			});
 
 			if (response.error) {
-				const errorMessage = extractErrorMessage(response.error, 'Failed to create invitations');
-				return fail(500, { errors: { form: errorMessage } });
+				// An unknown `tier_ids` entry used to be an unhandled 500; since
+				// backend #824 it is a 400 whose `detail` NAMES the offending ids, so
+				// report the real status and let the organizer see which tier is
+				// stale. `backendMessage` probes detail (string or the 422 list) →
+				// errors → message, so no union branch is read unnarrowed.
+				const errorMessage =
+					backendMessage(response.error) ??
+					extractErrorMessage(response.error, 'Failed to create invitations');
+				const status = response.response?.status;
+				return fail(status && status >= 400 && status < 500 ? status : 500, {
+					errors: { form: errorMessage }
+				});
 			}
 
 			return { success: true, action: 'created', data: response.data };

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.svelte
@@ -41,6 +41,7 @@
 	import MakeMemberModal from '$lib/components/members/MakeMemberModal.svelte';
 	import ExportButton from '$lib/components/common/ExportButton.svelte';
 	import { isSeriesPassCode } from '$lib/utils/series-pass-qr';
+	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
 	const { data }: { data: PageData } = $props();
 
@@ -188,11 +189,7 @@
 
 			if (response.error) {
 				const errorDetail =
-					typeof response.error === 'object' &&
-					response.error !== null &&
-					'detail' in response.error
-						? String(response.error.detail)
-						: m['eventTicketsAdmin.checkInError']();
+					extractApiErrorDetail(response.error) ?? m['eventTicketsAdmin.checkInError']();
 				// silent: the onError below shows the specific message; without the
 				// flag the global mutations.onError in +layout.svelte adds a second
 				// generic "Action failed" toast for the same failure.

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.server.ts
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.server.ts
@@ -7,6 +7,7 @@ import {
 	questionnaireListSubmissions
 } from '$lib/api/client';
 import { log } from '$lib/server/logger';
+import { backendMessage } from '$lib/utils/api-error-detail';
 
 // How many siblings to load for Next/Previous navigation. Covers the vast
 // majority of questionnaires; submissions beyond this window simply don't get
@@ -162,7 +163,11 @@ export const actions: Actions = {
 		}
 
 		// Submit evaluation
-		const { data: result, error: evaluationError } = await questionnaireEvaluateSubmission({
+		const {
+			data: result,
+			error: evaluationError,
+			response: evaluationResponse
+		} = await questionnaireEvaluateSubmission({
 			fetch,
 			path: {
 				org_questionnaire_id: id,
@@ -174,7 +179,14 @@ export const actions: Actions = {
 
 		if (evaluationError || !result) {
 			log.error('submission_evaluation_failed', { id, submission_id, error: evaluationError });
-			return fail(500, { error: 'Failed to submit evaluation. Please try again.' });
+			// The 400 is `ValidationErrorResponse | ErrorDetail` and an unknown
+			// submission_id is now a declared 404 `{detail}` rather than an unhandled
+			// 500 (backend #824) — both carry a usable sentence that the old blanket
+			// "please try again" threw away. Probe the union, never read it raw.
+			const status = evaluationResponse?.status;
+			return fail(status && status >= 400 && status < 500 ? status : 500, {
+				error: backendMessage(evaluationError) ?? 'Failed to submit evaluation. Please try again.'
+			});
 		}
 
 		// Stay on this submission (preserving the list's filter/sort context) so the

--- a/src/routes/(public)/join/event/[token_id]/+page.svelte
+++ b/src/routes/(public)/join/event/[token_id]/+page.svelte
@@ -18,6 +18,7 @@
 	import { toast } from 'svelte-sonner';
 	import { getExpirationDisplay, formatTokenUsage } from '$lib/utils/tokens';
 	import { formatEventDate } from '$lib/utils/date';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	const { data }: { data: PageData } = $props();
 
@@ -38,7 +39,11 @@
 			});
 
 			if (response.error) {
-				throw new Error(m['joinEventPage.error_claimFailed']());
+				// 400 here is genuinely `ResponseMessage` ({message}) and 404 is
+				// {detail} — one of only two endpoints where `.message` is real
+				// (backend #824). Surface the backend's own sentence: "already
+				// claimed" and "expired" need different remedies from the reader.
+				throw new Error(backendMessage(response.error) ?? m['joinEventPage.error_claimFailed']());
 			}
 
 			return response.data;
@@ -53,8 +58,8 @@
 				})
 			);
 		},
-		onError: () => {
-			toast.error(m['joinEventPage.toast_claimError']());
+		onError: (error: Error) => {
+			toast.error(error.message || m['joinEventPage.toast_claimError']());
 		}
 	}));
 

--- a/src/routes/(public)/join/org/[token_id]/+page.svelte
+++ b/src/routes/(public)/join/org/[token_id]/+page.svelte
@@ -18,6 +18,7 @@
 	import { toast } from 'svelte-sonner';
 	import { getExpirationDisplay, formatTokenUsage } from '$lib/utils/tokens';
 	import { escapeHtml } from '$lib/utils/sanitize';
+	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	const { data }: { data: PageData } = $props();
 
@@ -38,7 +39,11 @@
 			});
 
 			if (response.error) {
-				throw new Error(m['joinOrgPage.error_claimFailed']());
+				// 400 here is genuinely `ResponseMessage` ({message}) and 404 is
+				// {detail} — one of only two endpoints where `.message` is real
+				// (backend #824). Surface the backend's own sentence: "already
+				// claimed" and "expired" need different remedies from the reader.
+				throw new Error(backendMessage(response.error) ?? m['joinOrgPage.error_claimFailed']());
 			}
 
 			return response.data;
@@ -51,8 +56,8 @@
 			);
 			goto(resolve('/(public)/org/[slug]', { slug: org.slug }));
 		},
-		onError: () => {
-			toast.error(m['joinOrgPage.toast_claimError']());
+		onError: (error: Error) => {
+			toast.error(error.message || m['joinOrgPage.toast_claimError']());
 		}
 	}));
 


### PR DESCRIPTION
Backend PR [letsrevel/revel-backend#824](https://github.com/letsrevel/revel-backend/pull/824) made the OpenAPI error declarations honest, so most 4xx bodies are now `ErrorDetail`, `ValidationErrorResponse`, or an `anyOf` union of the two.

The regenerated client (Wave 0, #706) surfaced exactly **one** compile error — the app was already probing `'detail' in err` almost everywhere. But probing is not narrowing, and several sites then read the union through a cast that named a field the branch did not have. **This PR is the runtime half the type gate cannot see.** A green `pnpm check` was never evidence the work was done.

Closes #653

## Narrowing core — `src/lib/utils/api-error-detail.ts`

Real type predicates, no casts, no `any`:

| Guard | Shape |
|---|---|
| `isErrorDetail` | `{ detail: string }` — django-ninja domain refusals |
| `isValidationErrorResponse` | `{ errors: { field: string \| string[] } }` — model validation |
| `isResponseMessage` | `{ message: string }` |
| `isRequestValidationError` | `{ detail: [{ msg, loc, type }, …] }` — the **422 LIST** |

The 422 is the sharp edge called out in the issue: `detail` is a *list of objects*, not a string, and it is **not** `ErrorDetail`. `String(err.detail)` on one rendered `[object Object]`; `err.detail.toLowerCase()` would have thrown. 422 is systemically under-declared (backend #826), so it can arrive from an endpoint that never declares it — every reader now handles it defensively.

`backendMessage` now probes **detail (string or 422 list) → errors → message**. `message` moved *last*: outside the two claim-invitation endpoints its declaration was a lie and it was already `undefined` at runtime.

15 unit tests cover the guards; `backendMessage`'s precedence flip is asserted explicitly.

## Eligibility unions — the CTA re-render is the thing that must not regress

`rsvp_event`, `ticket_checkout`, `ticket_pwyc_checkout` are now `EventUserEligibility | ErrorDetail`.

- **`EventRSVP.svelte`** probes the eligibility branch first, keeps the payload as `Error.cause`, and **re-seats it into `userStatus` on error** — so a refusal re-renders the CTA against the *current* `next_step` instead of the stale one the page loaded with. Previously the refusal body was discarded entirely and the user saw the untranslated `"No data returned from RSVP"`.
- **`isNoteRejection`** now excludes eligibility refusals. It only checked `!('allowed' in error)`, so a refusal shaped slightly differently could be read as a note rejection and **silently re-submit an RSVP the backend had just refused**.
- **`event-checkout-controller.svelte.ts`** keeps reading the refusal first (preserving `isMembershipTierRefusal`) and falls through to the list-safe detail reader.
- `IneligibilityMessage.svelte`, `EligibilityStatusDisplay.svelte` and `utils/eligibility.ts` needed **no changes** — they consume a typed `EventUserEligibility` and never touch error bodies. Verified, not assumed.

4 new component tests on `EventRSVP` pin the behaviour: eligibility-400 adopts and re-renders the CTA; detail-400 shows the sentence and leaves the buttons; 422-list renders the messages and never `[object Object]`; a refusal triggers exactly **one** request.

## Waitlist join — the 400 → 200 behaviour change

The idempotent double-submit now lands in the success branch, which printed a generic `"Success!"`. It now prefers the backend's own sentence (*"You are already on the waitlist for this event."*), so the copy is honest for someone who was already on it. Its 400 probes eligibility → detail; the 409 special-case is untouched.

## Errors the backend now names, that were being thrown away

| Endpoint | Before | Now |
|---|---|---|
| `POST /event-admin/{id}/invitations` | unhandled 500 → blanket `fail(500)` | 400 `{detail}` **naming the offending tier ids**, real status |
| `POST /event-admin/{id}/tokens`, `PUT …/tokens/{id}` | hardcoded `'Failed to create token'` | newly declared 404, body names the offending tier ids |
| `POST /questionnaires/…/submissions/{id}/evaluate` | body discarded behind "Please try again" | declared 404 / 400 union surfaced, real status |
| `POST /events/claim-invitation/{token}` + org twin | read `detail` only → reason always dropped | the **only two** endpoints where `{message}` is genuine; all 4 call sites now read it |
| `POST /organizations/` (create-org) | `(error as {status?}).status` — never on the body, so both branches dead → always 500 | reads `response.status`; 400/403 reported correctly |

## Cast sweep

19 sites replaced `String(response.error.detail)` / `(response.error.detail as string)` with `extractApiErrorDetail`. `SubscriptionsTab`, `PollStatusBar`, `OrgContactEmailModal`, `NotificationPreferencesForm` and `StaffReviveModal` moved to `backendMessage` (the `{errors}` branch was being dropped). `PollStatusBar` no longer falls back to `JSON.stringify(error)` in a user-facing toast.

`CancelTicketDialog` validates the 409 `code` against the `CancellationBlockReason` enum instead of casting — that endpoint's 403/502 are among the twelve unaudited declarations.

## What I did NOT audit

- **The twelve remaining `ResponseMessage` error declarations** (backend #826): ticket cancellation-preview/cancel 403+502, the three checkout-session 404s, the two token-detail 404s, tier-seats 404, checkout-resume 404. Their declared types are **not trusted** — every reader treats the body as `unknown` and probes. No code assumes those declarations are accurate.
- **403/422 under-declaration.** Nothing here assumes an endpoint *cannot* return a status just because it is undeclared.
- **`guestAttendance.getLocalizedError`** — left as-is per the issue's own audit (graceful degradation: falls through to the backend message verbatim, which now arrives in the UI language via `Accept-Language`).
- **`RevivalRequestSchema.amount >= 0`** — already mirrored. `StaffReviveModal` is the only revive amount input and already has `min="0" step="0.01" required`; `RejoinCard` (online revive) sends an empty body. No change needed.
- **Plan-archive 502** — no 502 branch exists in the frontend, so there was no dead code to remove.
- **No new English string matcher was added.** `isBillingInfoRequiredError` already covers en/it/de/fr; everything else in this PR uses structured probing.
- **`/embed` + `/oembed`** (merged #707) reviewed at the coordinator's request: both use `{ data }` null-checks and log the error object structurally. Neither reads `.message` nor treats `detail` as a string. Nothing to fix.

## Verification

```
make check   # 0 ERRORS / 6082 files; "✓ Type gate is armed (deliberate errors in .ts and .svelte both caught)"
pnpm test    # 169 files, 2049 passed | 1 todo
```

Rebased onto `main` after #707 (`4ca8934a`) merged. E2E not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
