### PR TITLE
feat(events): granular attendance-visibility toggles + adopt is_full (#690)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1758,7 +1758,8 @@
 		"rsvpBy": "Anmeldung bis {deadline}",
 		"openInMaps": "In Karten öffnen",
 		"mapOf": "Karte von",
-		"visibilityNote": "Sichtbarkeit: {visibility}"
+		"visibilityNote": "Sichtbarkeit: {visibility}",
+		"eventFull": "Veranstaltung ausgebucht"
 	},
 	"eventRSVP": {
 		"goingTo": "You're going to {eventName}!",
@@ -8861,5 +8862,23 @@
 		"unavailableTitle": "Inhalt nicht verfügbar",
 		"unavailableBody": "Dieses Revel-Embed konnte gerade nicht geladen werden.",
 		"unavailableNotFound": "Wir konnten diesen Inhalt nicht finden. Das Embed verweist möglicherweise auf etwas, das umbenannt oder entfernt wurde."
+	},
+	"eventVisibility": {
+		"title": "Sichtbarkeit der Teilnahme",
+		"hint": "Lege fest, was Gäste über die Teilnehmer*innen sehen. Organisator*innen und Team sehen immer die echten Zahlen.",
+		"presetsLabel": "Schnellvorlagen",
+		"presetOpen": "Offen",
+		"presetOpenHint": "Alles anzeigen",
+		"presetDiscreet": "Diskret",
+		"presetDiscreetHint": "Zahlen und Gästeliste ausblenden",
+		"presetCustom": "Individuell",
+		"currentSelection": "Aktuelle Einstellung: {preset}",
+		"showAttendeeCount": "Teilnehmer*innenzahl anzeigen",
+		"showAttendeeCountHint": "Gäste sehen, wie viele Personen kommen.",
+		"showCapacity": "Kapazität anzeigen",
+		"showCapacityHint": "Gäste sehen das Teilnahmelimit, die freien Plätze und die Ticketverfügbarkeit.",
+		"showAttendeeList": "Gästeliste anzeigen",
+		"showAttendeeListHint": "Gäste sehen, wer sonst noch kommt. Wer sich gegen Gästelisten entschieden hat, bleibt weiterhin verborgen.",
+		"staffNote": "Für dich gelten diese Einstellungen nie: Organisator*innen und Team sehen immer alles."
 	}
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1758,7 +1758,8 @@
 		"rsvpBy": "RSVP by {deadline}",
 		"openInMaps": "Open in Maps",
 		"mapOf": "Map of",
-		"visibilityNote": "Visibility: {visibility}"
+		"visibilityNote": "Visibility: {visibility}",
+		"eventFull": "Event full"
 	},
 	"eventRSVP": {
 		"goingTo": "You're going to {eventName}!",
@@ -8861,5 +8862,23 @@
 		"unavailableTitle": "Content unavailable",
 		"unavailableBody": "This Revel embed could not be loaded right now.",
 		"unavailableNotFound": "We could not find this content. The embed may point at something that was renamed or removed."
+	},
+	"eventVisibility": {
+		"title": "Attendance visibility",
+		"hint": "Control what guests can see about who is coming. Organizers and staff always see the real numbers.",
+		"presetsLabel": "Quick presets",
+		"presetOpen": "Open",
+		"presetOpenHint": "Show everything",
+		"presetDiscreet": "Discreet",
+		"presetDiscreetHint": "Hide counts and guest list",
+		"presetCustom": "Custom",
+		"currentSelection": "Current setting: {preset}",
+		"showAttendeeCount": "Show attendee count",
+		"showAttendeeCountHint": "Guests can see how many people are coming.",
+		"showCapacity": "Show capacity",
+		"showCapacityHint": "Guests can see the attendee limit, the spots left, and per-ticket availability.",
+		"showAttendeeList": "Show guest list",
+		"showAttendeeListHint": "Guests can see who else is coming. People who opted out of guest lists stay hidden either way.",
+		"staffNote": "These settings never apply to you: organizers and staff always see the full picture."
 	}
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1645,7 +1645,8 @@
 		"rsvpBy": "Inscription avant {deadline}",
 		"openInMaps": "Ouvrir dans Plans",
 		"mapOf": "Carte de",
-		"visibilityNote": "Visibilité : {visibility}"
+		"visibilityNote": "Visibilité : {visibility}",
+		"eventFull": "Événement complet"
 	},
 	"eventRSVP": {
 		"goingTo": "Tu participes à {eventName} !",
@@ -8861,5 +8862,23 @@
 		"unavailableTitle": "Contenu indisponible",
 		"unavailableBody": "Cet embed Revel n'a pas pu être chargé pour le moment.",
 		"unavailableNotFound": "Nous n'avons pas trouvé ce contenu. L'embed pointe peut-être vers un élément renommé ou supprimé."
+	},
+	"eventVisibility": {
+		"title": "Visibilité des participations",
+		"hint": "Choisissez ce que les invités peuvent voir sur les personnes qui viennent. Les organisateurs et l'équipe voient toujours les vrais chiffres.",
+		"presetsLabel": "Préréglages rapides",
+		"presetOpen": "Ouvert",
+		"presetOpenHint": "Tout afficher",
+		"presetDiscreet": "Discret",
+		"presetDiscreetHint": "Masquer les compteurs et la liste des invités",
+		"presetCustom": "Personnalisé",
+		"currentSelection": "Réglage actuel : {preset}",
+		"showAttendeeCount": "Afficher le nombre de participants",
+		"showAttendeeCountHint": "Les invités voient combien de personnes viennent.",
+		"showCapacity": "Afficher la capacité",
+		"showCapacityHint": "Les invités voient la limite de participants, les places restantes et la disponibilité des billets.",
+		"showAttendeeList": "Afficher la liste des invités",
+		"showAttendeeListHint": "Les invités voient qui d'autre vient. Les personnes qui ont refusé de figurer sur les listes restent masquées.",
+		"staffNote": "Ces réglages ne s'appliquent jamais à vous : les organisateurs et l'équipe voient toujours tout."
 	}
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1758,7 +1758,8 @@
 		"rsvpBy": "RSVP entro {deadline}",
 		"openInMaps": "Apri in Mappe",
 		"mapOf": "Mappa di",
-		"visibilityNote": "Visibilità: {visibility}"
+		"visibilityNote": "Visibilità: {visibility}",
+		"eventFull": "Evento al completo"
 	},
 	"eventRSVP": {
 		"goingTo": "You're going to {eventName}!",
@@ -8861,5 +8862,23 @@
 		"unavailableTitle": "Contenuto non disponibile",
 		"unavailableBody": "Non è stato possibile caricare questo embed di Revel.",
 		"unavailableNotFound": "Non abbiamo trovato questo contenuto. L'embed potrebbe puntare a qualcosa che è stato rinominato o rimosso."
+	},
+	"eventVisibility": {
+		"title": "Visibilità delle presenze",
+		"hint": "Decidi cosa possono vedere gli ospiti su chi partecipa. Organizzatori e staff vedono sempre i numeri reali.",
+		"presetsLabel": "Preimpostazioni rapide",
+		"presetOpen": "Aperto",
+		"presetOpenHint": "Mostra tutto",
+		"presetDiscreet": "Discreto",
+		"presetDiscreetHint": "Nascondi conteggi e lista ospiti",
+		"presetCustom": "Personalizzato",
+		"currentSelection": "Impostazione attuale: {preset}",
+		"showAttendeeCount": "Mostra il numero di partecipanti",
+		"showAttendeeCountHint": "Gli ospiti possono vedere quante persone parteciperanno.",
+		"showCapacity": "Mostra la capienza",
+		"showCapacityHint": "Gli ospiti possono vedere il limite di partecipanti, i posti rimasti e la disponibilità dei biglietti.",
+		"showAttendeeList": "Mostra la lista degli ospiti",
+		"showAttendeeListHint": "Gli ospiti possono vedere chi altro partecipa. Chi ha scelto di non comparire resta comunque nascosto.",
+		"staffNote": "Queste impostazioni non si applicano a te: organizzatori e staff vedono sempre tutto."
 	}
 }

--- a/src/lib/components/event-series/admin/TemplateEditDialog.svelte
+++ b/src/lib/components/event-series/admin/TemplateEditDialog.svelte
@@ -24,6 +24,21 @@
 	import { invalidateSeries } from '$lib/queries/event-series';
 	import { formatEventDate } from '$lib/utils/date';
 	import TemplateLockedFields from './TemplateLockedFields.svelte';
+	import EventVisibilityFields from '$lib/components/events/admin/EventVisibilityFields.svelte';
+	import {
+		diffVisibilitySettings,
+		resolveVisibilitySettings,
+		VISIBILITY_DEFAULTS,
+		type ResolvedVisibilitySettings
+	} from '$lib/utils/event-visibility';
+	import {
+		buildAttendanceToggles,
+		buildCapacityToggles,
+		buildPropagateOptions,
+		type PropagateOption,
+		type TemplateFlagKey,
+		type TemplateToggleConfig
+	} from './template-edit-fields';
 
 	interface Props {
 		open: boolean;
@@ -58,7 +73,7 @@
 	// Grouped boolean flags. A single reactive object lets us drive the toggle
 	// rows off a small config array below rather than duplicating identical
 	// markup per field.
-	const flags = $state({
+	const flags = $state<Record<TemplateFlagKey, boolean>>({
 		requires_ticket: false,
 		waitlist_open: false,
 		requires_full_profile: false,
@@ -69,7 +84,11 @@
 		can_attend_without_login: false,
 		is_open_ended: false
 	});
-	type FlagKey = keyof typeof flags;
+
+	// Attendance-visibility toggles. Kept outside `flags` because they are a
+	// nested object on the wire (and merged sub-key-wise by the backend), not
+	// three sibling booleans.
+	let visibilitySettings = $state<ResolvedVisibilitySettings>({ ...VISIBILITY_DEFAULTS });
 
 	// Original snapshot for dirty-tracking. The backend rejects unknown fields
 	// (`additionalProperties=false`) — sending only changed fields is the
@@ -127,6 +146,7 @@
 		flags.public_pronoun_distribution = !!t.public_pronoun_distribution;
 		flags.can_attend_without_login = !!t.can_attend_without_login;
 		flags.is_open_ended = !!t.is_open_ended;
+		visibilitySettings = resolveVisibilitySettings(t.visibility_settings);
 		original = t;
 	});
 
@@ -184,96 +204,27 @@
 			d.can_attend_without_login = flags.can_attend_without_login;
 		if (flags.is_open_ended !== !!original.is_open_ended) d.is_open_ended = flags.is_open_ended;
 
+		// Sub-key patch only. The backend merges `visibility_settings` toggle by
+		// toggle, so an unchanged toggle is best left out entirely; an empty patch
+		// omits the field rather than sending `{}` or `null`. (`TemplateEditSchema`
+		// would accept `null` as "no change", but `EventEditSchema` 422s on it —
+		// never emitting one keeps both paths honest.)
+		const visibilityPatch = diffVisibilitySettings(
+			original.visibility_settings,
+			visibilitySettings
+		);
+		if (Object.keys(visibilityPatch).length > 0) d.visibility_settings = visibilityPatch;
+
 		return d;
 	});
 
 	// Config-driven toggle rows — replaces the near-identical markup blocks
 	// that otherwise ran up against the file-length gate. Each entry pairs a
 	// form field with the i18n key of its label and its Playwright testid.
