### PR TITLE
fix(embed): keep the org header on a list embed with no upcoming events

### DIFF
--- a/src/lib/embed/constants.ts
+++ b/src/lib/embed/constants.ts
@@ -60,6 +60,15 @@ export const EMBED_MAX_PAGE_SIZE = 24;
  */
 export const EMBED_PRICE_TIMEOUT_MS = 2000;
 
+/**
+ * Per-request budget for the organization lookup that backs an empty list
+ * embed's header.
+ *
+ * Same reasoning as the price lookups: the header is worth one bounded request,
+ * never a stalled SSR response inside a third party's page.
+ */
+export const EMBED_ORG_TIMEOUT_MS = 2000;
+
 /** Default iframe dimensions advertised through oEmbed, per surface. */
 export const EMBED_DEFAULT_DIMENSIONS: Record<Exclude<EmbedMedium, 'oembed'>, [number, number]> = {
 	event: [600, 460],

--- a/src/lib/server/embed-data.ts
+++ b/src/lib/server/embed-data.ts
@@ -9,11 +9,11 @@
  * (consistent with "has the link", the decision recorded in #689).
  */
 
-import { eventpublicticketsListTiers } from '$lib/api';
+import { eventpublicticketsListTiers, organizationGetOrganization } from '$lib/api';
 import { minimumTierPrice, type EmbedPrice } from '$lib/embed/pricing';
-import { EMBED_PRICE_TIMEOUT_MS } from '$lib/embed/constants';
+import { EMBED_ORG_TIMEOUT_MS, EMBED_PRICE_TIMEOUT_MS } from '$lib/embed/constants';
 import { log } from '$lib/server/logger';
-import type { EventInListSchema } from '$lib/api/generated/types.gen';
+import type { EventInListSchema, MinimalOrganizationSchema } from '$lib/api/generated/types.gen';
 
 /** The subset of an event this module needs — keeps callers free to pass either schema. */
 type PriceableEvent = Pick<EventInListSchema, 'id' | 'requires_ticket'>;
@@ -59,4 +59,36 @@ export async function loadEmbedPrices(
 		if (result.value.price) prices[result.value.id] = result.value.price;
 	}
 	return prices;
+}
+
+/**
+ * The organization behind a list embed, for its header.
+ *
+ * Call this ONLY when the event list came back empty. In the normal case the
+ * organization rides along on `EventInListSchema.organization` at no extra cost,
+ * so the common path stays a single request. The empty case is the one that
+ * needs help: an organization with nothing coming up would otherwise render an
+ * unbranded "nothing on right now" inside someone else's website.
+ *
+ * Returns `null` on any failure, including the 404 that a mistyped slug
+ * produces — that is the expected shape here, not an incident, and the page then
+ * renders exactly the anonymous empty state it rendered before. `data ?? null`
+ * covers the HTTP-error path (the client resolves rather than throws) while the
+ * `catch` covers the timeout, which does throw.
+ */
+export async function loadEmbedOrganization(
+	fetch: typeof globalThis.fetch,
+	slug: string
+): Promise<MinimalOrganizationSchema | null> {
+	try {
+		const { data } = await organizationGetOrganization({
+			fetch,
+			path: { slug },
+			signal: AbortSignal.timeout(EMBED_ORG_TIMEOUT_MS)
+		});
+		return data ?? null;
+	} catch (error) {
+		log.warning('embed_org_fetch_failed', { error, orgSlug: slug });
+		return null;
+	}
 }

--- a/src/routes/embed/[org_slug]/+page.server.ts
+++ b/src/routes/embed/[org_slug]/+page.server.ts
@@ -1,7 +1,7 @@
 import type { PageServerLoad } from './$types';
 import { eventpublicdiscoveryListEvents } from '$lib/api';
 import { parseEmbedListFilters } from '$lib/embed/params';
-import { loadEmbedPrices } from '$lib/server/embed-data';
+import { loadEmbedOrganization, loadEmbedPrices } from '$lib/server/embed-data';
 import { log } from '$lib/server/logger';
 
 /**
@@ -18,10 +18,12 @@ import { log } from '$lib/server/logger';
  * a surface living on someone else's website — a mistyped slug should read as
  * "nothing on right now", not as a stack trace in their layout.
  *
- * The organization's display identity comes from the events themselves
- * (`EventInListSchema.organization`); with no events there is nothing to head
- * the list with, so the header is omitted and only the empty state and the
- * footer link render.
+ * The organization's display identity normally rides along on the events
+ * (`EventInListSchema.organization`), which costs no extra request. An org with
+ * no upcoming events would otherwise render an unbranded "nothing on right now"
+ * on the customer's own website, so in exactly that case — and only then — we
+ * fall back to fetching the organization directly. The common path stays a
+ * single request.
  */
 export const load: PageServerLoad = async ({ params, url, fetch }) => {
 	const { org_slug } = params;
@@ -49,10 +51,11 @@ export const load: PageServerLoad = async ({ params, url, fetch }) => {
 	}
 
 	const events = eventsResponse.data?.results ?? [];
+	const organization = events[0]?.organization ?? (await loadEmbedOrganization(fetch, org_slug));
 
 	return {
 		orgSlug: org_slug,
-		organization: events[0]?.organization ?? null,
+		organization,
 		events,
 		prices: await loadEmbedPrices(fetch, events)
 	};

--- a/src/routes/embed/[org_slug]/page.server.test.ts
+++ b/src/routes/embed/[org_slug]/page.server.test.ts
@@ -3,16 +3,18 @@ import type { EventInListSchema } from '$lib/api/generated/types.gen';
 
 vi.mock('$lib/api', () => ({
 	eventpublicdiscoveryListEvents: vi.fn(),
-	eventpublicticketsListTiers: vi.fn()
+	eventpublicticketsListTiers: vi.fn(),
+	organizationGetOrganization: vi.fn()
 }));
 vi.mock('$lib/server/logger', () => ({
 	log: { warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() }
 }));
 
-import { eventpublicdiscoveryListEvents } from '$lib/api';
+import { eventpublicdiscoveryListEvents, organizationGetOrganization } from '$lib/api';
 import { load } from './+page.server';
 
 const listEvents = vi.mocked(eventpublicdiscoveryListEvents);
+const getOrganization = vi.mocked(organizationGetOrganization);
 
 const ORG = {
 	id: 'org-uuid',
@@ -49,6 +51,11 @@ function respond(results: EventInListSchema[]) {
 describe('embed list loader', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Default: the slug resolves to nothing. Tests that care override this.
+		getOrganization.mockResolvedValue({
+			data: undefined,
+			error: { detail: 'Not found' }
+		} as unknown as ReturnType<typeof organizationGetOrganization>);
 	});
 
 	it('filters by organization_slug and never sends the organization UUID too', async () => {
@@ -106,5 +113,54 @@ describe('embed list loader', () => {
 
 		expect(result.events).toEqual([]);
 		expect(result.organization).toBeNull();
+	});
+
+	describe('organization header fallback', () => {
+		it('does NOT spend a request when the events carry the organization', async () => {
+			respond([EVENT]);
+
+			const result = await load(loadEvent());
+
+			// The whole point of `organization_slug` was collapsing this to one
+			// request; the fallback must not quietly reintroduce the second.
+			expect(getOrganization).not.toHaveBeenCalled();
+			expect(result.organization).toEqual(ORG);
+		});
+
+		it('fetches the organization when the list is empty, so the header still renders', async () => {
+			respond([]);
+			getOrganization.mockResolvedValue({
+				data: { ...ORG, description: 'We throw parties.' },
+				error: undefined
+			} as unknown as ReturnType<typeof organizationGetOrganization>);
+
+			const result = await load(loadEvent());
+
+			expect(getOrganization).toHaveBeenCalledTimes(1);
+			expect(getOrganization.mock.calls[0][0]?.path).toEqual({ slug: 'acme' });
+			expect(result.events).toEqual([]);
+			expect(result.organization).toMatchObject({ name: 'Acme Collective', slug: 'acme' });
+		});
+
+		it('stays anonymous and unbranded for a slug that does not resolve', async () => {
+			respond([]);
+
+			const result = await load(loadEvent());
+
+			// A mistyped slug on someone else's website must read as "nothing on
+			// right now", never as an error panel or a header invented from the slug.
+			expect(result.organization).toBeNull();
+			expect(result.events).toEqual([]);
+		});
+
+		it('survives the organization request throwing (timeout)', async () => {
+			respond([]);
+			getOrganization.mockRejectedValue(new DOMException('TimeoutError'));
+
+			const result = await load(loadEvent());
+
+			expect(result.organization).toBeNull();
+			expect(result.events).toEqual([]);
+		});
 	});
 });


### PR DESCRIPTION
Follow-up to #707, which collapsed the list embed to a single request by filtering on `organization_slug` (backend #822).

## The problem

That change took the organization's display identity from the events themselves (`EventInListSchema.organization`). An organization with **no upcoming events** has no events to carry it, so its embed rendered an unbranded "nothing on right now" inside the customer's own website — no name, no logo, just the empty state and the footer link.

The embed agent flagged this trade-off explicitly rather than burying it, which is why it is a small follow-up instead of a bug report.

## The fix

Fetch the organization directly, **only when the event list came back empty**. The common path is untouched and still costs one request.

- New `loadEmbedOrganization()` in `src/lib/server/embed-data.ts`, alongside the existing anonymous loaders.
- Bounded by its own `EMBED_ORG_TIMEOUT_MS`, matching the reasoning already applied to the "from €X" tier lookups: a hanging upstream must cost the header, not hold the SSR response open inside a third party's page.
- Returns `null` on any failure. `data ?? null` covers the HTTP-error path (the client resolves rather than throws); the `catch` covers the timeout, which does throw.

`OrganizationRetrieveSchema` is a structural superset of `MinimalOrganizationSchema`, so the header component needs no change.

## Behaviour

| Case | Requests | Header |
|---|---|---|
| Org with upcoming events | 1 | From the events, as before |
| Org with **no** upcoming events | 2 | **Now renders** (was blank) |
| Slug that does not resolve | 2 | Stays blank, silent — no error panel |

A mistyped slug on someone else's website must read as "nothing on right now", never as a stack trace and never as a header invented from the raw slug. That is unchanged.

## Verification

- `make check` green — 6082 files, **0 errors**, and `✓ Type gate is armed` (the canary injects real errors into a `.ts` and a `.svelte`; a green run alone proves nothing, per #704).
- `pnpm test` — 169 files, **2055 passed**.
- **Mutation-checked** the key assertion: making the fallback unconditional fails `does NOT spend a request when the events carry the organization`, and only that test. Restoring makes it pass. The assertion is not vacuous.

Not run: `pnpm test:e2e` (needs a seeded backend). The embed surface still has no E2E coverage — worth a follow-up issue.

Refs #689.