### PR TITLE
chore(members): membership wave hygiene — cache-key constants, label dedup, prop hardening

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -3513,7 +3513,8 @@
 					"churn30d": "Abgewandert (30 Tage)",
 					"mixedCurrency": "Mehrere Währungen — MRR nicht verfügbar",
 					"error": "Abonnement-Kennzahlen konnten nicht geladen werden.",
-					"statusBreakdown": "Nach Status"
+					"statusBreakdown": "Nach Status",
+					"activeIncludesPastDue": "Aktiv + überfällig"
 				}
 			},
 			"payments": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -3513,7 +3513,8 @@
 					"churn30d": "Churned (30 days)",
 					"mixedCurrency": "Multiple currencies — MRR unavailable",
 					"error": "Couldn't load subscription metrics.",
-					"statusBreakdown": "By status"
+					"statusBreakdown": "By status",
+					"activeIncludesPastDue": "Active + past due"
 				}
 			},
 			"payments": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -3484,7 +3484,8 @@
 					"churn30d": "Résiliations (30 jours)",
 					"mixedCurrency": "Plusieurs devises — MRR indisponible",
 					"error": "Impossible de charger les statistiques d'abonnement.",
-					"statusBreakdown": "Par statut"
+					"statusBreakdown": "Par statut",
+					"activeIncludesPastDue": "Actifs + en retard de paiement"
 				}
 			},
 			"payments": {
@@ -6631,7 +6632,7 @@
 		},
 		"actions": {
 			"manageBilling": "Gérer la facturation",
-			"changePlan": "Changer de formule",
+			"changePlan": "Changer de forfait",
 			"cancel": "Résilier l'adhésion",
 			"resumePayment": "Reprendre le paiement",
 			"portalError": "Impossible d'ouvrir le portail de facturation. Réessaie.",
@@ -6726,7 +6727,7 @@
 			"already_active_member": "Tu es déjà membre.",
 			"not_accepting_requests": "Cette organisation n'accepte pas de nouveaux membres pour le moment.",
 			"tier_unavailable": "Ce niveau d'adhésion n'est pas disponible pour le moment.",
-			"plan_unavailable": "Cette formule n'est pas disponible pour le moment.",
+			"plan_unavailable": "Ce forfait n'est pas disponible pour le moment.",
 			"application_rejected": "Ta demande précédente n'a pas été approuvée.",
 			"membership_questionnaire_missing": "Cette organisation demande aux nouveaux membres de remplir d'abord un questionnaire.",
 			"membership_questionnaire_failed": "Ton questionnaire n'a pas été approuvé.",
@@ -6795,21 +6796,21 @@
 		"stripeUnreachable": "Impossible de joindre le prestataire de paiement : rien n'a été modifié, ton adhésion est intacte. Réessaie dans un instant."
 	},
 	"changePlan": {
-		"title": "Changer de formule",
+		"title": "Changer de forfait",
 		"description": "Ton adhésion à {org}",
-		"currentPlan": "Formule actuelle : {plan} ({price})",
+		"currentPlan": "Forfait actuel : {plan} ({price})",
 		"upgradeNote": "Tu paies la différence maintenant (au prorata) et changes immédiatement.",
 		"downgradeNoteDated": "Prend effet à ton prochain renouvellement le {date}.",
 		"downgradeNote": "Prend effet à ton prochain renouvellement.",
-		"noneAvailable": "Il n'y a pas d'autre formule disponible pour le moment.",
-		"confirmCta": "Changer de formule",
+		"noneAvailable": "Il n'y a pas d'autre forfait disponible pour le moment.",
+		"confirmCta": "Changer de forfait",
 		"switching": "Changement…",
 		"cancel": "Annuler",
-		"successUpgrade": "Formule changée.",
+		"successUpgrade": "Forfait changé.",
 		"successDowngradeDated": "Passage à {plan} le {date}.",
-		"successDowngrade": "Ta formule changera au prochain renouvellement.",
-		"error": "Impossible de changer de formule. Réessaie.",
-		"loadError": "Impossible de charger les formules disponibles."
+		"successDowngrade": "Ton forfait changera au prochain renouvellement.",
+		"error": "Impossible de changer de forfait. Réessaie.",
+		"loadError": "Impossible de charger les forfaits disponibles."
 	},
 	"subscribe": {
 		"title": "S'abonner à {plan}",
@@ -7568,7 +7569,7 @@
 	"permissionsEditor.perms.manageMembers.label": "Gérer les membres",
 	"permissionsEditor.perms.manageMembers.description": "Ajouter, retirer et gérer les membres de l'organisation",
 	"permissionsEditor.perms.manageSubscriptions.label": "Gérer les abonnements",
-	"permissionsEditor.perms.manageSubscriptions.description": "Créer et gérer les formules d'adhésion, les abonnements et les paiements",
+	"permissionsEditor.perms.manageSubscriptions.description": "Créer et gérer les forfaits d'adhésion, les abonnements et les paiements",
 	"permissionsEditor.perms.viewOrganizationDetails.label": "Voir les détails de l'organisation",
 	"permissionsEditor.perms.viewOrganizationDetails.description": "Accéder aux informations détaillées de l'organisation",
 	"permissionsEditor.perms.createEvent.label": "Créer des événements",

--- a/messages/it.json
+++ b/messages/it.json
@@ -3513,7 +3513,8 @@
 					"churn30d": "Abbandoni (30 giorni)",
 					"mixedCurrency": "Valute multiple — MRR non disponibile",
 					"error": "Impossibile caricare le metriche degli abbonamenti.",
-					"statusBreakdown": "Per stato"
+					"statusBreakdown": "Per stato",
+					"activeIncludesPastDue": "Attivi + in ritardo di pagamento"
 				}
 			},
 			"payments": {

--- a/src/lib/components/account/MembershipCard.svelte
+++ b/src/lib/components/account/MembershipCard.svelte
@@ -362,6 +362,7 @@
 						size="sm"
 						onclick={() => portalMutation.mutate()}
 						disabled={portalBusy}
+						aria-busy={portalBusy}
 					>
 						{#if portalBusy}
 							<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
@@ -406,7 +407,7 @@
 
 <!--
 	Deliberately outside the status chain and the action row above: both dialogs
-	rewrite `['me', 'memberships']` on success (`settleSubscriptionCaches`), so the
+	rewrite `MY_MEMBERSHIPS_KEY` on success (`settleSubscriptionCaches`), so the
 	card they were launched from re-renders with a subscription that no longer
 	offers that action.
 	Rendered inside, the open dialog would be destroyed mid-read — an unannounced

--- a/src/lib/components/account/MembershipCard.test.ts
+++ b/src/lib/components/account/MembershipCard.test.ts
@@ -5,6 +5,7 @@ import { QueryClient } from '@tanstack/svelte-query';
 import MembershipCard from './MembershipCard.svelte';
 import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
 import type {
+	MesubscriptionsSubscribe57C85BbbErrors,
 	MyMembershipSchema,
 	MySubscriptionSchema,
 	PublicPlanSchema
@@ -334,6 +335,14 @@ describe('MembershipCard', () => {
 		await waitFor(() =>
 			expect(window.location.href).toBe('https://billing.stripe.test/session/abc')
 		);
+		// Latched and ANNOUNCED, in parity with the resume/uncancel buttons (#702):
+		// `disabled` alone stops a second click but tells an assistive-technology
+		// user nothing about why the control went dead mid-navigation.
+		await waitFor(() => {
+			const btn = screen.getByRole('button', { name: /manage billing/i });
+			expect(btn).toBeDisabled();
+			expect(btn).toHaveAttribute('aria-busy', 'true');
+		});
 	});
 
 	it('names the queued plan from the org plan catalogue when a switch is pending', async () => {
@@ -390,12 +399,25 @@ describe('MembershipCard', () => {
 		);
 	});
 
+	/**
+	 * The error body is pinned to the endpoint's OWN generated error type rather
+	 * than written as a free-form object.
+	 *
+	 * #702 asked for `ResponseMessage {message}` here, but that would be a
+	 * fiction: since backend PR #824 the OpenAPI error declarations are honest,
+	 * and `MesubscriptionsSubscribe57C85BbbErrors` declares `ErrorDetail`
+	 * (`{ detail }`) for 400/404/502 — `{ message }` survives on exactly two
+	 * claim-invitation endpoints, of which this is neither. Mocking a shape the
+	 * backend cannot send would make the test prove something untrue. The typed
+	 * binding below is what keeps it honest from here on: if the declaration ever
+	 * does change, this stops compiling instead of quietly asserting a dead path.
+	 */
 	it('toasts the backend detail when the resume fails and stays on the page', async () => {
 		const user = userEvent.setup();
-		subscribeMock.mockResolvedValue({
-			data: undefined,
-			error: { detail: 'That checkout session has expired.' }
-		});
+		const expiredSession: MesubscriptionsSubscribe57C85BbbErrors[400] = {
+			detail: 'That checkout session has expired.'
+		};
+		subscribeMock.mockResolvedValue({ data: undefined, error: expiredSession });
 		renderCard(makeMembership(makeSub({ status: 'pending' })));
 
 		await user.click(screen.getByRole('button', { name: /resume payment/i }));

--- a/src/lib/components/account/MembershipPaymentHistory.svelte
+++ b/src/lib/components/account/MembershipPaymentHistory.svelte
@@ -6,6 +6,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { backendMessage } from '$lib/utils/api-error-detail';
+	import { MY_MEMBERSHIPS_KEY } from '$lib/utils/subscription-cache';
 	import { formatDate } from '$lib/utils/date';
 	import { formatMoney } from '$lib/utils/format';
 	import { ChevronDown, Loader2 } from '@lucide/svelte';
@@ -38,7 +39,10 @@
 	 * the member to actually open the history.
 	 */
 	const historyQuery = createQuery(() => ({
-		queryKey: ['me', 'memberships', organizationId, 'payments', page],
+		// Nested UNDER the memberships key on purpose: every mutation that already
+		// invalidates that prefix refreshes the receipts too. Spread from the
+		// exported constant so the prefix relationship cannot drift.
+		queryKey: [...MY_MEMBERSHIPS_KEY, organizationId, 'payments', page],
 		queryFn: async () => {
 			const res = await mesubscriptionsListMySubscriptionPayments({
 				path: { org_id: organizationId },

--- a/src/lib/components/account/applications/ApplicationRow.svelte
+++ b/src/lib/components/account/applications/ApplicationRow.svelte
@@ -41,6 +41,7 @@
 	import { formatDate } from '$lib/utils/date';
 	import { getImageUrl } from '$lib/utils/url';
 	import { backendMessage } from '$lib/utils/api-error-detail';
+	import { MY_MEMBERSHIPS_KEY, MY_SUBSCRIPTIONS_KEY } from '$lib/utils/subscription-cache';
 	import { resolve } from '$app/paths';
 	import { Loader2 } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
@@ -152,8 +153,8 @@
 	$effect(() => {
 		if (!becameMember || invalidated) return;
 		invalidated = true;
-		queryClient.invalidateQueries({ queryKey: ['me', 'memberships'] });
-		queryClient.invalidateQueries({ queryKey: ['me', 'subscriptions'] });
+		queryClient.invalidateQueries({ queryKey: MY_MEMBERSHIPS_KEY });
+		queryClient.invalidateQueries({ queryKey: MY_SUBSCRIPTIONS_KEY });
 	});
 
 	/**

--- a/src/lib/components/members/ApproveMembershipModal.svelte
+++ b/src/lib/components/members/ApproveMembershipModal.svelte
@@ -113,7 +113,7 @@
 			</div>
 
 			<!-- Actions -->
-			<div class="flex justify-end gap-2">
+			<div class="flex flex-wrap justify-end gap-2">
 				<Button variant="outline" onclick={onClose} disabled={isProcessing}>
 					{m['approveMembershipModal.cancel']()}
 				</Button>

--- a/src/lib/components/members/MakeMemberModal.svelte
+++ b/src/lib/components/members/MakeMemberModal.svelte
@@ -118,7 +118,7 @@
 			</div>
 
 			<!-- Actions -->
-			<div class="flex justify-end gap-2">
+			<div class="flex flex-wrap justify-end gap-2">
 				<Button variant="outline" onclick={onClose} disabled={isProcessing}>
 					{m['makeMemberModal.cancel']()}
 				</Button>

--- a/src/lib/components/members/MemberCombobox.svelte
+++ b/src/lib/components/members/MemberCombobox.svelte
@@ -52,6 +52,33 @@
 
 	const results = $derived(membersQuery.data?.results ?? []);
 
+	let listEl = $state<HTMLUListElement | null>(null);
+
+	/**
+	 * Keep the open listbox inside the visible part of whatever is scrolling
+	 * around us (#702 mobile pass).
+	 *
+	 * This listbox is deliberately NOT portalled — it has to stay inside the
+	 * hosting dialog's focus trap — so it is an absolutely positioned descendant
+	 * of that dialog's `overflow-y-auto` content box. Such a box is CLIPPED to
+	 * the scrollport and merely contributes to scrollable overflow: on a phone,
+	 * where this combobox is the first field of a `max-h-[90vh]` dialog, the
+	 * options below the fold are only reachable by scrolling the dialog — and
+	 * scrolling it means touching outside the input, which blurs it and closes
+	 * the list. A catch-22 the desktop viewport never shows.
+	 *
+	 * `block: 'nearest'` performs the MINIMUM scroll that makes the list visible
+	 * and does nothing when it already is, so it never yanks the view around.
+	 * Programmatic scrolling does not move focus, so the input stays focused and
+	 * the list stays open.
+	 */
+	$effect(() => {
+		if (!open || results.length === 0) return;
+		// Optional call: `scrollIntoView` is not implemented in jsdom, and this is
+		// a pure viewport nicety with nothing to assert in a unit test.
+		listEl?.scrollIntoView?.({ block: 'nearest' });
+	});
+
 	function pick(member: OrganizationMemberSchema) {
 		onSelect(member);
 		query = member.user.display_name;
@@ -72,10 +99,14 @@
 		aria-controls={listboxId}
 	/>
 	{#if open && results.length > 0}
+		<!-- Height: 15rem where there is room, but never more than 40% of a short
+		     viewport — on a phone with the software keyboard up, a fixed 15rem list
+		     is taller than the space left below the input. -->
 		<ul
+			bind:this={listEl}
 			id={listboxId}
 			role="listbox"
-			class="absolute z-50 mt-1 max-h-60 w-full overflow-y-auto rounded-md border bg-popover shadow-lg"
+			class="absolute z-50 mt-1 max-h-[min(15rem,40vh)] w-full overflow-y-auto rounded-md border bg-popover shadow-lg"
 		>
 			{#each results as r (r.user.id ?? r.user.email ?? r.user.display_name)}
 				<li

--- a/src/lib/components/members/MembershipRequestCard.svelte
+++ b/src/lib/components/members/MembershipRequestCard.svelte
@@ -338,10 +338,16 @@
 					{/if}
 					{#if request.user.email}
 						<div class="flex gap-2">
-							<dt class="font-medium text-muted-foreground">
+							<dt class="shrink-0 font-medium text-muted-foreground">
 								{m['membershipRequestCard.email']()}
 							</dt>
-							<dd class="truncate text-foreground">{request.user.email}</dd>
+							<!-- Wrapped, NOT truncated: this dialog exists to show the
+							     applicant's details, and at a phone's dialog width `truncate`
+							     hides the second half of most addresses — the half that says
+							     which domain they are from. `break-all` is needed because an
+							     email has no spaces to wrap at; `min-w-0` is what lets the
+							     flex item shrink far enough to use it. -->
+							<dd class="min-w-0 break-all text-foreground">{request.user.email}</dd>
 						</div>
 					{/if}
 					{#if phoneNumber}

--- a/src/lib/components/members/PaymentsTable.svelte
+++ b/src/lib/components/members/PaymentsTable.svelte
@@ -15,15 +15,26 @@
 		 * payments: money moved through Stripe has to come back through Stripe,
 		 * and the `charge.refunded` webhook records it here on its own. So we hide
 		 * the control entirely rather than render one the API will reject.
+		 *
+		 * REQUIRED, deliberately: an optional `= false` default fails OPEN. A
+		 * future consumer that simply forgets the prop would silently get the
+		 * offline branch back and render a refund button that can only ever 400.
+		 * Required makes that a compile error at the call site instead.
 		 */
-		isOnlinePlan?: boolean;
+		isOnlinePlan: boolean;
 		onRefund: (p: MembershipPaymentSchema) => void;
 	}
 
-	const { payments, isOnlinePlan = false, onRefund }: Props = $props();
+	const { payments, isOnlinePlan, onRefund }: Props = $props();
 
+	/**
+	 * The note tells staff to refund from the Stripe dashboard — so it only earns
+	 * its place when there is at least one succeeded payment that actually links
+	 * there. Without a link it is a URL-less dead end: it names a destination the
+	 * reader has no way to reach from this drawer.
+	 */
 	const showOnlineRefundNote = $derived(
-		isOnlinePlan && payments.some((p) => p.status === 'succeeded')
+		isOnlinePlan && payments.some((p) => p.status === 'succeeded' && !!p.stripe_dashboard_url)
 	);
 
 	function fmtDate(d: string | null | undefined): string {

--- a/src/lib/components/members/PaymentsTable.test.ts
+++ b/src/lib/components/members/PaymentsTable.test.ts
@@ -297,6 +297,34 @@ describe('PaymentsTable refund gating', () => {
 		expect(screen.getByRole('link', { name: 'View on Stripe' })).toBeInTheDocument();
 	});
 
+	// #702: the note names the Stripe Dashboard as the way to refund. With no
+	// `stripe_dashboard_url` on any succeeded row there is no way to GET there
+	// from this drawer, so the note is a dead end that only tells the organizer
+	// what they cannot do here.
+	it('withholds the online-refund note when no succeeded payment links to Stripe', () => {
+		renderTable([makePayment({ status: 'succeeded', stripe_dashboard_url: null })], true);
+
+		expect(screen.queryByText(/Stripe Dashboard/i)).not.toBeInTheDocument();
+	});
+
+	// The link must come from a SUCCEEDED row: a failed payment's Stripe page is
+	// not where a refund is issued.
+	it('withholds the online-refund note when only a non-succeeded payment links to Stripe', () => {
+		renderTable(
+			[
+				makePayment({ id: 'pay-1', status: 'succeeded', stripe_dashboard_url: null }),
+				makePayment({
+					id: 'pay-2',
+					status: 'failed',
+					stripe_dashboard_url: 'https://dashboard.stripe.com/test/payments/pi_999'
+				})
+			],
+			true
+		);
+
+		expect(screen.queryByText(/Stripe Dashboard/i)).not.toBeInTheDocument();
+	});
+
 	it('keeps the online-refund note out of the way for OFFLINE plans', () => {
 		renderTable([makePayment({ status: 'succeeded' })], false);
 

--- a/src/lib/components/members/StatusBadge.svelte
+++ b/src/lib/components/members/StatusBadge.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-	import * as m from '$lib/paraglide/messages.js';
-	import { getStatusConfig, type SubscriptionStatus } from '$lib/utils/subscriptions';
+	import {
+		getStatusConfig,
+		getStatusLabel,
+		type SubscriptionStatus
+	} from '$lib/utils/subscriptions';
 
 	interface Props {
 		status: SubscriptionStatus;
@@ -10,16 +13,7 @@
 	const { status, class: extraClass = '' }: Props = $props();
 
 	const config = $derived(getStatusConfig(status));
-	const label = $derived(
-		{
-			active: m['subscriptions.status.active'](),
-			pending: m['subscriptions.status.pending'](),
-			past_due: m['subscriptions.status.past_due'](),
-			paused: m['subscriptions.status.paused'](),
-			cancelled: m['subscriptions.status.cancelled'](),
-			expired: m['subscriptions.status.expired']()
-		}[status]
-	);
+	const label = $derived(getStatusLabel(status));
 </script>
 
 <span

--- a/src/lib/components/members/SubscriptionCreateModal.svelte
+++ b/src/lib/components/members/SubscriptionCreateModal.svelte
@@ -206,7 +206,7 @@
 				</div>
 			{/if}
 
-			<div class="flex justify-end gap-2">
+			<div class="flex flex-wrap justify-end gap-2">
 				<Button type="button" variant="outline" onclick={onClose} disabled={isSubmitting}>
 					{m['tierForm.cancel']()}
 				</Button>

--- a/src/lib/components/members/SubscriptionDrawer.svelte
+++ b/src/lib/components/members/SubscriptionDrawer.svelte
@@ -335,12 +335,18 @@
 		{:else}
 			<DialogHeader>
 				<DialogTitle>
+					<!-- `min-w-0` + `break-all` on the identity column: a flex item's
+					     automatic minimum size is its CONTENT size, so without them a long
+					     unbroken email (no spaces to wrap at) refuses to shrink, pushes the
+					     status badge out of the dialog and makes the whole drawer scroll
+					     sideways on a phone. `shrink-0` keeps the badge legible instead of
+					     being squeezed to a sliver once the email does yield. -->
 					<div class="flex items-start justify-between gap-4">
-						<div>
+						<div class="min-w-0">
 							<div class="text-base font-semibold">{sub.user_display_name}</div>
-							<div class="text-xs text-muted-foreground">{sub.user_email}</div>
+							<div class="break-all text-xs text-muted-foreground">{sub.user_email}</div>
 						</div>
-						<StatusBadge status={sub.status} />
+						<StatusBadge status={sub.status} class="shrink-0" />
 					</div>
 				</DialogTitle>
 			</DialogHeader>

--- a/src/lib/components/members/SubscriptionMetrics.svelte
+++ b/src/lib/components/members/SubscriptionMetrics.svelte
@@ -10,7 +10,12 @@
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { TriangleAlert } from '@lucide/svelte';
 	import { formatMoney, formatPercent } from '$lib/utils/format';
-	import { getStatusConfig, type SubscriptionStatus } from '$lib/utils/subscriptions';
+	import {
+		getStatusConfig,
+		getStatusLabel,
+		STATUS_ORDER,
+		type SubscriptionStatus
+	} from '$lib/utils/subscriptions';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -48,26 +53,6 @@
 
 	const churnDisplay = $derived(metrics ? formatPercent(metrics.churn_rate_30d) : null);
 
-	// Same order as the status filter in SubscriptionsTab, so the strip reads in
-	// the order an admin will look for a status in the dropdown.
-	const STATUS_ORDER: readonly SubscriptionStatus[] = [
-		'active',
-		'pending',
-		'past_due',
-		'paused',
-		'cancelled',
-		'expired'
-	];
-
-	const statusLabels = $derived<Record<SubscriptionStatus, string>>({
-		active: m['subscriptions.status.active'](),
-		pending: m['subscriptions.status.pending'](),
-		past_due: m['subscriptions.status.past_due'](),
-		paused: m['subscriptions.status.paused'](),
-		cancelled: m['subscriptions.status.cancelled'](),
-		expired: m['subscriptions.status.expired']()
-	});
-
 	interface StatusChip {
 		status: SubscriptionStatus;
 		label: string;
@@ -82,7 +67,7 @@
 		if (!breakdown) return [];
 		return STATUS_ORDER.filter((status) => (breakdown[status] ?? 0) > 0).map((status) => ({
 			status,
-			label: statusLabels[status],
+			label: getStatusLabel(status),
 			count: breakdown[status],
 			className: getStatusConfig(status).className
 		}));
@@ -119,6 +104,15 @@
 						{m['orgAdmin.members.subscriptions.metrics.active']()}
 					</p>
 					<p class="text-lg font-semibold">{metrics.active_count}</p>
+					<!-- The backend's `active_count` is `active + past_due`
+					     (`subscription_reporting._compute`), and the status strip right
+					     below spells both out separately — so without this line the tile
+					     reads as a third number that contradicts the two under it.
+					     Unconditional: it defines the metric, so it must not appear only
+					     when there happens to be a past-due row. -->
+					<p class="text-xs text-muted-foreground">
+						{m['orgAdmin.members.subscriptions.metrics.activeIncludesPastDue']()}
+					</p>
 				</CardContent>
 			</Card>
 			<Card>

--- a/src/lib/components/members/SubscriptionsTab.svelte
+++ b/src/lib/components/members/SubscriptionsTab.svelte
@@ -22,6 +22,7 @@
 	import SubscriptionMetrics from './SubscriptionMetrics.svelte';
 	import { onDestroy } from 'svelte';
 	import { backendMessage } from '$lib/utils/api-error-detail';
+	import { getStatusLabel, STATUS_ORDER } from '$lib/utils/subscriptions';
 
 	// Buffer matching the bits-ui Dialog close animation. Chaining a Dialog
 	// open inside another Dialog's close handler in the same tick leaves
@@ -140,12 +141,12 @@
 				aria-label={m['orgAdmin.members.subscriptions.filter.all']()}
 			>
 				<option value="all">{m['orgAdmin.members.subscriptions.filter.all']()}</option>
-				<option value="active">{m['subscriptions.status.active']()}</option>
-				<option value="pending">{m['subscriptions.status.pending']()}</option>
-				<option value="past_due">{m['subscriptions.status.past_due']()}</option>
-				<option value="paused">{m['subscriptions.status.paused']()}</option>
-				<option value="cancelled">{m['subscriptions.status.cancelled']()}</option>
-				<option value="expired">{m['subscriptions.status.expired']()}</option>
+				<!-- Driven off the shared, exhaustive-by-construction order rather than
+				     six hand-written options: a new backend status now reaches the
+				     dropdown, the metrics strip and the badge together. -->
+				{#each STATUS_ORDER as status (status)}
+					<option value={status}>{getStatusLabel(status)}</option>
+				{/each}
 			</select>
 		</div>
 		<Button onclick={() => (createOpen = true)}>

--- a/src/lib/components/organization/membership/CheckoutReturnCard.svelte
+++ b/src/lib/components/organization/membership/CheckoutReturnCard.svelte
@@ -11,6 +11,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { backendMessage } from '$lib/utils/api-error-detail';
 	import { isSubscriptionActivationPending } from '$lib/utils/subscriptions';
+	import { myOrgSubscriptionKey } from '$lib/utils/subscription-cache';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Loader2 } from '@lucide/svelte';
@@ -66,7 +67,11 @@
 		// `untrack` states the intent the compiler would otherwise warn about:
 		// the key is frozen at mount, because this card is rendered once per
 		// checkout-return page load and never re-targeted at another org.
-		queryKey: untrack(() => ['me', 'org', organizationId, 'subscription', 'checkout-return']),
+		// Built from the exported key so this poll cache stays a genuine CHILD of
+		// the per-org subscription key — that prefix relationship is what lets the
+		// invalidation below clear it, and a hand-written literal would break it
+		// silently on a rename.
+		queryKey: untrack(() => [...myOrgSubscriptionKey(organizationId), 'checkout-return']),
 		queryFn: fetchSubscription,
 		isDone: (sub) => sub?.status === 'active',
 		// `options()` is re-read on every reactive pass, so flipping
@@ -91,7 +96,7 @@
 		if (phase !== 'done' || invalidated) return;
 		invalidated = true;
 		// The inline membership card.
-		queryClient.invalidateQueries({ queryKey: ['me', 'org', organizationId, 'subscription'] });
+		queryClient.invalidateQueries({ queryKey: myOrgSubscriptionKey(organizationId) });
 		// Admin views of this org; a no-op on the public page, kept for the
 		// authenticated-admin case and future consumers of the prefix.
 		queryClient.invalidateQueries({ queryKey: ['organization', organizationSlug] });
@@ -108,7 +113,7 @@
 	// A single look, not a poll: nothing is going to change server-side until the
 	// member acts.
 	const cancelledQuery = createQuery(() => ({
-		queryKey: ['me', 'org', organizationId, 'subscription', 'checkout-cancelled'],
+		queryKey: [...myOrgSubscriptionKey(organizationId), 'checkout-cancelled'],
 		queryFn: fetchSubscription,
 		enabled: outcome === 'cancelled' && !!accessToken,
 		retry: false,

--- a/src/lib/utils/subscription-status.ts
+++ b/src/lib/utils/subscription-status.ts
@@ -1,0 +1,98 @@
+/**
+ * Presentation of one `SubscriptionStatus`: its tint, its localized name, and
+ * the order the six of them are listed in.
+ *
+ * Split out of `subscriptions.ts` (which is at its 500-line cap) rather than
+ * inlined per surface: the badge, the metrics strip and the admin status filter
+ * are three views of the same enum, and before #702 each carried its own copy
+ * of the label map — so a seventh status could reach two of them and be missed
+ * by the third. Everything here is re-exported from `$lib/utils/subscriptions`,
+ * which stays the documented import site.
+ */
+import * as m from '$lib/paraglide/messages.js';
+import type { SubscriptionStatus } from '$lib/api/generated/types.gen';
+
+export type StatusTone = 'green' | 'blue' | 'amber' | 'gray' | 'red' | 'muted';
+
+export interface StatusConfig {
+	tone: StatusTone;
+	className: string;
+}
+
+const STATUS_CONFIG: Record<SubscriptionStatus, StatusConfig> = {
+	active: {
+		tone: 'green',
+		className: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-100'
+	},
+	pending: {
+		tone: 'blue',
+		className: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-100'
+	},
+	past_due: {
+		tone: 'amber',
+		className: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-100'
+	},
+	paused: {
+		tone: 'gray',
+		className: 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
+	},
+	cancelled: { tone: 'muted', className: 'bg-muted text-muted-foreground' },
+	expired: {
+		tone: 'red',
+		className: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-100'
+	}
+};
+
+export function getStatusConfig(status: SubscriptionStatus): StatusConfig {
+	return STATUS_CONFIG[status];
+}
+
+/**
+ * Localized name of a subscription status.
+ *
+ * One copy, called from the badge, the metrics strip and the admin status
+ * filter — the three surfaces that previously each carried their own literal
+ * object of the same six messages, where a seventh status could reach two of
+ * them and be missed by the third.
+ *
+ * Thunks, not pre-rendered strings: Paraglide resolves the active language at
+ * *call* time, so a module-level map of already-called messages would freeze
+ * the language the module happened to be imported under.
+ */
+const STATUS_LABELS: Record<SubscriptionStatus, () => string> = {
+	active: () => m['subscriptions.status.active'](),
+	pending: () => m['subscriptions.status.pending'](),
+	past_due: () => m['subscriptions.status.past_due'](),
+	paused: () => m['subscriptions.status.paused'](),
+	cancelled: () => m['subscriptions.status.cancelled'](),
+	expired: () => m['subscriptions.status.expired']()
+};
+
+export function getStatusLabel(status: SubscriptionStatus): string {
+	return STATUS_LABELS[status]();
+}
+
+/**
+ * Display rank of each status: the order the metrics strip reads in and the
+ * order the admin filter lists, so an admin looks for a status in the same
+ * place in both.
+ *
+ * A `Record<SubscriptionStatus, …>` rather than a bare array on purpose: it is
+ * the construct that *fails to compile* when the backend enum gains a member.
+ * An array typed `readonly SubscriptionStatus[]` would happily stay
+ * five-elements-long, and a new status would then be silently absent from the
+ * strip and unfilterable in the dropdown, with nothing to notice it.
+ */
+const STATUS_RANK: Record<SubscriptionStatus, number> = {
+	active: 0,
+	pending: 1,
+	past_due: 2,
+	paused: 3,
+	cancelled: 4,
+	expired: 5
+};
+
+/** Every `SubscriptionStatus`, in display order. Exhaustive by construction. */
+export const STATUS_ORDER: readonly SubscriptionStatus[] = (
+	Object.keys(STATUS_RANK) as SubscriptionStatus[]
+).sort((a, b) => STATUS_RANK[a] - STATUS_RANK[b]);

--- a/src/lib/utils/subscriptions.ts
+++ b/src/lib/utils/subscriptions.ts
@@ -212,40 +212,18 @@ export function formatPlanPrice(
 	return `${amount} / ${periodLabel(plan.period_unit, plan.period_count ?? 1)}`;
 }
 
-export type StatusTone = 'green' | 'blue' | 'amber' | 'gray' | 'red' | 'muted';
-
-export interface StatusConfig {
-	tone: StatusTone;
-	className: string;
-}
-
-const STATUS_CONFIG: Record<SubscriptionStatus, StatusConfig> = {
-	active: {
-		tone: 'green',
-		className: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-100'
-	},
-	pending: {
-		tone: 'blue',
-		className: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-100'
-	},
-	past_due: {
-		tone: 'amber',
-		className: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-100'
-	},
-	paused: {
-		tone: 'gray',
-		className: 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
-	},
-	cancelled: { tone: 'muted', className: 'bg-muted text-muted-foreground' },
-	expired: {
-		tone: 'red',
-		className: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-100'
-	}
-};
-
-export function getStatusConfig(status: SubscriptionStatus): StatusConfig {
-	return STATUS_CONFIG[status];
-}
+/**
+ * Status presentation lives in its own module (this file is at its 500-line
+ * cap), but `$lib/utils/subscriptions` stays the single documented import site
+ * for everything subscription-shaped, so it is re-exported here.
+ */
+export {
+	getStatusConfig,
+	getStatusLabel,
+	STATUS_ORDER,
+	type StatusConfig,
+	type StatusTone
+} from './subscription-status';
 
 export type DateLineKind =
 	'renewal' | 'cancels' | 'period_ends' | 'paused_since' | 'ended' | 'pending';

--- a/src/routes/(auth)/account/memberships/+page.svelte
+++ b/src/routes/(auth)/account/memberships/+page.svelte
@@ -11,13 +11,18 @@
 	import RejoinCard from '$lib/components/account/RejoinCard.svelte';
 	import ApplicationsSection from '$lib/components/account/applications/ApplicationsSection.svelte';
 	import { isWithinRevivalWindow } from '$lib/utils/subscriptions';
+	import { MY_MEMBERSHIPS_KEY, MY_SUBSCRIPTIONS_KEY } from '$lib/utils/subscription-cache';
 	import { Button } from '$lib/components/ui/button';
 	import { Loader2 } from '@lucide/svelte';
 
 	const accessToken = $derived(authStore.accessToken);
 
 	const membershipsQuery = createQuery(() => ({
-		queryKey: ['me', 'memberships'],
+		// The exported constant, not a literal: `settleSubscriptionCaches` seeds
+		// this exact key after every member-facing mutation, and a rename that only
+		// landed on one side would silently no-op the seeding (#693) instead of
+		// failing loudly.
+		queryKey: MY_MEMBERSHIPS_KEY,
 		queryFn: async () => {
 			const res = await mesubscriptionsListMyMemberships({
 				query: { page_size: 50 },
@@ -34,7 +39,7 @@
 	// The memberships list only carries live rows; expired subscriptions — the
 	// ones a member can still revive — are only visible here.
 	const subscriptionsQuery = createQuery(() => ({
-		queryKey: ['me', 'subscriptions'],
+		queryKey: MY_SUBSCRIPTIONS_KEY,
 		queryFn: async () => {
 			const res = await mesubscriptionsListMySubscriptions({
 				query: { page_size: 50 },

--- a/tests/e2e/journeys/j23-subscriptions/revival.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/revival.spec.ts
@@ -235,9 +235,7 @@ test.describe('J23 revival window + past due @p2', () => {
 		// The page filters that row out in favour of the offer, which says
 		// strictly more; without the filter the org would render twice, a dead
 		// card up top and its rejoin offer far below.
-		await expect(
-			page.getByRole('region', { name: 'Memberships' }).getByRole('article', { name: ORG_NAME })
-		).toHaveCount(1);
+		await expect(membershipCard(page, ORG_NAME)).toHaveCount(1);
 		await expect(page.getByText(new RegExp(`^Member since ${DATE}$`))).toBeHidden();
 
 		await context.close();

--- a/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
@@ -7,7 +7,7 @@ import {
 	uniqueName
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
-import { planCard } from '../../support/membership-locators';
+import { membershipCard, planCard } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 import { completeStripeCheckout } from '../../support/stripe';
 
@@ -130,12 +130,10 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		// The account hub tells the same story.
 		await gotoHydrated(page, '/account/memberships');
 		await waitForClientAuth(page);
-		const membershipCard = page
-			.getByRole('region', { name: 'Memberships' })
-			.getByRole('article', { name: 'Revel Events Collective' });
-		await expect(membershipCard).toBeVisible({ timeout: 20_000 });
-		await expect(membershipCard.getByText(plan.name)).toBeVisible();
-		await expect(membershipCard.getByLabel('Active')).toBeVisible();
+		const card = membershipCard(page, 'Revel Events Collective');
+		await expect(card).toBeVisible({ timeout: 20_000 });
+		await expect(card.getByText(plan.name)).toBeVisible();
+		await expect(card.getByLabel('Active')).toBeVisible();
 
 		// BE #774 follow-up, ONLINE side. This is the only place the real Stripe
 		// handles exist, so it is the only place that can prove the admin schema's

--- a/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
@@ -8,6 +8,7 @@ import {
 	uniqueName
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
+import { membershipCard } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 
 // J23 (USER_JOURNEYS.md) — subscription lifecycle: staff creates a
@@ -94,12 +95,11 @@ test.describe('J23 subscription lifecycle @p2', () => {
 		const memberPage = await memberContext.newPage();
 		await gotoHydrated(memberPage, '/account/memberships');
 		await waitForClientAuth(memberPage);
-		// Scoped to the memberships section: the page's Applications section
-		// renders its own <article aria-label="{org name}"> for the (now
-		// completed) application this test's arrange created, so an unscoped
-		// article lookup is ambiguous.
-		const membershipsSection = memberPage.getByRole('region', { name: 'Memberships' });
-		const card = membershipsSection.getByRole('article', { name: org.name });
+		// The shared helper scopes to the Memberships region: the page's
+		// Applications section renders its own <article aria-label="{org name}">
+		// for the (now completed) application this test's arrange created, so an
+		// unscoped article lookup is ambiguous.
+		const card = membershipCard(memberPage, org.name);
 		await expect(card).toBeVisible({ timeout: 15_000 });
 		await expect(card.getByText(plan.name)).toBeVisible();
 		await expect(card.getByText('€15.00 / month')).toBeVisible();


### PR DESCRIPTION
Consolidated non-blocking follow-ups from the membership follow-up wave's reviews.

Closes #702

## 1. Cache-key constants at the query definition sites (top item)

`subscription-cache.ts` already exported `MY_MEMBERSHIPS_KEY`, `MY_SUBSCRIPTIONS_KEY` and `myOrgSubscriptionKey`, but production call sites still declared the same literals by hand. A key rename would have silently no-op'd every #693 cache seed — no error, just stale data. Five sites now read the constants:

| File | Was |
|---|---|
| `account/memberships/+page.svelte` ×2 | `['me','memberships']`, `['me','subscriptions']` |
| `applications/ApplicationRow.svelte` ×2 | same two, in its `becameMember` invalidation |
| `MembershipPaymentHistory.svelte` | `['me','memberships', orgId, 'payments', page]` |
| `CheckoutReturnCard.svelte` ×3 | `['me','org', id, 'subscription'(, …)]` |

The last two are worth calling out: they are prefix *children* of an exported key, so they had a second way to drift — the invalidation only reaches them because they share the prefix. They now spread the constant.

`OrgMembershipInline.svelte:24` (named in the issue) was already fixed: it reads `myOrgSubscriptionQueryOptions`, which builds its key from `myOrgSubscriptionKey`.

**Test files keep their literals on purpose** — they are the rename detector, and a test built from the constant would tautologically pass after a rename.

## 2. E2E locator stragglers

The last three inline `membershipCard` copies → `membership-locators.ts`: `subscribe-online.spec.ts`, `revival.spec.ts` and `subscription-lifecycle.spec.ts` (the issue's line numbers were stale; these are the three that were left).

## 3. `getStatusLabel` + exhaustive `STATUS_ORDER`

The status→label map had three copies (`StatusBadge`, `SubscriptionMetrics`, the `SubscriptionsTab` filter's six hand-written `<option>`s). Both the labels and the display order now come from a `Record<SubscriptionStatus, …>` — the construct that **fails to compile** when the backend enum gains a member, rather than a `readonly SubscriptionStatus[]` that would stay six-long and silently omit it from the strip *and* the filter.

Labels are stored as thunks, not pre-rendered strings: Paraglide resolves the active language at call time, so a module-level map of already-called messages would freeze whichever language the module was first imported under.

New module `src/lib/utils/subscription-status.ts` (`subscriptions.ts` is at its 500-line cap), re-exported from `$lib/utils/subscriptions` so that stays the documented import site.

## 4. `PaymentsTable` prop hardening

`isOnlinePlan` is now **required**. An optional `= false` fails open: a future consumer forgetting it gets the offline branch back and renders the refund button the backend 400s. Required makes that a compile error at the call site.

The online-refund note is additionally gated on a succeeded payment actually carrying a `stripe_dashboard_url`. The note names the Stripe Dashboard as the place to issue the refund — without a link it is a URL-less dead end that only tells the organizer what they *cannot* do here. Two tests added (no link at all; link only on a non-succeeded row).

## 5. `MembershipCard`

- `aria-busy` on the billing-portal button, for parity with the resume and uncancel buttons that already latch and announce. `disabled` alone stops a second click but tells an AT user nothing about why the control went dead mid-navigation. Asserted in the existing portal test.
- **#694's failure test: `{detail}` kept, and pinned to the endpoint's own generated type.** The issue asked for `ResponseMessage {message}`, but that would be a fiction: since backend PR #824, `MesubscriptionsSubscribe57C85BbbErrors` declares `ErrorDetail` for 400/404/502 (and `SubscriptionActivationPendingSchema` for 409). `{message}` is genuine on the two claim-invitation endpoints only — this is neither. Mocking a shape the backend cannot send would make the test actively misleading, so the fix is the *typed binding*: `const expiredSession: MesubscriptionsSubscribe57C85BbbErrors[400] = { detail: … }`, which stops compiling if the declaration ever does change.

## 6. Product copy

- The metrics tile's `active_count` is `active + past_due` (backend `subscription_reporting._compute`), and it sat directly above a strip spelling both out separately — reading as a third number that contradicts the two under it. A caption now defines it. Unconditional: it defines the metric, so it must not appear only when a past-due row happens to exist. New key `orgAdmin.members.subscriptions.metrics.activeIncludesPastDue` in **all four** catalogs.
- French: 11 `formule` strings → `forfait` (against 32 existing `forfait`), with the gender agreements fixed (`Formule actuelle` → `Forfait actuel`, `Ta formule changera` → `Ton forfait changera`, `Cette formule` → `Ce forfait`, …). `formule` count is now 0.

## 7. Mobile pass

Verified **by inspection of the markup only** — no device or browser was run.

| Component | Finding | Fix |
|---|---|---|
| `SubscriptionDrawer` | ❌ Header identity column had no `min-w-0`. A flex item's automatic minimum size is its content size, so a long unbroken email (no spaces to wrap at) refuses to shrink, pushes `StatusBadge` out of the dialog and makes the drawer scroll sideways. | `min-w-0` + `break-all` on the email, `shrink-0` on the badge. |
| `MembershipRequestCard` details dialog | ❌ `<dd class="truncate">` on the applicant's email — in a dialog whose entire job is showing their details. At phone width that hides the domain half. | `min-w-0 break-all` (wraps instead of truncating), `shrink-0` on the `<dt>`. |
| `SubscriptionCreateModal` → `MemberCombobox` | ❌ The riskiest one, as flagged. The listbox is deliberately not portalled (it must stay inside the dialog's focus trap), which makes it an abspos descendant of the dialog's `overflow-y-auto` box — clipped to the scrollport, contributing only to scrollable overflow. As the *first* field of a `max-h-[90vh]` dialog on a phone, options below the fold are reachable only by scrolling the dialog, and scrolling means touching outside the input, which blurs it and closes the list. A catch-22 the desktop viewport never shows. | `scrollIntoView({ block: 'nearest' })` on open (minimum scroll, no-op when already visible, does not move focus), and `max-h-[min(15rem,40vh)]` so the list never demands more room than a keyboard-shrunk viewport has. |
| `ApproveMembershipModal`, `MakeMemberModal`, `SubscriptionCreateModal` | ⚠️ Action rows were `flex justify-end gap-2` with no wrap; long localized labels (de/fr) can overflow at 320px. | `flex-wrap`. |
| `ApproveMembershipModal` / `MakeMemberModal` tier `Select` | ✅ bits-ui `SelectContent` portals and anchors to the trigger width; `SelectTrigger` has `[&>span]:line-clamp-1`. No change. |
| `MembershipRequestCard` `DialogFooter` (3 buttons) | ✅ Base `DialogFooter` is `flex-col-reverse sm:flex-row`, so the three buttons stack on mobile. No change. |

The shared `DialogContent` base (`fixed w-full max-w-lg`, no horizontal inset on mobile) is app-wide and predates this wave — deliberately left alone rather than changed under a hygiene PR.

## Verification

```
make check   →  6087 FILES 0 ERRORS
                ✓ Type gate is armed (deliberate errors in .ts and .svelte both caught)
                ✅ i18n / file-length / no-ssr-token / image-alt all clean
pnpm test    →  173 files, 2103 passed | 1 todo
playwright test --list  →  503 tests in 125 files (specs compile)
```

E2E suite deliberately not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)