-	const capacityToggles: { key: FlagKey; label: string; testid: string }[] = [
-		{
-			key: 'requires_ticket',
-			label: m['recurringEvents.templateDialog.toggles.requiresTicket'](),
-			testid: 'template-edit-requires-ticket'
-		},
-		{
-			key: 'waitlist_open',
-			label: m['recurringEvents.templateDialog.toggles.waitlistOpen'](),
-			testid: 'template-edit-waitlist-open'
-		}
-	];
-	type PropagateOption = {
-		scope: PropagateScope;
-		title: string;
-		body: string;
-		testid: string;
-		destructive: boolean;
-		recommended: boolean;
-	};
-	const propagateOptions: PropagateOption[] = [
-		{
-			scope: 'none',
-			title: m['recurringEvents.templateDialog.propagate.none.title'](),
-			body: m['recurringEvents.templateDialog.propagate.none.body'](),
-			testid: 'template-edit-propagate-none',
-			destructive: false,
-			recommended: false
-		},
-		{
-			scope: 'future_unmodified',
-			title: m['recurringEvents.templateDialog.propagate.futureUnmodified.title'](),
-			body: m['recurringEvents.templateDialog.propagate.futureUnmodified.body'](),
-			testid: 'template-edit-propagate-future-unmodified',
-			destructive: false,
-			recommended: true
-		},
-		{
-			scope: 'all_future',
-			title: m['recurringEvents.templateDialog.propagate.allFuture.title'](),
-			body: m['recurringEvents.templateDialog.propagate.allFuture.body'](),
-			testid: 'template-edit-propagate-all-future',
-			destructive: true,
-			recommended: false
-		}
-	];
-
-	const attendanceToggles: { key: FlagKey; label: string; testid: string }[] = [
-		{
-			key: 'requires_full_profile',
-			label: m['recurringEvents.templateDialog.toggles.requiresFullProfile'](),
-			testid: 'template-edit-requires-full-profile'
-		},
-		{
-			key: 'potluck_open',
-			label: m['recurringEvents.templateDialog.toggles.potluckOpen'](),
-			testid: 'template-edit-potluck-open'
-		},
-		{
-			key: 'accept_invitation_requests',
-			label: m['recurringEvents.templateDialog.toggles.acceptInvitationRequests'](),
-			testid: 'template-edit-accept-invitation-requests'
-		},
-		{
-			key: 'accept_rsvp_notes',
-			label: m['recurringEvents.templateDialog.toggles.acceptRsvpNotes'](),
-			testid: 'template-edit-accept-rsvp-notes'
-		},
-		{
-			key: 'public_pronoun_distribution',
-			label: m['recurringEvents.templateDialog.toggles.publicPronounDistribution'](),
-			testid: 'template-edit-public-pronoun-distribution'
-		},
-		{
-			key: 'can_attend_without_login',
-			label: m['recurringEvents.templateDialog.toggles.canAttendWithoutLogin'](),
-			testid: 'template-edit-can-attend-without-login'
-		},
-		{
-			key: 'is_open_ended',
-			label: m['recurringEvents.templateDialog.toggles.openEnded'](),
-			testid: 'template-edit-open-ended'
-		}
-	];
+	// The configs live in ./template-edit-fields.ts for the same reason.
+	const capacityToggles: TemplateToggleConfig[] = buildCapacityToggles();
+	const attendanceToggles: TemplateToggleConfig[] = buildAttendanceToggles();
+	const propagateOptions: PropagateOption[] = buildPropagateOptions();
 
 	const hasChanges = $derived(Object.keys(diff).length > 0);
 
@@ -364,7 +315,7 @@
 	);
 </script>
 
-{#snippet toggleRow(t: { key: FlagKey; label: string; testid: string })}
+{#snippet toggleRow(t: TemplateToggleConfig)}
 	<label
 		class="flex cursor-pointer items-center gap-3 rounded-md border border-input p-3 transition-colors hover:bg-accent"
 	>
@@ -664,6 +615,17 @@
 						{#each attendanceToggles as t (t.key)}
 							{@render toggleRow(t)}
 						{/each}
+					</section>
+
+					<!-- Attendance visibility -->
+					<section class="space-y-4 border-t border-border pt-6">
+						<h3 class="text-sm font-semibold">{m['eventVisibility.title']()}</h3>
+						<EventVisibilityFields
+							settings={visibilitySettings}
+							disabled={updateMutation.isPending}
+							idPrefix="template-visibility"
+							onChange={(next) => (visibilitySettings = next)}
+						/>
 					</section>
 
 					<TemplateLockedFields

--- a/src/lib/components/event-series/admin/TemplateEditDialog.svelte
+++ b/src/lib/components/event-series/admin/TemplateEditDialog.svelte
@@ -222,9 +222,11 @@
 	// that otherwise ran up against the file-length gate. Each entry pairs a
 	// form field with the i18n key of its label and its Playwright testid.
 	// The configs live in ./template-edit-fields.ts for the same reason.
-	const capacityToggles: TemplateToggleConfig[] = buildCapacityToggles();
-	const attendanceToggles: TemplateToggleConfig[] = buildAttendanceToggles();
-	const propagateOptions: PropagateOption[] = buildPropagateOptions();
+	// `$derived` so the labels track the active locale rather than the locale at
+	// component init.
+	const capacityToggles: TemplateToggleConfig[] = $derived(buildCapacityToggles());
+	const attendanceToggles: TemplateToggleConfig[] = $derived(buildAttendanceToggles());
+	const propagateOptions: PropagateOption[] = $derived(buildPropagateOptions());
 
 	const hasChanges = $derived(Object.keys(diff).length > 0);
 

--- a/src/lib/components/event-series/admin/template-edit-fields.ts
+++ b/src/lib/components/event-series/admin/template-edit-fields.ts
@@ -3,9 +3,14 @@
  *
  * These lists drive near-identical markup blocks from data instead of
  * duplicating them, and live here rather than in the component so the dialog
- * stays under the file-length cap. Each factory is a *function*, not a
- * module-level constant: the labels are Paraglide message calls and must be
- * evaluated per component instance so a language switch re-renders them.
+ * stays under the file-length cap.
+ *
+ * Each is a *factory*, not a module-level constant: the labels are Paraglide
+ * message calls, and evaluating them once at module-eval time would freeze the
+ * copy at whichever locale happened to import the module first. Callers invoke
+ * them inside `$derived` so the labels track the active locale. (Today that is
+ * belt-and-braces — `setLocale()` reloads the page — but neither the freeze nor
+ * the reload is a contract worth depending on.)
  */
 
 import * as m from '$lib/paraglide/messages.js';

--- a/src/lib/components/event-series/admin/template-edit-fields.ts
+++ b/src/lib/components/event-series/admin/template-edit-fields.ts
@@ -1,0 +1,123 @@
+/**
+ * Config for TemplateEditDialog's repetitive form rows.
+ *
+ * These lists drive near-identical markup blocks from data instead of
+ * duplicating them, and live here rather than in the component so the dialog
+ * stays under the file-length cap. Each factory is a *function*, not a
+ * module-level constant: the labels are Paraglide message calls and must be
+ * evaluated per component instance so a language switch re-renders them.
+ */
+
+import * as m from '$lib/paraglide/messages.js';
+import type { PropagateScope } from '$lib/api/generated/types.gen';
+
+/** The boolean template fields the dialog edits as simple checkboxes. */
+export type TemplateFlagKey =
+	| 'requires_ticket'
+	| 'waitlist_open'
+	| 'requires_full_profile'
+	| 'potluck_open'
+	| 'accept_invitation_requests'
+	| 'accept_rsvp_notes'
+	| 'public_pronoun_distribution'
+	| 'can_attend_without_login'
+	| 'is_open_ended';
+
+export interface TemplateToggleConfig {
+	key: TemplateFlagKey;
+	label: string;
+	testid: string;
+}
+
+export interface PropagateOption {
+	scope: PropagateScope;
+	title: string;
+	body: string;
+	testid: string;
+	destructive: boolean;
+	recommended: boolean;
+}
+
+export function buildCapacityToggles(): TemplateToggleConfig[] {
+	return [
+		{
+			key: 'requires_ticket',
+			label: m['recurringEvents.templateDialog.toggles.requiresTicket'](),
+			testid: 'template-edit-requires-ticket'
+		},
+		{
+			key: 'waitlist_open',
+			label: m['recurringEvents.templateDialog.toggles.waitlistOpen'](),
+			testid: 'template-edit-waitlist-open'
+		}
+	];
+}
+
+export function buildAttendanceToggles(): TemplateToggleConfig[] {
+	return [
+		{
+			key: 'requires_full_profile',
+			label: m['recurringEvents.templateDialog.toggles.requiresFullProfile'](),
+			testid: 'template-edit-requires-full-profile'
+		},
+		{
+			key: 'potluck_open',
+			label: m['recurringEvents.templateDialog.toggles.potluckOpen'](),
+			testid: 'template-edit-potluck-open'
+		},
+		{
+			key: 'accept_invitation_requests',
+			label: m['recurringEvents.templateDialog.toggles.acceptInvitationRequests'](),
+			testid: 'template-edit-accept-invitation-requests'
+		},
+		{
+			key: 'accept_rsvp_notes',
+			label: m['recurringEvents.templateDialog.toggles.acceptRsvpNotes'](),
+			testid: 'template-edit-accept-rsvp-notes'
+		},
+		{
+			key: 'public_pronoun_distribution',
+			label: m['recurringEvents.templateDialog.toggles.publicPronounDistribution'](),
+			testid: 'template-edit-public-pronoun-distribution'
+		},
+		{
+			key: 'can_attend_without_login',
+			label: m['recurringEvents.templateDialog.toggles.canAttendWithoutLogin'](),
+			testid: 'template-edit-can-attend-without-login'
+		},
+		{
+			key: 'is_open_ended',
+			label: m['recurringEvents.templateDialog.toggles.openEnded'](),
+			testid: 'template-edit-open-ended'
+		}
+	];
+}
+
+export function buildPropagateOptions(): PropagateOption[] {
+	return [
+		{
+			scope: 'none',
+			title: m['recurringEvents.templateDialog.propagate.none.title'](),
+			body: m['recurringEvents.templateDialog.propagate.none.body'](),
+			testid: 'template-edit-propagate-none',
+			destructive: false,
+			recommended: false
+		},
+		{
+			scope: 'future_unmodified',
+			title: m['recurringEvents.templateDialog.propagate.futureUnmodified.title'](),
+			body: m['recurringEvents.templateDialog.propagate.futureUnmodified.body'](),
+			testid: 'template-edit-propagate-future-unmodified',
+			destructive: false,
+			recommended: true
+		},
+		{
+			scope: 'all_future',
+			title: m['recurringEvents.templateDialog.propagate.allFuture.title'](),
+			body: m['recurringEvents.templateDialog.propagate.allFuture.body'](),
+			testid: 'template-edit-propagate-all-future',
+			destructive: true,
+			recommended: false
+		}
+	];
+}

--- a/src/lib/components/events/AttendeeList.svelte
+++ b/src/lib/components/events/AttendeeList.svelte
@@ -22,6 +22,13 @@
 		 */
 		totalAttendees: number | null | undefined;
 		isAuthenticated: boolean;
+		/**
+		 * `visibility_settings.show_attendee_list` (#825). When the organizer hides
+		 * the guest list the backend serves an empty page, so this only saves a
+		 * pointless request and lets the "hidden" copy appear without a spinner —
+		 * the gate itself is enforced server-side.
+		 */
+		listDisclosed?: boolean;
 		userVisibility?: VisibilityPreference | null;
 		showPronounDistribution?: boolean;
 	}
@@ -30,6 +37,7 @@
 		eventId,
 		totalAttendees,
 		isAuthenticated,
+		listDisclosed = true,
 		userVisibility = null,
 		showPronounDistribution: canShowPronounDistribution = false
 	}: Props = $props();
@@ -81,7 +89,7 @@
 
 			return response.data;
 		},
-		enabled: isAuthenticated
+		enabled: isAuthenticated && listDisclosed
 	}));
 
 	// Query for pronoun distribution (only fetched when expanded)
@@ -151,7 +159,13 @@
 			{/if}
 		</div>
 
