### PR TITLE
fix(questionnaires): invalidate the org questionnaire cache on every mutation (#722)

### DIFF
--- a/src/lib/components/questionnaires/DuplicateQuestionnaireModal.svelte
+++ b/src/lib/components/questionnaires/DuplicateQuestionnaireModal.svelte
@@ -2,8 +2,9 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { Dialog, DialogContent, DialogHeader, DialogTitle } from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { createMutation } from '@tanstack/svelte-query';
+	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
 	import { questionnaireDuplicateOrgQuestionnaire } from '$lib/api/generated/sdk.gen';
+	import { invalidateOrgQuestionnaires } from '$lib/queries/org-questionnaires';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -28,6 +29,7 @@
 	}: Props = $props();
 
 	const accessToken = $derived(authStore.accessToken);
+	const queryClient = useQueryClient();
 
 	let newName = $state('');
 	let copyAssociations = $state(false);
@@ -62,7 +64,11 @@
 			}
 			return response.data;
 		},
-		onSuccess: (data) => {
+		onSuccess: async (data) => {
+			// The copy carries the original's `questionnaire_type`, so duplicating a
+			// membership questionnaire adds a row the members admin's cached picker
+			// must show. Awaited before navigating away (#722).
+			await invalidateOrgQuestionnaires(queryClient, organizationSlug);
 			goto(
 				resolve('/(auth)/org/[slug]/admin/questionnaires/[id]', {
 					slug: organizationSlug,

--- a/src/lib/components/questionnaires/DuplicateQuestionnaireModal.test.ts
+++ b/src/lib/components/questionnaires/DuplicateQuestionnaireModal.test.ts
@@ -4,9 +4,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient } from '@tanstack/svelte-query';
 import DuplicateQuestionnaireModal from './DuplicateQuestionnaireModal.svelte';
 import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import { orgQuestionnairesKey } from '$lib/queries/org-questionnaires';
 
 vi.mock('$lib/api/generated/sdk.gen', () => ({
-	questionnaireDuplicateOrgQuestionnaire: vi.fn().mockResolvedValue({ data: { id: 'new-q-id' } })
+	questionnaireDuplicateOrgQuestionnaire: vi.fn().mockResolvedValue({ data: { id: 'new-q-id' } }),
+	// Pulled in by `$lib/queries/org-questionnaires` (the invalidation helper); never
+	// called here, but the mocked module must still declare it.
+	questionnaireListOrgQuestionnaires: vi.fn()
 }));
 vi.mock('$lib/stores/auth.svelte', () => ({
 	authStore: { accessToken: 'test-token' as string | null }
@@ -71,6 +75,24 @@ describe('DuplicateQuestionnaireModal', () => {
 			expect(goto).toHaveBeenCalledWith('/org/acme/admin/questionnaires/new-q-id')
 		);
 		await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+	});
+
+	it('drops the org questionnaire cache before navigating away (#722)', async () => {
+		// The copy inherits `questionnaire_type`, so duplicating a membership
+		// questionnaire adds a row the members admin's tier picker has to show —
+		// and this component navigates away, so the invalidation cannot wait for it.
+		const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+		const user = userEvent.setup();
+		renderModal();
+		await user.click(screen.getByRole('button', { name: /^duplicate$/i }));
+
+		await waitFor(() => expect(goto).toHaveBeenCalled());
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: orgQuestionnairesKey('acme') });
+		// Ordering matters: this component navigates away, so an invalidation fired
+		// after `goto` could be lost with the unmounting component.
+		expect(invalidate.mock.invocationCallOrder[0]).toBeLessThan(
+			vi.mocked(goto).mock.invocationCallOrder[0]
+		);
 	});
 
 	it('blocks submit and shows an error when the name is empty', async () => {

--- a/src/lib/queries/org-questionnaires.coverage.test.ts
+++ b/src/lib/queries/org-questionnaires.coverage.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Structural guard for #722.
+ *
+ * The behavioural tests prove `invalidateOrgQuestionnaires` works; nothing in
+ * them notices when a *new* mutation site forgets to call it — which is exactly
+ * how the bug shipped (create was the only path that never invalidated, and no
+ * test could see the omission).
+ *
+ * So: every source file that calls a mutating org-questionnaire SDK operation
+ * must either invalidate the cache itself, or be listed below with the file that
+ * covers it. Adding a new mutation site fails this test until one of the two is
+ * true.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+/** SDK operations that add, remove, or retype an organization questionnaire. */
+const MUTATING_OPERATIONS = [
+	'questionnaireCreateOrgQuestionnaire',
+	'questionnaireUpdateOrgQuestionnaire',
+	'questionnaireDeleteOrgQuestionnaire',
+	'questionnaireDuplicateOrgQuestionnaire',
+	'questionnaireUpdateQuestionnaireStatus'
+] as const;
+
+const INVALIDATOR = 'invalidateOrgQuestionnaires';
+
+/**
+ * Mutation sites that legitimately do not invalidate in place, each mapped to
+ * the file that invalidates on their behalf. Both halves are checked, so the
+ * exemption cannot outlive its cover.
+ */
+const COVERED_ELSEWHERE: Record<string, string> = {
+	// Pure API-sync helper: it takes ids and payloads, not a QueryClient. Its only
+	// caller — the questionnaire edit page — invalidates after awaiting it.
+	'src/lib/utils/questionnaire-api-sync.ts':
+		'src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte',
+	// The card deletes and calls `invalidateAll()`, which re-runs the questionnaire
+	// admin list's server load; that route drops the client cache on every (re)load.
+	'src/lib/components/questionnaires/QuestionnaireCard.svelte':
+		'src/routes/(auth)/org/[slug]/admin/questionnaires/+page.svelte'
+};
+
+const SRC = join(process.cwd(), 'src');
+
+function sourceFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			// The generated client declares these operations; it never calls them.
+			if (full.endsWith(join('lib', 'api', 'generated'))) continue;
+			out.push(...sourceFiles(full));
+			continue;
+		}
+		if (!/\.(svelte|ts)$/.test(entry.name)) continue;
+		if (/\.(test|spec)\.ts$/.test(entry.name)) continue;
+		out.push(full);
+	}
+	return out;
+}
+
+function toPosix(absolute: string): string {
+	return `src/${relative(SRC, absolute).split(sep).join('/')}`;
+}
+
+describe('org-questionnaire mutation sites', () => {
+	const mutationSites = sourceFiles(SRC)
+		.map((path) => ({ path: toPosix(path), source: readFileSync(path, 'utf8') }))
+		.filter(({ source }) => MUTATING_OPERATIONS.some((op) => source.includes(`${op}(`)));
+
+	it('finds the known mutation sites (the scan itself still works)', () => {
+		expect(mutationSites.map((f) => f.path).sort()).toEqual([
+			'src/lib/components/questionnaires/DuplicateQuestionnaireModal.svelte',
+			'src/lib/components/questionnaires/QuestionnaireCard.svelte',
+			'src/lib/utils/questionnaire-api-sync.ts',
+			'src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte',
+			'src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte'
+		]);
+	});
+
+	it('all invalidate the members admin picker, directly or through their cover', () => {
+		const uncovered = mutationSites
+			.filter(({ path, source }) => {
+				if (source.includes(INVALIDATOR)) return false;
+				const cover = COVERED_ELSEWHERE[path];
+				if (!cover) return true;
+				return !readFileSync(join(process.cwd(), cover), 'utf8').includes(INVALIDATOR);
+			})
+			.map(({ path }) => path);
+
+		expect(uncovered).toEqual([]);
+	});
+
+	it('the create page invalidates before it navigates away', () => {
+		// The reported symptom (#722): create succeeds, `goto` takes the user to the
+		// new questionnaire, and the members admin still lists the pre-create set.
+		// An invalidation issued after the navigation can be lost with the unmounting
+		// page, so the call has to come first in the handler.
+		const createPage = readFileSync(
+			join(SRC, 'routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte'),
+			'utf8'
+		);
+		const invalidateAt = createPage.indexOf(`${INVALIDATOR}(`);
+		const gotoAt = createPage.indexOf('await goto(');
+		expect(invalidateAt).toBeGreaterThan(-1);
+		expect(gotoAt).toBeGreaterThan(-1);
+		expect(invalidateAt).toBeLessThan(gotoAt);
+	});
+
+	it('the members admin reads the shared key instead of spelling one inline', () => {
+		const membersPage = readFileSync(
+			join(SRC, 'routes/(auth)/org/[slug]/admin/members/+page.svelte'),
+			'utf8'
+		);
+		expect(membersPage).toContain('orgQuestionnairesQueryOptions');
+		expect(membersPage).not.toContain("'membership-questionnaires'");
+	});
+});

--- a/src/lib/queries/org-questionnaires.test.ts
+++ b/src/lib/queries/org-questionnaires.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import {
+	orgQuestionnairesKey,
+	orgQuestionnairesQueryOptions,
+	invalidateOrgQuestionnaires
+} from './org-questionnaires';
+
+vi.mock('$lib/api/generated/sdk.gen', () => ({
+	questionnaireListOrgQuestionnaires: vi.fn()
+}));
+
+import { questionnaireListOrgQuestionnaires } from '$lib/api/generated/sdk.gen';
+
+const listMock = vi.mocked(questionnaireListOrgQuestionnaires);
+
+/** Minimal stand-in for the paginated list endpoint; only ids are asserted on. */
+function page(ids: string[]) {
+	return { data: { count: ids.length, results: ids.map((id) => ({ id })) }, error: undefined };
+}
+
+/**
+ * Same `staleTime` the app sets globally (`src/routes/+layout.svelte`). Without
+ * it every read refetches and these tests would pass with the invalidation
+ * deleted — the 60s freshness window *is* the bug (#722).
+ */
+function productionLikeClient(): QueryClient {
+	return new QueryClient({ defaultOptions: { queries: { staleTime: 60 * 1000, retry: false } } });
+}
+
+describe('orgQuestionnairesKey', () => {
+	it('is the key the members admin tier picker reads', () => {
+		// Pinned deliberately: the picker's cache entry is what #722 was leaving
+		// stale, and any silent change of shape here would just move the bug.
+		expect(orgQuestionnairesKey('acme')).toEqual([
+			'organization',
+			'acme',
+			'membership-questionnaires'
+		]);
+	});
+
+	it('scopes the cache per organization', () => {
+		expect(orgQuestionnairesKey('acme')).not.toEqual(orgQuestionnairesKey('globex'));
+	});
+});
+
+describe('orgQuestionnairesQueryOptions', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('reads the very key the invalidator writes off', () => {
+		const options = orgQuestionnairesQueryOptions({
+			organizationId: 'org-1',
+			organizationSlug: 'acme',
+			accessToken: 'tok'
+		});
+		expect(options.queryKey).toEqual(orgQuestionnairesKey('acme'));
+	});
+
+	it('fetches the org list with the bearer token', async () => {
+		listMock.mockResolvedValue(page(['vibe-check']) as never);
+
+		const client = productionLikeClient();
+		const data = await client.fetchQuery(
+			orgQuestionnairesQueryOptions({
+				organizationId: 'org-1',
+				organizationSlug: 'acme',
+				accessToken: 'tok'
+			})
+		);
+
+		expect(listMock).toHaveBeenCalledWith({
+			query: { organization_id: 'org-1', page_size: 100 },
+			headers: { Authorization: 'Bearer tok' }
+		});
+		expect(data).toEqual(page(['vibe-check']).data);
+	});
+
+	it('is disabled without a token, and when the caller has no permission', () => {
+		expect(
+			orgQuestionnairesQueryOptions({
+				organizationId: 'org-1',
+				organizationSlug: 'acme',
+				accessToken: null
+			}).enabled
+		).toBe(false);
+
+		expect(
+			orgQuestionnairesQueryOptions({
+				organizationId: 'org-1',
+				organizationSlug: 'acme',
+				accessToken: 'tok',
+				enabled: false
+			}).enabled
+		).toBe(false);
+	});
+});
+
+describe('invalidateOrgQuestionnaires', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('marks the cached list stale even though nothing is observing it', async () => {
+		// The shape of the bug: the questionnaire admin mutates and navigates away
+		// while the members admin is unmounted. Nothing refetches at that moment —
+		// what has to survive is the *invalidated* flag, so the next mount refetches
+		// instead of serving the 60s-fresh pre-mutation list.
+		listMock.mockResolvedValue(page(['vibe-check']) as never);
+
+		const client = productionLikeClient();
+		const options = orgQuestionnairesQueryOptions({
+			organizationId: 'org-1',
+			organizationSlug: 'acme',
+			accessToken: 'tok'
+		});
+		await client.fetchQuery(options);
+		expect(client.getQueryState(orgQuestionnairesKey('acme'))?.isInvalidated).toBe(false);
+
+		await invalidateOrgQuestionnaires(client, 'acme');
+
+		expect(client.getQueryState(orgQuestionnairesKey('acme'))?.isInvalidated).toBe(true);
+	});
+
+	it('control: without it, a fresh cache keeps serving the pre-mutation list', async () => {
+		listMock.mockResolvedValue(page(['vibe-check']) as never);
+
+		const client = productionLikeClient();
+		const options = orgQuestionnairesQueryOptions({
+			organizationId: 'org-1',
+			organizationSlug: 'acme',
+			accessToken: 'tok'
+		});
+		await client.fetchQuery(options);
+
+		// A membership questionnaire is created elsewhere and nobody invalidates —
+		// this is precisely what the members admin was showing before #722.
+		listMock.mockResolvedValue(page(['vibe-check', 'membership-vetting']) as never);
+		const stale = await client.fetchQuery(options);
+
+		expect(stale?.results.map((q) => q.id)).toEqual(['vibe-check']);
+		expect(listMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('refetches on the next read, so a newly created questionnaire appears', async () => {
+		listMock.mockResolvedValue(page(['vibe-check']) as never);
+
+		const client = productionLikeClient();
+		const options = orgQuestionnairesQueryOptions({
+			organizationId: 'org-1',
+			organizationSlug: 'acme',
+			accessToken: 'tok'
+		});
+		await client.fetchQuery(options);
+
+		// …a membership questionnaire is created elsewhere…
+		listMock.mockResolvedValue(page(['vibe-check', 'membership-vetting']) as never);
+		await invalidateOrgQuestionnaires(client, 'acme');
+
+		const refreshed = await client.fetchQuery(options);
+		expect(refreshed?.results.map((q) => q.id)).toEqual(['vibe-check', 'membership-vetting']);
+		expect(listMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('leaves other organizations alone', async () => {
+		listMock.mockResolvedValue(page(['vibe-check']) as never);
+
+		const client = productionLikeClient();
+		await client.fetchQuery(
+			orgQuestionnairesQueryOptions({
+				organizationId: 'org-2',
+				organizationSlug: 'globex',
+				accessToken: 'tok'
+			})
+		);
+
+		await invalidateOrgQuestionnaires(client, 'acme');
+
+		expect(client.getQueryState(orgQuestionnairesKey('globex'))?.isInvalidated).toBe(false);
+	});
+});

--- a/src/lib/queries/org-questionnaires.ts
+++ b/src/lib/queries/org-questionnaires.ts
@@ -1,0 +1,90 @@
+/**
+ * The organization's questionnaires, as the *client* caches them (#722).
+ *
+ * One surface reads this through TanStack: the members admin, whose tier form
+ * offers every `questionnaire_type === 'membership'` questionnaire as the tier's
+ * membership-questionnaire override. Everything else — the questionnaire admin
+ * list, the org settings default picker — is `+page.server.ts`-loaded and
+ * therefore re-reads the server on every navigation.
+ *
+ * That split is the whole bug: creating a questionnaire mutates the server list
+ * while the cached copy behind this key keeps answering for `staleTime`
+ * (60 s, set globally in `src/routes/+layout.svelte`), so a brand-new membership
+ * questionnaire was missing from the picker until a hard refresh.
+ *
+ * The rule this module exists to enforce: **every mutation of an org
+ * questionnaire — create, update (a `questionnaire_type` change moves a row into
+ * or out of the picker), delete, duplicate — calls
+ * `invalidateOrgQuestionnaires`.** The key is never written inline again;
+ * `orgQuestionnairesQueryOptions` and `invalidateOrgQuestionnaires` are the only
+ * two places that know it, so a reader and an invalidator cannot drift apart.
+ *
+ * Mutations that also change server-loaded data pair this with `invalidateAll()`
+ * — the two caches are independent and neither refreshes the other.
+ */
+import { queryOptions, type QueryClient } from '@tanstack/svelte-query';
+import { questionnaireListOrgQuestionnaires } from '$lib/api/generated/sdk.gen';
+
+/**
+ * Cache key for one organization's questionnaire list.
+ *
+ * Keyed by slug — not id — because that is what every other query on the members
+ * admin is keyed by, so the whole page's cache stays inspectable under one
+ * `['organization', slug]` prefix.
+ */
+export function orgQuestionnairesKey(
+	organizationSlug: string
+): readonly ['organization', string, 'membership-questionnaires'] {
+	return ['organization', organizationSlug, 'membership-questionnaires'] as const;
+}
+
+interface OrgQuestionnairesQueryArgs {
+	organizationId: string;
+	organizationSlug: string;
+	accessToken: string | null;
+	enabled?: boolean;
+}
+
+/**
+ * The list itself. The endpoint has no `questionnaire_type` filter, so callers
+ * narrow client-side — which is also why a *retyped* questionnaire has to
+ * invalidate: the row is already cached, just under the wrong type.
+ */
+export function orgQuestionnairesQueryOptions({
+	organizationId,
+	organizationSlug,
+	accessToken,
+	enabled = true
+}: OrgQuestionnairesQueryArgs) {
+	return queryOptions({
+		queryKey: orgQuestionnairesKey(organizationSlug),
+		queryFn: async () => {
+			const response = await questionnaireListOrgQuestionnaires({
+				query: { organization_id: organizationId, page_size: 100 },
+				headers: { Authorization: `Bearer ${accessToken}` }
+			});
+
+			if (response.error) {
+				throw new Error('Failed to fetch questionnaires');
+			}
+
+			return response.data;
+		},
+		enabled: !!accessToken && enabled
+	});
+}
+
+/**
+ * Drop the cached list for one organization after mutating its questionnaires.
+ *
+ * Safe to call from a handler that is about to `goto(...)`: with no mounted
+ * observer this only marks the entry stale (no request, resolves immediately),
+ * and the members admin refetches the next time it mounts the query. Await it
+ * before navigating anyway, so the marking cannot be lost to an unmount.
+ */
+export function invalidateOrgQuestionnaires(
+	queryClient: QueryClient,
+	organizationSlug: string
+): Promise<void> {
+	return queryClient.invalidateQueries({ queryKey: orgQuestionnairesKey(organizationSlug) });
+}

--- a/src/routes/(auth)/org/[slug]/admin/members/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/members/+page.svelte
@@ -6,9 +6,9 @@
 	import {
 		organizationadminmembersListMembers,
 		organizationadminmembersListStaff,
-		organizationadminmembersListMembershipTiers,
-		questionnaireListOrgQuestionnaires
+		organizationadminmembersListMembershipTiers
 	} from '$lib/api/generated/sdk.gen';
+	import { orgQuestionnairesQueryOptions } from '$lib/queries/org-questionnaires';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { Tabs, TabsList, TabsTrigger, TabsContent } from '$lib/components/ui/tabs';
 	import { Button } from '$lib/components/ui/button';
@@ -134,22 +134,16 @@
 
 	// Options for the tier-level questionnaire override (value = OrganizationQuestionnaire id).
 	// The endpoint has no type filter, so narrow to MEMBERSHIP client-side.
-	const questionnairesQuery = createQuery(() => ({
-		queryKey: ['organization', organization.slug, 'membership-questionnaires'],
-		queryFn: async () => {
-			const response = await questionnaireListOrgQuestionnaires({
-				query: { organization_id: organization.id, page_size: 100 },
-				headers: { Authorization: `Bearer ${accessToken}` }
-			});
-
-			if (response.error) {
-				throw new Error('Failed to fetch questionnaires');
-			}
-
-			return response.data;
-		},
-		enabled: !!accessToken && canManageMembers
-	}));
+	// Key + fetcher come from the shared factory so the questionnaire admin's
+	// mutations invalidate exactly what this reads (#722).
+	const questionnairesQuery = createQuery(() =>
+		orgQuestionnairesQueryOptions({
+			organizationId: organization.id,
+			organizationSlug: organization.slug,
+			accessToken,
+			enabled: canManageMembers
+		})
+	);
 
 	// Derived data for badge counts and shared state
 	const members = $derived(membersQuery.data?.results || []);

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/+page.svelte
@@ -5,6 +5,8 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import QuestionnaireCard from '$lib/components/questionnaires/QuestionnaireCard.svelte';
+	import { useQueryClient } from '@tanstack/svelte-query';
+	import { invalidateOrgQuestionnaires } from '$lib/queries/org-questionnaires';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -12,6 +14,23 @@
 	}
 
 	const { data }: Props = $props();
+
+	const queryClient = useQueryClient();
+
+	// Deleting a questionnaire happens inside `QuestionnaireCard`, which answers with
+	// `invalidateAll()` — that re-runs *this* route's server load and nothing else.
+	// The members admin's tier picker reads the same data from a TanStack cache with
+	// a 60s staleTime, so a deleted (or renamed, or retyped) questionnaire would keep
+	// showing up there (#722).
+	//
+	// This list is the authoritative server copy, so every (re)load of it is exactly
+	// the moment the client copy stops being trustworthy — drop it. Cheap: with the
+	// members admin unmounted this only marks the entry stale, so it refetches the
+	// next time the picker opens.
+	$effect(() => {
+		void data.questionnaires; // tracked: a fresh array on load and on invalidateAll
+		void invalidateOrgQuestionnaires(queryClient, data.organization.slug);
+	});
 
 	// Search state
 	let searchQuery = $state('');

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
@@ -11,6 +11,8 @@
 	import QuestionnaireEditAssignments from '$lib/components/questionnaires/QuestionnaireEditAssignments.svelte';
 	import QuestionnaireEditQuestionsCard from '$lib/components/questionnaires/QuestionnaireEditQuestionsCard.svelte';
 	import { questionnaireUpdateQuestionnaireStatus } from '$lib/api/generated/sdk.gen';
+	import { useQueryClient } from '@tanstack/svelte-query';
+	import { invalidateOrgQuestionnaires } from '$lib/queries/org-questionnaires';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import type { PageData } from './$types';
 	import type {
@@ -28,6 +30,8 @@
 	}
 
 	const { data }: Props = $props();
+
+	const queryClient = useQueryClient();
 
 	// ===== Load and Convert Data =====
 
@@ -181,7 +185,12 @@
 				throw new Error(m['questionnaireEditPage.error_statusChangeFailed']());
 			}
 
-			await invalidateAll();
+			// This page is server-loaded, the members admin's picker is TanStack-cached
+			// and neither refreshes the other — refresh both (#722).
+			await Promise.all([
+				invalidateAll(),
+				invalidateOrgQuestionnaires(queryClient, data.organizationSlug)
+			]);
 		} catch (err) {
 			console.error('Failed to change status:', err);
 			alert(m['questionnaireEditPage.error_statusChangeFailedMessage']());
@@ -231,8 +240,13 @@
 				sections: builder.sections
 			});
 
-			// Refresh data, re-initialize state from API, and exit edit mode (stay on same page)
-			await invalidateAll();
+			// Refresh data, re-initialize state from API, and exit edit mode (stay on same page).
+			// `questionnaire_type` is editable here, so a save can move this row into or
+			// out of the members admin's membership picker — invalidate that cache too (#722).
+			await Promise.all([
+				invalidateAll(),
+				invalidateOrgQuestionnaires(queryClient, data.organizationSlug)
+			]);
 			initializeFromApi(); // Explicitly re-init with fresh data (avoids race with $effect)
 			isEditMode = false;
 

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte
@@ -16,6 +16,8 @@
 	import QuestionnaireCreateBasicInfo from '$lib/components/questionnaires/QuestionnaireCreateBasicInfo.svelte';
 	import QuestionnaireCreateAdvancedSettings from '$lib/components/questionnaires/QuestionnaireCreateAdvancedSettings.svelte';
 	import { questionnaireCreateOrgQuestionnaire } from '$lib/api/generated/sdk.gen';
+	import { useQueryClient } from '@tanstack/svelte-query';
+	import { invalidateOrgQuestionnaires } from '$lib/queries/org-questionnaires';
 	import type {
 		SectionCreateSchema,
 		MultipleChoiceQuestionCreateSchema,
@@ -37,6 +39,8 @@
 	}
 
 	const { data }: Props = $props();
+
+	const queryClient = useQueryClient();
 
 	// Form state
 	let name = $state('');
@@ -181,6 +185,12 @@
 				}
 				return;
 			}
+
+			// The members admin caches this org's questionnaire list for 60s; a
+			// membership questionnaire created here has to reach its tier picker
+			// without a reload (#722). Awaited *before* `goto` so the marking cannot
+			// be lost to this component unmounting mid-navigation.
+			await invalidateOrgQuestionnaires(queryClient, data.organization.slug);
 
 			// Redirect to the edit page of the newly created questionnaire
 			await goto(


### PR DESCRIPTION
Closes #722

## The bug

A membership questionnaire created in the questionnaire admin did not show up in
**Members → Tiers → edit tier → Membership questionnaire** until a hard refresh.

The picker reads `['organization', slug, 'membership-questionnaires']` from TanStack;
the global default is `staleTime: 60 * 1000` (`src/routes/+layout.svelte`); and no
org-questionnaire mutation anywhere in the repo invalidated that key. So for 60s
after creating one, the members admin served the pre-create list.

## What changed

**New `src/lib/queries/org-questionnaires.ts`** — the key, the fetcher and the
invalidator in one place. The members admin now builds its query from
`orgQuestionnairesQueryOptions(...)` instead of spelling the key inline, so a reader
and an invalidator can no longer drift apart.

Every mutation site now invalidates:

| Site | Mutation | How |
| --- | --- | --- |
| `questionnaires/new/+page.svelte` | create | `await invalidateOrgQuestionnaires(...)` **before** `goto` |
| `questionnaires/[id]/+page.svelte` | save (incl. `questionnaire_type`) | paired with `invalidateAll()` |
| `questionnaires/[id]/+page.svelte` | status change | paired with `invalidateAll()` |
| `DuplicateQuestionnaireModal.svelte` | duplicate | awaited in `onSuccess` before `goto` |
| `QuestionnaireCard.svelte` | delete | covered by the list route (below) |

Delete lives in `QuestionnaireCard.svelte`, which a parallel branch owns and this PR
does not touch. It answers with `invalidateAll()`, which re-runs the questionnaire
admin list's server load — so that route now drops the client copy on every (re)load
of its own authoritative server data. Same effect, no edit to the card. If the card
later grows a callback, the invalidation can move inline and the exemption in the
guard test goes away.

The retype cases work because the endpoint has no type filter: the picker narrows to
`questionnaire_type === 'membership'` client-side, so a retyped row is already cached
under the wrong type and only a refetch can fix it.

## Tests (written, not run — house rule)

- `src/lib/queries/org-questionnaires.test.ts` — key shape, that the query options
  read the key the invalidator writes off, that invalidation survives with **no**
  mounted observer (the exact shape of the bug), that the next read refetches, and
  that other orgs are untouched. All against a **production-like `staleTime` of 60s**,
  plus a control test asserting that without invalidation the fresh cache keeps
  serving the pre-mutation list — so these cannot pass with the fix deleted.
- `src/lib/queries/org-questionnaires.coverage.test.ts` — structural guard: scans
  `src/` for calls to the five mutating org-questionnaire SDK operations and fails
  unless each file invalidates, or is listed with the file that covers it (both halves
  checked). Also pins create's invalidate-before-`goto` ordering. A **new** mutation
  site fails this test until it invalidates — which is what nothing could catch before.
- `DuplicateQuestionnaireModal.test.ts` — asserts the invalidation fires with the
  shared key and strictly before `goto`.

## Verification

`make check` green: **0 errors**, 374 warnings (the accepted #361 baseline).

## Manual check

1. Create a membership questionnaire for an org.
2. Immediately (well inside 60s) go to Members → Tiers → edit a tier — it is listed.
3. Retype it to `admission`, save, reopen the tier form — it is gone. Retype back — it returns.
4. Delete it from the questionnaire list — it disappears from the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP
