### PR TITLE
feat(members): free and non-renewing membership plans (#724)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -3327,7 +3327,9 @@
 					"online": "Online · Stripe",
 					"offline": "Offline · manuell",
 					"soldOut": "Ausverkauft",
-					"paused": "Verkauf pausiert"
+					"paused": "Verkauf pausiert",
+					"free": "Kostenlos · Selbstbedienung",
+					"lifetime": "Läuft nie ab"
 				},
 				"occupancy": "{active} aktiv",
 				"occupancyCapped": "{active} / {cap} aktiv",
@@ -3360,7 +3362,11 @@
 						"nameRequired": "Name ist erforderlich",
 						"priceInvalid": "Der Preis muss 0 oder höher sein",
 						"periodInvalid": "Die Anzahl der Zeiträume muss zwischen 1 und 120 liegen",
-						"maxSubsInvalid": "Die maximale Anzahl an Abonnements muss mindestens 1 sein — oder leer für unbegrenzt"
+						"maxSubsInvalid": "Die maximale Anzahl an Abonnements muss mindestens 1 sein — oder leer für unbegrenzt",
+						"freePriceNotZero": "Kostenlose Pläne müssen den Preis 0 haben.",
+						"freeNeedsLifetime": "Kostenlose Pläne müssen den Zeitraum „lebenslang“ verwenden.",
+						"onlinePriceZero": "Online-Pläne müssen mehr als 0 kosten. Nutze für eine kostenlose Mitgliedschaft einen kostenlosen Plan.",
+						"onlineNoLifetime": "Online-Pläne können nicht lebenslang sein — Stripe rechnet monatlich oder jährlich ab. Nutze für eine einmalig bezahlte Mitgliedschaft einen Offline-Plan."
 					},
 					"periodMonth": "Monat(e)",
 					"periodYear": "Jahr(e)",
@@ -3374,7 +3380,12 @@
 					"maxSubscriptionsUnlimited": "Unbegrenzt",
 					"maxSubscriptionsHelp": "Obergrenze für gleichzeitige Abonnent*innen. Plätze werden frei, sobald ein Abonnement endet.",
 					"pauseSales": "Verkauf pausieren",
-					"pauseSalesHelp": "Mitglieder*innen können diesen Plan nicht abonnieren oder zu ihm wechseln, solange er pausiert ist. Bestehende Abonnent*innen sind nicht betroffen; du kannst weiterhin Personen manuell eintragen."
+					"pauseSalesHelp": "Mitglieder*innen können diesen Plan nicht abonnieren oder zu ihm wechseln, solange er pausiert ist. Bestehende Abonnent*innen sind nicht betroffen; du kannst weiterhin Personen manuell eintragen.",
+					"paymentFree": "Kostenlos — Mitglieder treten gratis bei",
+					"paymentFreeHelp": "Kostenlose Pläne haben keinen Preis und laufen nie ab. Mitglieder treten selbst bei, ohne Zahlungsschritt.",
+					"periodLifetime": "lebenslang (keine Verlängerung)",
+					"freeShapeLocked": "Kostenlose Pläne haben immer den Preis 0 und laufen lebenslang — das lässt sich nicht ändern.",
+					"lifetimeNoCount": "Ein lebenslanger Plan wird nie verlängert, daher gibt es keinen Abrechnungsrhythmus."
 				},
 				"errors": {
 					"createFailed": "Plan konnte nicht erstellt werden: {detail}",
@@ -5146,7 +5157,10 @@
 		"pausedHelper": "Die Organisation hat die Anmeldung vorübergehend geschlossen.",
 		"offlineManaged": "Wird von der Organisation verwaltet — melde dich bei ihr, um diesen Plan zu buchen.",
 		"refundPolicy": "Rückerstattungsrichtlinie",
-		"viewMembership": "Mitgliedschaftsoptionen ansehen"
+		"viewMembership": "Mitgliedschaftsoptionen ansehen",
+		"joinFreeCta": "Kostenlos beitreten",
+		"loginToJoin": "Zum Beitreten anmelden",
+		"freeHelper": "Keine Zahlung nötig — du kannst sofort beitreten."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Du musst eingeloggt sein, um eine Verifizierung anzufordern",
@@ -6637,7 +6651,8 @@
 			"month": "Monat",
 			"months": "{n} Monate",
 			"year": "Jahr",
-			"years": "{n} Jahre"
+			"years": "{n} Jahre",
+			"lifetime": "lebenslang"
 		},
 		"status": {
 			"active": "Aktiv",
@@ -6669,7 +6684,8 @@
 			"uncancel": "Verlängerung fortsetzen",
 			"uncancelling": "Wird fortgesetzt…",
 			"uncancelSuccess": "Die Verlängerung ist wieder aktiv.",
-			"uncancelError": "Die Verlängerung konnte nicht fortgesetzt werden. Bitte versuche es erneut."
+			"uncancelError": "Die Verlängerung konnte nicht fortgesetzt werden. Bitte versuche es erneut.",
+			"alreadyActive": "Diese Mitgliedschaft ist bereits aktiv."
 		},
 		"cancelScheduledHint": "Die Verlängerung ist deaktiviert. Du kannst sie bis zu diesem Datum jederzeit wieder aktivieren.",
 		"cancelScheduledHintManaged": "Die Verlängerung ist deaktiviert. Um deine Mitgliedschaft zu behalten, wende dich an die Organisation.",
@@ -6704,7 +6720,12 @@
 			"cta": "Wieder beitreten",
 			"returnHint": "Du zahlst sicher über Stripe und kehrst danach zur Seite der Organisation zurück.",
 			"error": "Die Zahlung konnte nicht gestartet werden. Bitte versuche es erneut."
-		}
+		},
+		"price": {
+			"free": "Kostenlos",
+			"oneTime": "{price} · einmalig"
+		},
+		"neverExpires": "Läuft nie ab"
 	},
 	"account": {
 		"memberships": {
@@ -6884,7 +6905,11 @@
 			"cancelledTitle": "Bezahlung nicht abgeschlossen",
 			"cancelledBody": "Deine Zahlung wurde nicht abgeschlossen. Du kannst sie fortsetzen, wann immer du möchtest.",
 			"resumeCta": "Zahlung fortsetzen"
-		}
+		},
+		"titleFree": "{plan} beitreten",
+		"freeNoCharge": "Es fällt nichts an. Deine Mitgliedschaft startet, sobald du bestätigst.",
+		"neverRenews": "Diese Mitgliedschaft läuft nie ab und wird nie verlängert oder erneut berechnet.",
+		"confirmFreeCta": "Jetzt beitreten"
 	},
 	"waitlistSettings.title": "Advanced waitlist settings",
 	"waitlistSettings.description": "Configure how seats are offered to waitlist members.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3327,7 +3327,9 @@
 					"online": "Online · Stripe",
 					"offline": "Offline · manual",
 					"soldOut": "Sold out",
-					"paused": "Sales paused"
+					"paused": "Sales paused",
+					"free": "Free · self-serve",
+					"lifetime": "Never expires"
 				},
 				"occupancy": "{active} active",
 				"occupancyCapped": "{active} / {cap} active",
@@ -3360,7 +3362,11 @@
 						"nameRequired": "Name is required",
 						"priceInvalid": "Price must be 0 or more",
 						"periodInvalid": "Period count must be between 1 and 120",
-						"maxSubsInvalid": "Maximum subscriptions must be 1 or more, or empty for unlimited"
+						"maxSubsInvalid": "Maximum subscriptions must be 1 or more, or empty for unlimited",
+						"freePriceNotZero": "Free plans must be priced 0.",
+						"freeNeedsLifetime": "Free plans must use the lifetime period.",
+						"onlinePriceZero": "Online plans must be priced above 0. Use a free plan for a no-cost membership.",
+						"onlineNoLifetime": "Online plans can't be lifetime — Stripe bills monthly or yearly. Use an offline plan for a one-off paid membership."
 					},
 					"periodMonth": "month(s)",
 					"periodYear": "year(s)",
@@ -3374,7 +3380,12 @@
 					"maxSubscriptionsUnlimited": "Unlimited",
 					"maxSubscriptionsHelp": "Cap on concurrent subscribers. Spots free up when a subscription ends.",
 					"pauseSales": "Pause sales",
-					"pauseSalesHelp": "Members can't subscribe or switch into this plan while paused. Current subscribers are unaffected; you can still enroll people manually."
+					"pauseSalesHelp": "Members can't subscribe or switch into this plan while paused. Current subscribers are unaffected; you can still enroll people manually.",
+					"paymentFree": "Free — members join at no cost",
+					"paymentFreeHelp": "Free plans have no price and never expire. Members join themselves, with no payment step.",
+					"periodLifetime": "lifetime (never renews)",
+					"freeShapeLocked": "Free plans are always priced 0 and always last a lifetime, so these can't be changed.",
+					"lifetimeNoCount": "A lifetime plan never renews, so there's no billing frequency to set."
 				},
 				"errors": {
 					"createFailed": "Failed to create plan: {detail}",
@@ -5146,7 +5157,10 @@
 		"pausedHelper": "The organization has temporarily closed sign-ups.",
 		"offlineManaged": "Managed by the organization — contact them to join this plan.",
 		"refundPolicy": "Refund policy",
-		"viewMembership": "View membership options"
+		"viewMembership": "View membership options",
+		"joinFreeCta": "Join for free",
+		"loginToJoin": "Log in to join",
+		"freeHelper": "No payment needed — you can join right away."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "You must be logged in to request verification",
@@ -6637,7 +6651,8 @@
 			"month": "month",
 			"months": "{n} months",
 			"year": "year",
-			"years": "{n} years"
+			"years": "{n} years",
+			"lifetime": "lifetime"
 		},
 		"status": {
 			"active": "Active",
@@ -6669,7 +6684,8 @@
 			"uncancel": "Resume renewal",
 			"uncancelling": "Resuming renewal…",
 			"uncancelSuccess": "Renewal is back on.",
-			"uncancelError": "Could not resume the renewal. Please try again."
+			"uncancelError": "Could not resume the renewal. Please try again.",
+			"alreadyActive": "This membership is already active."
 		},
 		"cancelScheduledHint": "Renewal is off. Resume it any time before this date to keep your membership.",
 		"cancelScheduledHintManaged": "Renewal is off. To keep your membership, contact the organization.",
@@ -6704,7 +6720,12 @@
 			"cta": "Rejoin",
 			"returnHint": "You'll pay securely with Stripe and return to the organization's page.",
 			"error": "Could not start the payment. Please try again."