-		{#if attendeesQuery.isLoading}
+		{#if !listDisclosed}
+			<!-- Guest list withheld by the event (#825). Same copy as an empty list:
+			     the two are indistinguishable to a guest by design. -->
+			<p class="text-sm text-muted-foreground">
+				{m['attendeeList.listHidden']()}
+			</p>
+		{:else if attendeesQuery.isLoading}
 			<div class="flex items-center justify-center py-8">
 				<Loader2 class="h-6 w-6 animate-spin text-muted-foreground" aria-hidden="true" />
 				<span class="sr-only">{m['attendeeList.loadingAttendees']()}</span>

--- a/src/lib/components/events/AttendeeList.test.ts
+++ b/src/lib/components/events/AttendeeList.test.ts
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import AttendeeList from './AttendeeList.svelte';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import {
+	eventpublicdetailsGetEventAttendees,
+	eventpublicdetailsGetPronounDistribution
+} from '$lib/api';
+
+vi.mock('$lib/api', () => ({
+	eventpublicdetailsGetEventAttendees: vi.fn(),
+	eventpublicdetailsGetPronounDistribution: vi.fn()
+}));
+
+function mockAttendees(displayNames: string[]) {
+	vi.mocked(eventpublicdetailsGetEventAttendees).mockResolvedValue({
+		data: { results: displayNames.map((display_name) => ({ display_name })), next: null }
+	} as unknown as ReturnType<typeof eventpublicdetailsGetEventAttendees>);
+}
+
+function renderList(props: Record<string, unknown>) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(QueryClientTestWrapper, {
+		props: { client, component: AttendeeList, componentProps: { eventId: 'e1', ...props } }
+	});
+}
+
+describe('AttendeeList — guest-list disclosure', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(eventpublicdetailsGetPronounDistribution).mockResolvedValue({
+			data: {}
+		} as unknown as ReturnType<typeof eventpublicdetailsGetPronounDistribution>);
+	});
+
+	it('renders the attendees when the guest list is disclosed', async () => {
+		mockAttendees(['Ada Lovelace']);
+
+		renderList({ totalAttendees: 1, isAuthenticated: true, listDisclosed: true });
+
+		await waitFor(() => expect(screen.getByText('Ada Lovelace')).toBeInTheDocument());
+	});
+
+	// #690: `visibility_settings.show_attendee_list === false`. The backend
+	// already serves an empty page; skipping the request keeps the "hidden" copy
+	// from arriving behind a spinner.
+	it('shows the hidden-list copy and never queries when the guest list is withheld', async () => {
+		mockAttendees(['Ada Lovelace']);
+
+		renderList({ totalAttendees: null, isAuthenticated: true, listDisclosed: false });
+
+		expect(await screen.findByText(/hidden/i)).toBeInTheDocument();
+		expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+		expect(eventpublicdetailsGetEventAttendees).not.toHaveBeenCalled();
+	});
+
+	it('defaults to disclosed when the caller does not say', async () => {
+		mockAttendees(['Ada Lovelace']);
+
+		renderList({ totalAttendees: 1, isAuthenticated: true });
+
+		await waitFor(() => expect(eventpublicdetailsGetEventAttendees).toHaveBeenCalled());
+	});
+});

--- a/src/lib/components/events/EventDetails.svelte
+++ b/src/lib/components/events/EventDetails.svelte
@@ -26,13 +26,22 @@
 	});
 
 	// Compute capacity info.
+	//
 	// Both numbers may be withheld (`null`) since #825 — an `=== undefined` guard
 	// would let a withheld capacity through and render "Full" (null - count < 0),
-	// so both are checked with `== null`. Without both, say nothing at all.
+	// so both are checked with `== null`.
+	//
+	// When the numbers are withheld the always-public `is_full` still lets us say
+	// "Event is full" — the one fact that matters most and that the organizer
+	// cannot hide. We deliberately do NOT show a "limited spots" hedge in the
+	// not-full case: `is_full === false` is equally true of an uncapped event, so
+	// it would invent scarcity. No numbers and not full ⇒ omit the row.
 	const capacityText = $derived.by(() => {
 		const max = event.max_attendees;
 		const count = event.attendee_count;
-		if (max == null || max === 0 || count == null) return null;
+		if (max == null || max === 0 || count == null) {
+			return event.is_full === true ? m['eventDetails.attendance_full']() : null;
+		}
 		const remaining = max - count;
 		if (remaining <= 0) return m['eventDetails.attendance_full']();
 		if (remaining <= 10) return m['eventDetails.attendance_spotsLeft']({ count: remaining });

--- a/src/lib/components/events/EventDetails.test.ts
+++ b/src/lib/components/events/EventDetails.test.ts
@@ -88,4 +88,20 @@ describe('EventDetails — capacity disclosure', () => {
 		expect(screen.queryByText(/Event is full/i)).not.toBeInTheDocument();
 		expect(screen.queryByText(/spots left/i)).not.toBeInTheDocument();
 	});
+
+	// #690: `is_full` is always public, so the one fact the organizer cannot hide
+	// still gets said even when both numbers are withheld.
+	it('still says the event is full when the numbers are withheld but is_full is set', () => {
+		const event = createMockEvent({ max_attendees: null, attendee_count: null, is_full: true });
+		render(EventDetails, { props: { event } });
+		expect(screen.getByText(/Event is full/i)).toBeInTheDocument();
+	});
+
+	// Deliberately no "limited spots" hedge: `is_full === false` is equally true
+	// of an uncapped event, so a scarcity cue there would be invented.
+	it('omits the attendance row entirely when the numbers are withheld and it is not full', () => {
+		const event = createMockEvent({ max_attendees: null, attendee_count: null, is_full: false });
+		render(EventDetails, { props: { event } });
+		expect(screen.queryByText(/Attendance/i)).not.toBeInTheDocument();
+	});
 });

--- a/src/lib/components/events/EventQuickInfo.svelte
+++ b/src/lib/components/events/EventQuickInfo.svelte
@@ -128,7 +128,10 @@
 	});
 
 	// Capacity and attendee count are each withheld (`null`) when the event hides
-	// them (#825). Each line is only rendered when the numbers it needs are known.
+	// them (#825). Each line is only rendered when the numbers it needs are known;
+	// with none of them known the always-public `is_full` can still state the one
+	// fact the organizer cannot hide. "Not full" says nothing (an uncapped event
+	// is never full either), so that case omits the row entirely.
 	const capacityDisplay = $derived.by(() => {
 		const max = event.max_attendees;
 		const count = event.attendee_count;
@@ -140,6 +143,7 @@
 		if (count != null && count > 0) {
 			return m['eventQuickInfo.attendeeCount']({ count });
 		}
+		if (event.is_full === true) return m['eventQuickInfo.eventFull']();
 		return null;
 	});
 

--- a/src/lib/components/events/EventQuickInfo.test.ts
+++ b/src/lib/components/events/EventQuickInfo.test.ts
@@ -203,3 +203,26 @@ describe('EventQuickInfo', () => {
 		expect(icons.length).toBeGreaterThan(0);
 	});
 });
+
+// #690: capacity/count may be withheld (#825), but `is_full` is always public.
+describe('EventQuickInfo — capacity disclosure', () => {
+	it('shows "Event full" when the numbers are withheld but is_full is set', () => {
+		const event = { ...mockEvent, max_attendees: null, attendee_count: null, is_full: true };
+		render(EventQuickInfo, { props: { event } });
+		expect(screen.getByText(/Event full/i)).toBeInTheDocument();
+	});
+
+	it('omits the capacity row when the numbers are withheld and it is not full', () => {
+		const event = { ...mockEvent, max_attendees: null, attendee_count: null, is_full: false };
+		render(EventQuickInfo, { props: { event } });
+		expect(screen.queryByText(/Event full/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/spots taken/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/attending/i)).not.toBeInTheDocument();
+	});
+
+	it('prefers the real tally over the is_full fallback when both are known', () => {
+		const event = { ...mockEvent, max_attendees: 50, attendee_count: 50, is_full: true };
+		render(EventQuickInfo, { props: { event } });
+		expect(screen.getByText(/50 \/ 50 spots taken/i)).toBeInTheDocument();
+	});
+});

--- a/src/lib/components/events/EventStatusBadge.svelte
+++ b/src/lib/components/events/EventStatusBadge.svelte
@@ -18,10 +18,9 @@
 	 * Only the fields the badge actually reads. Both EventDetailSchema and
 	 * EventInListSchema satisfy this, so the badge works in list contexts too.
 	 */
-	type EventStatusBadgeEvent = Pick<
-		EventDetailSchema,
-		'status' | 'start' | 'end' | 'max_attendees' | 'attendee_count'
-	> & { status: EventStatus };
+	type EventStatusBadgeEvent = Pick<EventDetailSchema, 'status' | 'start' | 'end' | 'is_full'> & {
+		status: EventStatus;
+	};
 
 	interface Props {
 		event: EventStatusBadgeEvent;
@@ -91,18 +90,10 @@
 			};
 		}
 
