### PR TITLE
fix(questionnaires): let organizers pick the Membership type

### DIFF
--- a/src/lib/components/questionnaires/QuestionnaireCreateBasicInfo.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireCreateBasicInfo.svelte
@@ -130,8 +130,10 @@
 				type="single"
 				value={questionnaireType}
 				onValueChange={(v) => {
-					// Allow admission and feedback types
-					if (v === 'admission' || v === 'feedback') {
+					// `generic` is the only type still gated: the backend has the enum value
+					// but nothing reads it, so picking it would produce a questionnaire that
+					// never fires. Its SelectItem is disabled to match.
+					if (v === 'admission' || v === 'feedback' || v === 'membership') {
 						questionnaireType = v;
 					}
 				}}
@@ -156,19 +158,9 @@
 							</div>
 						</div>
 					</SelectItem>
-					<SelectItem
-						value="membership"
-						label={m['questionnaireNewPage.typeMembershipLabel']()}
-						disabled
-					>
+					<SelectItem value="membership" label={m['questionnaireNewPage.typeMembershipLabel']()}>
 						<div class="flex flex-col gap-0.5">
-							<div class="flex items-center gap-2 font-medium">
-								{m['questionnaireNewPage.typeMembershipLabel']()}
-								<span
-									class="rounded bg-muted px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground"
-									>{m['questionnaireNewPage.comingSoon']()}</span
-								>
-							</div>
+							<div class="font-medium">{m['questionnaireNewPage.typeMembershipLabel']()}</div>
 							<div class="text-xs text-muted-foreground">
 								{m['questionnaireNewPage.typeMembershipDescription']()}
 							</div>

--- a/src/lib/components/questionnaires/QuestionnaireFormFields.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireFormFields.svelte
@@ -189,16 +189,9 @@
 					<SelectItem
 						value="membership"
 						label={m['questionnaireEditPage.types.membership_label']()}
-						disabled
 					>
 						<div class="flex flex-col gap-0.5">
-							<div class="flex items-center gap-2 font-medium">
-								{m['questionnaireEditPage.types.membership_label']()}
-								<span
-									class="rounded bg-muted px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground"
-									>{m['questionnaireFormFields.comingSoon']()}</span
-								>
-							</div>
+							<div class="font-medium">{m['questionnaireEditPage.types.membership_label']()}</div>
 							<div class="text-xs text-muted-foreground">
 								{m['questionnaireEditPage.types.membership_description']()}
 							</div>

--- a/tests/e2e/journeys/j05-rsvp/waitlist.spec.ts
+++ b/tests/e2e/journeys/j05-rsvp/waitlist.spec.ts
@@ -40,7 +40,17 @@ test.describe('J5 waitlist @p2', () => {
 		// Join: inline success state, then the page reloads itself into the
 		// on-waitlist gate (disabled status button + Leave).
 		await page.getByRole('button', { name: 'Join Waitlist' }).click();
-		await expect(page.getByText('Success!')).toBeVisible({ timeout: 15_000 });
+		// The banner carries the BACKEND's own sentence, not the generic "Success!"
+		// copy: since backend #824 join-waitlist is idempotent and answers 200 with
+		// either "Successfully joined the waitlist." or "You are already on the
+		// waitlist for this event.", and IneligibilityActionButton prefers that
+		// message because it is the only thing distinguishing the two. Accept both.
+		// Matching the sentences rather than role=status is deliberate — this page
+		// carries two other live regions (the full-event panel and a badge), so a
+		// bare getByRole('status') trips strict mode.
+		await expect(
+			page.getByText(/Successfully joined the waitlist\.|You are already on the waitlist/i)
+		).toBeVisible({ timeout: 15_000 });
 		const onWaitlistButton = page.getByRole('button', { name: "You're on the Waitlist" });
 		await expect(onWaitlistButton).toBeVisible({ timeout: 30_000 });
 		await expect(onWaitlistButton).toBeDisabled();

--- a/tests/e2e/journeys/j11-questionnaires/membership-type.spec.ts
+++ b/tests/e2e/journeys/j11-questionnaires/membership-type.spec.ts
@@ -1,0 +1,201 @@
+import type { Locator } from '@playwright/test';
+import { test, expect } from '../../support/fixtures';
+import { createOrganization, createOrgQuestionnaire, uniqueName } from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { pickSelectOption } from '../../support/ui';
+
+// Both membership pickers are NATIVE <select>s (unlike the questionnaire type
+// picker, which is a bits-ui listbox). Their <option>s are attached but never
+// "visible", so assert on the DOM rather than on visibility, and read the
+// selection back through the select's value rather than a `selected` attribute
+// — Svelte binds the value and emits no such attribute.
+function optionIn(select: Locator, label: string): Locator {
+	return select.locator('option').filter({ hasText: label });
+}
+
+async function expectSelectedOptionLabel(select: Locator, label: string): Promise<void> {
+	const value = await select.inputValue();
+	expect(value).not.toBe('');
+	await expect(select.locator(`option[value="${value}"]`)).toHaveText(label);
+}
+
+// J11.1 (USER_JOURNEYS.md, "Create Questionnaire (Organizer)") — the MEMBERSHIP
+// variant, authored through the admin UI, plus the two org-admin pickers that
+// consume it. What it produces is the gate the J27 journey then walks.
+//
+// Why this spec exists: the whole membership-application journey was already
+// covered by j27-applications, but every one of those specs arranges its
+// questionnaire through the `createMembershipQuestionnaire` API factory. The
+// admin UI's own type <Select> had `membership` hard-disabled behind a "Coming
+// soon" badge since #337 — and on the CREATE form a second gate in
+// `onValueChange` swallowed the value even if the item were clickable. Both
+// gates outlived the backend feature by a long way, with a fully green E2E
+// suite, precisely because nothing here drove the authoring UI. So this spec
+// covers the seam the factory skips over, in both directions:
+//
+//   1. CREATE form (QuestionnaireCreateBasicInfo) — build one from scratch.
+//   2. EDIT form (QuestionnaireFormFields) — retype an existing admission one.
+//
+// The payoff assertion in both is the same and is deliberately NOT a read-back
+// of the type <Select>: it is the questionnaire appearing in the org-settings
+// default-questionnaire picker, which the server filters to
+// `questionnaire_type === 'membership'` (settings/+page.server.ts). If it shows
+// up there, the type genuinely round-tripped through the API — a trigger label
+// would only prove local component state.
+//
+// Isolation: a throwaway org per test, so the org-wide default questionnaire
+// and tier overrides written here never leak into another spec's org.
+
+test.describe('J11 membership questionnaire type @p2', () => {
+	test('an organizer builds a membership questionnaire and both pickers offer it', async ({
+		browser
+	}) => {
+		test.setTimeout(180_000);
+		const org = await createOrganization({ acceptMembershipRequests: true });
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		// ---- Before: the org has no membership questionnaire, and the settings
+		// picker says so. This is the empty state the disabled option stranded
+		// organizers in — its "manage questionnaires" link led to the very form
+		// where the type could not be chosen.
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await waitForClientAuth(page);
+		await expect(page.getByText('No membership questionnaires yet.')).toBeVisible({
+			timeout: 15_000
+		});
+
+		// ---- Build. Defaults are Admission type + Manual evaluation, so the type
+		// is the only field that has to move.
+		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires/new`);
+		await waitForClientAuth(page);
+		const qName = uniqueName('Join Screening');
+		await page.getByLabel('Questionnaire Name').fill(qName);
+
+		// The regression, twice over: the option has to be ENABLED to be clicked
+		// at all, and `onValueChange` has to accept 'membership' for the click to
+		// stick. A no-op leaves the trigger reading "Admission", so asserting the
+		// trigger here separates a swallowed value from a disabled item.
+		const typeTrigger = page.locator('#type');
+		await expect(typeTrigger).toHaveText(/Admission/);
+		await pickSelectOption(page, typeTrigger, 'Membership');
+		await expect(typeTrigger).toHaveText(/Membership/);
+
+		// One mandatory free-text question — manual evaluation, so nothing here
+		// needs a grader (and free text under automatic grading is refused
+		// outright: it would want LLM guidelines).
+		const FT_TEXT = 'Why do you want to join?';
+		await page.getByRole('button', { name: 'Free Text' }).first().click();
+		const ftEditor = page.getByRole('textbox', { name: 'Question Text (Markdown)' }).first();
+		await ftEditor.fill(FT_TEXT);
+
+		// A freshly-mounted Tiptap editor can silently drop a fill() while it
+		// settles, which blocks the save with "All questions must have text" and no
+		// navigation — re-fill what got lost, keyed on the redirect (same trap as
+		// builder.spec.ts).
+		await expect(async () => {
+			if (!(await ftEditor.innerText()).includes(FT_TEXT)) {
+				await ftEditor.fill(FT_TEXT);
+			}
+			await page.getByRole('button', { name: 'Save Questionnaire' }).click();
+			await page.waitForURL(/\/admin\/questionnaires\/(?!new)[0-9a-f-]+$/, { timeout: 8_000 });
+		}).toPass({ timeout: 60_000 });
+		await expect(page.getByText(qName).first()).toBeVisible();
+
+		// ---- Publish (status changes fire a native confirm()).
+		page.once('dialog', (dialog) => void dialog.accept());
+		await page.getByRole('button', { name: 'Publish' }).click();
+		await expect(page.getByRole('button', { name: 'Unpublish' })).toBeVisible();
+
+		// ---- Picker 1: the org-wide default. Selecting and SAVING it is the part
+		// that proves the backend agrees about the type — `default_membership_
+		// questionnaire` both limits choices to membership wrappers and re-checks
+		// the type on clean, so a mistyped wrapper would come back 4xx here.
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await waitForClientAuth(page);
+		await expect(page.getByText('No membership questionnaires yet.')).toBeHidden();
+		const defaultPicker = page.locator('#default_membership_questionnaire_id');
+		await expect(optionIn(defaultPicker, qName)).toBeAttached();
+		await defaultPicker.selectOption({ label: qName });
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(
+			page.getByText('Your organization settings have been updated successfully.')
+		).toBeVisible({ timeout: 15_000 });
+
+		// Reload rather than trusting the in-page state: the picker is seeded from
+		// the load function, so a surviving selection after a fresh SSR read is the
+		// persistence proof — and it proves the BACKEND accepted the wrapper, which
+		// it only does for a membership-typed one.
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await waitForClientAuth(page);
+		await expectSelectedOptionLabel(page.locator('#default_membership_questionnaire_id'), qName);
+
+		// ---- Picker 2: the per-tier override, which reads the same filtered list.
+		await gotoHydrated(page, `/org/${org.slug}/admin/members?tab=tiers`);
+		await waitForClientAuth(page);
+		// The tier cards arrive on a client query, so wait the row out before
+		// clicking its icon-only edit button (named solely by aria-label).
+		const editTier = page.getByRole('button', { name: 'Edit General membership' });
+		await expect(editTier).toBeVisible({ timeout: 20_000 });
+		await editTier.click();
+		const tierDialog = page.getByRole('dialog', { name: 'Edit Membership Tier' });
+		await expect(tierDialog).toBeVisible({ timeout: 15_000 });
+		const tierPicker = tierDialog.locator('#tier-questionnaire');
+		await expect(optionIn(tierPicker, qName)).toBeAttached();
+		// The override is genuinely settable, not merely listed.
+		await tierPicker.selectOption({ label: qName });
+		await expectSelectedOptionLabel(tierPicker, qName);
+
+		await context.close();
+	});
+
+	test('an existing admission questionnaire can be retyped to membership', async ({ browser }) => {
+		test.setTimeout(180_000);
+		const org = await createOrganization({ acceptMembershipRequests: true });
+		// Arrange via API — this test is about the EDIT form, not the builder.
+		const questionnaire = await createOrgQuestionnaire(org.owner, org.slug, {
+			evaluationMode: 'manual',
+			questionnaireType: 'admission'
+		});
+
+		const context = await browser.newContext();
+		await authenticateContext(context, org.owner);
+		const page = await context.newPage();
+
+		// An admission questionnaire is invisible to the membership picker.
+		await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+		await waitForClientAuth(page);
+		await expect(page.getByText('No membership questionnaires yet.')).toBeVisible({
+			timeout: 15_000
+		});
+
+		// ---- Retype. The edit page lands in READ-ONLY mode (`isEditMode` starts
+		// false and gates `canEdit`), so the type <Select> is disabled until the
+		// "Edit Questionnaire" button flips it — clicking the trigger first would
+		// silently do nothing.
+		await gotoHydrated(page, `/org/${org.slug}/admin/questionnaires/${questionnaire.id}`);
+		await waitForClientAuth(page);
+		await page.getByRole('button', { name: 'Edit Questionnaire' }).click();
+
+		const typeTrigger = page.locator('#type');
+		await expect(typeTrigger).toHaveText(/Admission/);
+		await pickSelectOption(page, typeTrigger, 'Membership');
+		await expect(typeTrigger).toHaveText(/Membership/);
+		await page.getByRole('button', { name: 'Save Changes' }).first().click();
+
+		// ---- And now it is a membership questionnaire everywhere that matters.
+		await expect(async () => {
+			await gotoHydrated(page, `/org/${org.slug}/admin/settings`);
+			await waitForClientAuth(page);
+			await expect(
+				optionIn(page.locator('#default_membership_questionnaire_id'), questionnaire.name)
+			).toBeAttached({ timeout: 10_000 });
+		}).toPass({ timeout: 45_000 });
+		await expect(page.getByText('No membership questionnaires yet.')).toBeHidden();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j27-applications/requests-admin.spec.ts
+++ b/tests/e2e/journeys/j27-applications/requests-admin.spec.ts
@@ -360,9 +360,13 @@ test.describe('j27 requests admin @p2', () => {
 			'href',
 			`/org/${org.slug}/admin/questionnaires/${wrapper.id}/submissions/${submissionId}`
 		);
-		// …and it carries the reason it is worth clicking, as its accessible
-		// description (the hint is a sibling <span>, tied on by aria-describedby).
-		await expect(link).toHaveAccessibleDescription(/review pending/i);
+		// …and it carries the reason it is worth clicking, folded into its accessible
+		// NAME (#716). It is deliberately not a description: the visible hint stays a
+		// sibling <span> for sighted users, and pointing aria-describedby at that span
+		// too would announce the same three words three times over — see the comment
+		// on `submissionLinkLabel` in MembershipRequestCard.svelte. The name is a
+		// substring match above, so both assertions can coexist on one link.
+		await expect(link).toHaveAccessibleName(/review pending/i);
 
 		await page.context().close();
 	});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1519,7 +1519,25 @@ export async function createMembershipQuestionnaire(
 	owner: ThrowawayUser,
 	orgSlug: string,
 	opts: { evaluationMode: 'automatic' | 'manual' | 'hybrid' }
-): Promise<{ id: string }> {
+): Promise<{ id: string; name: string }> {
+	return createOrgQuestionnaire(owner, orgSlug, { ...opts, questionnaireType: 'membership' });
+}
+
+/**
+ * createMembershipQuestionnaire with the wrapper TYPE left to the caller — for
+ * specs that need a NON-membership questionnaire (e.g. an admission one to
+ * retype through the admin edit form). Everything else is identical; see
+ * createMembershipQuestionnaire for why the question shape follows the
+ * evaluation mode, and for what the returned id is (and is not).
+ */
+export async function createOrgQuestionnaire(
+	owner: ThrowawayUser,
+	orgSlug: string,
+	opts: {
+		evaluationMode: 'automatic' | 'manual' | 'hybrid';
+		questionnaireType: 'admission' | 'membership' | 'feedback' | 'generic';
+	}
+): Promise<{ id: string; name: string }> {
 	const api = await ApiClient.login(owner.email, owner.password);
 	const org = await api.get<{ id: string }>(`/api/organizations/${orgSlug}`);
 	const questions =
@@ -1543,14 +1561,20 @@ export async function createMembershipQuestionnaire(
 						{ question: MEMBERSHIP_QUESTION.manual.question, is_mandatory: true }
 					]
 				};
-	return api.post<{ id: string }>(`/api/questionnaires/${org.id}/create-questionnaire`, {
-		name: uniqueName('Membership Questionnaire'),
-		min_score: 0,
-		evaluation_mode: opts.evaluationMode,
-		status: 'published',
-		questionnaire_type: 'membership',
-		...questions
-	});
+	const typeLabel = opts.questionnaireType[0].toUpperCase() + opts.questionnaireType.slice(1);
+	const name = uniqueName(`${typeLabel} Questionnaire`);
+	const created = await api.post<{ id: string }>(
+		`/api/questionnaires/${org.id}/create-questionnaire`,
+		{
+			name,
+			min_score: 0,
+			evaluation_mode: opts.evaluationMode,
+			status: 'published',
+			questionnaire_type: opts.questionnaireType,
+			...questions
+		}
+	);
+	return { id: created.id, name };
 }
 
 /**


### PR DESCRIPTION
## What

Membership questionnaires were unreachable from the UI. The type `<Select>` had `membership` hard-disabled behind a "Coming soon" badge, so the two admin pickers that consume them filtered an always-empty list — and the org-settings empty state linked organizers back to the very form where the type could not be chosen. A closed loop with no exit.

This was a **frontend-only** gate. The backend has supported the feature for a long time:

- `OrganizationQuestionnaire.QuestionnaireType.MEMBERSHIP` (`events/models/questionnaire.py:89`)
- `Organization.default_membership_questionnaire` and `MembershipTier.membership_questionnaire`, both `limit_choices_to={"questionnaire_type": "membership"}` **and** re-checked on clean (`events/models/organization.py:435`/`:484`, `:632`/`:669`)
- `MeMembershipQuestionnaireController` (GET + submit), with its own test module
- `create_org_questionnaire`'s only type-specific validation is about `feedback`; `membership` passes straight through (`event_questionnaire_service.py:517`)

And the rest of the frontend was already built against it and merely starved: the settings picker, the per-tier override, the member-facing `/org/{slug}/questionnaire/{id}` fill route, and the `membership_questionnaire_*` eligibility reason codes.

## Why it went unnoticed

The gate **predates the feature**. It arrived in `b3dfef17` (#337, a file-split refactor) and was only ever touched again by `ff170a58` (#484's i18n pass, which swapped the literal for a message key). Nothing re-evaluated it when the backend landed membership questionnaires.

It also survived a fully green E2E suite, for a specific reason — see below.

## Changes

**`QuestionnaireCreateBasicInfo.svelte`** — two gates, not one. Besides the disabled `SelectItem`, `onValueChange` accepted only `admission` and `feedback`, so the value would have been silently swallowed even with the item enabled. Both removed.

**`QuestionnaireFormFields.svelte`** (edit form) — disabled flag removed; its `onValueChange` already accepted `membership`.

`generic` stays disabled in both: the backend has the enum value but **no code reads it**, so choosing it would build a questionnaire that never fires. The "Coming soon" badge is honest there.

Not touched: the `hybrid` evaluation mode gate, per discussion — LLM evaluation is disabled in the backend.

## E2E

The full application journey — membership offered → applicant applies → staff approves → membership active, including both questionnaire evaluation modes — **was already covered** by `j27-applications/` (4 specs, ~1000 lines).

But every one of those specs arranges its questionnaire through the `createMembershipQuestionnaire` API factory, which POSTs `questionnaire_type: 'membership'` directly. That is precisely why a disabled option in the authoring UI survived a green suite: nothing ever drove that form.

New `j11-questionnaires/membership-type.spec.ts` covers the seam the factory skips, in both directions:

1. **Create form** — organizer builds a membership questionnaire from scratch, publishes it, then it appears in *and is settable in* the org-settings default picker (asserted through a save + fresh SSR read) and the per-tier override modal.
2. **Edit form** — an existing admission questionnaire is retyped to membership and shows up in the settings picker.

The payoff assertion in both is deliberately **not** a read-back of the type trigger — that would only prove local component state. It is the questionnaire appearing in the settings picker, which the server filters on `questionnaire_type === 'membership'`, so the type is proven to have round-tripped through the API.

`createMembershipQuestionnaire` is now a thin wrapper over a type-parameterised `createOrgQuestionnaire` and also returns the generated name. Existing callers are untouched.

## Bundled: two pre-existing spec repairs

The full-suite run surfaced two specs already failing **on `main`** — verified by checking out `main` and running them there (identical errors, 4 failed / 8 passed). Unrelated to this PR's subject, bundled so this branch leaves the suite green.

- **`j05-rsvp/waitlist.spec.ts`** asserted the generic `"Success!"` copy. Backend #824 made join-waitlist idempotent with its own 200 sentence, and `IneligibilityActionButton` now prefers `backendMessage(response.data)` — that message being the only thing that distinguishes "you just joined" from "you already had". Accepts either sentence now. Matching the text rather than `role=status` is deliberate: the page carries two other live regions, so a bare `getByRole('status')` trips strict mode.
- **`j27-applications/requests-admin.spec.ts`** asserted the review-pending hint as the link's accessible **description**. #716 folded it into the accessible **name** and deliberately dropped the `aria-describedby` (name + description + the hint span's own text announced the same three words three times — see the `submissionLinkLabel` comment in `MembershipRequestCard.svelte`). That PR updated the component unit test but not the E2E.

Both are the "copy/a11y change breaks E2E invisibly" pattern: neither `make check` nor the unit suite can see an assertion on a rendered literal.

## Verification

- `make check` — exit 0, including the type-gate canary (`✓ Type gate is armed`)
- **Full E2E suite run from scratch against a live local stack: 509 passed / 0 failed / 1 flaky / 3 skipped (513 total, 9.3m), exit 0.** Skip count equals the baseline 3 intentional `test.skip(isMobile, …)` cases, so this is not the probe-cache mass-skip false green.
- Environment: stale `:5173` preview killed so the bundle rebuilt; backend restarted fresh via `make run-e2e` (gunicorn + PgBouncer); reseeded in canonical order `reset_events --no-input` → `make seed` → `make bootstrap-tests`; all personas confirmed by real token exchange.
- The 1 flaky (`j10 manage-tickets`) was retry-green in the suite and passes in isolation in 9–10s — the documented load-induced flake, not related to these changes.
- The 4 new tests pass on both `chromium` and `mobile-chrome` (3.1–4.6s each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled selecting **Membership** as a questionnaire type when creating or editing questionnaires.
  * Membership questionnaires can be configured as organization defaults and assigned to membership tiers.
* **Bug Fixes**
  * Removed the outdated “Coming soon” disabled state for the **Membership** questionnaire type option.
* **Tests**
  * Added end-to-end coverage for Membership questionnaire creation/editing, publishing, picker visibility, and persistence.
  * Updated existing E2E assertions around waitlist messaging and questionnaire submission link accessibility naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