-		}
+		},
+		"price": {
+			"free": "Free",
+			"oneTime": "{price} · one-time"
+		},
+		"neverExpires": "Never expires"
 	},
 	"account": {
 		"memberships": {
@@ -6884,7 +6905,11 @@
 			"cancelledTitle": "Checkout not completed",
 			"cancelledBody": "Your payment wasn't completed. You can resume it whenever you're ready.",
 			"resumeCta": "Resume payment"
-		}
+		},
+		"titleFree": "Join {plan}",
+		"freeNoCharge": "There's nothing to pay. Your membership starts as soon as you confirm.",
+		"neverRenews": "This membership never expires and is never renewed or charged again.",
+		"confirmFreeCta": "Join now"
 	},
 	"waitlistSettings.title": "Advanced waitlist settings",
 	"waitlistSettings.description": "Configure how seats are offered to waitlist members.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -3298,7 +3298,9 @@
 					"online": "En ligne · Stripe",
 					"offline": "Hors ligne · manuel",
 					"soldOut": "Complet",
-					"paused": "Ventes suspendues"
+					"paused": "Ventes suspendues",
+					"free": "Gratuit · libre-service",
+					"lifetime": "N'expire jamais"
 				},
 				"occupancy": "{active} actif(s)",
 				"occupancyCapped": "{active} / {cap} actif(s)",
@@ -3331,7 +3333,11 @@
 						"nameRequired": "Le nom est obligatoire",
 						"priceInvalid": "Le prix doit être de 0 ou plus",
 						"periodInvalid": "Le nombre de périodes doit être compris entre 1 et 120",
-						"maxSubsInvalid": "Le nombre maximum d'abonnements doit être de 1 ou plus, ou vide pour illimité"
+						"maxSubsInvalid": "Le nombre maximum d'abonnements doit être de 1 ou plus, ou vide pour illimité",
+						"freePriceNotZero": "Les formules gratuites doivent être au prix de 0.",
+						"freeNeedsLifetime": "Les formules gratuites doivent utiliser la période à vie.",
+						"onlinePriceZero": "Les formules en ligne doivent coûter plus de 0. Utilisez une formule gratuite pour une adhésion sans frais.",
+						"onlineNoLifetime": "Les formules en ligne ne peuvent pas être à vie — Stripe facture au mois ou à l'année. Utilisez une formule hors ligne pour une adhésion payée une seule fois."
 					},
 					"periodMonth": "mois",
 					"periodYear": "an(s)",
@@ -3345,7 +3351,12 @@
 					"maxSubscriptionsUnlimited": "Illimité",
 					"maxSubscriptionsHelp": "Plafond d'abonnés simultanés. Des places se libèrent lorsqu'un abonnement se termine.",
 					"pauseSales": "Suspendre les ventes",
-					"pauseSalesHelp": "Les membres ne peuvent pas s'abonner ou passer à ce forfait tant qu'il est suspendu. Les abonnés actuels ne sont pas concernés ; vous pouvez toujours inscrire des personnes manuellement."
+					"pauseSalesHelp": "Les membres ne peuvent pas s'abonner ou passer à ce forfait tant qu'il est suspendu. Les abonnés actuels ne sont pas concernés ; vous pouvez toujours inscrire des personnes manuellement.",
+					"paymentFree": "Gratuit — les membres rejoignent sans frais",
+					"paymentFreeHelp": "Les formules gratuites n'ont pas de prix et n'expirent jamais. Les membres s'inscrivent eux-mêmes, sans étape de paiement.",
+					"periodLifetime": "à vie (sans renouvellement)",
+					"freeShapeLocked": "Les formules gratuites sont toujours au prix de 0 et à vie : ces champs ne sont pas modifiables.",
+					"lifetimeNoCount": "Une formule à vie ne se renouvelle jamais : il n'y a pas de fréquence de facturation à définir."
 				},
 				"errors": {
 					"createFailed": "Échec de la création du forfait : {detail}",
@@ -5117,7 +5128,10 @@
 		"pausedHelper": "L'organisation a temporairement fermé les inscriptions.",
 		"offlineManaged": "Géré par l'organisation — contacte-la pour rejoindre ce forfait.",
 		"refundPolicy": "Politique de remboursement",
-		"viewMembership": "Voir les options d'adhésion"
+		"viewMembership": "Voir les options d'adhésion",
+		"joinFreeCta": "Rejoindre gratuitement",
+		"loginToJoin": "Se connecter pour rejoindre",
+		"freeHelper": "Aucun paiement requis — vous pouvez rejoindre immédiatement."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Tu dois être connecté pour demander une vérification",
@@ -6608,7 +6622,8 @@
 			"month": "mois",
 			"months": "{n} mois",
 			"year": "an",
-			"years": "{n} ans"
+			"years": "{n} ans",
+			"lifetime": "à vie"
 		},
 		"status": {
 			"active": "Actif",
@@ -6640,7 +6655,8 @@
 			"uncancel": "Réactiver le renouvellement",
 			"uncancelling": "Réactivation…",
 			"uncancelSuccess": "Le renouvellement est réactivé.",
-			"uncancelError": "Impossible de réactiver le renouvellement. Réessaie."
+			"uncancelError": "Impossible de réactiver le renouvellement. Réessaie.",
+			"alreadyActive": "Cette adhésion est déjà active."
 		},
 		"cancelScheduledHint": "Le renouvellement est désactivé. Tu peux le réactiver à tout moment avant cette date.",
 		"cancelScheduledHintManaged": "Le renouvellement est désactivé. Pour conserver ton adhésion, contacte l'organisation.",
@@ -6675,7 +6691,12 @@
 			"cta": "Reprendre l'adhésion",
 			"returnHint": "Tu paieras en toute sécurité via Stripe puis reviendras sur la page de l'organisation.",
 			"error": "Impossible de démarrer le paiement. Réessaie."
-		}
+		},
+		"price": {
+			"free": "Gratuit",
+			"oneTime": "{price} · paiement unique"
+		},
+		"neverExpires": "N'expire jamais"
 	},
 	"account": {
 		"memberships": {
@@ -6855,7 +6876,11 @@
 			"cancelledTitle": "Paiement non finalisé",
 			"cancelledBody": "Ton paiement n'a pas été finalisé. Tu peux le reprendre quand tu veux.",
 			"resumeCta": "Reprendre le paiement"
-		}
+		},
+		"titleFree": "Rejoindre {plan}",
+		"freeNoCharge": "Il n'y a rien à payer. Votre adhésion démarre dès la confirmation.",
+		"neverRenews": "Cette adhésion n'expire jamais et n'est jamais renouvelée ni refacturée.",
+		"confirmFreeCta": "Rejoindre"
 	},
 	"waitlistSettings.title": "Paramètres avancés de liste d'attente",
 	"waitlistSettings.description": "Configure la façon dont les places sont proposées aux personnes en liste d'attente.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -3327,7 +3327,9 @@
 					"online": "Online · Stripe",
 					"offline": "Offline · manuale",
 					"soldOut": "Esaurito",
-					"paused": "Vendite sospese"
+					"paused": "Vendite sospese",
+					"free": "Gratuito · self-service",
+					"lifetime": "Non scade mai"
 				},
 				"occupancy": "{active} attivi",
 				"occupancyCapped": "{active} / {cap} attivi",
@@ -3360,7 +3362,11 @@
 						"nameRequired": "Il nome è obbligatorio",
 						"priceInvalid": "Il prezzo deve essere 0 o superiore",
 						"periodInvalid": "Il numero di periodi deve essere compreso tra 1 e 120",
-						"maxSubsInvalid": "Il numero massimo di abbonamenti deve essere almeno 1, oppure vuoto per illimitato"
+						"maxSubsInvalid": "Il numero massimo di abbonamenti deve essere almeno 1, oppure vuoto per illimitato",
+						"freePriceNotZero": "I piani gratuiti devono avere prezzo 0.",
+						"freeNeedsLifetime": "I piani gratuiti devono usare il periodo a vita.",
+						"onlinePriceZero": "I piani online devono costare più di 0. Per un'iscrizione senza costi usa un piano gratuito.",
+						"onlineNoLifetime": "I piani online non possono essere a vita: Stripe fattura mensilmente o annualmente. Per un'iscrizione pagata una tantum usa un piano offline."
 					},
 					"periodMonth": "mese/i",
 					"periodYear": "anno/i",
@@ -3374,7 +3380,12 @@
 					"maxSubscriptionsUnlimited": "Illimitato",
 					"maxSubscriptionsHelp": "Limite di iscritti simultanei. I posti si liberano quando un abbonamento termina.",
 					"pauseSales": "Sospendi le vendite",
-					"pauseSalesHelp": "I membri non possono iscriversi o passare a questo piano mentre è sospeso. Gli abbonati attuali non sono interessati; puoi comunque iscrivere persone manualmente."
+					"pauseSalesHelp": "I membri non possono iscriversi o passare a questo piano mentre è sospeso. Gli abbonati attuali non sono interessati; puoi comunque iscrivere persone manualmente.",
+					"paymentFree": "Gratuito — i membri si iscrivono senza costi",
+					"paymentFreeHelp": "I piani gratuiti non hanno prezzo e non scadono mai. I membri si iscrivono da soli, senza passaggio di pagamento.",
+					"periodLifetime": "a vita (nessun rinnovo)",
+					"freeShapeLocked": "I piani gratuiti hanno sempre prezzo 0 e durata a vita: questi campi non sono modificabili.",
+					"lifetimeNoCount": "Un piano a vita non si rinnova mai, quindi non c'è una frequenza di fatturazione da impostare."
 				},
 				"errors": {
 					"createFailed": "Impossibile creare il piano: {detail}",
@@ -5146,7 +5157,10 @@
 		"pausedHelper": "L'organizzazione ha temporaneamente chiuso le iscrizioni.",
 		"offlineManaged": "Gestito dall'organizzazione — contattala per aderire a questo piano.",
 		"refundPolicy": "Politica di rimborso",
-		"viewMembership": "Vedi le opzioni di iscrizione"
+		"viewMembership": "Vedi le opzioni di iscrizione",
+		"joinFreeCta": "Iscriviti gratis",
+		"loginToJoin": "Accedi per iscriverti",
+		"freeHelper": "Nessun pagamento richiesto: puoi iscriverti subito."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Devi essere loggato per richiedere la verifica",
@@ -6637,7 +6651,8 @@
 			"month": "mese",
 			"months": "{n} mesi",
 			"year": "anno",
-			"years": "{n} anni"
+			"years": "{n} anni",
+			"lifetime": "a vita"
 		},
 		"status": {
 			"active": "Attivo",
@@ -6669,7 +6684,8 @@
 			"uncancel": "Riattiva il rinnovo",
 			"uncancelling": "Riattivazione…",
 			"uncancelSuccess": "Il rinnovo è di nuovo attivo.",
-			"uncancelError": "Non è stato possibile riattivare il rinnovo. Riprova."
+			"uncancelError": "Non è stato possibile riattivare il rinnovo. Riprova.",
+			"alreadyActive": "Questa iscrizione è già attiva."
 		},
 		"cancelScheduledHint": "Il rinnovo è disattivato. Puoi riattivarlo in qualsiasi momento prima di questa data.",
 		"cancelScheduledHintManaged": "Il rinnovo è disattivato. Per mantenere l'abbonamento, contatta l'organizzazione.",