-		// 2. Check if full (has capacity and reached it).
-		// Either number may be withheld (`null`) since #825 — with capacity or the
-		// attendee count hidden we cannot assert fullness, so fall through to the
-		// temporal states rather than guess.
-		const maxAttendees = event.max_attendees;
-		const attendeeCount = event.attendee_count;
-		if (
-			maxAttendees != null &&
-			maxAttendees > 0 &&
-			attendeeCount != null &&
-			attendeeCount >= maxAttendees
-		) {
+		// 2. Check if full. `is_full` (#825) is always public, so this badge stays
+		// truthful even when the event withholds `max_attendees`/`attendee_count`;
+		// deriving fullness from those would silently read as "not full".
+		if (event.is_full === true) {
 			return {
 				label: m['eventStatus.full'](),
 				variant: 'destructive',

--- a/src/lib/components/events/EventStatusBadge.test.ts
+++ b/src/lib/components/events/EventStatusBadge.test.ts
@@ -68,13 +68,15 @@ describe('EventStatusBadge', () => {
 		});
 	});
 
+	// #690: the badge reads the backend's always-public `is_full` (#825) rather
+	// than deriving fullness from `max_attendees`/`attendee_count`, which the
+	// organizer can withhold — a discreet sold-out event used to read "not full".
 	describe('Full Status', () => {
-		it('shows "Full" when event is at capacity', () => {
+		it('shows "Full" when the backend flags the event as full', () => {
 			vi.setSystemTime(new Date('2025-12-01T10:00:00Z'));
 
 			const event = createMockEvent({
-				max_attendees: 50,
-				attendee_count: 50,
+				is_full: true,
 				start: '2025-12-01T18:00:00Z',
 				end: '2025-12-01T22:00:00Z'
 			});
@@ -85,12 +87,13 @@ describe('EventStatusBadge', () => {
 			expect(screen.getByRole('status')).toHaveClass('bg-destructive');
 		});
 
-		it('shows "Full" when attendee count exceeds capacity', () => {
+		it('shows "Full" even when capacity and count are withheld', () => {
 			vi.setSystemTime(new Date('2025-12-01T10:00:00Z'));
 
 			const event = createMockEvent({
-				max_attendees: 50,
-				attendee_count: 55,
+				is_full: true,
+				max_attendees: null,
+				attendee_count: null,
 				start: '2025-12-01T18:00:00Z',
 				end: '2025-12-01T22:00:00Z'
 			});
@@ -100,38 +103,13 @@ describe('EventStatusBadge', () => {
 			expect(screen.getByRole('status')).toHaveTextContent('Full');
 		});
 
-		it('does not show "Full" when max_attendees is 0 (unlimited)', () => {
+		it('does not show "Full" when the flag is false, whatever the numbers say', () => {
+			vi.setSystemTime(new Date('2025-12-01T10:00:00Z'));
+
 			const event = createMockEvent({
-				max_attendees: 0,
-				attendee_count: 100,
-				start: '2025-12-01T18:00:00Z',
-				end: '2025-12-01T22:00:00Z'
-			});
-
-			render(EventStatusBadge, { props: { event } });
-
-			expect(screen.getByRole('status')).not.toHaveTextContent('Full');
-		});
-
-		it('does not show "Full" when max_attendees is null', () => {
-			const event = createMockEvent({
-				max_attendees: undefined,
-				attendee_count: 100,
-				start: '2025-12-01T18:00:00Z',
-				end: '2025-12-01T22:00:00Z'
-			});
-
-			render(EventStatusBadge, { props: { event } });
-
-			expect(screen.getByRole('status')).not.toHaveTextContent('Full');
-		});
-
-		// #825: capacity and count are withheld (null) when the organizer hides
-		// them. Fullness is not assertable then, so the badge must not claim it.
-		it('does not show "Full" when attendee_count is withheld', () => {
-			const event = createMockEvent({
+				is_full: false,
 				max_attendees: 50,
-				attendee_count: null,
+				attendee_count: 50,
 				start: '2025-12-01T18:00:00Z',
 				end: '2025-12-01T22:00:00Z'
 			});
@@ -141,10 +119,11 @@ describe('EventStatusBadge', () => {
 			expect(screen.getByRole('status')).not.toHaveTextContent('Full');
 		});
 
-		it('does not show "Full" when max_attendees is withheld', () => {
+		it('does not show "Full" when the flag is absent', () => {
+			vi.setSystemTime(new Date('2025-12-01T10:00:00Z'));
+
 			const event = createMockEvent({
-				max_attendees: null,
-				attendee_count: 100,
+				is_full: undefined,
 				start: '2025-12-01T18:00:00Z',
 				end: '2025-12-01T22:00:00Z'
 			});
@@ -263,8 +242,7 @@ describe('EventStatusBadge', () => {
 		it('prioritizes "Cancelled" over "Full"', () => {
 			const event = createMockEvent({
 				status: 'cancelled',
-				max_attendees: 50,
-				attendee_count: 50,
+				is_full: true,
 				start: '2025-12-01T18:00:00Z',
 				end: '2025-12-01T22:00:00Z'
 			});
@@ -278,8 +256,7 @@ describe('EventStatusBadge', () => {
 			vi.setSystemTime(new Date('2025-12-01T12:00:00Z'));
 
 			const event = createMockEvent({
-				max_attendees: 50,
-				attendee_count: 50,
+				is_full: true,
 				start: '2025-12-01T18:00:00Z',
 				end: '2025-12-01T22:00:00Z'
 			});
@@ -293,8 +270,7 @@ describe('EventStatusBadge', () => {
 			vi.setSystemTime(new Date('2025-12-02T10:00:00Z'));
 
 			const event = createMockEvent({
-				max_attendees: 50,
-				attendee_count: 50,
+				is_full: true,
 				start: '2025-12-01T18:00:00Z',
 				end: '2025-12-01T22:00:00Z'
 			});

--- a/src/lib/components/events/admin/DetailsStep.svelte
+++ b/src/lib/components/events/admin/DetailsStep.svelte
@@ -27,6 +27,8 @@
 	import AdmissionScreeningSection from './AdmissionScreeningSection.svelte';
 	import DetailsStepTagsInput from './DetailsStepTagsInput.svelte';
 	import DetailsStepMediaSection from './DetailsStepMediaSection.svelte';
+	import EventVisibilitySection from './EventVisibilitySection.svelte';
+	import { isNonDefaultVisibility } from '$lib/utils/event-visibility';
 	import type { OrganizationQuestionnaireInListSchema } from '$lib/api/generated';
 	import { SvelteSet } from 'svelte/reactivity';
 
@@ -156,7 +158,9 @@
 		[
 			'basic',
 			formData.tags && formData.tags.length > 0 ? 'advanced' : null,
-			hasScreeningSettings ? 'screening' : null
+			hasScreeningSettings ? 'screening' : null,
+			// Never leave a non-default disclosure choice collapsed out of sight.
+			isNonDefaultVisibility(formData.visibility_settings) ? 'visibility' : null
 		].filter((s): s is string => s !== null)
 	);
 
@@ -442,6 +446,14 @@
 			</div>
 		{/if}
 	</div>
+
+	<!-- Attendance Visibility Section -->
+	<EventVisibilitySection
+		settings={formData.visibility_settings}
+		isOpen={isSectionOpen('visibility')}
+		onToggle={() => toggleSection('visibility')}
+		onChange={(next) => onUpdate({ visibility_settings: next })}
+	/>
 
 	<!-- Admission & Screening Section -->
 	<AdmissionScreeningSection

--- a/src/lib/components/events/admin/EventEditor.svelte
+++ b/src/lib/components/events/admin/EventEditor.svelte
@@ -126,6 +126,11 @@
 		potluck_open: existingEvent?.potluck_open || false,
 		accept_invitation_requests: existingEvent?.accept_invitation_requests || false,
 		accept_rsvp_notes: existingEvent?.accept_rsvp_notes || false,
+		// Seeded from the server so an edit round-trips the organizer's real
+		// disclosure choices. Left `undefined` on create, which omits the field
+		// (see visibilitySettingsForWrite in event-payload.ts) — an unseeded
+		// all-`true` default would silently re-disclose a hidden count.
+		visibility_settings: existingEvent?.visibility_settings,
 		public_pronoun_distribution: existingEvent?.public_pronoun_distribution || false,
 		apply_before: toDateTimeLocal(existingEvent?.apply_before) || null,
 		can_attend_without_login: existingEvent?.can_attend_without_login || false,

--- a/src/lib/components/events/admin/EventVisibilityFields.svelte
+++ b/src/lib/components/events/admin/EventVisibilityFields.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import type { EventVisibilitySettings } from '$lib/api/generated/types.gen';
+	import {
+		VISIBILITY_PRESETS,
+		VISIBILITY_PRESET_IDS,
+		matchVisibilityPreset,
+		resolveVisibilitySettings,
+		type ResolvedVisibilitySettings,
+		type VisibilityPresetId,
+		type VisibilityToggleKey
+	} from '$lib/utils/event-visibility';
+
+	interface Props {
+		/** Current settings; absent toggles resolve to the backend default (`true`). */
+		settings?: EventVisibilitySettings | null;
+		disabled?: boolean;
+		/** Prefix for the generated input ids, so two instances never collide. */
+		idPrefix?: string;
+		/** Emits the complete resolved triple — never a partial. */
+		onChange: (next: ResolvedVisibilitySettings) => void;
+	}
+
+	const {
+		settings = null,
+		disabled = false,
+		idPrefix = 'event-visibility',
+		onChange
+	}: Props = $props();
+
+	const resolved = $derived(resolveVisibilitySettings(settings));
+	const activePreset = $derived(matchVisibilityPreset(settings));
+
+	const presetLabels: Record<VisibilityPresetId, { label: string; hint: string }> = $derived({
+		open: {
+			label: m['eventVisibility.presetOpen'](),
+			hint: m['eventVisibility.presetOpenHint']()
+		},
+		discreet: {
+			label: m['eventVisibility.presetDiscreet'](),
+			hint: m['eventVisibility.presetDiscreetHint']()
+		}
+	});
+
+	const currentSelectionText = $derived(
+		m['eventVisibility.currentSelection']({
+			preset: activePreset ? presetLabels[activePreset].label : m['eventVisibility.presetCustom']()
+		})
+	);
+
+	const toggles: { key: VisibilityToggleKey; label: string; hint: string; testid: string }[] =
+		$derived([
+			{
+				key: 'show_attendee_count',
+				label: m['eventVisibility.showAttendeeCount'](),
+				hint: m['eventVisibility.showAttendeeCountHint'](),
+				testid: 'visibility-show-attendee-count'
+			},
+			{
+				key: 'show_capacity',
+				label: m['eventVisibility.showCapacity'](),
+				hint: m['eventVisibility.showCapacityHint'](),
+				testid: 'visibility-show-capacity'
+			},
+			{
+				key: 'show_attendee_list',
+				label: m['eventVisibility.showAttendeeList'](),
+				hint: m['eventVisibility.showAttendeeListHint'](),
+				testid: 'visibility-show-attendee-list'
+			}
+		]);
+
+	/**
+	 * Presets are a frontend-only shortcut: they set the three granular toggles
+	 * and nothing else. A preset name is never sent to the backend, which rejects
+	 * unknown keys with a 422 (`extra="forbid"`).
+	 */
+	function applyPreset(id: VisibilityPresetId): void {
+		onChange({ ...VISIBILITY_PRESETS[id] });
+	}
+
+	function setToggle(key: VisibilityToggleKey, value: boolean): void {
+		onChange({ ...resolved, [key]: value });
+	}
+</script>
+
+<div class="space-y-4">
+	<p class="text-sm text-muted-foreground">{m['eventVisibility.hint']()}</p>
+
+	<!-- Preset shortcuts. Toggle buttons rather than a radio group: the current
+	     combination may match no preset ("Custom"), which a radio group cannot
+	     represent without a phantom option. -->
+	<div class="space-y-2">
+		<div
+			class="flex flex-wrap items-center gap-2"
+			role="group"
+			aria-label={m['eventVisibility.presetsLabel']()}
+		>
+			<span class="text-sm font-medium">{m['eventVisibility.presetsLabel']()}</span>
+			{#each VISIBILITY_PRESET_IDS as presetId (presetId)}
+				<button
+					type="button"
+					{disabled}
+					aria-pressed={activePreset === presetId}
+					onclick={() => applyPreset(presetId)}
+					class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {activePreset ===
+					presetId
+						? 'border-primary bg-primary text-primary-foreground'
+						: 'border-input bg-background hover:bg-accent hover:text-accent-foreground'}"
+					data-testid="visibility-preset-{presetId}"
+				>
+					{presetLabels[presetId].label}
+					<span class="sr-only">— {presetLabels[presetId].hint}</span>
+				</button>
+			{/each}
+		</div>
+		<p
+			class="text-xs text-muted-foreground"
+			aria-live="polite"
+			data-testid="visibility-current-preset"
+		>
+			{currentSelectionText}
+		</p>
+	</div>
+
+	<!-- Granular toggles. These are the only values ever written; a preset simply
+	     sets all three at once. -->
+	{#each toggles as toggle (toggle.key)}
+		<label
+			class="flex cursor-pointer items-center gap-3 rounded-md border border-input p-3 transition-colors hover:bg-accent"
+		>
+			<input
+				id="{idPrefix}-{toggle.key}"
+				type="checkbox"
+				checked={resolved[toggle.key]}
+				{disabled}
+				onchange={(e) => setToggle(toggle.key, e.currentTarget.checked)}
+				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+				data-testid={toggle.testid}
+			/>
+			<div class="flex-1">
+				<div class="font-medium">{toggle.label}</div>
+				<div class="text-sm text-muted-foreground">{toggle.hint}</div>
+			</div>
+		</label>
+	{/each}
+
+	<p class="text-xs text-muted-foreground">{m['eventVisibility.staffNote']()}</p>
+</div>

--- a/src/lib/components/events/admin/EventVisibilityFields.test.ts
+++ b/src/lib/components/events/admin/EventVisibilityFields.test.ts
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import EventVisibilityFields from './EventVisibilityFields.svelte';
+import type { ResolvedVisibilitySettings } from '$lib/utils/event-visibility';
+
+function setup(settings?: Partial<ResolvedVisibilitySettings>) {
+	const onChange = vi.fn<(next: ResolvedVisibilitySettings) => void>();
+	render(EventVisibilityFields, { props: { settings, onChange } });
+	return { onChange, user: userEvent.setup() };
+}
+
+describe('EventVisibilityFields', () => {
+	it('reflects the backend defaults when no settings are supplied', () => {
+		setup();
+
+		for (const name of [/attendee count/i, /capacity/i, /guest list/i]) {
+			expect(screen.getByRole('checkbox', { name })).toBeChecked();
+		}
+	});
+
+	it('reflects a partially withheld setting', () => {
+		setup({ show_capacity: false });
+
+		expect(screen.getByRole('checkbox', { name: /capacity/i })).not.toBeChecked();
+		expect(screen.getByRole('checkbox', { name: /attendee count/i })).toBeChecked();
+	});
+
+	// Presets are frontend-only: they set the three granular toggles and the
+	// preset name is never part of the payload (the backend 422s unknown keys).
+	it('the Discreet preset emits all three toggles off — and nothing else', async () => {
+		const { onChange, user } = setup();
+
+		await user.click(screen.getByRole('button', { name: /discreet/i }));
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange).toHaveBeenCalledWith({
+			show_attendee_count: false,
+			show_capacity: false,
+			show_attendee_list: false
+		});
+	});
+
+	it('the Open preset re-enables every disclosure explicitly', async () => {
+		const { onChange, user } = setup({
+			show_attendee_count: false,
+			show_capacity: false,
+			show_attendee_list: false
+		});
+
+		await user.click(screen.getByRole('button', { name: /open/i }));
+
+		expect(onChange).toHaveBeenCalledWith({
+			show_attendee_count: true,
+			show_capacity: true,
+			show_attendee_list: true
+		});
+	});
+
+	it('a single toggle emits the complete triple, preserving the others', async () => {
+		const { onChange, user } = setup({ show_attendee_count: false });
+
+		await user.click(screen.getByRole('checkbox', { name: /guest list/i }));
+
+		expect(onChange).toHaveBeenCalledWith({
+			show_attendee_count: false,
+			show_capacity: true,
+			show_attendee_list: false
+		});
+	});
+
+	it('marks the matching preset pressed, and none when the combination is custom', () => {
+		const { unmount } = render(EventVisibilityFields, {
+			props: { settings: undefined, onChange: vi.fn() }
+		});
+		expect(screen.getByRole('button', { name: /open/i })).toHaveAttribute('aria-pressed', 'true');
+		unmount();
+
+		render(EventVisibilityFields, {
+			props: { settings: { show_capacity: false }, onChange: vi.fn() }
+		});
+		for (const name of [/open/i, /discreet/i]) {
+			expect(screen.getByRole('button', { name })).toHaveAttribute('aria-pressed', 'false');
+		}
+	});
+});

--- a/src/lib/components/events/admin/EventVisibilitySection.svelte
+++ b/src/lib/components/events/admin/EventVisibilitySection.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import type { EventVisibilitySettings } from '$lib/api/generated/types.gen';
+	import type { ResolvedVisibilitySettings } from '$lib/utils/event-visibility';
+	import { ChevronDown, ChevronRight, Eye } from '@lucide/svelte';
+	import EventVisibilityFields from './EventVisibilityFields.svelte';
+
+	interface Props {
+		settings?: EventVisibilitySettings | null;
+		isOpen: boolean;
+		onToggle: () => void;
+		onChange: (next: ResolvedVisibilitySettings) => void;
+	}
+
+	const { settings = null, isOpen, onToggle, onChange }: Props = $props();
+</script>
+
+<div class="overflow-hidden rounded-lg border border-border">
+	<button
+		type="button"
+		onclick={onToggle}
+		class="flex w-full items-center justify-between bg-muted/50 p-4 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+		aria-expanded={isOpen}
+		data-testid="visibility-section-toggle"
+	>
+		<div class="flex items-center gap-2 font-semibold">
+			<Eye class="h-5 w-5" aria-hidden="true" />
+			{m['eventVisibility.title']()}
+		</div>
+		{#if isOpen}
+			<ChevronDown class="h-5 w-5" aria-hidden="true" />
+		{:else}
+			<ChevronRight class="h-5 w-5" aria-hidden="true" />
+		{/if}
+	</button>
+
+	{#if isOpen}
+		<div class="p-4">
+			<EventVisibilityFields {settings} {onChange} />
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/events/admin/EventWizard.svelte
+++ b/src/lib/components/events/admin/EventWizard.svelte
@@ -142,6 +142,11 @@
 		potluck_open: existingEvent?.potluck_open || false,
 		accept_invitation_requests: existingEvent?.accept_invitation_requests || false,
 		accept_rsvp_notes: existingEvent?.accept_rsvp_notes || false,
+		// Seeded from the server so an edit round-trips the organizer's real
+		// disclosure choices. Left `undefined` on create, which omits the field
+		// (see visibilitySettingsForWrite in event-payload.ts) — an unseeded
+		// all-`true` default would silently re-disclose a hidden count.
+		visibility_settings: existingEvent?.visibility_settings,
 		apply_before: toDateTimeLocal(existingEvent?.apply_before) || null,
 		can_attend_without_login: existingEvent?.can_attend_without_login || false,
 		requires_full_profile: existingEvent?.requires_full_profile || false,

--- a/src/lib/components/events/admin/TierCard.svelte
+++ b/src/lib/components/events/admin/TierCard.svelte
@@ -77,6 +77,10 @@
 
 	const quantityDisplay = $derived(() => {
 		if (tier.total_quantity === null) return 'Unlimited';
+		// `?? 0` is safe here and only here: this is a staff-only admin surface, and
+		// organization owners/staff bypass `visibility_settings` entirely (#825), so
+		// `total_available` is never withheld from this reader. On any guest-facing
+		// surface the same expression would render a hidden count as zero.
 		const available = tier.total_available ?? 0;
 		return `${available} of ${tier.total_quantity} remaining`;
 	});

--- a/src/lib/components/events/admin/event-payload.test.ts
+++ b/src/lib/components/events/admin/event-payload.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildRecurringTemplateCreateData, type EventFormPayloadData } from './event-payload';
+import {
+	buildEditorUpdateData,
+	buildRecurringTemplateCreateData,
+	buildWizardStep1UpdateData,
+	buildWizardStep2UpdateData,
+	type EventFormPayloadData
+} from './event-payload';
 
 const NAME = 'Weekly Game Night';
 const START_ISO = '2026-08-01T18:00:00+02:00';
@@ -71,4 +77,58 @@ describe('buildRecurringTemplateCreateData', () => {
 			location_maps_embed: null
 		});
 	});
+});
+
+// #690 / backend #825. Three contract rules are load-bearing here:
+//   - `visibility_settings` MERGES sub-key-wise, so a whole-object round-trip is
+//     safe and an omitted field means "no change".
+//   - `EventEditSchema` declares the field non-nullable → an explicit `null` is a
+//     422. `TemplateEditSchema` accepts `null` as "no change". We never emit one.
+//   - `extra="forbid"` → only the three known toggles may be sent; preset names
+//     are frontend-only.
+describe('visibility_settings write semantics', () => {
+	const builders = {
+		'wizard step 1': (f: EventFormPayloadData) => buildWizardStep1UpdateData(f),
+		'wizard step 2': (f: EventFormPayloadData) => buildWizardStep2UpdateData(f),
+		editor: (f: EventFormPayloadData) => buildEditorUpdateData(f, START_ISO),
+		'recurring template': (f: EventFormPayloadData) =>
+			buildRecurringTemplateCreateData(f, NAME, START_ISO, CITY_ID)
+	};
+
+	for (const [label, build] of Object.entries(builders)) {
+		it(`${label}: omits the field entirely when the form never carried one`, () => {
+			const payload = build({});
+
+			expect(payload.visibility_settings).toBeUndefined();
+			// `undefined` — never `null`, which EventEditSchema rejects with a 422.
+			expect(payload.visibility_settings).not.toBeNull();
+			expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty('visibility_settings');
+		});
+
+		it(`${label}: round-trips the full resolved triple when the form carries one`, () => {
+			const payload = build({ visibility_settings: { show_capacity: false } });
+
+			expect(payload.visibility_settings).toEqual({
+				show_attendee_count: true,
+				show_capacity: false,
+				show_attendee_list: true
+			});
+		});
+
+		it(`${label}: sends nothing but the three known toggles`, () => {
+			const payload = build({
+				visibility_settings: {
+					show_attendee_count: false,
+					show_capacity: false,
+					show_attendee_list: false
+				}
+			});
+
+			expect(Object.keys(payload.visibility_settings ?? {}).sort()).toEqual([
+				'show_attendee_count',
+				'show_attendee_list',
+				'show_capacity'
+			]);
+		});
+	}
 });

--- a/src/lib/components/events/admin/event-payload.ts
+++ b/src/lib/components/events/admin/event-payload.ts
@@ -1,9 +1,11 @@
 import type {
 	EventCreateSchema,
 	EventEditSchema,
+	EventVisibilitySettings,
 	ResourceVisibility
 } from '$lib/api/generated/types.gen';
 import { toISOString } from '$lib/utils/datetime';
+import { resolveVisibilitySettings } from '$lib/utils/event-visibility';
 
 /**
  * Shape of the wizard/editor `formData` reactive object, as far as the payload
@@ -19,6 +21,35 @@ export type EventFormPayloadData = Partial<EventCreateSchema> & {
 	location_maps_embed?: string | null;
 	public_pronoun_distribution?: boolean;
 };
+
+/**
+ * The `visibility_settings` value to write, or `undefined` to omit the field.
+ *
+ * Three rules from backend #825, all satisfied by this one helper:
+ *
+ * 1. The backend **merges** this object at sub-key granularity — omitting a
+ *    toggle means "no change", so both a whole-object round-trip and a partial
+ *    write are correct. We round-trip the resolved triple, which keeps the
+ *    payload honest even when the user edited only one toggle.
+ * 2. Explicit `null` is a 422 against `EventEditSchema` (it is declared
+ *    non-nullable there, unlike `TemplateEditSchema`). We never emit `null`:
+ *    the field is either a concrete object or absent, which is valid against
+ *    both schemas.
+ * 3. `extra="forbid"` — only the three known toggles are ever sent; preset
+ *    names live entirely in the UI.
+ *
+ * Returning `undefined` (rather than the all-`true` default) matters: a create
+ * flow that never opened the visibility section must not assert a disclosure
+ * choice, and an edit whose `formData` was never seeded must not silently
+ * re-disclose a count the organizer had hidden.
+ */
+function visibilitySettingsForWrite(
+	formData: EventFormPayloadData
+): EventVisibilitySettings | undefined {
+	return formData.visibility_settings
+		? resolveVisibilitySettings(formData.visibility_settings)
+		: undefined;
+}
 
 /**
  * Build the create-event payload (essential fields only). Identical between
@@ -83,7 +114,8 @@ export function buildRecurringTemplateCreateData(
 		requires_full_profile: formData.requires_full_profile ?? false,
 		venue_id: formData.venue_id ?? null,
 		location_maps_url: formData.location_maps_url ?? null,
-		location_maps_embed: formData.location_maps_embed ?? null
+		location_maps_embed: formData.location_maps_embed ?? null,
+		visibility_settings: visibilitySettingsForWrite(formData)
 	};
 }
 
@@ -123,7 +155,8 @@ export function buildWizardStep1UpdateData(
 		event_series_id: formData.event_series_id || null,
 		venue_id: formData.venue_id || null,
 		location_maps_url: formData.location_maps_url || null,
-		location_maps_embed: formData.location_maps_embed || null
+		location_maps_embed: formData.location_maps_embed || null,
+		visibility_settings: visibilitySettingsForWrite(formData)
 	};
 }
 
@@ -157,7 +190,8 @@ export function buildWizardStep2UpdateData(
 		event_series_id: formData.event_series_id || null,
 		venue_id: formData.venue_id || null,
 		location_maps_url: formData.location_maps_url || null,
-		location_maps_embed: formData.location_maps_embed || null
+		location_maps_embed: formData.location_maps_embed || null,
+		visibility_settings: visibilitySettingsForWrite(formData)
 	};
 }
 
@@ -199,6 +233,7 @@ export function buildEditorUpdateData(
 		event_series_id: formData.event_series_id || null,
 		venue_id: formData.venue_id || null,
 		location_maps_url: formData.location_maps_url || null,
-		location_maps_embed: formData.location_maps_embed || null
+		location_maps_embed: formData.location_maps_embed || null,
+		visibility_settings: visibilitySettingsForWrite(formData)
 	};
 }

--- a/src/lib/components/tickets/TicketTierList.svelte
+++ b/src/lib/components/tickets/TicketTierList.svelte
@@ -31,6 +31,8 @@
 		tierRemainingTickets?: TierRemainingTicketsSchema[];
 		/** The event's IANA timezone, so tier sales windows & deadlines render event-local (#474). */
 		timezone?: string | null;
+		/** The event's `visibility_settings.show_capacity` (#825) — see TierCard. */
+		capacityDisclosed?: boolean;
 		onSelectTier: (tier: TierSchemaWithId) => void;
 		onGuestTierClick?: (tier: TierSchemaWithId) => void;
 		/** Map-first entry point (#679): opens the whole-venue seating overview. */
@@ -51,6 +53,7 @@
 		canAttendWithoutLogin = false,
 		tierRemainingTickets,
 		timezone,
+		capacityDisclosed = true,
 		onSelectTier,
 		onGuestTierClick,
 		onViewSeatingMap
@@ -128,6 +131,7 @@
 					{canAttendWithoutLogin}
 					tierRemainingInfo={getTierRemainingInfo(tier.id)}
 					{timezone}
+					{capacityDisclosed}
 					{onSelectTier}
 					{onGuestTierClick}
 				/>

--- a/src/lib/components/tickets/TicketTierModal.svelte
+++ b/src/lib/components/tickets/TicketTierModal.svelte
@@ -33,6 +33,8 @@
 		tierRemainingTickets?: TierRemainingTicketsSchema[];
 		/** The event's IANA timezone, so tier sales windows render event-local (#474). */
 		timezone?: string | null;
+		/** The event's `visibility_settings.show_capacity` (#825) — see TierCard. */
+		capacityDisclosed?: boolean;
 		/** Event-level max tickets per user (fallback when tier-specific limit is null) */
 		eventMaxTicketsPerUser?: number | null;
 		/** User's display name for auto-fill */
@@ -95,6 +97,7 @@
 		canAttendWithoutLogin = false,
 		tierRemainingTickets,
 		timezone,
+		capacityDisclosed = true,
 		eventMaxTicketsPerUser = null,
 		userName = '',
 		preSelectedTier = null,
@@ -395,6 +398,7 @@
 						{canAttendWithoutLogin}
 						tierRemainingInfo={getTierRemainingInfo(tier.id)}
 						{timezone}
+						{capacityDisclosed}
 						onSelectTier={handleTierClick}
 						{onGuestTierClick}
 					/>

--- a/src/lib/components/tickets/TierCard.svelte
+++ b/src/lib/components/tickets/TierCard.svelte
@@ -24,6 +24,13 @@
 		tierRemainingInfo?: TierRemainingTicketsSchema;
 		/** The event's IANA timezone, so sales windows render event-local (#474). */
 		timezone?: string | null;
+		/**
+		 * The event's `visibility_settings.show_capacity` (#825). Disambiguates a
+		 * `null` `total_available`: unlimited when capacity is disclosed, withheld
+		 * when it is not. Defaults to `true` so a caller that cannot know behaves
+		 * like the pre-#825 world.
+		 */
+		capacityDisclosed?: boolean;
 		onSelectTier: (tier: TierSchemaWithId) => void;
 		onGuestTierClick?: (tier: TierSchemaWithId) => void;
 	}
@@ -37,6 +44,7 @@
 		canAttendWithoutLogin = false,
 		tierRemainingInfo,
 		timezone,
+		capacityDisclosed = true,
 		onSelectTier,
 		onGuestTierClick
 	}: Props = $props();
@@ -138,19 +146,23 @@
 	/**
 	 * Check availability.
 	 *
-	 * `total_available === null` is ambiguous since backend #825: it used to mean
-	 * only "unlimited", but the field is now also nulled when the event withholds
-	 * capacity (`visibility_settings.show_capacity === false`). The two are
-	 * indistinguishable from the tier alone, so the card states nothing about
-	 * inventory for a null — calling withheld inventory "unlimited" would be a
-	 * lie, and the sold-out signal for such tiers comes from
-	 * `tierRemainingInfo.sold_out`, which is not gated.
+	 * `total_available === null` is ambiguous from the tier alone since backend
+	 * #825: it means "unlimited" when the event discloses capacity, and "withheld"
+	 * when it does not. `capacityDisclosed` is the event-level fact that resolves
+	 * it — with capacity disclosed a null genuinely means an uncapped tier and we
+	 * say so; with capacity hidden the card states nothing about inventory, since
+	 * calling withheld inventory "unlimited" would be a lie. Either way the
+	 * sold-out signal still arrives via `tierRemainingInfo.sold_out`, which is not
+	 * gated.
 	 *
 	 * `message === null` is what suppresses the inventory row in the template.
 	 */
 	const availabilityStatus = $derived.by(() => {
 		if (tier.total_available === null) {
-			return { available: true, message: null };
+			return {
+				available: true,
+				message: capacityDisclosed ? m['tierCard.unlimited']() : null
+			};
 		}
 
 		if (tier.total_available === 0) {

--- a/src/lib/components/tickets/TierCard.test.ts
+++ b/src/lib/components/tickets/TierCard.test.ts
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import TierCard from './TierCard.svelte';
+import type { TierSchemaWithId } from '$lib/types/tickets';
+
+function makeTier(overrides: Partial<TierSchemaWithId> = {}): TierSchemaWithId {
+	return {
+		id: 'tier-1',
+		event_id: 'event-1',
+		name: 'General Admission',
+		description: null,
+		price: '0',
+		currency: 'EUR',
+		payment_method: 'free',
+		price_type: 'fixed',
+		total_available: null,
+		can_purchase: true,
+		...overrides
+	} as TierSchemaWithId;
+}
+
+function renderCard(tier: TierSchemaWithId, capacityDisclosed?: boolean) {
+	render(TierCard, {
+		props: { tier, isAuthenticated: true, capacityDisclosed, onSelectTier: vi.fn() }
+	});
+}
+
+// #690 / backend #825: `total_available === null` means "unlimited" when the
+// event discloses capacity and "withheld" when it does not. Only the event-level
+// `show_capacity` distinguishes them.
+describe('TierCard — inventory disclosure', () => {
+	it('says "Unlimited" for a null quantity when capacity is disclosed', () => {
+		renderCard(makeTier({ total_available: null }), true);
+		expect(screen.getByText(/unlimited/i)).toBeInTheDocument();
+	});
+
+	it('defaults to disclosed when the caller cannot say', () => {
+		renderCard(makeTier({ total_available: null }));
+		expect(screen.getByText(/unlimited/i)).toBeInTheDocument();
+	});
+
+	it('says nothing about inventory for a null quantity when capacity is withheld', () => {
+		renderCard(makeTier({ total_available: null }), false);
+		expect(screen.queryByText(/unlimited/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/remaining/i)).not.toBeInTheDocument();
+	});
+
+	it('still reports a concrete remaining count regardless of the flag', () => {
+		renderCard(makeTier({ total_available: 7 }), false);
+		expect(screen.getByText(/7 remaining/i)).toBeInTheDocument();
+	});
+
+	it('still reports sold out regardless of the flag', () => {
+		// Two nodes: the inventory row and the disabled CTA.
+		renderCard(makeTier({ total_available: 0 }), false);
+		expect(screen.getAllByText(/sold out/i).length).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/seo/jsonld/event.test.ts
+++ b/src/lib/seo/jsonld/event.test.ts
@@ -46,22 +46,39 @@ describe('generateEventJsonLd', () => {
 		expect(ld.offers?.availability).toBe('https://schema.org/InStock');
 	});
 
-	it('marks the Offer SoldOut when capacity is reached', () => {
-		const e = { ...baseEvent, max_attendees: 10, attendee_count: 10 } as EventDetailSchema;
+	// #690: availability comes from the always-public `is_full` (#825). Deriving
+	// it from `max_attendees`/`attendee_count` published "InStock" for a discreet
+	// event that was actually sold out.
+	it('marks the Offer SoldOut when the backend flags the event as full', () => {
+		const e = { ...baseEvent, is_full: true } as EventDetailSchema;
 		const ld = generateEventJsonLd(e, 'https://letsrevel.io/x');
 		expect(ld.offers?.availability).toBe('https://schema.org/SoldOut');
 	});
 
-	// #825: either number may be withheld (null). Structured data must not
-	// publish a guess — an unknown occupancy stays InStock.
-	it('stays InStock when the attendee count is withheld', () => {
-		const e = { ...baseEvent, max_attendees: 10, attendee_count: null } as EventDetailSchema;
+	it('marks the Offer SoldOut even when capacity and count are withheld', () => {
+		const e = {
+			...baseEvent,
+			is_full: true,
+			max_attendees: null,
+			attendee_count: null
+		} as EventDetailSchema;
+		const ld = generateEventJsonLd(e, 'https://letsrevel.io/x');
+		expect(ld.offers?.availability).toBe('https://schema.org/SoldOut');
+	});
+
+	it('stays InStock when the flag is false, whatever the numbers say', () => {
+		const e = {
+			...baseEvent,
+			is_full: false,
+			max_attendees: 10,
+			attendee_count: 10
+		} as EventDetailSchema;
 		const ld = generateEventJsonLd(e, 'https://letsrevel.io/x');
 		expect(ld.offers?.availability).toBe('https://schema.org/InStock');
 	});
 
-	it('stays InStock when capacity is withheld', () => {
-		const e = { ...baseEvent, max_attendees: null, attendee_count: 999 } as EventDetailSchema;
+	it('stays InStock when the flag is absent', () => {
+		const e = { ...baseEvent, is_full: undefined } as EventDetailSchema;
 		const ld = generateEventJsonLd(e, 'https://letsrevel.io/x');
 		expect(ld.offers?.availability).toBe('https://schema.org/InStock');
 	});

--- a/src/lib/seo/jsonld/event.ts
+++ b/src/lib/seo/jsonld/event.ts
@@ -78,16 +78,10 @@ export function generateEventJsonLd(event: EventDetailSchema, eventUrl: string):
 	if (images.length > 0) ld.image = images;
 
 	if (!event.requires_ticket) {
-		// Capacity and attendee count may both be withheld (`null`) since #825.
-		// Without both we cannot claim SoldOut, so the offer stays InStock rather
-		// than publishing a guess into structured data.
-		const maxAttendees = event.max_attendees;
-		const attendeeCount = event.attendee_count;
-		const isFull =
-			maxAttendees != null &&
-			maxAttendees > 0 &&
-			attendeeCount != null &&
-			attendeeCount >= maxAttendees;
+		// `is_full` (#825) is always public, unlike `max_attendees`/`attendee_count`
+		// which the organizer may withhold. Deriving occupancy from those two would
+		// publish "InStock" for a discreet event that is actually sold out.
+		const isFull = event.is_full === true;
 		ld.offers = {
 			'@type': 'Offer',
 			url: eventUrl,

--- a/src/lib/utils/event-visibility.test.ts
+++ b/src/lib/utils/event-visibility.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+	VISIBILITY_DEFAULTS,
+	VISIBILITY_PRESETS,
+	diffVisibilitySettings,
+	isNonDefaultVisibility,
+	matchVisibilityPreset,
+	resolveVisibilitySettings
+} from './event-visibility';
+
+describe('resolveVisibilitySettings', () => {
+	it('fills every absent toggle with the backend default (disclosed)', () => {
+		expect(resolveVisibilitySettings(undefined)).toEqual(VISIBILITY_DEFAULTS);
+		expect(resolveVisibilitySettings(null)).toEqual(VISIBILITY_DEFAULTS);
+		expect(resolveVisibilitySettings({})).toEqual(VISIBILITY_DEFAULTS);
+	});
+
+	it('keeps explicit values and only defaults the absent ones', () => {
+		expect(resolveVisibilitySettings({ show_capacity: false })).toEqual({
+			show_attendee_count: true,
+			show_capacity: false,
+			show_attendee_list: true
+		});
+	});
+});
+
+describe('matchVisibilityPreset', () => {
+	it('recognises the two presets', () => {
+		expect(matchVisibilityPreset(VISIBILITY_PRESETS.open)).toBe('open');
+		expect(matchVisibilityPreset(VISIBILITY_PRESETS.discreet)).toBe('discreet');
+	});
+
+	it('treats the backend default as the "open" preset', () => {
+		expect(matchVisibilityPreset(undefined)).toBe('open');
+	});
+
+	it('returns null (custom) for a mixed combination', () => {
+		expect(
+			matchVisibilityPreset({
+				show_attendee_count: true,
+				show_capacity: false,
+				show_attendee_list: true
+			})
+		).toBeNull();
+	});
+});
+
+describe('isNonDefaultVisibility', () => {
+	it('is false for the defaults', () => {
+		expect(isNonDefaultVisibility(undefined)).toBe(false);
+		expect(isNonDefaultVisibility(VISIBILITY_PRESETS.open)).toBe(false);
+	});
+
+	it('is true as soon as one toggle is off', () => {
+		expect(isNonDefaultVisibility({ show_attendee_list: false })).toBe(true);
+	});
+});
+
+describe('diffVisibilitySettings', () => {
+	// The backend merges this object sub-key by sub-key: an omitted toggle means
+	// "no change". A minimal patch is therefore both correct and the lightest
+	// option — and critically, it never restates a toggle the user did not touch.
+	it('returns only the toggles that changed', () => {
+		const patch = diffVisibilitySettings(
+			{ show_attendee_count: false, show_capacity: true, show_attendee_list: true },
+			{ show_attendee_count: false, show_capacity: false, show_attendee_list: true }
+		);
+		expect(patch).toEqual({ show_capacity: false });
+	});
+
+	it('returns an empty object when nothing changed', () => {
+		expect(
+			diffVisibilitySettings(VISIBILITY_PRESETS.discreet, VISIBILITY_PRESETS.discreet)
+		).toEqual({});
+	});
+
+	it('can re-enable a disclosure by naming it explicitly', () => {
+		const patch = diffVisibilitySettings(VISIBILITY_PRESETS.discreet, VISIBILITY_PRESETS.open);
+		expect(patch).toEqual({
+			show_attendee_count: true,
+			show_capacity: true,
+			show_attendee_list: true
+		});
+	});
+
+	it('treats an absent original as the all-disclosed default', () => {
+		expect(diffVisibilitySettings(undefined, { show_capacity: false })).toEqual({
+			show_capacity: false
+		});
+	});
+
+	it('never emits null for any toggle', () => {
+		const patch = diffVisibilitySettings(VISIBILITY_PRESETS.open, VISIBILITY_PRESETS.discreet);
+		for (const value of Object.values(patch)) {
+			expect(typeof value).toBe('boolean');
+		}
+	});
+});

--- a/src/lib/utils/event-visibility.test.ts
+++ b/src/lib/utils/event-visibility.test.ts
@@ -5,7 +5,8 @@ import {
 	diffVisibilitySettings,
 	isNonDefaultVisibility,
 	matchVisibilityPreset,
-	resolveVisibilitySettings
+	resolveVisibilitySettings,
+	resolveViewerVisibility
 } from './event-visibility';
 
 describe('resolveVisibilitySettings', () => {
@@ -42,6 +43,34 @@ describe('matchVisibilityPreset', () => {
 				show_attendee_list: true
 			})
 		).toBeNull();
+	});
+});
+
+// Owners and staff bypass visibility_settings server-side (#825): the API hands
+// them the real numbers and the real guest list. Any UI that branches on the
+// toggles must not re-impose the public gate on them.
+describe('resolveViewerVisibility', () => {
+	const discreet = { show_attendee_count: false, show_capacity: false, show_attendee_list: false };
+
+	it('discloses everything to an owner regardless of the settings', () => {
+		expect(resolveViewerVisibility(discreet, { isOwner: true, isStaff: false })).toEqual(
+			VISIBILITY_DEFAULTS
+		);
+	});
+
+	it('discloses everything to staff regardless of the settings', () => {
+		expect(resolveViewerVisibility(discreet, { isOwner: false, isStaff: true })).toEqual(
+			VISIBILITY_DEFAULTS
+		);
+	});
+
+	it('applies the public settings to everyone else', () => {
+		expect(resolveViewerVisibility(discreet, { isOwner: false, isStaff: false })).toEqual(discreet);
+	});
+
+	it('treats absent viewer flags as a plain guest', () => {
+		expect(resolveViewerVisibility(discreet, {})).toEqual(discreet);
+		expect(resolveViewerVisibility(discreet, { isOwner: null, isStaff: null })).toEqual(discreet);
 	});
 });
 

--- a/src/lib/utils/event-visibility.ts
+++ b/src/lib/utils/event-visibility.ts
@@ -55,10 +55,8 @@ export const VISIBILITY_PRESETS: Record<VisibilityPresetId, ResolvedVisibilitySe
 	discreet: { show_attendee_count: false, show_capacity: false, show_attendee_list: false }
 };
 
-export const VISIBILITY_PRESET_IDS = ['open', 'discreet'] as const satisfies readonly [
-	VisibilityPresetId,
-	VisibilityPresetId
-];
+/** Presentation order of the preset buttons. */
+export const VISIBILITY_PRESET_IDS: readonly VisibilityPresetId[] = ['open', 'discreet'];
 
 /**
  * Fill in any absent toggle with its backend default.

--- a/src/lib/utils/event-visibility.ts
+++ b/src/lib/utils/event-visibility.ts
@@ -1,0 +1,122 @@
+/**
+ * Granular event visibility settings (backend #825).
+ *
+ * `visibility_settings` carries three independent disclosure switches. Every
+ * one defaults to `true`, and the backend serialises all three on every read,
+ * so a resolved value is always fully known once an event has been fetched.
+ *
+ * ## Write semantics (the part that bites)
+ *
+ * The backend **merges** this object at sub-key granularity: sending
+ * `{"show_capacity": false}` leaves `show_attendee_count` at its stored value
+ * rather than resetting it to the schema default. Partial writes and whole-
+ * object round-trips are therefore both safe. (The first backend implementation
+ * replaced the whole blob, which silently re-disclosed a count the organizer
+ * had hidden whenever an unrelated toggle was edited.)
+ *
+ * Two asymmetries this module exists to keep straight:
+ *
+ * - `extra="forbid"` — unknown keys are rejected with a 422. Preset shortcuts
+ *   are a frontend-only affordance: they set the three granular toggles and a
+ *   preset name is never sent to the backend.
+ * - Explicit `null` differs by schema. `EventEditSchema` declares the field
+ *   non-nullable, so `null` is a 422; `TemplateEditSchema` declares it
+ *   `| None` and reads `null` as "no change". Nothing here ever emits `null` —
+ *   writers either send a concrete object or omit the key entirely, which is
+ *   valid against both schemas.
+ */
+
+import type { EventVisibilitySettings } from '$lib/api/generated/types.gen';
+
+/** The three granular toggles, in the order they are presented to organizers. */
+export const VISIBILITY_TOGGLE_KEYS = [
+	'show_attendee_count',
+	'show_capacity',
+	'show_attendee_list'
+] as const;
+
+export type VisibilityToggleKey = (typeof VISIBILITY_TOGGLE_KEYS)[number];
+
+/** `EventVisibilitySettings` with every toggle known — no optional members. */
+export type ResolvedVisibilitySettings = Record<VisibilityToggleKey, boolean>;
+
+/** Backend defaults: everything disclosed, reproducing pre-#825 behaviour. */
+export const VISIBILITY_DEFAULTS: ResolvedVisibilitySettings = {
+	show_attendee_count: true,
+	show_capacity: true,
+	show_attendee_list: true
+};
+
+/** Frontend-only preset shortcuts. Each is just a set of the three toggles. */
+export type VisibilityPresetId = 'open' | 'discreet';
+
+export const VISIBILITY_PRESETS: Record<VisibilityPresetId, ResolvedVisibilitySettings> = {
+	open: { show_attendee_count: true, show_capacity: true, show_attendee_list: true },
+	discreet: { show_attendee_count: false, show_capacity: false, show_attendee_list: false }
+};
+
+export const VISIBILITY_PRESET_IDS = ['open', 'discreet'] as const satisfies readonly [
+	VisibilityPresetId,
+	VisibilityPresetId
+];
+
+/**
+ * Fill in any absent toggle with its backend default.
+ *
+ * Reads always carry all three, so this only matters for form state that has
+ * not been seeded yet (create flows) — never for a fetched event.
+ */
+export function resolveVisibilitySettings(
+	settings: EventVisibilitySettings | null | undefined
+): ResolvedVisibilitySettings {
+	return {
+		show_attendee_count: settings?.show_attendee_count ?? VISIBILITY_DEFAULTS.show_attendee_count,
+		show_capacity: settings?.show_capacity ?? VISIBILITY_DEFAULTS.show_capacity,
+		show_attendee_list: settings?.show_attendee_list ?? VISIBILITY_DEFAULTS.show_attendee_list
+	};
+}
+
+/**
+ * Which preset (if any) the current toggles correspond to.
+ *
+ * `null` means "custom" — a combination no preset expresses. Presets are a
+ * shortcut, not a mode: nothing downstream branches on the answer.
+ */
+export function matchVisibilityPreset(
+	settings: EventVisibilitySettings | null | undefined
+): VisibilityPresetId | null {
+	const resolved = resolveVisibilitySettings(settings);
+	for (const id of VISIBILITY_PRESET_IDS) {
+		const preset = VISIBILITY_PRESETS[id];
+		if (VISIBILITY_TOGGLE_KEYS.every((key) => resolved[key] === preset[key])) return id;
+	}
+	return null;
+}
+
+/** True when the toggles differ from the backend defaults in any way. */
+export function isNonDefaultVisibility(
+	settings: EventVisibilitySettings | null | undefined
+): boolean {
+	const resolved = resolveVisibilitySettings(settings);
+	return VISIBILITY_TOGGLE_KEYS.some((key) => resolved[key] !== VISIBILITY_DEFAULTS[key]);
+}
+
+/**
+ * The minimal patch that moves `original` to `next`.
+ *
+ * Returns only the sub-keys that actually changed, which is exactly what the
+ * backend's merge semantics reward: an omitted toggle means "no change". An
+ * empty object means nothing changed and the caller should omit the field.
+ */
+export function diffVisibilitySettings(
+	original: EventVisibilitySettings | null | undefined,
+	next: EventVisibilitySettings | null | undefined
+): EventVisibilitySettings {
+	const before = resolveVisibilitySettings(original);
+	const after = resolveVisibilitySettings(next);
+	const patch: EventVisibilitySettings = {};
+	for (const key of VISIBILITY_TOGGLE_KEYS) {
+		if (before[key] !== after[key]) patch[key] = after[key];
+	}
+	return patch;
+}

--- a/src/lib/utils/event-visibility.ts
+++ b/src/lib/utils/event-visibility.ts
@@ -100,6 +100,24 @@ export function isNonDefaultVisibility(
 }
 
 /**
+ * What *this viewer* may see, as opposed to what the event discloses publicly.
+ *
+ * Organization owners and staff bypass `visibility_settings` entirely on the
+ * backend: the API serves them the real counts, the real capacity and the real
+ * guest list no matter what the toggles say. Gating their UI on the public
+ * toggles would hide an organizer's own event data from them — the numeric
+ * surfaces get this for free (the numbers simply arrive non-null), but anything
+ * that branches on the toggles themselves has to ask this instead.
+ */
+export function resolveViewerVisibility(
+	settings: EventVisibilitySettings | null | undefined,
+	viewer: { isOwner?: boolean | null; isStaff?: boolean | null }
+): ResolvedVisibilitySettings {
+	if (viewer.isOwner || viewer.isStaff) return { ...VISIBILITY_DEFAULTS };
+	return resolveVisibilitySettings(settings);
+}
+
+/**
  * The minimal patch that moves `original` to `next`.
  *
  * Returns only the sub-keys that actually changed, which is exactly what the

--- a/src/lib/utils/event.test.ts
+++ b/src/lib/utils/event.test.ts
@@ -10,29 +10,34 @@ function makeEvent(overrides: Partial<EventInListSchema> = {}): EventInListSchem
 	} as EventInListSchema;
 }
 
+// #690: fullness comes from the backend's always-public `is_full` (#825), not
+// from `max_attendees`/`attendee_count` — those two are withheld (null) when the
+// organizer hides capacity or the count, and deriving from them made a discreet
+// sold-out event read as "not full".
 describe('isEventFull', () => {
-	it('is true when the count has reached the capacity', () => {
-		expect(isEventFull(makeEvent({ max_attendees: 50, attendee_count: 50 }))).toBe(true);
-		expect(isEventFull(makeEvent({ max_attendees: 50, attendee_count: 55 }))).toBe(true);
+	it('is true when the backend says the event is full', () => {
+		expect(isEventFull(makeEvent({ is_full: true }))).toBe(true);
 	});
 
-	it('is false below capacity', () => {
-		expect(isEventFull(makeEvent({ max_attendees: 50, attendee_count: 49 }))).toBe(false);
+	it('is false when the backend says it is not full', () => {
+		expect(isEventFull(makeEvent({ is_full: false }))).toBe(false);
 	});
 
-	it('is false when there is no capacity limit', () => {
-		expect(isEventFull(makeEvent({ max_attendees: 0, attendee_count: 999 }))).toBe(false);
+	it('is true even when capacity and count are withheld', () => {
+		expect(
+			isEventFull(makeEvent({ is_full: true, max_attendees: null, attendee_count: null }))
+		).toBe(true);
 	});
 
-	// #825: capacity and count are withheld (null) when the organizer hides them.
-	// Fullness is not assertable then — answering false keeps "Full" off the UI
-	// rather than fabricating a verdict from a missing number.
-	it('is false when capacity is withheld', () => {
-		expect(isEventFull(makeEvent({ max_attendees: null, attendee_count: 999 }))).toBe(false);
+	it('ignores the raw numbers entirely', () => {
+		// Numbers that would have read as "full" under the old derivation.
+		expect(isEventFull(makeEvent({ is_full: false, max_attendees: 50, attendee_count: 50 }))).toBe(
+			false
+		);
 	});
 
-	it('is false when the attendee count is withheld', () => {
-		expect(isEventFull(makeEvent({ max_attendees: 50, attendee_count: null }))).toBe(false);
+	it('is false when the flag is absent', () => {
+		expect(isEventFull(makeEvent({ is_full: undefined }))).toBe(false);
 	});
 });
 

--- a/src/lib/utils/event.ts
+++ b/src/lib/utils/event.ts
@@ -39,20 +39,17 @@ export function getEventAccessDisplay(
 /**
  * Check if event is at capacity
  *
- * Since backend #825 both `max_attendees` and `attendee_count` may be withheld
- * (`null`) when the organizer hides capacity or the attendee count. Fullness is
- * only assertable with both numbers in hand — with either missing we answer
- * `false` rather than guess, so a withheld count never renders as "Full".
+ * Reads the backend's `is_full` flag (#825), which is always public: deriving
+ * fullness from `max_attendees`/`attendee_count` stopped working when those two
+ * became withholdable, and a hidden capacity would then have read as "not full".
+ * `is_full` is computed server-side from the real numbers regardless of what the
+ * event discloses, so sold-out signalling survives a discreet event.
  *
  * @param event Event data
- * @returns true if event is known to be at capacity
+ * @returns true if the event is at capacity
  */
 export function isEventFull(event: EventInListSchema): boolean {
-	const maxAttendees = event.max_attendees;
-	const attendeeCount = event.attendee_count;
-	if (maxAttendees == null || maxAttendees === 0) return false; // No limit, or withheld
-	if (attendeeCount == null) return false; // Count withheld — not assertable
-	return attendeeCount >= maxAttendees;
+	return event.is_full === true;
 }
 
 /**

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -423,6 +423,7 @@
 						canAttendWithoutLogin={event.can_attend_without_login}
 						{tierRemainingTickets}
 						timezone={event.timezone}
+						capacityDisclosed={event.visibility_settings?.show_capacity !== false}
 						onSelectTier={handleSelectTier}
 						onGuestTierClick={openGuestTicketDialog}
 						onViewSeatingMap={hasSeatingMap
@@ -491,6 +492,7 @@
 						eventId={event.id}
 						totalAttendees={event.attendee_count}
 						isAuthenticated={data.isAuthenticated}
+						listDisclosed={event.visibility_settings?.show_attendee_list !== false}
 						userVisibility={data.userVisibility}
 						showPronounDistribution={event.public_pronoun_distribution ||
 							data.isOwner ||
@@ -560,6 +562,7 @@
 						eventId={event.id}
 						totalAttendees={event.attendee_count}
 						isAuthenticated={data.isAuthenticated}
+						listDisclosed={event.visibility_settings?.show_attendee_list !== false}
 						userVisibility={data.userVisibility}
 						showPronounDistribution={event.public_pronoun_distribution ||
 							data.isOwner ||
@@ -605,6 +608,7 @@
 	canAttendWithoutLogin={event.can_attend_without_login}
 	{tierRemainingTickets}
 	timezone={event.timezone}
+	capacityDisclosed={event.visibility_settings?.show_capacity !== false}
 	eventMaxTicketsPerUser={event.max_tickets_per_user}
 	userName={userDisplayName}
 	{preSelectedTier}

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -3,6 +3,7 @@
 	import type { PageData } from './$types';
 	import { useQueryClient } from '@tanstack/svelte-query';
 	import type { TierSchemaWithId } from '$lib/types/tickets';
+	import { resolveViewerVisibility } from '$lib/utils/event-visibility';
 	import EventHeader from '$lib/components/events/EventHeader.svelte';
 	import EventDetails from '$lib/components/events/EventDetails.svelte';
 	import EventActionSidebar from '$lib/components/events/EventActionSidebar.svelte';
@@ -53,6 +54,17 @@
 
 	// Create mutable copies for client-side updates
 	const event = $state(data.event);
+
+	// What THIS viewer may see. Owners and staff bypass `visibility_settings`
+	// server-side (#825) — the API serves them the real guest list and the real
+	// capacity — so gating their UI on the public toggles would hide an
+	// organizer's own event data from them.
+	const viewerVisibility = $derived(
+		resolveViewerVisibility(event.visibility_settings, {
+			isOwner: data.isOwner,
+			isStaff: data.isStaff
+		})
+	);
 	let userStatus = $state(data.userStatus);
 	const ticketTiers = $state<TierSchemaWithId[]>(data.ticketTiers as TierSchemaWithId[]);
 
@@ -423,7 +435,7 @@
 						canAttendWithoutLogin={event.can_attend_without_login}
 						{tierRemainingTickets}
 						timezone={event.timezone}
-						capacityDisclosed={event.visibility_settings?.show_capacity !== false}
+						capacityDisclosed={viewerVisibility.show_capacity}
 						onSelectTier={handleSelectTier}
 						onGuestTierClick={openGuestTicketDialog}
 						onViewSeatingMap={hasSeatingMap
@@ -492,7 +504,7 @@
 						eventId={event.id}
 						totalAttendees={event.attendee_count}
 						isAuthenticated={data.isAuthenticated}
-						listDisclosed={event.visibility_settings?.show_attendee_list !== false}
+						listDisclosed={viewerVisibility.show_attendee_list}
 						userVisibility={data.userVisibility}
 						showPronounDistribution={event.public_pronoun_distribution ||
 							data.isOwner ||
@@ -562,7 +574,7 @@
 						eventId={event.id}
 						totalAttendees={event.attendee_count}
 						isAuthenticated={data.isAuthenticated}
-						listDisclosed={event.visibility_settings?.show_attendee_list !== false}
+						listDisclosed={viewerVisibility.show_attendee_list}
 						userVisibility={data.userVisibility}
 						showPronounDistribution={event.public_pronoun_distribution ||
 							data.isOwner ||
@@ -608,7 +620,7 @@
 	canAttendWithoutLogin={event.can_attend_without_login}
 	{tierRemainingTickets}
 	timezone={event.timezone}
-	capacityDisclosed={event.visibility_settings?.show_capacity !== false}
+	capacityDisclosed={viewerVisibility.show_capacity}
 	eventMaxTicketsPerUser={event.max_tickets_per_user}
 	userName={userDisplayName}
 	{preSelectedTier}


### PR DESCRIPTION
Closes #690

Frontend counterpart of letsrevel/revel-backend#825. Picks up where Wave 0 (#706) stopped: #706 regenerated the client and made the nine newly-nullable numbers render honestly; this PR adds the organizer UX that produces those settings, and adopts the always-public `is_full` that #706 deliberately left out of scope.

## Organizer UX

A new **Attendance visibility** section carrying the three granular toggles — `show_attendee_count`, `show_capacity`, `show_attendee_list`. It appears in `DetailsStep` (so: event wizard, event editor, and the recurring-event wizard, which all mount it) and as its own section in `TemplateEditDialog`. The accordion auto-expands when the stored settings are non-default, so a disclosure the organizer turned off is never collapsed out of sight.

Two preset shortcuts, **Open** and **Discreet**, sit above the toggles as `aria-pressed` buttons with a live-region readback that reads "Custom" when the combination matches neither. Toggle buttons rather than a radio group because a radio group cannot represent "custom" without a phantom option; there is no roving-tabindex or focus trap, so every control stays individually tabbable.

## Write semantics — the decisions

All three backend contract rules are documented in one place, `src/lib/utils/event-visibility.ts`, and enforced by `event-payload.test.ts`.

**Merge, not replace.** `visibility_settings` merges sub-key-wise: an omitted toggle means "no change". Both a whole-object round-trip and a minimal patch are therefore correct, and each surface uses whichever fits its existing style:

- `EventWizard` / `EventEditor` / `RecurringEventWizard` round-trip the **complete resolved triple** through `event-payload.ts`. These forms already PUT their whole state, so a full object keeps the payload self-consistent.
- `TemplateEditDialog` is diff-based throughout (it must be — `extra="forbid"`), so it sends **only the toggles that actually changed**, via `diffVisibilitySettings`.

**Presets never reach the wire.** `extra="forbid"` 422s unknown keys. `applyPreset` sets the three granular booleans and nothing else; the preset id lives only in component state. A test asserts every builder emits exactly `show_attendee_count`, `show_attendee_list`, `show_capacity` and no other key.

**Explicit `null` is never emitted.** `EventEditSchema` declares the field non-nullable (a `null` is a 422); `TemplateEditSchema` declares it `| None` and reads `null` as "no change". Rather than branch on which schema a given call hits, nothing in this PR can produce a `null`: `visibilitySettingsForWrite` returns either a concrete object or `undefined`, and `undefined` is dropped by `JSON.stringify` — valid against both schemas. The asymmetry is therefore neutralised at the source rather than handled per-caller. Tests assert `not.toBeNull()` and that the serialised body has no `visibility_settings` property at all.

**Why `undefined` and not the all-`true` default.** This is the trap the backend caught in its own review, and the same one exists on the frontend. If an edit form's `formData` were unseeded, resolving to all-`true` and sending it would silently re-disclose a count the organizer had hidden. So: `EventWizard` and `EventEditor` seed `visibility_settings` from `existingEvent`, *and* the payload helper omits the field entirely when the form never carried one. Either guard alone would do; both together mean a future field-init omission degrades to "no change" instead of "re-disclose".

## Adopting `is_full`

`isEventFull`, `EventStatusBadge` and the JSON-LD `eventStatus` derivation now read `is_full` instead of comparing `max_attendees` against `attendee_count`. Those two are withholdable, so the derived form made a discreet sold-out event read as "not full" and published a guessed `InStock` into structured data. `EventBadges` inherits the fix through `isEventFull`. No compatibility fallback — backend and frontend ship together in 2.0, so `is_full` is always present.

## Copy pass

With counts hidden, `EventDetails` and `EventQuickInfo` fall back to "Event is full" / "Event full" when `is_full` is set, and **omit the row entirely** otherwise.

The issue suggested a "Limited spots" hedge for the not-full case. I did not implement it: `is_full === false` is equally true of an event with no capacity at all, and with `show_capacity` off we cannot tell the two apart. Rendering scarcity there would be inventing it — which is the same failure mode as `?? 0`, just in prose. Omitting the row is the honest option the issue also allows.

## Ticket tiers — a product decision, stated as one

`TierCard` gains `capacityDisclosed`, threaded from the event page through `TicketTierList` and `TicketTierModal` (the only two mount sites of this component; `events/admin/TicketingStep.svelte` mounts a *different* `TierCard`).

With capacity disclosed, a `null` `total_available` genuinely means unlimited, and the card now says so. **This is a new affordance, not a restored one**: before #706, the row was guarded by `{#if tier.total_available !== null}` while `m['tierCard.unlimited']()` was computed on exactly the null branch — it was dead code that never rendered. #706's change was byte-identical in output. The judgement here is that "Unlimited" is useful information for the common case of an uncapped tier, and the visibility work is what finally makes it safely expressible. With capacity withheld it stays suppressed, because "unlimited" and "withheld" are indistinguishable from the tier alone. The orphaned `tierCard.unlimited` key is in use again as a result.

`events/admin/TierCard.svelte` keeps its `total_available ?? 0`, now annotated: it is a staff-only surface and staff bypass visibility gating, so that reader never sees a withheld number. Same expression on any guest-facing surface would be a bug.

## Attendee list

`AttendeeList` gains `listDisclosed`, wired at **both** mount sites in the public event page (mobile and desktop). When the guest list is withheld it skips the query and shows the existing `attendeeList.listHidden` copy immediately instead of after a spinner resolves to an empty page. The gate itself stays server-side — this only removes a pointless request and a misleading loading state.

Dietary summary was re-verified rather than changed: entries and notes still render, only the per-entry `attendee_count` is suppressed. That is #706's behaviour and it is correct.

## Housekeeping

`TemplateEditDialog` was at 748/750 lines. Its toggle and propagation configs moved to `template-edit-fields.ts` as *factories*, not module-level constants — the labels are Paraglide message calls and must be evaluated per component instance so a language switch re-renders them.

## Verification

```
make fix && make check    # 0 type errors; type-gate canary armed; i18n, file-length, a11y audits clean
pnpm test                 # 173 files, 2072 passed, 1 todo
```

New tests: `event-visibility.test.ts` (resolve/match/diff, including "never emits null"), `EventVisibilityFields.test.ts` (preset and toggle emissions, aria-pressed states), `TierCard.test.ts`, `AttendeeList.test.ts`, plus visibility-write cases across all four payload builders and `is_full` rewrites of the badge/JSON-LD/`isEventFull` suites.

Rebased onto `main` after #707 (`/embed`) landed; the embed surface renders no counts and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attendance visibility settings for event creators, with open, discreet, and custom presets.
  * Creators can control whether guests see attendee counts, capacity, and guest lists.
  * Added localized visibility controls and full-event messaging in English, German, French, and Italian.

* **Bug Fixes**
  * Events now consistently display “Full” status even when capacity details are hidden.
  * Hidden attendee lists and capacity information are no longer fetched or displayed to guests.
  * Updated structured event data to accurately reflect sold-out status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->