@@ -6704,7 +6720,12 @@
 			"cta": "Riabbonati",
 			"returnHint": "Pagherai in modo sicuro con Stripe e tornerai alla pagina dell'organizzazione.",
 			"error": "Non è stato possibile avviare il pagamento. Riprova."
-		}
+		},
+		"price": {
+			"free": "Gratuito",
+			"oneTime": "{price} · una tantum"
+		},
+		"neverExpires": "Non scade mai"
 	},
 	"account": {
 		"memberships": {
@@ -6884,7 +6905,11 @@
 			"cancelledTitle": "Pagamento non completato",
 			"cancelledBody": "Il tuo pagamento non è stato completato. Puoi riprenderlo quando vuoi.",
 			"resumeCta": "Riprendi il pagamento"
-		}
+		},
+		"titleFree": "Iscriviti a {plan}",
+		"freeNoCharge": "Non c'è nulla da pagare. L'iscrizione parte appena confermi.",
+		"neverRenews": "Questa iscrizione non scade mai e non viene mai rinnovata né riaddebitata.",
+		"confirmFreeCta": "Iscriviti ora"
 	},
 	"waitlistSettings.title": "Advanced waitlist settings",
 	"waitlistSettings.description": "Configure how seats are offered to waitlist members.",

--- a/src/lib/components/account/MembershipCard.svelte
+++ b/src/lib/components/account/MembershipCard.svelte
@@ -172,14 +172,22 @@
 			if (res.error || !res.data) {
 				throw new Error(backendMessage(res.error) || m['subscriptions.actions.resumeError']());
 			}
-			// See SubscribeDialog: `checkout_url` is nullable since FREE plans landed.
-			// Resuming a PENDING row has nowhere to go without a session URL.
-			if (!res.data.checkout_url) {
-				throw new Error(m['subscriptions.actions.resumeError']());
-			}
-			return { ...res.data, checkout_url: res.data.checkout_url };
+			return res.data;
 		},
 		onSuccess: (data) => {
+			// `checkout_url` is nullable since FREE plans landed (#832), and a null one
+			// means the subscribe answered without creating a Stripe session — the row
+			// it returns is already ACTIVE. This button should never be offered for
+			// such a plan (`getMemberActions` withdraws everything for a non-ONLINE
+			// row, and a FREE subscription is never PENDING because it is activated in
+			// the same transaction that creates it), but if the state ever arrives
+			// anyway, "could not resume the payment" would be a lie about a membership
+			// that is live. Settle the caches so the card re-renders the truth.
+			if (!data.checkout_url) {
+				void settleSubscriptionCaches(queryClient, data.subscription);
+				toast.success(m['subscriptions.actions.alreadyActive']());
+				return;
+			}
 			resuming = true;
 			// Hosted Stripe Checkout is another origin: a real document navigation.
 			window.location.href = data.checkout_url;

--- a/src/lib/components/members/PlanFormModal.svelte
+++ b/src/lib/components/members/PlanFormModal.svelte
@@ -14,6 +14,7 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Loader2 } from '@lucide/svelte';
+	import { untrack } from 'svelte';
 	import { CURRENCY_OPTIONS } from '$lib/utils/currencies';
 
 	export type PlanFormPayload = PlanCreateSchema;
@@ -33,10 +34,6 @@
 	let description = $state('');
 	let price = $state('0.00');
 	let currency = $state<string>('EUR');
-	// Widened to the generated enum when the backend added `lifetime` (non-renewing
-	// plans). The picker below still offers only month/year: authoring a lifetime or
-	// free plan is its own piece of work, and until it lands this state can only
-	// hold `lifetime` when editing a plan created outside this form.
 	let periodUnit = $state<PeriodUnit>('month');
 	let periodCount = $state(1);
 	let isActive = $state(true);
@@ -79,6 +76,43 @@
 		errors = {};
 	});
 
+	/**
+	 * The payment method the shape rules are judged against.
+	 *
+	 * It is immutable once a plan exists (`PlanUpdateSchema` has no
+	 * `payment_method`), so an edit is validated against the *plan's* method —
+	 * the radio group isn't even rendered then, and its state is only a leftover
+	 * from whatever was last created.
+	 */
+	const effectiveMethod = $derived<SubscriptionPaymentMethod>(
+		plan ? plan.payment_method : paymentMethod
+	);
+	const isFree = $derived(effectiveMethod === 'free');
+	const isOnline = $derived(effectiveMethod === 'online');
+	const isLifetime = $derived(periodUnit === 'lifetime');
+
+	/**
+	 * Keep the (method, price, cadence) triple coherent as the organizer types.
+	 *
+	 * `events.utils.subscription_plan_rules.validate_plan_shape` refuses a FREE
+	 * plan that isn't priced 0 *and* lifetime, and an ONLINE plan that is
+	 * lifetime — so those combinations are made unreachable here rather than
+	 * offered and then rejected. `validate()` still asserts them: this effect
+	 * cannot fire for a value the user never touched (e.g. a price typed before
+	 * switching to Free would be cleared here, but a stale one must not slip
+	 * through if the ordering ever changes).
+	 */
+	$effect(() => {
+		if (paymentMethod === 'free') {
+			price = '0.00';
+			periodUnit = 'lifetime';
+		} else if (paymentMethod === 'online' && untrack(() => periodUnit) === 'lifetime') {
+			// Only reachable by picking lifetime under Offline and then switching to
+			// Online — the option is withdrawn for Online, so it cannot be re-chosen.
+			periodUnit = 'month';
+		}
+	});
+
 	/** `null` = unlimited (field left empty or cleared). */
 	function normalizedCap(): number | null {
 		if (maxSubscriptions == null || maxSubscriptions === '') return null;
@@ -96,7 +130,28 @@
 			errors.price = m['orgAdmin.members.plans.form.errors.priceInvalid']();
 			return false;
 		}
-		if (!Number.isInteger(periodCount) || periodCount < 1 || periodCount > 120) {
+		// The three shape rules `validate_plan_shape` enforces server-side. The
+		// controls above already make each violation hard to reach, but a form that
+		// can submit something the backend can only refuse is a form that lies.
+		if (isFree && numeric !== 0) {
+			errors.price = m['orgAdmin.members.plans.form.errors.freePriceNotZero']();
+			return false;
+		}
+		if (isOnline && numeric <= 0) {
+			errors.price = m['orgAdmin.members.plans.form.errors.onlinePriceZero']();
+			return false;
+		}
+		if (isFree && !isLifetime) {
+			errors.period = m['orgAdmin.members.plans.form.errors.freeNeedsLifetime']();
+			return false;
+		}
+		if (isOnline && isLifetime) {
+			errors.period = m['orgAdmin.members.plans.form.errors.onlineNoLifetime']();
+			return false;
+		}
+		// A lifetime term never renews, so `period_count` describes nothing — the
+		// field is withdrawn from the form and its value is not asserted.
+		if (!isLifetime && (!Number.isInteger(periodCount) || periodCount < 1 || periodCount > 120)) {
 			errors.period = m['orgAdmin.members.plans.form.errors.periodInvalid']();
 			return false;
 		}
@@ -117,7 +172,9 @@
 			price,
 			currency: currency as PlanCreateSchema['currency'],
 			period_unit: periodUnit,
-			period_count: periodCount,
+			// A lifetime plan is never renewed, so the backend ignores this; pin it to
+			// 1 rather than shipping whatever the (hidden) field last held.
+			period_count: isLifetime ? 1 : periodCount,
 			is_active: isActive,
 			sales_status: salesPaused ? 'paused' : 'open',
 			max_subscriptions: normalizedCap(),
@@ -156,9 +213,13 @@
 				<div class="space-y-1 text-sm">
 					<span class="font-medium">{m['orgAdmin.members.plans.form.paymentMethod']()}</span>
 					<span class="text-muted-foreground">
-						{plan.payment_method === 'online'
-							? m['orgAdmin.members.plans.form.paymentOnline']()
-							: m['orgAdmin.members.plans.form.paymentOffline']()}
+						{#if plan.payment_method === 'online'}
+							{m['orgAdmin.members.plans.form.paymentOnline']()}
+						{:else if plan.payment_method === 'free'}
+							{m['orgAdmin.members.plans.form.paymentFree']()}
+						{:else}
+							{m['orgAdmin.members.plans.form.paymentOffline']()}
+						{/if}
 					</span>
 					<p class="text-xs text-muted-foreground">
 						{m['orgAdmin.members.plans.form.paymentMethodImmutable']()}
@@ -169,7 +230,8 @@
 					<legend class="text-sm font-medium">
 						{m['orgAdmin.members.plans.form.paymentMethod']()}
 					</legend>
-					<div class="flex gap-4">
+					<!-- Wraps on a phone: three options no longer fit one row. -->
+					<div class="flex flex-wrap gap-x-4 gap-y-2">
 						<label class="flex items-center gap-2 text-sm">
 							<input
 								type="radio"
@@ -193,12 +255,29 @@
 							/>
 							{m['orgAdmin.members.plans.form.paymentOnline']()}
 						</label>
+						<!-- No Stripe gate: a FREE plan has no Stripe object at all, so it is
+						     offered even to an organization that never connected an account. -->
+						<label class="flex items-center gap-2 text-sm">
+							<input
+								type="radio"
+								name="payment-method"
+								value="free"
+								bind:group={paymentMethod}
+								disabled={isSaving}
+							/>
+							{m['orgAdmin.members.plans.form.paymentFree']()}
+						</label>
 					</div>
 					<p class="text-xs text-muted-foreground">
 						{organization.is_stripe_connected
 							? m['orgAdmin.members.plans.form.paymentMethodHelp']()
 							: m['orgAdmin.members.plans.form.paymentOnlineNeedsStripe']()}
 					</p>
+					{#if isFree}
+						<p class="text-xs text-muted-foreground">
+							{m['orgAdmin.members.plans.form.paymentFreeHelp']()}
+						</p>
+					{/if}
 				</fieldset>
 			{/if}
 
@@ -210,6 +289,10 @@
 			<div class="grid grid-cols-2 gap-3">
 				<div class="space-y-1">
 					<Label for="plan-price">{m['orgAdmin.members.plans.form.price']()}</Label>
+					<!-- A FREE plan is priced 0 by definition (the backend refuses anything
+					     else), so the field is locked rather than left to be rejected. The
+					     reason is announced with it via `aria-describedby`, not left to the
+					     greyed-out styling. -->
 					<Input
 						id="plan-price"
 						type="number"
@@ -217,7 +300,8 @@
 						step="0.01"
 						bind:value={price}
 						required
-						disabled={isSaving}
+						disabled={isSaving || isFree}
+						aria-describedby={isFree ? 'plan-shape-locked' : undefined}
 					/>
 				</div>
 				<div class="space-y-1">
@@ -237,31 +321,50 @@
 			{#if errors.price}<p class="text-sm text-destructive">{errors.price}</p>{/if}
 
 			<div class="grid grid-cols-2 gap-3">
-				<div class="space-y-1">
-					<Label for="plan-period-count">{m['orgAdmin.members.plans.form.periodCount']()}</Label>
-					<Input
-						id="plan-period-count"
-						type="number"
-						min="1"
-						max="120"
-						bind:value={periodCount}
-						required
-						disabled={isSaving}
-					/>
-				</div>
+				{#if !isLifetime}
+					<div class="space-y-1">
+						<Label for="plan-period-count">{m['orgAdmin.members.plans.form.periodCount']()}</Label>
+						<Input
+							id="plan-period-count"
+							type="number"
+							min="1"
+							max="120"
+							bind:value={periodCount}
+							required
+							disabled={isSaving}
+						/>
+					</div>
+				{/if}
 				<div class="space-y-1">
 					<Label for="plan-period-unit">{m['orgAdmin.members.plans.form.periodUnit']()}</Label>
 					<select
 						id="plan-period-unit"
 						bind:value={periodUnit}
-						disabled={isSaving}
+						disabled={isSaving || isFree}
+						aria-describedby={isFree ? 'plan-shape-locked' : undefined}
 						class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 					>
 						<option value="month">{m['orgAdmin.members.plans.form.periodMonth']()}</option>
 						<option value="year">{m['orgAdmin.members.plans.form.periodYear']()}</option>
+						<!-- Withdrawn for ONLINE: Stripe bills monthly or yearly, so the
+						     backend refuses a lifetime Stripe plan outright. -->
+						{#if !isOnline}
+							<option value="lifetime">
+								{m['orgAdmin.members.plans.form.periodLifetime']()}
+							</option>
+						{/if}
 					</select>
 				</div>
 			</div>
+			{#if isFree}
+				<p id="plan-shape-locked" class="text-xs text-muted-foreground">
+					{m['orgAdmin.members.plans.form.freeShapeLocked']()}
+				</p>
+			{:else if isLifetime}
+				<p class="text-xs text-muted-foreground">
+					{m['orgAdmin.members.plans.form.lifetimeNoCount']()}
+				</p>
+			{/if}
 			{#if errors.period}<p class="text-sm text-destructive">{errors.period}</p>{/if}
 
 			<div class="space-y-1">

--- a/src/lib/components/members/PlanFormModal.test.ts
+++ b/src/lib/components/members/PlanFormModal.test.ts
@@ -20,6 +20,13 @@ async function renderModal(props: ComponentProps<typeof PlanFormModal>) {
 	return result;
 }
 
+/** Replace the price the form starts at (`0.00`) with `value`. */
+async function setPrice(user: ReturnType<typeof userEvent.setup>, value: string): Promise<void> {
+	const price = screen.getByLabelText(/^price$/i);
+	await user.clear(price);
+	await user.type(price, value);
+}
+
 describe('PlanFormModal payment method', () => {
 	it('disables the online option when the org has no Stripe account', () => {
 		render(PlanFormModal, {
@@ -47,6 +54,9 @@ describe('PlanFormModal payment method', () => {
 		});
 		await user.type(screen.getByLabelText(/name/i), 'Monthly');
 		await user.click(screen.getByRole('radio', { name: /online/i }));
+		// An online plan may not be priced 0 (`validate_plan_shape`), and the form
+		// starts at 0.00 — so a real price is part of the minimum valid input.
+		await setPrice(user, '10');
 		await user.type(screen.getByLabelText(/maximum subscriptions/i), '20');
 		await user.click(screen.getByRole('button', { name: /create/i }));
 		expect(onSave).toHaveBeenCalledWith(
@@ -123,5 +133,216 @@ describe('PlanFormModal payment method', () => {
 		});
 		expect(screen.queryByRole('radio', { name: /online/i })).toBeNull();
 		expect(screen.getByText(/archive and recreate/i)).toBeInTheDocument();
+	});
+});
+
+/**
+ * The three shape rules `events.utils.subscription_plan_rules.validate_plan_shape`
+ * enforces: FREE ⇒ price 0 AND lifetime; ONLINE ⇒ price > 0 AND not lifetime;
+ * OFFLINE ⇒ anything. The form has to make the invalid combinations unreachable
+ * *and* refuse them if they are reached anyway — a form that submits something
+ * the backend can only 400 is a form that lies about what it accepts.
+ */
+describe('PlanFormModal free and lifetime plans', () => {
+	function makeFreePlan(overrides: Record<string, unknown> = {}) {
+		return {
+			id: 'p1',
+			tier_id: 't1',
+			tier_name: 'Gold',
+			name: 'Supporter',
+			price: '0.00',
+			currency: 'EUR',
+			period_unit: 'lifetime',
+			period_count: 1,
+			is_active: true,
+			payment_method: 'free',
+			sales_status: 'open',
+			max_subscriptions: null,
+			active_subscription_count: 0,
+			description: null,
+			...overrides
+		} as never;
+	}
+
+	// A FREE plan needs no Stripe account: there is no product, price or session.
+	it('offers Free even when the organization has no Stripe account', () => {
+		render(PlanFormModal, {
+			props: {
+				plan: null,
+				open: true,
+				onClose: vi.fn(),
+				onSave: vi.fn(),
+				organization: orgNotConnected
+			}
+		});
+		expect(screen.getByRole('radio', { name: /free/i })).toBeEnabled();
+	});
+
+	it('locks price and period to 0/lifetime when Free is chosen, and says why', async () => {
+		const user = userEvent.setup();
+		await renderModal({
+			plan: null,
+			open: true,
+			onClose: vi.fn(),
+			onSave: vi.fn(),
+			organization: orgConnected
+		});
+
+		await user.click(screen.getByRole('radio', { name: /free/i }));
+
+		const price = screen.getByLabelText(/^price$/i);
+		const period = screen.getByLabelText(/^period$/i);
+		expect(price).toBeDisabled();
+		expect(price).toHaveValue(0);
+		expect(period).toBeDisabled();
+		expect(period).toHaveValue('lifetime');
+		// The reason a disabled control is disabled has to reach a screen reader,
+		// not just the greyed-out pixels.
+		const explanation = screen.getByText(/always priced 0 and always last a lifetime/i);
+		expect(price).toHaveAttribute('aria-describedby', explanation.id);
+		expect(period).toHaveAttribute('aria-describedby', explanation.id);
+	});
+
+	it('creates a free plan priced 0 on a lifetime period', async () => {
+		const user = userEvent.setup();
+		const onSave = vi.fn();
+		await renderModal({
+			plan: null,
+			open: true,
+			onClose: vi.fn(),
+			onSave,
+			organization: orgConnected
+		});
+
+		await user.type(screen.getByLabelText(/name/i), 'Supporter');
+		await user.click(screen.getByRole('radio', { name: /free/i }));
+		await user.click(screen.getByRole('button', { name: /create/i }));
+
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({
+				payment_method: 'free',
+				price: '0.00',
+				period_unit: 'lifetime',
+				period_count: 1
+			})
+		);
+	});
+
+	// `period_count` describes a renewal frequency, and a lifetime plan has none.
+	it('withdraws the period count for a lifetime plan and explains the absence', async () => {
+		const user = userEvent.setup();
+		await renderModal({
+			plan: null,
+			open: true,
+			onClose: vi.fn(),
+			onSave: vi.fn(),
+			organization: orgConnected
+		});
+		expect(screen.getByLabelText(/^every$/i)).toBeInTheDocument();
+
+		await user.selectOptions(screen.getByLabelText(/^period$/i), 'lifetime');
+
+		expect(screen.queryByLabelText(/^every$/i)).toBeNull();
+		expect(screen.getByText(/never renews, so there's no billing frequency/i)).toBeInTheDocument();
+	});
+
+	// Stripe bills monthly or yearly; the backend refuses a lifetime online plan.
+	it('does not offer lifetime for an online plan', async () => {
+		const user = userEvent.setup();
+		await renderModal({
+			plan: null,
+			open: true,
+			onClose: vi.fn(),
+			onSave: vi.fn(),
+			organization: orgConnected
+		});
+
+		expect(screen.getByRole('option', { name: /lifetime/i })).toBeInTheDocument();
+		await user.click(screen.getByRole('radio', { name: /online/i }));
+
+		expect(screen.queryByRole('option', { name: /lifetime/i })).toBeNull();
+	});
+
+	// Switching Offline→Online with lifetime already picked is the one way to hold
+	// a combination the Online option itself never offers.
+	it('falls back to a monthly period when a lifetime plan is switched to online', async () => {
+		const user = userEvent.setup();
+		const onSave = vi.fn();
+		await renderModal({
+			plan: null,
+			open: true,
+			onClose: vi.fn(),
+			onSave,
+			organization: orgConnected
+		});
+
+		await user.type(screen.getByLabelText(/name/i), 'Annual');
+		await user.selectOptions(screen.getByLabelText(/^period$/i), 'lifetime');
+		await user.click(screen.getByRole('radio', { name: /online/i }));
+		await setPrice(user, '10');
+		await user.click(screen.getByRole('button', { name: /create/i }));
+
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({ payment_method: 'online', period_unit: 'month' })
+		);
+	});
+
+	// The backend's own rule: an online plan priced 0 would create a Stripe Price
+	// of zero. The remedy is a free plan, which the message names.
+	it('refuses a zero-priced online plan and points at the free option', async () => {
+		const user = userEvent.setup();
+		const onSave = vi.fn();
+		await renderModal({
+			plan: null,
+			open: true,
+			onClose: vi.fn(),
+			onSave,
+			organization: orgConnected
+		});
+
+		await user.type(screen.getByLabelText(/name/i), 'Monthly');
+		await user.click(screen.getByRole('radio', { name: /online/i }));
+		await user.click(screen.getByRole('button', { name: /create/i }));
+
+		expect(onSave).not.toHaveBeenCalled();
+		expect(screen.getByText(/must be priced above 0/i)).toBeInTheDocument();
+	});
+
+	// `payment_method` is not patchable, so an edit is judged against the plan's
+	// own method — and a free plan's locked fields stay locked.
+	it('keeps a free plan locked when editing it', () => {
+		render(PlanFormModal, {
+			props: {
+				plan: makeFreePlan(),
+				open: true,
+				onClose: vi.fn(),
+				onSave: vi.fn(),
+				organization: orgConnected
+			}
+		});
+
+		expect(screen.getByText('Free — members join at no cost')).toBeInTheDocument();
+		expect(screen.getByLabelText(/^price$/i)).toBeDisabled();
+		expect(screen.getByLabelText(/^period$/i)).toBeDisabled();
+		expect(screen.queryByLabelText(/^every$/i)).toBeNull();
+	});
+
+	// Before #724 the picker offered only month/year, so an externally created
+	// lifetime plan opened this form with a blank period.
+	it('shows the lifetime period when editing an offline lifetime plan', () => {
+		render(PlanFormModal, {
+			props: {
+				plan: makeFreePlan({ payment_method: 'offline', price: '50.00' }),
+				open: true,
+				onClose: vi.fn(),
+				onSave: vi.fn(),
+				organization: orgConnected
+			}
+		});
+
+		const period = screen.getByLabelText(/^period$/i);
+		expect(period).toHaveValue('lifetime');
+		expect(period).toBeEnabled();
+		expect(screen.getByLabelText(/^price$/i)).toBeEnabled();
 	});
 });

--- a/src/lib/components/members/PlansList.svelte
+++ b/src/lib/components/members/PlansList.svelte
@@ -21,7 +21,7 @@
 	import { AlertTriangle, Pencil, Archive, Trash2, Plus, Loader2, RefreshCw } from '@lucide/svelte';
 	import PlanFormModal, { type PlanFormPayload } from './PlanFormModal.svelte';
 	import MigrateSubscribersDialog from './MigrateSubscribersDialog.svelte';
-	import { formatPlanPrice } from '$lib/utils/subscriptions';
+	import { formatPlanPrice, isLifetimePlan } from '$lib/utils/subscriptions';
 	import { backendMessage } from '$lib/utils/api-error-detail';
 
 	interface Props {
@@ -231,10 +231,22 @@
 								<p class="text-sm text-muted-foreground">{formatPlanPrice(p)}</p>
 								<div class="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
 									<span class="rounded-full bg-muted px-2 py-0.5 text-muted-foreground">
-										{p.payment_method === 'online'
-											? m['orgAdmin.members.plans.badge.online']()
-											: m['orgAdmin.members.plans.badge.offline']()}
+										{#if p.payment_method === 'online'}
+											{m['orgAdmin.members.plans.badge.online']()}
+										{:else if p.payment_method === 'free'}
+											{m['orgAdmin.members.plans.badge.free']()}
+										{:else}
+											{m['orgAdmin.members.plans.badge.offline']()}
+										{/if}
 									</span>
+									<!-- A lifetime term has no renewal to quote, and the price line
+									     above says so too ("Free" / "€50.00 · one-time") — this names
+									     the fact rather than leaving it implied by an absence. -->
+									{#if isLifetimePlan(p)}
+										<span class="rounded-full bg-muted px-2 py-0.5 text-muted-foreground">
+											{m['orgAdmin.members.plans.badge.lifetime']()}
+										</span>
+									{/if}
 									<span class="text-muted-foreground">
 										{p.max_subscriptions != null
 											? m['orgAdmin.members.plans.occupancyCapped']({

--- a/src/lib/components/members/PlansList.test.ts
+++ b/src/lib/components/members/PlansList.test.ts
@@ -172,3 +172,41 @@ describe('PlansList delete confirmation', () => {
 		expect(screen.queryByText(/has subscribers/i)).not.toBeInTheDocument();
 	});
 });
+
+// A lifetime free plan rendered as "€0.00 / month" is wrong twice over: it
+// quotes a charge that never happens, on a cadence that never comes round.
+describe('PlansList row labelling', () => {
+	it('labels a free lifetime plan as free and non-expiring', async () => {
+		arrangePlans([
+			makePlan({
+				name: 'Supporter',
+				payment_method: 'free',
+				price: '0.00',
+				period_unit: 'lifetime'
+			})
+		]);
+		renderList();
+
+		expect(await screen.findByText('Free')).toBeInTheDocument();
+		expect(screen.getByText('Free · self-serve')).toBeInTheDocument();
+		expect(screen.getByText('Never expires')).toBeInTheDocument();
+		expect(screen.queryByText(/€0\.00/)).not.toBeInTheDocument();
+	});
+
+	it('quotes a paid lifetime plan as a one-time amount', async () => {
+		arrangePlans([makePlan({ price: '50.00', period_unit: 'lifetime' })]);
+		renderList();
+
+		expect(await screen.findByText('€50.00 · one-time')).toBeInTheDocument();
+		expect(screen.getByText('Offline · manual')).toBeInTheDocument();
+		expect(screen.getByText('Never expires')).toBeInTheDocument();
+	});
+
+	it('leaves a recurring plan reading as a rate', async () => {
+		arrangePlans([makePlan()]);
+		renderList();
+
+		expect(await screen.findByText('€10.00 / month')).toBeInTheDocument();
+		expect(screen.queryByText('Never expires')).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/components/organization/membership/CheckoutReturnCard.svelte
+++ b/src/lib/components/organization/membership/CheckoutReturnCard.svelte
@@ -179,11 +179,16 @@
 			if (res.error || !res.data) {
 				throw new Error(backendMessage(res.error) || m['subscribe.error']());
 			}
-			// See SubscribeDialog: `checkout_url` is nullable since FREE plans landed,
-			// and resuming an abandoned Checkout has nowhere to go without one.
-			// Unreachable until free plans are authorable here; loud rather than mute.
+			// `checkout_url` is nullable since FREE plans landed (#832). A null one is
+			// not a failure and has nothing to resume: the row it comes back with is
+			// already ACTIVE. (Practically unreachable — only a `pending` row reaches
+			// this button, and a FREE subscription is created ACTIVE — but reporting
+			// "could not start the checkout" for a live membership would be a lie.)
+			// The confirming state is the honest landing: its poll sees `active` on
+			// its first tick and runs the same invalidations the Stripe path does.
 			if (!res.data.checkout_url) {
-				throw new Error(m['subscribe.error']());
+				enterActivationPending(null);
+				return null;
 			}
 			return { ...res.data, checkout_url: res.data.checkout_url };
 		},

--- a/src/lib/components/organization/membership/PlanCard.svelte
+++ b/src/lib/components/organization/membership/PlanCard.svelte
@@ -4,7 +4,12 @@
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { canSwitchToPlan, formatPlanPrice } from '$lib/utils/subscriptions';
+	import {
+		canSwitchToPlan,
+		formatPlanPrice,
+		isFreePlan,
+		isLifetimePlan
+	} from '$lib/utils/subscriptions';
 	import { resolve } from '$app/paths';
 
 	interface Props {
@@ -45,6 +50,11 @@
 	 *
 	 * `none` covers a plan the backend exposes without an id: it cannot be
 	 * subscribed to, and a CTA would only produce a failed checkout.
+	 *
+	 * Only OFFLINE is a dead end. A FREE plan is un-billed too, but it is
+	 * *member* self-serve — `POST …/subscribe` accepts it and activates the
+	 * subscription on the spot — so it takes the ordinary join path, with the
+	 * label and dialog copy adjusted for the absent charge.
 	 */
 	const action = $derived.by(() => {
 		if (subscription) {
@@ -77,6 +87,11 @@
 	 * points at the account hub, where the resume-payment action lives.
 	 */
 	const isPendingCheckout = $derived(subscription?.status === 'pending');
+
+	const isFree = $derived(isFreePlan(plan));
+	/** A non-renewing term — said in words, because the price line no longer
+	    carries a cadence to imply it. */
+	const neverExpires = $derived(isLifetimePlan(plan));
 
 	/** Only linked when the change-plan flow would really offer this plan. */
 	const canSwitch = $derived(subscription ? canSwitchToPlan(subscription, plan) : false);
@@ -111,6 +126,10 @@
 		</div>
 
 		<p class="text-xl font-semibold">{formatPlanPrice(plan)}</p>
+
+		{#if neverExpires}
+			<p class="-mt-2 text-sm text-muted-foreground">{m['subscriptions.neverExpires']()}</p>
+		{/if}
 
 		{#if plan.description}
 			<p class="whitespace-pre-line text-sm text-muted-foreground">{plan.description}</p>
@@ -154,13 +173,16 @@
 				     transient state on a control that keeps its label and its box, so
 				     nothing shifts and nothing is conveyed by colour alone. -->
 				<Button class="w-full sm:w-auto" onclick={handleSubscribe} disabled={subscriptionLoading}>
-					{m['membershipPlans.subscribeCta']()}
+					{isFree ? m['membershipPlans.joinFreeCta']() : m['membershipPlans.subscribeCta']()}
 				</Button>
+				{#if isFree}
+					<p class="mt-2 text-sm text-muted-foreground">{m['membershipPlans.freeHelper']()}</p>
+				{/if}
 			{:else if action === 'login'}
 				<!-- A real link, not a scripted redirect: it survives no-JS,
 				     middle-click and "open in new tab". -->
 				<Button href={loginHref} class="w-full sm:w-auto">
-					{m['membershipPlans.loginToSubscribe']()}
+					{isFree ? m['membershipPlans.loginToJoin']() : m['membershipPlans.loginToSubscribe']()}
 				</Button>
 			{/if}
 		</div>

--- a/src/lib/components/organization/membership/PlanCard.test.ts
+++ b/src/lib/components/organization/membership/PlanCard.test.ts
@@ -236,4 +236,61 @@ describe('PlanCard', () => {
 
 		expect(screen.getByRole('button', { name: /subscribe/i })).toBeDisabled();
 	});
+
+	// A FREE plan is un-billed like an OFFLINE one but, unlike it, members take it
+	// themselves: `POST …/subscribe` accepts it and activates on the spot. Routing
+	// it into the "managed by the organization" dead end would hide a plan the
+	// backend is willing to grant.
+	describe('a free plan', () => {
+		const freePlan = () =>
+			makePlan({
+				name: 'Supporter',
+				payment_method: 'free',
+				price: '0.00',
+				period_unit: 'lifetime'
+			});
+
+		it('states the price as Free and says the membership never expires', () => {
+			renderCard({ plan: freePlan() });
+
+			expect(screen.getByText('Free')).toBeInTheDocument();
+			expect(screen.getByText('Never expires')).toBeInTheDocument();
+			expect(screen.queryByText(/€0\.00/)).toBeNull();
+			expect(screen.queryByText(/managed by the organization/i)).toBeNull();
+		});
+
+		it('offers a join CTA that hands the plan to the caller', async () => {
+			const user = userEvent.setup();
+			const { onSubscribe } = renderCard({ plan: freePlan() });
+
+			await user.click(screen.getByRole('button', { name: /join for free/i }));
+
+			expect(onSubscribe).toHaveBeenCalledWith(expect.objectContaining({ id: 'plan-1' }));
+		});
+
+		it('sends a guest to log in with join wording, not subscribe wording', () => {
+			renderCard({ plan: freePlan(), isAuthenticated: false });
+
+			const link = screen.getByRole('link', { name: /log in to join/i });
+			expect(link).toHaveAttribute('href', '/login?returnUrl=%2Forg%2Facme');
+		});
+
+		// Plan-level stops still apply: a capped free plan can fill up.
+		it('still withdraws the CTA when it is sold out', () => {
+			renderCard({ plan: makePlan({ payment_method: 'free', price: '0.00', sold_out: true }) });
+
+			expect(screen.getByText('Sold out')).toBeInTheDocument();
+			expect(screen.queryByRole('button')).toBeNull();
+		});
+	});
+
+	// An OFFLINE plan may also be lifetime — it just has a real price to state.
+	it('quotes a paid lifetime plan as a one-time amount', () => {
+		renderCard({
+			plan: makePlan({ payment_method: 'offline', price: '50.00', period_unit: 'lifetime' })
+		});
+
+		expect(screen.getByText('€50.00 · one-time')).toBeInTheDocument();
+		expect(screen.getByText('Never expires')).toBeInTheDocument();
+	});
 });

--- a/src/lib/components/organization/membership/SubscribeDialog.svelte
+++ b/src/lib/components/organization/membership/SubscribeDialog.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { createMutation } from '@tanstack/svelte-query';
+	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
+	import { invalidateAll } from '$app/navigation';
 	import { mesubscriptionsSubscribe } from '$lib/api/generated/sdk.gen';
 	import type { PublicPlanSchema } from '$lib/api/generated/types.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { backendMessage } from '$lib/utils/api-error-detail';
+	import { settleSubscriptionCaches } from '$lib/utils/subscription-cache';
 	import {
 		Dialog,
 		DialogContent,
@@ -15,7 +17,12 @@
 	} from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
-	import { formatPlanPrice, isSubscriptionActivationPending } from '$lib/utils/subscriptions';
+	import {
+		formatPlanPrice,
+		isFreePlan,
+		isLifetimePlan,
+		isSubscriptionActivationPending
+	} from '$lib/utils/subscriptions';
 	import { formatMoney } from '$lib/utils/format';
 	import { Loader2 } from '@lucide/svelte';
 
@@ -58,6 +65,17 @@
 	}: Props = $props();
 
 	const accessToken = $derived(authStore.accessToken);
+	const queryClient = useQueryClient();
+
+	/**
+	 * A FREE plan: nothing is charged, no Stripe session is created, and the
+	 * subscription comes back already ACTIVE. Every line of copy below that
+	 * quotes a charge, a renewal or Stripe is withdrawn for it — none of them
+	 * would be true.
+	 */
+	const isFree = $derived(isFreePlan(plan));
+	/** LIFETIME: never renews, so there is no cadence to promise. */
+	const neverExpires = $derived(isLifetimePlan(plan));
 
 	let errorMessage = $state<string | null>(null);
 	// Set on success and never cleared: the browser is on its way to Stripe, so
@@ -76,6 +94,11 @@
 	let activationPending = $state(false);
 	/** The backend's translated explanation for that 409, when it sent one. */
 	let activationDetail = $state<string | null>(null);
+
+	// The FREE outcome: `checkout_url` was null, so the subscription is already
+	// ACTIVE and the membership granted. There is nowhere to redirect to, so the
+	// dialog itself has to report the result.
+	let joined = $state(false);
 
 	const priceLine = $derived(m['subscribe.priceLine']({ price: formatPlanPrice(plan) }));
 
@@ -147,18 +170,30 @@
 			if (res.error || !res.data) {
 				throw new Error(backendMessage(res.error) || m['subscribe.error']());
 			}
-			// `checkout_url` became nullable when the backend added FREE plans, which
-			// activate on the spot with no Stripe session. This dialog only knows how
-			// to hand off to Checkout, and nothing in this UI can create a free plan
-			// yet, so the case is unreachable today — surface it rather than
-			// silently doing nothing if that ever stops being true.
+			// A null `checkout_url` is the FREE answer, not a failure: there is no
+			// Stripe object to pay at, `subscription.status` is already `active` and
+			// the membership has been granted. Settle the member-facing caches from
+			// the response body itself — every surface that cached "not a member"
+			// (this org page's inline card, the account hub, the join-eligibility
+			// verdict, and the server-rendered `isMember`) is refreshed here, because
+			// unlike the Stripe path no return-page mount will do it later.
 			if (!res.data.checkout_url) {
-				throw new Error(m['subscribe.error']());
+				await settleSubscriptionCaches(queryClient, res.data.subscription);
+				// Prefix invalidations: this dialog is handed an org *id*, and the
+				// eligibility/admin caches are keyed by slug — so the whole prefix goes,
+				// rather than guessing a key. It costs a refetch of a couple of active
+				// queries, once, at the moment the member joins.
+				queryClient.invalidateQueries({ queryKey: ['org'] });
+				queryClient.invalidateQueries({ queryKey: ['organization'] });
+				await invalidateAll();
+				joined = true;
+				return null;
 			}
 			return { ...res.data, checkout_url: res.data.checkout_url };
 		},
 		onSuccess: (data) => {
-			// `null` is the activation-pending answer: no Checkout session to go to.
+			// `null` is the activation-pending or the free-join answer: either way
+			// there is no Checkout session to go to, and the body already says so.
 			if (!data) return;
 			redirecting = true;
 			// Hosted Stripe Checkout lives on another origin, so this is a real
@@ -194,7 +229,11 @@
 		showCloseButton={!isBusy}
 	>
 		<DialogHeader>
-			<DialogTitle>{m['subscribe.title']({ plan: plan.name })}</DialogTitle>
+			<DialogTitle>
+				{isFree
+					? m['subscribe.titleFree']({ plan: plan.name })
+					: m['subscribe.title']({ plan: plan.name })}
+			</DialogTitle>
 			<DialogDescription>{tierName}</DialogDescription>
 		</DialogHeader>
 
@@ -208,35 +247,56 @@
 					<p class="text-sm text-muted-foreground">{activationDetail}</p>
 				{/if}
 			</div>
+		{:else if joined}
+			<!-- The free join is already done server-side; this is the only place it
+			     can be reported, since there is no Stripe return page to land on. -->
+			<div class="space-y-1" role="status" aria-live="polite">
+				<h3 class="text-lg font-semibold">{m['subscribe.return.welcome']()}</h3>
+				<p class="text-sm text-muted-foreground">{m['subscribe.return.welcomeBody']()}</p>
+			</div>
 		{:else}
 			<div class="space-y-4">
 				<div class="rounded-lg border bg-muted/40 p-3">
 					<p class="text-sm text-muted-foreground">{organizationName}</p>
 					<p class="text-lg font-semibold">{priceLine}</p>
 					<p class="mt-1 text-sm text-muted-foreground">
-						{m['subscribe.firstCharge']({ price: firstChargeAmount })}
+						{isFree
+							? m['subscribe.freeNoCharge']()
+							: m['subscribe.firstCharge']({ price: firstChargeAmount })}
 					</p>
 				</div>
 
-				<p class="text-sm text-muted-foreground">{m['subscribe.autoRenew']({ cadence })}</p>
+				<p class="text-sm text-muted-foreground">
+					{#if neverExpires}
+						{m['subscribe.neverRenews']()}
+					{:else}
+						{m['subscribe.autoRenew']({ cadence })}
+					{/if}
+				</p>
 
 				<!-- The one canonical billing disclosure. Collapsed by default, and
-				     deliberately not repeated on any other membership surface. -->
-				<details class="rounded-lg border p-3">
-					<summary
-						class="cursor-pointer text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-					>
-						{m['subscribe.billing.title']()}
-					</summary>
-					<ul class="ml-4 mt-2 list-disc space-y-1 text-sm text-muted-foreground">
-						<li>{m['subscribe.billing.renewal']()}</li>
-						<li>{gracePeriodLine}</li>
-						<li>{m['subscribe.billing.cancelling']()}</li>
-						<li>{revivalLine}</li>
-					</ul>
-				</details>
+				     deliberately not repeated on any other membership surface.
+				     Withdrawn for a FREE plan: all four bullets describe renewals,
+				     failed payments and revival windows that can never happen when
+				     nothing is ever charged. -->
+				{#if !isFree}
+					<details class="rounded-lg border p-3">
+						<summary
+							class="cursor-pointer text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						>
+							{m['subscribe.billing.title']()}
+						</summary>
+						<ul class="ml-4 mt-2 list-disc space-y-1 text-sm text-muted-foreground">
+							<li>{m['subscribe.billing.renewal']()}</li>
+							<li>{gracePeriodLine}</li>
+							<li>{m['subscribe.billing.cancelling']()}</li>
+							<li>{revivalLine}</li>
+						</ul>
+					</details>
+				{/if}
 
-				{#if refundPolicy}
+				<!-- Nothing was paid, so a refund policy has nothing to speak about. -->
+				{#if refundPolicy && !isFree}
 					<details class="rounded-lg border p-3">
 						<summary
 							class="cursor-pointer text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
@@ -247,7 +307,11 @@
 					</details>
 				{/if}
 
-				<p class="text-xs text-muted-foreground">{m['subscribe.stripeDisclaimer']()}</p>
+				<!-- No Stripe object is involved in a free plan; saying otherwise would
+				     imply a payment step that never comes. -->
+				{#if !isFree}
+					<p class="text-xs text-muted-foreground">{m['subscribe.stripeDisclaimer']()}</p>
+				{/if}
 
 				{#if errorMessage}
 					<p role="alert" class="text-sm font-medium text-destructive">{errorMessage}</p>
@@ -256,9 +320,10 @@
 		{/if}
 
 		<DialogFooter class="gap-2">
-			{#if activationPending}
-				<!-- No retry: a second attempt can only hit the same 409 until the
-				     webhook lands. Dismissing is the only useful action left. -->
+			{#if activationPending || joined}
+				<!-- Nothing left to press: a second attempt can only hit the same 409
+				     until the webhook lands, and a completed free join would only be
+				     refused as a duplicate subscription. -->
 				<Button variant="outline" onclick={() => handleOpenChange(false)}>
 					{m['common.close']()}
 				</Button>
@@ -270,7 +335,7 @@
 					{#if isBusy}
 						<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
 					{/if}
-					{m['subscribe.confirmCta']()}
+					{isFree ? m['subscribe.confirmFreeCta']() : m['subscribe.confirmCta']()}
 				</Button>
 			{/if}
 		</DialogFooter>

--- a/src/lib/components/organization/membership/SubscribeDialog.test.ts
+++ b/src/lib/components/organization/membership/SubscribeDialog.test.ts
@@ -5,6 +5,7 @@ import { QueryClient } from '@tanstack/svelte-query';
 import SubscribeDialog from './SubscribeDialog.svelte';
 import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
 import { mesubscriptionsSubscribe } from '$lib/api/generated/sdk.gen';
+import { invalidateAll } from '$app/navigation';
 import type { PublicPlanSchema } from '$lib/api/generated/types.gen';
 
 vi.mock('$lib/api/generated/sdk.gen', () => ({
@@ -13,6 +14,12 @@ vi.mock('$lib/api/generated/sdk.gen', () => ({
 
 vi.mock('$lib/stores/auth.svelte', () => ({
 	authStore: { accessToken: 'test-token' }
+}));
+
+// A free join grants the membership server-side, so the page's server load —
+// which decided `isMember` before it existed — has to be re-run.
+vi.mock('$app/navigation', () => ({
+	invalidateAll: vi.fn()
 }));
 
 type Plan = PublicPlanSchema & { id: string };
@@ -345,6 +352,125 @@ describe('SubscribeDialog', () => {
 			});
 			expect(screen.queryByRole('status')).toBeNull();
 			expect(screen.getByRole('button', { name: /continue to payment/i })).toBeInTheDocument();
+		});
+	});
+
+	// A FREE plan has no Stripe object: `checkout_url` comes back null and the
+	// subscription is already ACTIVE. Every line that quotes a charge, a renewal
+	// or Stripe would be false, and there is no return page to report the result,
+	// so the dialog has to do it itself.
+	describe('a free plan', () => {
+		const freePlan = () =>
+			makePlan({
+				name: 'Supporter',
+				payment_method: 'free',
+				price: '0.00',
+				period_unit: 'lifetime'
+			});
+
+		/** The FREE answer: no session, and the row already active. */
+		function mockFreeSubscribe() {
+			vi.mocked(mesubscriptionsSubscribe).mockResolvedValue({
+				data: {
+					subscription: {
+						id: 's1',
+						organization_id: 'org-1',
+						plan_id: 'plan-1',
+						status: 'active',
+						current_period_end: null
+					},
+					checkout_url: null
+				},
+				error: undefined,
+				response: { ok: true } as unknown as Response
+			} as unknown as Awaited<ReturnType<typeof mesubscriptionsSubscribe>>);
+		}
+
+		it('withdraws every charge, renewal and Stripe claim', () => {
+			renderDialog({ plan: freePlan(), refundPolicy: 'No refunds after 14 days.' });
+
+			expect(screen.getByRole('heading', { name: /join supporter/i })).toBeInTheDocument();
+			expect(screen.getByText('Free')).toBeInTheDocument();
+			expect(screen.getByText(/there's nothing to pay/i)).toBeInTheDocument();
+			expect(screen.getByText(/never expires and is never renewed/i)).toBeInTheDocument();
+			expect(screen.queryByText(/you'll be charged/i)).toBeNull();
+			expect(screen.queryByText(/renews automatically/i)).toBeNull();
+			expect(screen.queryByText(/how billing works/i)).toBeNull();
+			expect(screen.queryByText(/refund policy/i)).toBeNull();
+			expect(screen.queryByText(/processed securely by stripe/i)).toBeNull();
+			expect(screen.getByRole('button', { name: /join now/i })).toBeInTheDocument();
+		});
+
+		it('reports the membership as live instead of navigating anywhere', async () => {
+			const user = userEvent.setup();
+			mockFreeSubscribe();
+			renderDialog({ plan: freePlan() });
+
+			await user.click(screen.getByRole('button', { name: /join now/i }));
+
+			await waitFor(() => {
+				expect(screen.getByRole('status')).toHaveTextContent(/welcome, member/i);
+			});
+			expect(screen.queryByRole('alert')).toBeNull();
+			// No Checkout session exists, so nothing may replace the document.
+			expect(window.location.href).toBe('');
+		});
+
+		// The org page cached "not a member" before the join; nothing else will
+		// refresh it, because there is no Stripe return page to mount.
+		it('refreshes the caches that still say the viewer is not a member', async () => {
+			const user = userEvent.setup();
+			const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+			mockFreeSubscribe();
+			renderDialog({ plan: freePlan() });
+
+			await user.click(screen.getByRole('button', { name: /join now/i }));
+
+			await waitFor(() => {
+				expect(vi.mocked(invalidateAll)).toHaveBeenCalledTimes(1);
+			});
+			const keys = invalidateSpy.mock.calls.map(
+				([arg]) => (arg as { queryKey?: unknown[] } | undefined)?.queryKey?.[0]
+			);
+			// The per-org subscription cache the inline membership card reads…
+			expect(keys).toContain('me');
+			// …the join-eligibility verdict, and the admin views of this org.
+			expect(keys).toContain('org');
+			expect(keys).toContain('organization');
+		});
+
+		it('withdraws the confirm CTA once the join has landed', async () => {
+			const user = userEvent.setup();
+			mockFreeSubscribe();
+			const { onOpenChange } = renderDialog({ plan: freePlan() });
+
+			await user.click(screen.getByRole('button', { name: /join now/i }));
+
+			await waitFor(() => {
+				expect(screen.queryByRole('button', { name: /join now/i })).toBeNull();
+			});
+			expect(screen.queryByRole('button', { name: /^cancel$/i })).toBeNull();
+
+			// Two answer to "Close" now: the footer's and the dialog's own ✕.
+			await waitFor(() => {
+				expect(screen.getAllByRole('button', { name: /^close$/i })).toHaveLength(2);
+			});
+			await user.click(screen.getAllByRole('button', { name: /^close$/i })[0]);
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+		});
+
+		// A refusal is still a refusal: the free path must not swallow one.
+		it('renders a refusal as an error, not as a successful join', async () => {
+			const user = userEvent.setup();
+			mockSubscribeError('This plan is sold out.');
+			renderDialog({ plan: freePlan() });
+
+			await user.click(screen.getByRole('button', { name: /join now/i }));
+
+			await waitFor(() => {
+				expect(screen.getByRole('alert')).toHaveTextContent('This plan is sold out.');
+			});
+			expect(screen.queryByRole('status')).toBeNull();
 		});
 	});
 

--- a/src/lib/utils/subscriptions.test.ts
+++ b/src/lib/utils/subscriptions.test.ts
@@ -6,6 +6,8 @@ import {
 	getStatusConfig,
 	getDateLine,
 	getMemberActions,
+	isFreePlan,
+	isLifetimePlan,
 	isMembershipSuspended,
 	isWithinRevivalWindow,
 	monthlyEquivalent,
@@ -339,6 +341,48 @@ describe('formatPlanPrice', () => {
 		expect(formatPlanPrice({ ...basePlan, period_unit: 'year', period_count: 2 })).toBe(
 			'€10.00 / 2 years'
 		);
+	});
+
+	// "€0.00 / month" is wrong twice over on a free plan: it quotes a charge that
+	// never happens, on a cadence that never comes round.
+	it('says "Free" for a free plan instead of quoting a zero amount', () => {
+		expect(
+			formatPlanPrice({
+				...basePlan,
+				payment_method: 'free',
+				price: '0.00',
+				period_unit: 'lifetime'
+			})
+		).toBe('Free');
+	});
+
+	// A LIFETIME term never renews, so there is no "/ month" to append — an
+	// offline one-off membership still has a real price to state.
+	it('quotes a lifetime plan as a one-time amount, with no cadence', () => {
+		expect(
+			formatPlanPrice({ ...basePlan, price: '50.00', period_unit: 'lifetime', period_count: 1 })
+		).toBe('€50.00 · one-time');
+	});
+
+	// The FREE branch is decided by the payment method, not by the amount: a
+	// zero-priced OFFLINE plan is a staff-assigned comp, not a self-serve one.
+	it('does not call a zero-priced offline plan free', () => {
+		expect(formatPlanPrice({ ...basePlan, price: '0.00' })).toBe('€0.00 / month');
+	});
+});
+
+describe('isFreePlan / isLifetimePlan', () => {
+	it('recognises only the free payment method', () => {
+		expect(isFreePlan({ payment_method: 'free' })).toBe(true);
+		expect(isFreePlan({ payment_method: 'offline' })).toBe(false);
+		expect(isFreePlan({ payment_method: 'online' })).toBe(false);
+		expect(isFreePlan({})).toBe(false);
+	});
+
+	it('recognises only the lifetime period unit', () => {
+		expect(isLifetimePlan({ period_unit: 'lifetime' })).toBe(true);
+		expect(isLifetimePlan({ period_unit: 'month' })).toBe(false);
+		expect(isLifetimePlan({ period_unit: 'year' })).toBe(false);
 	});
 });
 

--- a/src/lib/utils/subscriptions.ts
+++ b/src/lib/utils/subscriptions.ts
@@ -1,5 +1,5 @@
 import * as m from '$lib/paraglide/messages.js';
-import { getDateLocale } from './date';
+import { formatMoney } from './format';
 import type {
 	MembershipStatus,
 	MySubscriptionSchema,
@@ -8,6 +8,7 @@ import type {
 	PublicPlanSchema,
 	SubscriptionStatus,
 	SubscriptionActivationPendingSchema,
+	SubscriptionPaymentMethod,
 	PeriodUnit
 } from '$lib/api/generated/types.gen';
 
@@ -182,6 +183,10 @@ export function getAvailableActions(
 
 /** Localized billing-period label, pluralized on `period_count`. */
 function periodLabel(unit: PeriodUnit, count: number): string {
+	// `lifetime` never renews, so it has no count to pluralize. It is handled
+	// ahead of every call site below; the branch is kept so the function stays
+	// total over the enum rather than silently rendering "lifetime" as "month".
+	if (unit === 'lifetime') return m['subscriptions.period.lifetime']();
 	if (unit === 'year') {
 		return count === 1
 			? m['subscriptions.period.year']()
@@ -193,22 +198,49 @@ function periodLabel(unit: PeriodUnit, count: number): string {
 }
 
 /**
- * Render a plan as "<amount> / <period>", e.g. "€10.00 / month".
+ * The plan the member takes at no cost and grants themselves (#832).
  *
- * Both halves follow the active UI language: the amount is pinned to
- * `getDateLocale()` like every other currency helper (so SSR and CSR agree,
- * regardless of the server's ICU locale), and the period label comes from the
- * message catalog rather than a hardcoded English table.
+ * Distinct from OFFLINE, which is also un-billed here but is *staff-assigned*:
+ * a FREE plan has no Stripe object, is priced 0 by construction, and members
+ * self-subscribe — so it earns a real CTA where OFFLINE earns an explanation.
+ *
+ * `payment_method` is optional in the parameter type only so partial plan
+ * literals (tests, narrow picks) keep type-checking; every wire schema carries it.
  */
-export function formatPlanPrice(
-	plan: Pick<PlanSchema, 'price' | 'currency' | 'period_unit' | 'period_count'>
-): string {
-	const amount = new Intl.NumberFormat(getDateLocale(), {
-		style: 'currency',
-		currency: plan.currency,
-		minimumFractionDigits: 2,
-		maximumFractionDigits: 2
-	}).format(Number(plan.price));
+export function isFreePlan(plan: { payment_method?: SubscriptionPaymentMethod }): boolean {
+	return plan.payment_method === 'free';
+}
+
+/**
+ * A non-renewing term: `current_period_end` stays NULL forever, so no
+ * renewal/lapse/expiry beat ever selects the subscription. Callers use it to
+ * say "never expires" where they would otherwise quote a renewal cadence.
+ */
+export function isLifetimePlan(plan: Pick<PlanSchema, 'period_unit'>): boolean {
+	return plan.period_unit === 'lifetime';
+}
+
+/** What `formatPlanPrice` needs; `payment_method` optional — see `isFreePlan`. */
+type PricedPlan = Pick<PlanSchema, 'price' | 'currency' | 'period_unit' | 'period_count'> &
+	Partial<Pick<PlanSchema, 'payment_method'>>;
+
+/**
+ * Render a plan's headline price.
+ *
+ * Three shapes, so no call site has to branch on the cadence itself:
+ * - FREE → "Free". Never "€0.00 / month", which reads as a charge *and* as a
+ *   renewal, and is wrong twice over.
+ * - LIFETIME → "€50.00 · one-time". There is no renewal to quote.
+ * - otherwise → "€10.00 / month".
+ *
+ * Both halves follow the active UI language: the amount goes through
+ * `formatMoney` (pinned to the UI locale, so SSR and CSR agree regardless of the
+ * server's ICU locale) and the period label comes from the message catalog.
+ */
+export function formatPlanPrice(plan: PricedPlan): string {
+	if (isFreePlan(plan)) return m['subscriptions.price.free']();
+	const amount = formatMoney(plan.price, plan.currency);
+	if (isLifetimePlan(plan)) return m['subscriptions.price.oneTime']({ price: amount });
 	return `${amount} / ${periodLabel(plan.period_unit, plan.period_count ?? 1)}`;
 }
 


### PR DESCRIPTION
Closes #724

Base is `integration/membership-tier-unlock`, **not** `main`.

Backend letsrevel/revel-backend#832 landed the `free` payment method (price 0, no
Stripe object, member self-serve) and the `lifetime` period unit (never renews),
and made `SubscribeResponseSchema.checkout_url` nullable. The API-sync commit kept
the tree green and left three deliberate loud-failure placeholders behind. This
replaces all of them and builds the surfaces.

## Authoring — `PlanFormModal`, `PlansList`

`Free` joins Online/Offline in the payment-method group. It is offered even when
the organization has no Stripe account, because a free plan creates no Stripe
Product or Price.

Form rules, mirroring `events.utils.subscription_plan_rules.validate_plan_shape`
exactly — each one is both made unreachable in the controls *and* asserted in
`validate()`, so the form can never submit a shape the backend can only 400:

| shape | rule | how the form holds it |
|---|---|---|
| `free` | price must be `0` | price pinned to `0.00` and the input disabled |
| `free` | period must be `lifetime` | period pinned to `lifetime` and the select disabled |
| `online` | price must be `> 0` | validation error naming the free plan as the remedy |
| `online` | period may not be `lifetime` | the `lifetime` option is withdrawn from the select; picking it under Offline and then switching to Online falls back to `month` |
| `lifetime` (any method) | `period_count` is meaningless | the field is withdrawn and `period_count: 1` is sent |
| `offline` | anything | unchanged |

`payment_method` is not patchable, so an **edit** is validated against the plan's
own method (`effectiveMethod`), not the leftover radio state — a free plan opens
with both fields already locked. Editing a lifetime plan created outside this
form no longer shows a blank period picker.

Accessibility: the disabled price input and period select both carry
`aria-describedby` pointing at the sentence that explains the lock, so the reason
is programmatically associated rather than conveyed by the greyed-out styling
alone. The (now three-option) radio row wraps on a phone.

`PlansList` labels the row: a `Free · self-serve` badge, a `Never expires` badge
for any lifetime plan, and the corrected price line.

## Display — `src/lib/utils/subscriptions.ts`

`formatPlanPrice` gained the two shapes rather than every call site branching:

- `free` → **"Free"** (never `€0.00 / month`, which quotes a charge that never
  happens on a cadence that never comes round)
- `lifetime` → **"€50.00 · one-time"**
- otherwise unchanged

The FREE branch keys on the *payment method*, not on a zero amount: a
zero-priced OFFLINE plan is a staff-assigned comp and still reads `€0.00 / month`.
Two small predicates — `isFreePlan` / `isLifetimePlan` — are exported alongside so
no component re-derives either fact. The hand-rolled `Intl.NumberFormat` in this
file was replaced with `formatMoney`, the house currency helper (same locale
pinning, plus its malformed-currency-code fallback).

All ~14 existing `formatPlanPrice` call sites pick up the new rendering for free.

## Member-facing — `PlanCard`, `SubscribeDialog`

`PlanCard`'s CTA chain already dead-ended only on `payment_method === 'offline'`,
so a free plan reaches the join path; it now gets the right **label** for it
("Join for free" / "Log in to join") plus a "no payment needed" helper, and says
`Never expires` in words under the price. Plan-level stops (sold out, sales
paused) still apply.

`SubscribeDialog` for a free plan withdraws every line that would be false —
the first-charge quote, the auto-renew cadence, the whole billing disclosure
(all four bullets are about renewals, failed payments and revival windows), the
refund policy (nothing was paid) and the Stripe disclaimer — and retitles to
"Join {plan}" with a "Join now" CTA.

### How the no-Checkout subscribe path settles

A null `checkout_url` is not a failure: the subscription is already `active`
(the backend's `subscribe_to_plan` calls `create_subscription` in the same
transaction) and the membership is granted. So the dialog:

1. `settleSubscriptionCaches(queryClient, res.data.subscription)` — seeds and
   invalidates the three member-facing caches from the response body;
2. invalidates the `['org']` and `['organization']` prefixes — this component is
   handed an org **id**, while the join-eligibility and admin caches are keyed by
   **slug**, and `MembershipSection` (owned by #720) is off-limits so no slug prop
   could be added; the prefix costs one refetch of a couple of active queries,
   once, at the moment of joining;
3. `invalidateAll()` — the server load decided `isMember` before the membership
   existed;
4. swaps the body for an announced success state (`role="status"`, reusing
   `subscribe.return.welcome` / `welcomeBody`) and leaves only Close.

This has to happen here: unlike the Stripe path there is no return page to mount
`CheckoutReturnCard`, so nothing else would ever refresh the stale "not a member"
verdict.

## `CheckoutReturnCard` (shared with #720) — exactly what changed

**One hunk, in the resume mutation only.** The
`if (!res.data.checkout_url) throw new Error(m['subscribe.error']())` placeholder
became `enterActivationPending(null); return null;`, plus its comment. Its
Stripe-return detection, polling, phase rendering, invalidation effect and scroll
behaviour are untouched. Rationale: only a `pending` row reaches that button and a
free subscription is never `pending`, so the branch is practically unreachable —
but reporting "could not start the checkout" for a membership that is live would
be a lie, and the confirming state's poll sees `active` on its first tick and runs
the same invalidations the Stripe path does.

## Can a free subscription be PENDING?

No. `subscribe_to_plan` takes the `is_free` branch straight to
`create_subscription`, which lands the row ACTIVE with a null `current_period_end`
in one transaction; no webhook ever runs for it. Both resume paths therefore keep
a guard but say something true about the state instead of reusing the generic
error:

- **`MembershipCard`** — the throw is gone. A null `checkout_url` settles the
  subscription caches and toasts "This membership is already active." (The button
  is doubly unreachable for a free plan: `getMemberActions` withdraws everything
  for a non-ONLINE row.)
- **`CheckoutReturnCard`** — as above.

**No placeholder `throw` on a null `checkout_url` remains anywhere in the
subscribe path.** (`RejoinCard.svelte` keeps its own pre-existing null guard for
the *revive* endpoint — it predates #832, refers to the OFFLINE answer, has its
own test, and is out of scope here.)

## New i18n keys (23 × 4 locales) — for merge-conflict prediction

```
subscriptions.period.lifetime
subscriptions.price.free
subscriptions.price.oneTime
subscriptions.neverExpires
subscriptions.actions.alreadyActive
membershipPlans.joinFreeCta
membershipPlans.loginToJoin
membershipPlans.freeHelper
subscribe.titleFree
subscribe.freeNoCharge
subscribe.neverRenews
subscribe.confirmFreeCta
orgAdmin.members.plans.badge.free
orgAdmin.members.plans.badge.lifetime
orgAdmin.members.plans.form.paymentFree
orgAdmin.members.plans.form.paymentFreeHelp
orgAdmin.members.plans.form.periodLifetime
orgAdmin.members.plans.form.freeShapeLocked
orgAdmin.members.plans.form.lifetimeNoCount
orgAdmin.members.plans.form.errors.freePriceNotZero
orgAdmin.members.plans.form.errors.freeNeedsLifetime
orgAdmin.members.plans.form.errors.onlinePriceZero
orgAdmin.members.plans.form.errors.onlineNoLifetime
```

All additive — **no existing message value was edited**, and every insertion is an
append inside an existing group (`subscriptions.price` is the one new group).
en/de/fr/it all filled; `make i18n-check` passes.

## File ownership

Touched: `PlanCard.svelte`, `SubscribeDialog.svelte`, `PlanFormModal.svelte`,
`PlansList.svelte`, `MembershipCard.svelte`, `src/lib/utils/subscriptions.ts`,
their tests, `messages/*.json`, and the one hunk in `CheckoutReturnCard.svelte`
described above.

Not touched: `MembershipSection.svelte`, `MembershipCta.svelte`,
`ApplyDialog.svelte`, `src/lib/utils/membership-eligibility.ts`,
`src/lib/components/questionnaires/**`. No routes added.

## Tests

Written, **not run** — this project's rule is that the user runs the suite.

- `subscriptions.test.ts` — free / lifetime / zero-priced-offline rendering,
  `isFreePlan` / `isLifetimePlan`.
- `PlanFormModal.test.ts` — a new `free and lifetime plans` block: Free offered
  without Stripe; price+period locked with the `aria-describedby` association
  asserted; a free create payload; the period count withdrawn for lifetime; the
  lifetime option withdrawn for online; the Offline→Online fallback; a
  zero-priced online plan refused; a free plan still locked on edit; an
  externally created lifetime plan opening with its period selected. One existing
  test now types a price, because an online plan may no longer be priced 0.
- `PlanCard.test.ts` — a free plan's price/never-expires copy, its Join CTA, its
  guest login wording, sold-out still winning; a paid lifetime plan's one-time
  amount.
- `SubscribeDialog.test.ts` — a free plan withdrawing every charge/renewal/Stripe
  claim; the no-Checkout path reporting a live membership with no navigation; the
  cache invalidations it fires; the CTA withdrawn afterwards; a refusal still
  rendering as an error.
- `PlansList.test.ts` — free / paid-lifetime / recurring row labelling.

`make fix` + `make check` are green: **0 errors**, 374 warnings (the accepted
#361 baseline), i18n validation clean, type gate armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP
