### PR TITLE
feat(membership): let a member choose a tier, on a page of its own (#720)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -6771,7 +6771,9 @@
 		"wait": {
 			"questionnaire_evaluation": "Dein Fragebogen wird gerade geprüft — wir melden uns, sobald er ausgewertet ist.",
 			"approval": "Deine Bewerbung liegt der Organisation zur Prüfung vor. Du hörst von uns, sobald entschieden ist."
-		}
+		},
+		"joinTier": "{tier} beitreten",
+		"choosePlan": "Du erfüllst die Voraussetzungen – wähle unten einen Tarif, um beizutreten."
 	},
 	"membershipApply": {
 		"title": "{orgName} beitreten",
@@ -6789,7 +6791,22 @@
 		"pendingTitle": "Bewerbung eingegangen",
 		"pendingBody": "Die Organisation hat deine Bewerbung — so geht es weiter:",
 		"trackLink": "Deine Bewerbung verfolgen",
-		"error": "Deine Bewerbung konnte nicht gesendet werden. Bitte versuch es noch einmal."
+		"error": "Deine Bewerbung konnte nicht gesendet werden. Bitte versuch es noch einmal.",
+		"titleTier": "{tier} beitreten",
+		"reapplyTitleTier": "Erneut für {tier} bewerben"
+	},
+	"membershipTiers": {
+		"heading": "Mitgliedschaft",
+		"subtitle": "Wähle, wie du Teil von {organizationName} sein möchtest.",
+		"tiersHeading": "Mitgliedschaftsstufen",
+		"empty": "{organizationName} hat noch keine Mitgliedschaftsstufen veröffentlicht.",
+		"backToOrg": "Zurück zu {organizationName}",
+		"freeBadge": "Kostenlos",
+		"requiresApproval": "Die Organisation prüft und genehmigt jede Anfrage.",
+		"questionnaireRequired": "Ein Mitgliedschaftsfragebogen ist erforderlich.",
+		"questionnaireLink": "Fragebogen öffnen",
+		"questionnaireLinkAria": "Mitgliedschaftsfragebogen für {tier} öffnen",
+		"landingBlurb": "Sieh dir die Mitgliedschaftsstufen von {organizationName} an und wie du beitreten kannst."
 	},
 	"membershipQuestionnairePage": {
 		"title": "Mitgliedschafts-Fragebogen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -6771,7 +6771,9 @@
 		"wait": {
 			"questionnaire_evaluation": "Your questionnaire is being reviewed — we'll let you know once it's evaluated.",
 			"approval": "Your application is with the organization for review. You'll hear back once they decide."
-		}
+		},
+		"joinTier": "Join {tier}",
+		"choosePlan": "You're eligible — choose a plan below to join."
 	},
 	"membershipApply": {
 		"title": "Join {orgName}",
@@ -6789,7 +6791,22 @@
 		"pendingTitle": "Application received",
 		"pendingBody": "The organization has your application — here's what happens next:",
 		"trackLink": "Track your application",
-		"error": "Could not send your application. Please try again."
+		"error": "Could not send your application. Please try again.",
+		"titleTier": "Join {tier}",
+		"reapplyTitleTier": "Re-apply to {tier}"
+	},
+	"membershipTiers": {
+		"heading": "Membership",
+		"subtitle": "Choose how you want to be part of {organizationName}.",
+		"tiersHeading": "Membership tiers",
+		"empty": "{organizationName} hasn't published any membership tiers yet.",
+		"backToOrg": "Back to {organizationName}",
+		"freeBadge": "Free",
+		"requiresApproval": "The organization reviews and approves each application.",
+		"questionnaireRequired": "A membership questionnaire is required.",
+		"questionnaireLink": "Open the questionnaire",
+		"questionnaireLinkAria": "Open the membership questionnaire for {tier}",
+		"landingBlurb": "See the membership tiers {organizationName} offers and how to join."
 	},
 	"membershipQuestionnairePage": {
 		"title": "Membership questionnaire",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -6742,7 +6742,9 @@
 		"wait": {
 			"questionnaire_evaluation": "Ton questionnaire est en cours d'évaluation — nous te préviendrons dès qu'il sera examiné.",
 			"approval": "Ta candidature est en cours d'examen par l'organisation. Tu auras une réponse dès qu'elle aura décidé."
-		}
+		},
+		"joinTier": "Rejoindre {tier}",
+		"choosePlan": "Vous êtes éligible : choisissez une formule ci-dessous pour adhérer."
 	},
 	"membershipApply": {
 		"title": "Rejoindre {orgName}",
@@ -6760,7 +6762,22 @@
 		"pendingTitle": "Demande reçue",
 		"pendingBody": "L'organisation a bien reçu ta demande — voici la suite :",
 		"trackLink": "Suivre ta demande",
-		"error": "Impossible d'envoyer ta demande. Réessaie."
+		"error": "Impossible d'envoyer ta demande. Réessaie.",
+		"titleTier": "Rejoindre {tier}",
+		"reapplyTitleTier": "Postuler à nouveau pour {tier}"
+	},
+	"membershipTiers": {
+		"heading": "Adhésion",
+		"subtitle": "Choisissez comment vous souhaitez faire partie de {organizationName}.",
+		"tiersHeading": "Niveaux d'adhésion",
+		"empty": "{organizationName} n'a pas encore publié de niveaux d'adhésion.",
+		"backToOrg": "Retour à {organizationName}",
+		"freeBadge": "Gratuit",
+		"requiresApproval": "L'organisation examine et approuve chaque demande.",
+		"questionnaireRequired": "Un questionnaire d'adhésion est requis.",
+		"questionnaireLink": "Ouvrir le questionnaire",
+		"questionnaireLinkAria": "Ouvrir le questionnaire d'adhésion pour {tier}",
+		"landingBlurb": "Découvrez les niveaux d'adhésion proposés par {organizationName} et comment adhérer."
 	},
 	"membershipQuestionnairePage": {
 		"title": "Questionnaire d'adhésion",

--- a/messages/it.json
+++ b/messages/it.json
@@ -6771,7 +6771,9 @@
 		"wait": {
 			"questionnaire_evaluation": "Il tuo questionario è in fase di valutazione — ti avviseremo appena sarà esaminato.",
 			"approval": "La tua candidatura è in fase di revisione da parte dell'organizzazione. Riceverai una risposta appena avranno deciso."
-		}
+		},
+		"joinTier": "Iscriviti a {tier}",
+		"choosePlan": "Hai i requisiti: scegli un piano qui sotto per iscriverti."
 	},
 	"membershipApply": {
 		"title": "Unisciti a {orgName}",
@@ -6789,7 +6791,22 @@
 		"pendingTitle": "Richiesta ricevuta",
 		"pendingBody": "L'organizzazione ha ricevuto la tua richiesta — ecco cosa succede adesso:",
 		"trackLink": "Segui la tua richiesta",
-		"error": "Non è stato possibile inviare la tua richiesta. Riprova."
+		"error": "Non è stato possibile inviare la tua richiesta. Riprova.",
+		"titleTier": "Iscriviti a {tier}",
+		"reapplyTitleTier": "Invia una nuova richiesta per {tier}"
+	},
+	"membershipTiers": {
+		"heading": "Iscrizione",
+		"subtitle": "Scegli come vuoi far parte di {organizationName}.",
+		"tiersHeading": "Livelli di iscrizione",
+		"empty": "{organizationName} non ha ancora pubblicato livelli di iscrizione.",
+		"backToOrg": "Torna a {organizationName}",
+		"freeBadge": "Gratuito",
+		"requiresApproval": "L'organizzazione esamina e approva ogni richiesta.",
+		"questionnaireRequired": "È richiesto un questionario di iscrizione.",
+		"questionnaireLink": "Apri il questionario",
+		"questionnaireLinkAria": "Apri il questionario di iscrizione per {tier}",
+		"landingBlurb": "Scopri i livelli di iscrizione offerti da {organizationName} e come iscriverti."
 	},
 	"membershipQuestionnairePage": {
 		"title": "Questionario di adesione",

--- a/src/lib/components/events/IneligibilityActionButton.svelte
+++ b/src/lib/components/events/IneligibilityActionButton.svelte
@@ -163,7 +163,7 @@
 		// membership plans, where every tier it offers is listed. Until now this
 		// step fell through every branch and the button did nothing.
 		if (nextStep === 'upgrade_membership') {
-			window.location.href = `/org/${organizationSlug}#membership`;
+			window.location.href = `/org/${organizationSlug}/membership`;
 			return;
 		}
 

--- a/src/lib/components/events/OrganizationInfo.svelte
+++ b/src/lib/components/events/OrganizationInfo.svelte
@@ -45,10 +45,10 @@
 	// Compute full logo URL - prefer thumbnail for small display sizes
 	const logoUrl = $derived(getImageUrl(organization.logo_thumbnail_url || organization.logo));
 
-	// The plans live in the org page's `#membership` section; the fragment
-	// cannot be expressed through resolve(), so it is appended to it.
+	// The tiers have their own page since #720 — a real route, so no fragment to
+	// append and nothing for resolve() to be worked around.
 	const membershipHref = $derived(
-		`${resolve('/(public)/org/[slug]', { slug: organization.slug })}#membership`
+		resolve('/(public)/org/[slug]/membership', { slug: organization.slug })
 	);
 </script>
 

--- a/src/lib/components/organization/membership/ApplyDialog.svelte
+++ b/src/lib/components/organization/membership/ApplyDialog.svelte
@@ -32,9 +32,26 @@
 		organizationName: string;
 		/** `reapply` only changes the framing — the request is identical. */
 		mode: 'join' | 'reapply';
+		/**
+		 * The tier being applied to. Sent to the backend, which resolves that
+		 * tier's questionnaire/approval overrides instead of only the org-wide
+		 * defaults — without it the application is tier-less and staff have to
+		 * guess the tier at approval time (#720).
+		 */
+		tierId?: string | null;
+		/** Names the tier in the dialog heading. */
+		tierName?: string | null;
 	}
 
-	const { open, onOpenChange, organizationSlug, organizationName, mode }: Props = $props();
+	const {
+		open,
+		onOpenChange,
+		organizationSlug,
+		organizationName,
+		mode,
+		tierId = null,
+		tierName = null
+	}: Props = $props();
 
 	const accessToken = $derived(authStore.accessToken);
 	const queryClient = useQueryClient();
@@ -75,8 +92,10 @@
 			const res = await memembershipapplicationsApply({
 				path: { slug: organizationSlug },
 				// An empty note is no note: sending `''` would store a blank message
-				// on the application.
-				body: { notes: notes || undefined },
+				// on the application. `tier_id` is likewise omitted rather than sent
+				// as null when the caller has no tier, so the backend keeps its
+				// org-default resolution for the legacy tier-less path.
+				body: { tier_id: tierId ?? undefined, notes: notes || undefined },
 				headers: { Authorization: `Bearer ${accessToken}` }
 			});
 			// hey-api resolves rather than throws — a missing payload is a failure
@@ -146,6 +165,13 @@
 			return completed
 				? m['membershipApply.completedTitle']()
 				: m['membershipApply.pendingTitle']();
+		}
+		if (tierName) {
+			// The tier is the thing being joined, so it — not the org — names the
+			// dialog. The org still appears in the description line below.
+			return mode === 'reapply'
+				? m['membershipApply.reapplyTitleTier']({ tier: tierName })
+				: m['membershipApply.titleTier']({ tier: tierName });
 		}
 		return mode === 'reapply'
 			? m['membershipApply.reapplyTitle']({ orgName: organizationName })

--- a/src/lib/components/organization/membership/ApplyDialog.test.ts
+++ b/src/lib/components/organization/membership/ApplyDialog.test.ts
@@ -166,7 +166,7 @@ describe('ApplyDialog', () => {
 			expect(vi.mocked(memembershipapplicationsApply)).toHaveBeenCalledWith(
 				expect.objectContaining({
 					path: { slug: 'acme' },
-					body: { notes: 'hello' }
+					body: { tier_id: undefined, notes: 'hello' }
 				})
 			);
 		});
@@ -181,9 +181,40 @@ describe('ApplyDialog', () => {
 
 		await waitFor(() => {
 			expect(vi.mocked(memembershipapplicationsApply)).toHaveBeenCalledWith(
-				expect.objectContaining({ body: { notes: undefined } })
+				expect.objectContaining({ body: { tier_id: undefined, notes: undefined } })
 			);
 		});
+	});
+
+	// The whole point of #720: without `tier_id` the application is tier-less and
+	// the backend resolves only the org-wide questionnaire/approval policy, leaving
+	// every tier-level override dead configuration.
+	it('posts the tier it was opened for', async () => {
+		const user = userEvent.setup();
+		mockApplySuccess(makeResult());
+		renderDialog({ tierId: 'tier-gold', tierName: 'Gold' });
+
+		await user.click(screen.getByRole('button', { name: /send application/i }));
+
+		await waitFor(() => {
+			expect(vi.mocked(memembershipapplicationsApply)).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: { slug: 'acme' },
+					body: { tier_id: 'tier-gold', notes: undefined }
+				})
+			);
+		});
+	});
+
+	// The tier is what is being joined, so it names the dialog; the org still
+	// appears in the description line underneath.
+	it('titles itself after the tier when it has one', () => {
+		const { unmount } = renderDialog({ tierId: 'tier-gold', tierName: 'Gold' });
+		expect(screen.getByRole('heading', { name: 'Join Gold' })).toBeInTheDocument();
+		unmount();
+
+		renderDialog({ tierId: 'tier-gold', tierName: 'Gold', mode: 'reapply' });
+		expect(screen.getByRole('heading', { name: 'Re-apply to Gold' })).toBeInTheDocument();
 	});
 
 	it('celebrates an instantly completed application and refreshes the page data', async () => {

--- a/src/lib/components/organization/membership/MembershipCta.svelte
+++ b/src/lib/components/organization/membership/MembershipCta.svelte
@@ -20,6 +20,7 @@
 		Check,
 		ClipboardList,
 		Clock,
+		CreditCard,
 		Crown,
 		RefreshCw,
 		Shield,
@@ -39,6 +40,26 @@
 		isOwner?: boolean;
 		isStaff?: boolean;
 		class?: string;
+		/**
+		 * The tier this CTA asks about.
+		 *
+		 * Present → *tier mode*: the verdict is resolved against that tier (its own
+		 * questionnaire/approval overrides, not just the org defaults) and joining
+		 * posts the tier, so the application is no longer tier-less.
+		 *
+		 * Absent → *summary mode*, for surfaces that stand outside the tier grid
+		 * (the org landing hero). There every actionable verdict becomes a link to
+		 * `/org/[slug]/membership`, because there is no honest way to apply without
+		 * first choosing a tier — that is exactly the hole #720 exists to close.
+		 */
+		tierId?: string | null;
+		/** Names the tier in the CTA, so N cards do not all read "Join". */
+		tierName?: string | null;
+		/**
+		 * Tier mode only: this tier's plans are on screen next to the CTA, so a
+		 * `proceed_to_payment` verdict points at them instead of linking away.
+		 */
+		plansInline?: boolean;
 	}
 
 	const {
@@ -50,8 +71,13 @@
 		membershipStatus = null,
 		isOwner = false,
 		isStaff = false,
-		class: className
+		class: className,
+		tierId = null,
+		tierName = null,
+		plansInline = false
 	}: Props = $props();
+
+	const isTierMode = $derived(!!tierId);
 
 	// Status badge styling, kept in step with MemberCard.svelte.
 	const statusStyles: Record<MembershipStatus, string> = {
@@ -82,10 +108,16 @@
 	});
 
 	const eligibilityQuery = createQuery(() => ({
-		queryKey: ['org', organizationSlug, 'join-eligibility'],
+		// The tier is part of the key, not just the request: verdicts are per tier
+		// (one may be joinable while its neighbour wants a questionnaire) and a
+		// shared key would serve whichever card asked first to all of them. The
+		// existing `['org', slug, 'join-eligibility']` invalidations still reach
+		// every entry — TanStack matches keys by prefix.
+		queryKey: ['org', organizationSlug, 'join-eligibility', tierId ?? null],
 		queryFn: async (): Promise<MembershipEligibilitySchema> => {
 			const res = await memembershipapplicationsGetJoinEligibility({
 				path: { slug: organizationSlug },
+				query: tierId ? { tier_id: tierId } : undefined,
 				headers: { Authorization: `Bearer ${accessToken}` }
 			});
 			// hey-api resolves rather than throws — a missing payload is a failure
@@ -129,10 +161,23 @@
 		return failed && authed && !settled;
 	});
 
+	/** The tier grid: where a membership is actually chosen. */
+	const membershipHref = $derived(
+		resolve('/(public)/org/[slug]/membership', { slug: organizationSlug })
+	);
+
+	// Tier mode only, and it comes back to the grid rather than the org landing
+	// page: the login round trip exists so the visitor can press Join on a tier,
+	// so it must return them to where that button is.
 	const loginHref = $derived(
-		`${resolve('/(public)/login', {})}?returnUrl=${encodeURIComponent(
-			resolve('/(public)/org/[slug]', { slug: organizationSlug })
-		)}`
+		`${resolve('/(public)/login', {})}?returnUrl=${encodeURIComponent(membershipHref)}`
+	);
+
+	/** The label a join button carries: the tier when there is one, else the org. */
+	const joinLabel = $derived(
+		tierName
+			? m['membershipEligibility.joinTier']({ tier: tierName })
+			: m['membershipEligibility.join']({ orgName: organizationName })
 	);
 
 	const membershipsHref = resolve('/(auth)/account/memberships', {});
@@ -219,23 +264,56 @@
 	{@render memberBadge()}
 {:else if !isAuthenticated}
 	<!-- A real link, not a scripted redirect: it survives no-JS, middle-click and
-	     the browser's own "open in new tab". SvelteKit routes it client-side. -->
-	<Button href={loginHref} class={className}>
+	     the browser's own "open in new tab". SvelteKit routes it client-side.
+	     Summary mode sends the visitor to the tier grid rather than straight to
+	     login: the grid is public, so they get to see what they would be joining
+	     before being asked for an account. -->
+	<Button href={isTierMode ? loginHref : membershipHref} class={className}>
 		<UserPlus class="h-4 w-4" aria-hidden="true" />
-		{m['membershipEligibility.join']({ orgName: organizationName })}
+		{joinLabel}
 	</Button>
 {:else if eligibility && ctaKind}
 	<div class={cn('flex flex-col items-start gap-2', className)}>
 		{#if ctaKind === 'join'}
-			<Button onclick={() => openApply('join')}>
-				<UserPlus class="h-4 w-4" aria-hidden="true" />
-				{m['membershipEligibility.join']({ orgName: organizationName })}
-			</Button>
+			{#if isTierMode}
+				<Button onclick={() => openApply('join')}>
+					<UserPlus class="h-4 w-4" aria-hidden="true" />
+					{joinLabel}
+				</Button>
+			{:else}
+				<!-- Summary mode: applying from here would create the tier-less
+				     application #720 is about, so it offers the grid instead. -->
+				<Button href={membershipHref}>
+					<UserPlus class="h-4 w-4" aria-hidden="true" />
+					{m['membershipPlans.viewMembership']()}
+				</Button>
+			{/if}
 		{:else if ctaKind === 'reapply'}
-			<Button onclick={() => openApply('reapply')}>
-				<UserPlus class="h-4 w-4" aria-hidden="true" />
-				{m['membershipEligibility.reapply']()}
-			</Button>
+			{#if isTierMode}
+				<Button onclick={() => openApply('reapply')}>
+					<UserPlus class="h-4 w-4" aria-hidden="true" />
+					{m['membershipEligibility.reapply']()}
+				</Button>
+			{:else}
+				<Button href={membershipHref}>
+					<UserPlus class="h-4 w-4" aria-hidden="true" />
+					{m['membershipEligibility.reapply']()}
+				</Button>
+			{/if}
+		{:else if ctaKind === 'payment'}
+			<!-- Every gate is cleared and only the charge is left. With the tier's
+			     plans on screen the CTA is one of those cards, so this says so in
+			     words; anywhere else it links to where they live. -->
+			{#if plansInline}
+				<p role="note" class="text-sm text-muted-foreground">
+					{m['membershipEligibility.choosePlan']()}
+				</p>
+			{:else}
+				<Button href={membershipHref}>
+					<CreditCard class="h-4 w-4" aria-hidden="true" />
+					{m['membershipPlans.viewMembership']()}
+				</Button>
+			{/if}
 		{:else if ctaKind === 'questionnaire' && questionnaireHref}
 			<!-- Button-styled, but left as a link: `role="button"` would demand a
 			     Space-key handler the anchor does not have. -->
@@ -325,11 +403,18 @@
 	focus to <body> (WCAG 3.2). Here the badge simply appears behind it, and the
 	dialog lives until the user closes it. Its own `open` state is the only gate;
 	nothing outside the CTA branches can set it.
+
+	Summary mode never opens it — there is no tier to apply to from there — so it
+	is not mounted at all, rather than mounted and unreachable.
 -->
-<ApplyDialog
-	open={applyOpen}
-	onOpenChange={(next) => (applyOpen = next)}
-	{organizationSlug}
-	{organizationName}
-	mode={applyMode}
-/>
+{#if isTierMode}
+	<ApplyDialog
+		open={applyOpen}
+		onOpenChange={(next) => (applyOpen = next)}
+		{organizationSlug}
+		{organizationName}
+		{tierId}
+		{tierName}
+		mode={applyMode}
+	/>
+{/if}

--- a/src/lib/components/organization/membership/MembershipCta.test.ts
+++ b/src/lib/components/organization/membership/MembershipCta.test.ts
@@ -9,6 +9,7 @@ import {
 	memembershipapplicationsGetJoinEligibility
 } from '$lib/api/generated/sdk.gen';
 import type { MembershipEligibilitySchema } from '$lib/api/generated/types.gen';
+import * as m from '$lib/paraglide/messages.js';
 
 vi.mock('$lib/api/generated/sdk.gen', () => ({
 	memembershipapplicationsGetJoinEligibility: vi.fn(),
@@ -89,11 +90,68 @@ describe('MembershipCta', () => {
 		});
 	}
 
-	it('offers a join button when the verdict allows joining', async () => {
+	/**
+	 * The tier-grid usage (#720): the CTA asks about ONE tier and can act on it.
+	 * Summary mode — `renderCta` above, no `tierId` — deliberately cannot: applying
+	 * without a tier is the tier-less application this issue exists to remove, so
+	 * there every actionable verdict becomes a link to the tier page instead.
+	 */
+	function renderTierCta(props: Record<string, unknown> = {}) {
+		return renderCta({ tierId: 'tier-gold', tierName: 'Gold', ...props });
+	}
+
+	it('offers a tier-named join button when the verdict allows joining', async () => {
+		mockEligibility(makeEligibility({ allowed: true }));
+		renderTierCta();
+
+		// Named with the tier, not a bare "Join": a screen-reader user hears these
+		// out of context, and N identical buttons would be indistinguishable.
+		expect(await screen.findByRole('button', { name: 'Join Gold' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: /join acme/i })).toBeNull();
+	});
+
+	it('asks the backend about that specific tier', async () => {
+		mockEligibility(makeEligibility({ allowed: true }));
+		renderTierCta();
+
+		await screen.findByRole('button', { name: 'Join Gold' });
+		expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalledWith(
+			expect.objectContaining({ query: { tier_id: 'tier-gold' } })
+		);
+	});
+
+	// Summary mode has no tier to apply to, so an allowed verdict is not a Join
+	// button — it is the pointer at the page where a tier can be chosen.
+	it('links to the tier page instead of applying when it has no tier', async () => {
 		mockEligibility(makeEligibility({ allowed: true }));
 		renderCta();
 
-		expect(await screen.findByRole('button', { name: /join acme/i })).toBeInTheDocument();
+		const link = await screen.findByRole('link', {
+			name: m['membershipPlans.viewMembership']()
+		});
+		expect(link).toHaveAttribute('href', '/org/acme/membership');
+		expect(screen.queryByRole('button', { name: /join/i })).toBeNull();
+	});
+
+	// BE #831: a tier can be gated AND paid, and this step is the positive end of
+	// that chain — the gates are satisfied and only the charge is left.
+	it('points at the plans on screen for a proceed_to_payment verdict', async () => {
+		mockEligibility(makeEligibility({ allowed: false, next_step: 'proceed_to_payment' }));
+		renderTierCta({ plansInline: true });
+
+		expect(await screen.findByRole('note')).toHaveTextContent(
+			m['membershipEligibility.choosePlan']()
+		);
+		expect(screen.queryByRole('button', { name: /join/i })).toBeNull();
+	});
+
+	it('links to the tier page for proceed_to_payment when the plans are elsewhere', async () => {
+		mockEligibility(makeEligibility({ allowed: false, next_step: 'proceed_to_payment' }));
+		renderCta();
+
+		expect(
+			await screen.findByRole('link', { name: m['membershipPlans.viewMembership']() })
+		).toHaveAttribute('href', '/org/acme/membership');
 	});
 
 	it('links to the membership questionnaire when one must be submitted first', async () => {
@@ -156,9 +214,9 @@ describe('MembershipCta', () => {
 	// is policy context here, not a blocker — the user must still be able to apply.
 	it('still offers join when approval is required but no application exists yet', async () => {
 		mockEligibility(makeEligibility({ allowed: true, reason_code: 'requires_approval' }));
-		renderCta();
+		renderTierCta();
 
-		expect(await screen.findByRole('button', { name: /join acme/i })).toBeInTheDocument();
+		expect(await screen.findByRole('button', { name: 'Join Gold' })).toBeInTheDocument();
 	});
 
 	it('counts down to the retake date when the questionnaire is on cooldown', async () => {
@@ -231,11 +289,24 @@ describe('MembershipCta', () => {
 		expect(screen.queryByText(/couldn't load your join options/i)).toBeNull();
 	});
 
-	it('sends a guest to the login page with a return URL back to the org', () => {
+	// The return URL is the tier grid, not the org landing page: the round trip
+	// exists so the visitor can press Join on a tier, so it has to come back to
+	// where that button is.
+	it('sends a guest on a tier card to login and back to the tier grid', () => {
+		renderTierCta({ isAuthenticated: false });
+
+		const link = screen.getByRole('link', { name: 'Join Gold' });
+		expect(link).toHaveAttribute('href', '/login?returnUrl=%2Forg%2Facme%2Fmembership');
+		expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalled();
+	});
+
+	// The grid is public, so a guest gets to see what they would be joining before
+	// being asked for an account.
+	it('sends a guest on the org page to the tier grid rather than to login', () => {
 		renderCta({ isAuthenticated: false });
 
 		const link = screen.getByRole('link', { name: /join acme/i });
-		expect(link).toHaveAttribute('href', '/login?returnUrl=%2Forg%2Facme');
+		expect(link).toHaveAttribute('href', '/org/acme/membership');
 		expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalled();
 	});
 
@@ -328,7 +399,7 @@ describe('MembershipCta', () => {
 	it('recovers the join button when the retry succeeds', async () => {
 		const user = userEvent.setup();
 		mockEligibilityFailure();
-		renderCta();
+		renderTierCta();
 
 		const retry = await screen.findByRole('button', { name: /try again/i });
 		expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalledTimes(1);
@@ -336,7 +407,7 @@ describe('MembershipCta', () => {
 		mockEligibility(makeEligibility({ allowed: true }));
 		await user.click(retry);
 
-		expect(await screen.findByRole('button', { name: /join acme/i })).toBeInTheDocument();
+		expect(await screen.findByRole('button', { name: 'Join Gold' })).toBeInTheDocument();
 		expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalledTimes(2);
 		expect(screen.queryByText(/couldn't load your join options/i)).toBeNull();
 	});
@@ -344,12 +415,12 @@ describe('MembershipCta', () => {
 	it('opens the apply dialog from the join button', async () => {
 		const user = userEvent.setup();
 		mockEligibility(makeEligibility({ allowed: true }));
-		renderCta();
+		renderTierCta();
 
-		await user.click(await screen.findByRole('button', { name: /join acme/i }));
+		await user.click(await screen.findByRole('button', { name: 'Join Gold' }));
 
 		const dialog = await screen.findByRole('dialog');
-		expect(dialog).toHaveTextContent('Join Acme');
+		expect(dialog).toHaveTextContent('Join Gold');
 		expect(vi.mocked(memembershipapplicationsApply)).not.toHaveBeenCalled();
 	});
 
@@ -359,10 +430,10 @@ describe('MembershipCta', () => {
 	it('keeps the open apply dialog mounted when the CTA flips to the member badge', async () => {
 		const user = userEvent.setup();
 		mockEligibility(makeEligibility({ allowed: true }));
-		const { rerender } = renderCta();
+		const { rerender } = renderTierCta();
 
-		await user.click(await screen.findByRole('button', { name: /join acme/i }));
-		expect(await screen.findByRole('dialog')).toHaveTextContent('Join Acme');
+		await user.click(await screen.findByRole('button', { name: 'Join Gold' }));
+		expect(await screen.findByRole('dialog')).toHaveTextContent('Join Gold');
 
 		// `rerender` treats a top-level `props` key as its legacy call shape and
 		// unwraps one level, so the wrapper's own props are nested under it. The
@@ -376,6 +447,8 @@ describe('MembershipCta', () => {
 					organizationSlug: 'acme',
 					organizationName: 'Acme',
 					isAuthenticated: true,
+					tierId: 'tier-gold',
+					tierName: 'Gold',
 					isMember: true,
 					membershipStatus: 'active',
 					membershipTier: { id: 'tier-1', name: 'Gold' }
@@ -387,17 +460,45 @@ describe('MembershipCta', () => {
 		// The chain behind the dialog really did switch to the member badge — queried
 		// by text, since the open modal aria-hides everything outside itself.
 		expect(screen.getByText('Active')).toBeInTheDocument();
-		expect(screen.getByText('Gold')).toBeInTheDocument();
-		expect(screen.getByRole('dialog')).toHaveTextContent('Join Acme');
+		expect(screen.getAllByText('Gold').length).toBeGreaterThan(0);
+		expect(screen.getByRole('dialog')).toHaveTextContent('Join Gold');
 	});
 
 	it('opens the apply dialog in re-apply mode when a past application ended', async () => {
 		const user = userEvent.setup();
 		mockEligibility(makeEligibility({ allowed: false, next_step: 'reapply' }));
-		renderCta();
+		renderTierCta();
 
 		await user.click(await screen.findByRole('button', { name: /re-apply/i }));
 
-		expect(await screen.findByRole('dialog')).toHaveTextContent('Re-apply to Acme');
+		expect(await screen.findByRole('dialog')).toHaveTextContent('Re-apply to Gold');
+	});
+
+	// The cache key carries the tier (#720). Without it the first card's verdict
+	// would be served to every other tier on the page — one tier's "you can join"
+	// answering for a tier that wants a questionnaire.
+	it('keeps per-tier verdicts apart in the cache', async () => {
+		vi.mocked(memembershipapplicationsGetJoinEligibility).mockImplementation((async (options: {
+			query?: { tier_id?: string };
+		}) => ({
+			data:
+				options.query?.tier_id === 'tier-gold'
+					? makeEligibility({ allowed: true })
+					: makeEligibility({
+							allowed: false,
+							next_step: 'submit_questionnaire',
+							questionnaire_id: 'q1'
+						}),
+			error: undefined,
+			response: { ok: true } as unknown as Response
+		})) as unknown as typeof memembershipapplicationsGetJoinEligibility);
+
+		renderTierCta();
+		renderCta({ tierId: 'tier-silver', tierName: 'Silver' });
+
+		expect(await screen.findByRole('button', { name: 'Join Gold' })).toBeInTheDocument();
+		expect(
+			await screen.findByRole('link', { name: m['membershipEligibility.questionnaireCta']() })
+		).toHaveAttribute('href', '/org/acme/questionnaire/q1');
 	});
 });

--- a/src/lib/components/organization/membership/MembershipSection.svelte
+++ b/src/lib/components/organization/membership/MembershipSection.svelte
@@ -4,29 +4,59 @@
 	import { browser } from '$app/environment';
 	import { resolve } from '$app/paths';
 	import { createQuery } from '@tanstack/svelte-query';
-	import type { OrganizationRetrieveSchema, PublicPlanSchema } from '$lib/api/generated/types.gen';
+	import type {
+		MembershipStatus,
+		MembershipTierSchema,
+		OrganizationRetrieveSchema,
+		PublicMembershipTierSchema,
+		PublicPlanSchema
+	} from '$lib/api/generated/types.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { myOrgSubscriptionQueryOptions } from '$lib/queries/my-org-subscription';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
-	import PlanCard from './PlanCard.svelte';
+	import MembershipCta from './MembershipCta.svelte';
+	import TierCard from './TierCard.svelte';
 	import SubscribeDialog from './SubscribeDialog.svelte';
 	import CheckoutReturnCard from './CheckoutReturnCard.svelte';
 
 	interface Props {
 		organization: OrganizationRetrieveSchema;
-		plans: PublicPlanSchema[];
+		/**
+		 * Every tier the org offers, already in `display_order` from the backend.
+		 *
+		 * Deliberately the tier listing and not the plan listing: grouping plans by
+		 * tier — what this component used to do — renders zero cards for a tier
+		 * with no plan, which is exactly the free/gated tier a member is supposed
+		 * to be able to choose (#720).
+		 */
+		tiers: PublicMembershipTierSchema[];
 		isAuthenticated: boolean;
+		/** The viewer's standing in the org, from the server load. */
+		isMember?: boolean;
+		membershipTier?: MembershipTierSchema | null;
+		membershipStatus?: MembershipStatus | null;
+		isOwner?: boolean;
+		isStaff?: boolean;
 	}
 
-	const { organization, plans, isAuthenticated }: Props = $props();
+	const {
+		organization,
+		tiers,
+		isAuthenticated,
+		isMember = false,
+		membershipTier = null,
+		membershipStatus = null,
+		isOwner = false,
+		isStaff = false
+	}: Props = $props();
 
 	const accessToken = $derived(authStore.accessToken);
 
 	/**
 	 * The viewer's own subscription in this org — the same query key
-	 * `OrgMembershipInline` (rendered higher up the same page) and
-	 * `CheckoutReturnCard` already use, so TanStack serves both observers from
-	 * one request and one invalidation refreshes both.
+	 * `OrgMembershipInline` and `CheckoutReturnCard` already use, so TanStack
+	 * serves every observer from one request and one invalidation refreshes them
+	 * all.
 	 *
 	 * Without it the grid offered "Subscribe" to people who already pay: the
 	 * backend refuses a second non-terminal subscription with a 400, so that
@@ -44,38 +74,25 @@
 	let sectionEl = $state<HTMLElement | null>(null);
 
 	/**
-	 * Tiers alphabetically, plans cheapest-first inside a tier: the backend
-	 * order is not specified, and a shifting card order between renders is
-	 * worse than an arbitrary but stable one.
+	 * Owners and staff already have standing here; the page is configuration to
+	 * them, not an offer. Suppressing the per-tier CTA also spares them one
+	 * eligibility round trip per tier for a question they never asked — their
+	 * badge is rendered once, above the grid.
 	 */
-	interface TierGroup {
-		tierId: string;
-		tierName: string;
-		plans: PublicPlanSchema[];
-	}
+	const showJoinCtas = $derived.by(() => {
+		// Both operands read unconditionally: `||` inside a `$derived` would leave
+		// the skipped one untracked.
+		const owner = isOwner;
+		const staff = isStaff;
+		return !owner && !staff;
+	});
 
-	const tierGroups = $derived.by(() => {
-		// A plain record, not a Map: `svelte/prefer-svelte-reactivity` bans
-		// mutable Maps, and this one is a throwaway inside the derived anyway.
-		const byTier: Record<string, TierGroup> = {};
-		for (const plan of plans) {
-			const group = byTier[plan.tier_id];
-			if (group) {
-				group.plans.push(plan);
-			} else {
-				byTier[plan.tier_id] = {
-					tierId: plan.tier_id,
-					tierName: plan.tier_name,
-					plans: [plan]
-				};
-			}
-		}
-		return Object.values(byTier)
-			.map((group) => ({
-				...group,
-				plans: [...group.plans].sort((a, b) => Number(a.price) - Number(b.price))
-			}))
-			.sort((a, b) => a.tierName.localeCompare(b.tierName));
+	/** The viewer's standing, shown once rather than repeated on every card. */
+	const hasStanding = $derived.by(() => {
+		const owner = isOwner;
+		const staff = isStaff;
+		const member = isMember;
+		return owner || staff || member;
 	});
 
 	const refundPolicy = $derived(
@@ -111,7 +128,7 @@
 		window.history.replaceState(
 			{},
 			'',
-			resolve('/(public)/org/[slug]', { slug: organization.slug })
+			resolve('/(public)/org/[slug]/membership', { slug: organization.slug })
 		);
 
 		// The card mounts on the next flush, so the scroll waits for it —
@@ -122,59 +139,85 @@
 	});
 </script>
 
-{#if plans.length > 0 || returnOutcome}
-	<section
-		id="membership"
-		aria-labelledby="membership-heading"
-		class="mb-12 space-y-6"
-		bind:this={sectionEl}
-	>
-		{#if returnOutcome && isAuthenticated}
-			<!-- Authenticated only: the card polls `me/subscriptions`, so a logged
-			     out visitor landing here would watch a spinner forever. -->
-			<CheckoutReturnCard
-				organizationId={organization.id}
-				organizationSlug={organization.slug}
-				outcome={returnOutcome}
-			/>
-		{/if}
+<section
+	id="membership"
+	aria-labelledby="membership-heading"
+	class="space-y-6"
+	bind:this={sectionEl}
+>
+	{#if returnOutcome && isAuthenticated}
+		<!-- Authenticated only: the card polls `me/subscriptions`, so a logged
+		     out visitor landing here would watch a spinner forever. -->
+		<CheckoutReturnCard
+			organizationId={organization.id}
+			organizationSlug={organization.slug}
+			outcome={returnOutcome}
+		/>
+	{/if}
 
-		<h2 id="membership-heading" class="text-2xl font-bold">{m['membershipPlans.heading']()}</h2>
+	<div class="space-y-2">
+		<h1 id="membership-heading" class="text-3xl font-bold tracking-tight md:text-4xl">
+			{m['membershipTiers.heading']()}
+		</h1>
+		<p class="text-muted-foreground">
+			{m['membershipTiers.subtitle']({ organizationName: organization.name })}
+		</p>
+	</div>
 
-		{#each tierGroups as group (group.tierId)}
-			<div class="space-y-3">
-				<h3 class="text-lg font-semibold">{group.tierName}</h3>
-				<div class="grid gap-4 sm:grid-cols-2">
-					{#each group.plans as plan (plan.id ?? `${group.tierId}-${plan.name}`)}
-						<PlanCard
-							{plan}
-							{isAuthenticated}
-							{subscription}
-							{subscriptionLoading}
-							organizationSlug={organization.slug}
-							onSubscribe={handleSubscribe}
-						/>
-					{/each}
-				</div>
+	{#if hasStanding}
+		<!-- Summary mode (no tierId): the badge branches only, no eligibility
+		     request — the props already answer the question. -->
+		<MembershipCta
+			organizationSlug={organization.slug}
+			organizationName={organization.name}
+			{isAuthenticated}
+			{isMember}
+			{membershipTier}
+			{membershipStatus}
+			{isOwner}
+			{isStaff}
+		/>
+	{/if}
+
+	{#if tiers.length === 0}
+		<p class="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+			{m['membershipTiers.empty']({ organizationName: organization.name })}
+		</p>
+	{:else}
+		<div aria-labelledby="tiers-heading">
+			<h2 id="tiers-heading" class="sr-only">{m['membershipTiers.tiersHeading']()}</h2>
+			<div class="grid gap-4 sm:grid-cols-2">
+				{#each tiers as tier (tier.id ?? tier.name)}
+					<TierCard
+						{tier}
+						organizationSlug={organization.slug}
+						organizationName={organization.name}
+						{isAuthenticated}
+						{subscription}
+						{subscriptionLoading}
+						onSubscribe={handleSubscribe}
+						showJoinCta={showJoinCtas}
+					/>
+				{/each}
 			</div>
-		{/each}
+		</div>
+	{/if}
 
-		{#if refundPolicy}
-			<details class="rounded-lg border p-3">
-				<summary
-					class="cursor-pointer text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				>
-					{m['membershipPlans.refundPolicy']()}
-				</summary>
-				<MarkdownContent
-					content={refundPolicy}
-					ariaLabel={m['membershipPlans.refundPolicy']()}
-					class="mt-2 text-sm"
-				/>
-			</details>
-		{/if}
-	</section>
-{/if}
+	{#if refundPolicy}
+		<details class="rounded-lg border p-3">
+			<summary
+				class="cursor-pointer text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+			>
+				{m['membershipPlans.refundPolicy']()}
+			</summary>
+			<MarkdownContent
+				content={refundPolicy}
+				ariaLabel={m['membershipPlans.refundPolicy']()}
+				class="mt-2 text-sm"
+			/>
+		</details>
+	{/if}
+</section>
 
 {#if selectedPlan}
 	<!-- Mounted outside the section so a closed dialog keeps its error state,

--- a/src/lib/components/organization/membership/MembershipSection.test.ts
+++ b/src/lib/components/organization/membership/MembershipSection.test.ts
@@ -3,22 +3,34 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { QueryClient } from '@tanstack/svelte-query';
 import MembershipSection from './MembershipSection.svelte';
 import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
-import { mesubscriptionsGetMySubscription } from '$lib/api/generated/sdk.gen';
+import {
+	memembershipapplicationsGetJoinEligibility,
+	mesubscriptionsGetMySubscription
+} from '$lib/api/generated/sdk.gen';
 import type {
+	MembershipEligibilitySchema,
 	MySubscriptionSchema,
 	OrganizationRetrieveSchema,
+	PublicMembershipTierSchema,
 	PublicPlanSchema
 } from '$lib/api/generated/types.gen';
+import * as m from '$lib/paraglide/messages.js';
 
 vi.mock('$lib/stores/auth.svelte', () => ({
 	authStore: { accessToken: 'test-token' }
 }));
 
-// Only the membership lookup is stubbed; the rest of the generated client stays
-// real so the dialogs mounted alongside the grid keep their own imports.
+// ApplyDialog (mounted by every tier CTA) invalidates the page data on success.
+vi.mock('$app/navigation', () => ({
+	invalidateAll: vi.fn()
+}));
+
+// Only the two lookups the grid makes are stubbed; the rest of the generated
+// client stays real so the dialogs mounted alongside it keep their own imports.
 vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
 	...(await importOriginal<typeof import('$lib/api/generated/sdk.gen')>()),
-	mesubscriptionsGetMySubscription: vi.fn()
+	mesubscriptionsGetMySubscription: vi.fn(),
+	memembershipapplicationsGetJoinEligibility: vi.fn()
 }));
 
 /**
@@ -31,6 +43,21 @@ function mockSub(sub: MySubscriptionSchema | null) {
 		error: sub ? undefined : { detail: 'Not found' },
 		response: { ok: !!sub } as unknown as Response
 	} as unknown as ReturnType<typeof mesubscriptionsGetMySubscription>);
+}
+
+function makeEligibility(
+	overrides: Partial<MembershipEligibilitySchema> = {}
+): MembershipEligibilitySchema {
+	return { allowed: true, organization_id: 'org-1', ...overrides };
+}
+
+/** One verdict for every tier, unless a test keys them apart itself. */
+function mockEligibility(eligibility: MembershipEligibilitySchema) {
+	vi.mocked(memembershipapplicationsGetJoinEligibility).mockResolvedValue({
+		data: eligibility,
+		error: undefined,
+		response: { ok: true } as unknown as Response
+	} as unknown as Awaited<ReturnType<typeof memembershipapplicationsGetJoinEligibility>>);
 }
 
 function makeSub(overrides: Partial<MySubscriptionSchema> = {}): MySubscriptionSchema {
@@ -86,6 +113,20 @@ function makePlan(overrides: Partial<PublicPlanSchema> = {}): PublicPlanSchema {
 	};
 }
 
+function makeTier(overrides: Partial<PublicMembershipTierSchema> = {}): PublicMembershipTierSchema {
+	return {
+		id: 't-gold',
+		name: 'Gold',
+		description: null,
+		display_order: 0,
+		requires_approval: false,
+		questionnaire_id: null,
+		plans: [],
+		is_free: true,
+		...overrides
+	};
+}
+
 function makeOrg(overrides: Partial<OrganizationRetrieveSchema> = {}): OrganizationRetrieveSchema {
 	return {
 		id: 'org-1',
@@ -105,6 +146,7 @@ describe('MembershipSection', () => {
 		});
 		vi.clearAllMocks();
 		mockSub(null);
+		mockEligibility(makeEligibility());
 	});
 
 	function renderSection(props: Record<string, unknown> = {}) {
@@ -114,7 +156,7 @@ describe('MembershipSection', () => {
 				component: MembershipSection,
 				componentProps: {
 					organization: makeOrg(),
-					plans: [],
+					tiers: [],
 					isAuthenticated: true,
 					...props
 				}
@@ -122,71 +164,161 @@ describe('MembershipSection', () => {
 		});
 	}
 
-	// Most organizations sell nothing — the section must not leave an empty
-	// "Membership" heading behind on their page.
-	it('renders nothing when the organization has no plans', () => {
+	// The page exists to answer "how do I join this org", so it answers even when
+	// the answer is "you can't yet" — unlike the old landing-page section, which
+	// rendered nothing at all.
+	it('says so plainly when the organization has published no tiers', () => {
 		renderSection();
-		expect(screen.queryByRole('heading', { name: 'Membership' })).toBeNull();
-		expect(document.querySelector('#membership')).toBeNull();
+		expect(screen.getByRole('heading', { level: 1, name: 'Membership' })).toBeInTheDocument();
+		expect(
+			screen.getByText(m['membershipTiers.empty']({ organizationName: 'Acme' }))
+		).toBeInTheDocument();
 	});
 
-	it('groups plans by tier, tiers alphabetically and plans cheapest first', () => {
+	// The bug this whole issue is about: the grid used to be built by grouping the
+	// PLANS endpoint by tier, so a tier with no plan produced zero cards and could
+	// never be chosen — which is precisely the free, questionnaire-gated tier.
+	it('renders a plan-less tier as a real, joinable card', async () => {
 		renderSection({
-			plans: [
-				makePlan({
-					id: 'p-gold-annual',
-					tier_id: 't-gold',
-					tier_name: 'Gold',
-					name: 'Annual',
-					price: '100.00'
-				}),
-				makePlan({
-					id: 'p-basic',
-					tier_id: 't-basic',
-					tier_name: 'Basic',
-					name: 'Basic monthly',
-					price: '5.00'
-				}),
-				makePlan({
-					id: 'p-gold-monthly',
-					tier_id: 't-gold',
-					tier_name: 'Gold',
-					name: 'Gold monthly',
-					price: '10.00'
+			tiers: [makeTier({ id: 't-free', name: 'Supporter', is_free: true, plans: [] })]
+		});
+
+		expect(screen.getByRole('heading', { level: 3, name: 'Supporter' })).toBeInTheDocument();
+		expect(await screen.findByRole('button', { name: 'Join Supporter' })).toBeInTheDocument();
+	});
+
+	// `display_order` is the organizer's decision and the backend already applied
+	// it; re-sorting here (the old alphabetical grouping) would override them.
+	it('keeps the backend display order', () => {
+		renderSection({
+			tiers: [
+				makeTier({ id: 't-basic', name: 'Basic', display_order: 0 }),
+				makeTier({ id: 't-gold', name: 'Gold', display_order: 1 }),
+				makeTier({ id: 't-alpha', name: 'Alpha', display_order: 2 })
+			]
+		});
+
+		expect(screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent)).toEqual([
+			'Basic',
+			'Gold',
+			'Alpha'
+		]);
+	});
+
+	it("lists a tier's plans cheapest first", () => {
+		renderSection({
+			tiers: [
+				makeTier({
+					id: 't-gold',
+					name: 'Gold',
+					is_free: false,
+					plans: [
+						makePlan({ id: 'p-annual', name: 'Annual', price: '100.00' }),
+						makePlan({ id: 'p-monthly', name: 'Monthly', price: '10.00' })
+					]
 				})
 			]
 		});
 
-		const tierHeadings = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent);
-		expect(tierHeadings).toEqual(['Basic', 'Gold']);
+		expect(screen.getAllByRole('heading', { level: 4 }).map((h) => h.textContent)).toEqual([
+			'Monthly',
+			'Annual'
+		]);
+	});
 
-		const planHeadings = screen.getAllByRole('heading', { level: 4 }).map((h) => h.textContent);
-		expect(planHeadings).toEqual(['Basic monthly', 'Gold monthly', 'Annual']);
+	// Since BE #831 gated and monetized are not mutually exclusive: the same tier
+	// can want a questionnaire AND charge for a plan, so both affordances have to
+	// coexist on one card.
+	it('shows the gates and the plans of a tier that is both gated and paid', () => {
+		renderSection({
+			tiers: [
+				makeTier({
+					id: 't-gold',
+					name: 'Gold',
+					is_free: false,
+					requires_approval: true,
+					questionnaire_id: 'q1',
+					plans: [makePlan({ id: 'p-monthly', name: 'Monthly' })]
+				})
+			]
+		});
+
+		expect(screen.getByText(m['membershipTiers.requiresApproval']())).toBeInTheDocument();
+		expect(screen.getByText(m['membershipTiers.questionnaireRequired']())).toBeInTheDocument();
+		expect(
+			screen.getByRole('link', {
+				name: m['membershipTiers.questionnaireLinkAria']({ tier: 'Gold' })
+			})
+		).toHaveAttribute('href', '/org/acme/questionnaire/q1');
+		expect(screen.getByRole('heading', { level: 4, name: 'Monthly' })).toBeInTheDocument();
+	});
+
+	// Per-tier verdicts: one tier joinable while its neighbour wants a
+	// questionnaire. A shared cache key would have served the first answer to both.
+	it('renders a different CTA per tier from per-tier verdicts', async () => {
+		vi.mocked(memembershipapplicationsGetJoinEligibility).mockImplementation((async (options: {
+			query?: { tier_id?: string };
+		}) => ({
+			data:
+				options.query?.tier_id === 't-open'
+					? makeEligibility({ allowed: true })
+					: makeEligibility({
+							allowed: false,
+							next_step: 'submit_questionnaire',
+							questionnaire_id: 'q1'
+						}),
+			error: undefined,
+			response: { ok: true } as unknown as Response
+		})) as unknown as typeof memembershipapplicationsGetJoinEligibility);
+
+		renderSection({
+			tiers: [
+				makeTier({ id: 't-open', name: 'Open' }),
+				makeTier({ id: 't-gated', name: 'Gated', questionnaire_id: 'q1' })
+			]
+		});
+
+		expect(await screen.findByRole('button', { name: 'Join Open' })).toBeInTheDocument();
+		expect(
+			await screen.findByRole('link', { name: m['membershipEligibility.questionnaireCta']() })
+		).toBeInTheDocument();
+	});
+
+	// Owners and staff are configuring this page, not shopping on it: N eligibility
+	// round trips would answer a question they never asked.
+	it('shows the owner badge instead of a join CTA on every tier', async () => {
+		renderSection({
+			isOwner: true,
+			tiers: [
+				makeTier({ id: 't-gold', name: 'Gold' }),
+				makeTier({ id: 't-silver', name: 'Silver' })
+			]
+		});
+
+		expect(screen.getByRole('status')).toHaveTextContent(/owner/i);
+		await waitFor(() => {
+			expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalled();
+		});
+		expect(screen.queryByRole('button', { name: /^join /i })).toBeNull();
 	});
 
 	// The grid is one query away from the truth `OrgMembershipInline` already
-	// shows on the same page; before #803 it never asked, and offered a paying
-	// member a concrete new charge the backend can only refuse with a 400.
+	// shows; before #803 it never asked, and offered a paying member a concrete new
+	// charge the backend can only refuse with a 400.
 	describe('for a member who already subscribes here', () => {
-		const gridPlans = [
-			makePlan({
-				id: 'p-gold-monthly',
-				tier_id: 't-gold',
-				tier_name: 'Gold',
-				name: 'Gold monthly'
-			}),
-			makePlan({
-				id: 'p-gold-annual',
-				tier_id: 't-gold',
-				tier_name: 'Gold',
-				name: 'Annual',
-				price: '100.00'
-			})
-		];
+		const paidTier = makeTier({
+			id: 't-gold',
+			name: 'Gold',
+			is_free: false,
+			plans: [
+				makePlan({ id: 'p-gold-monthly', tier_id: 't-gold', name: 'Gold monthly' }),
+				makePlan({ id: 'p-gold-annual', tier_id: 't-gold', name: 'Annual', price: '100.00' })
+			]
+		});
 
 		it('withdraws Subscribe from every plan and marks the one they are on', async () => {
 			mockSub(makeSub({ plan_id: 'p-gold-monthly' }));
-			renderSection({ plans: gridPlans });
+			renderSection({ tiers: [paidTier] });
 
 			await waitFor(() => {
 				expect(screen.getByText('Your plan')).toBeInTheDocument();
@@ -194,14 +326,14 @@ describe('MembershipSection', () => {
 			expect(screen.queryByRole('button', { name: /^subscribe$/i })).toBeNull();
 			expect(screen.getByText(/already have a subscription/i)).toBeInTheDocument();
 			// The plans themselves stay on the page — they are still the org's offer.
-			expect(screen.getByRole('heading', { name: 'Annual' })).toBeInTheDocument();
+			expect(screen.getByRole('heading', { level: 4, name: 'Annual' })).toBeInTheDocument();
 		});
 
 		// Cancelled and expired rows are excluded by the endpoint, so a member
 		// whose membership ended looks exactly like a newcomer and can rejoin.
 		it('keeps Subscribe for a member whose subscription has ended', async () => {
 			mockSub(null);
-			renderSection({ plans: gridPlans });
+			renderSection({ tiers: [paidTier] });
 
 			// Enabled, not merely present: the buttons are held disabled until the
 			// membership lookup answers, so presence alone would pass while loading.
@@ -216,12 +348,13 @@ describe('MembershipSection', () => {
 	});
 
 	it('discloses the refund policy only when the organization has one', () => {
-		const { unmount } = renderSection({ plans: [makePlan()] });
+		const tiers = [makeTier({ is_free: false, plans: [makePlan()] })];
+		const { unmount } = renderSection({ tiers });
 		expect(screen.queryByText('Refund policy')).toBeNull();
 		unmount();
 
 		renderSection({
-			plans: [makePlan()],
+			tiers,
 			organization: makeOrg({ membership_refund_policy: 'No refunds after 14 days.' })
 		});
 		expect(screen.getByText('Refund policy')).toBeInTheDocument();

--- a/src/lib/components/organization/membership/TierCard.svelte
+++ b/src/lib/components/organization/membership/TierCard.svelte
@@ -61,7 +61,16 @@
 	// Cheapest first, and stably: the backend does not promise an order inside a
 	// tier, and cards that reshuffle between renders are worse than an arbitrary
 	// but fixed order. Same rule the old plan grid used.
-	const plans = $derived([...tier.plans].sort((a, b) => Number(a.price) - Number(b.price)));
+	// Block body, not a concise one: `scripts/check-i18n-hardcoded.mjs` scans the
+	// whole file for markup text nodes and does not skip script bodies. A concise
+	// arrow makes the `>` of `=>` open a match that runs all the way to the script
+	// block's closing tag, flagging this code as untranslated prose. The `{` here
+	// ends that match immediately. Scanner bug, tracked separately.
+	const plans = $derived(
+		[...tier.plans].sort((a, b) => {
+			return Number(a.price) - Number(b.price);
+		})
+	);
 
 	/**
 	 * Since BE #831 a tier can be gated AND paid, so these are independent

--- a/src/lib/components/organization/membership/TierCard.svelte
+++ b/src/lib/components/organization/membership/TierCard.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import { resolve } from '$app/paths';
+	import type {
+		MySubscriptionSchema,
+		PublicMembershipTierSchema,
+		PublicPlanSchema
+	} from '$lib/api/generated/types.gen';
+	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import { ClipboardList, Gift, ShieldCheck } from '@lucide/svelte';
+	import MembershipCta from './MembershipCta.svelte';
+	import PlanCard from './PlanCard.svelte';
+
+	interface Props {
+		tier: PublicMembershipTierSchema;
+		organizationSlug: string;
+		organizationName: string;
+		isAuthenticated: boolean;
+		/**
+		 * The viewer's live subscription in this org, forwarded untouched to every
+		 * PlanCard — see that component for why a non-null value withdraws the
+		 * subscribe CTA everywhere.
+		 */
+		subscription?: MySubscriptionSchema | null;
+		subscriptionLoading?: boolean;
+		onSubscribe: (plan: PublicPlanSchema & { id: string }) => void;
+		/**
+		 * Whether to ask the backend what THIS viewer may do with THIS tier.
+		 *
+		 * False for owners and staff: they already have standing in the org (shown
+		 * once at the top of the page), so a verdict per tier would be N pointless
+		 * round trips answering a question they never asked.
+		 */
+		showJoinCta?: boolean;
+	}
+
+	const {
+		tier,
+		organizationSlug,
+		organizationName,
+		isAuthenticated,
+		subscription = null,
+		subscriptionLoading = false,
+		onSubscribe,
+		showJoinCta = true
+	}: Props = $props();
+
+	// Unique per instance: several of these cards sit side by side, and each needs
+	// its own accessible name.
+	const uid = $props.id();
+	const headingId = `${uid}-tier-name`;
+
+	/**
+	 * `id` is optional in the generated schema (it is a model field with a
+	 * server-side default), but nothing here can act on a tier without one — no
+	 * eligibility question to ask, no `tier_id` to post.
+	 */
+	const tierId = $derived(tier.id ?? null);
+
+	// Cheapest first, and stably: the backend does not promise an order inside a
+	// tier, and cards that reshuffle between renders are worse than an arbitrary
+	// but fixed order. Same rule the old plan grid used.
+	const plans = $derived([...tier.plans].sort((a, b) => Number(a.price) - Number(b.price)));
+
+	/**
+	 * Since BE #831 a tier can be gated AND paid, so these are independent
+	 * statements about the same tier rather than a single mutually-exclusive
+	 * mode. Each badge pairs an icon with its own words — nothing here is carried
+	 * by colour (WCAG 1.4.1).
+	 */
+	const isFree = $derived(tier.is_free);
+</script>
+
+<!-- `<article>` + `aria-labelledby`, not a labelled `region`: the cards are peers
+     in a list and each must announce which tier it is, but N landmarks on one
+     page would drown the page's real ones. -->
+<article class="h-full" aria-labelledby={headingId}>
+	<Card class="flex h-full flex-col">
+		<CardContent class="flex flex-1 flex-col gap-4 p-4 sm:p-5">
+			<div class="space-y-2">
+				<div class="flex flex-wrap items-start justify-between gap-2">
+					<h3 id={headingId} class="text-lg font-semibold">{tier.name}</h3>
+					{#if isFree}
+						<span
+							class="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground"
+						>
+							<Gift class="h-3 w-3" aria-hidden="true" />
+							{m['membershipTiers.freeBadge']()}
+						</span>
+					{/if}
+				</div>
+
+				{#if tier.description}
+					<MarkdownContent content={tier.description} class="text-sm text-muted-foreground" />
+				{/if}
+			</div>
+
+			<!-- What it takes to get in. Rendered for everyone, member or not: it is a
+		     description of the tier, not of the viewer's progress through it. -->
+			{#if tier.requires_approval || tier.questionnaire_id}
+				<ul class="space-y-1.5 text-sm">
+					{#if tier.requires_approval}
+						<li class="flex items-start gap-2">
+							<ShieldCheck
+								class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+								aria-hidden="true"
+							/>
+							<span>{m['membershipTiers.requiresApproval']()}</span>
+						</li>
+					{/if}
+					{#if tier.questionnaire_id}
+						<li class="flex items-start gap-2">
+							<ClipboardList
+								class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+								aria-hidden="true"
+							/>
+							<span>
+								{m['membershipTiers.questionnaireRequired']()}
+								{#if tier.questionnaire_id}
+									<!-- Named with the tier: a screen-reader user tabbing the page
+								     would otherwise hear the same link text on every card. -->
+									<a
+										href={resolve('/(public)/org/[slug]/questionnaire/[id]', {
+											slug: organizationSlug,
+											id: tier.questionnaire_id
+										})}
+										aria-label={m['membershipTiers.questionnaireLinkAria']({ tier: tier.name })}
+										class="font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+									>
+										{m['membershipTiers.questionnaireLink']()}
+									</a>
+								{/if}
+							</span>
+						</li>
+					{/if}
+				</ul>
+			{/if}
+
+			{#if plans.length > 0}
+				<div class="space-y-3">
+					{#each plans as plan (plan.id ?? `${tier.id}-${plan.name}`)}
+						<PlanCard
+							{plan}
+							{isAuthenticated}
+							{subscription}
+							{subscriptionLoading}
+							{organizationSlug}
+							{onSubscribe}
+						/>
+					{/each}
+				</div>
+			{/if}
+
+			<div class="mt-auto pt-1">
+				{#if showJoinCta && tierId}
+					<MembershipCta
+						{organizationSlug}
+						{organizationName}
+						{isAuthenticated}
+						{tierId}
+						tierName={tier.name}
+						plansInline={plans.length > 0}
+					/>
+				{/if}
+			</div>
+		</CardContent>
+	</Card>
+</article>

--- a/src/lib/components/organization/membership/TierCard.test.ts
+++ b/src/lib/components/organization/membership/TierCard.test.ts
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import TierCard from './TierCard.svelte';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import { memembershipapplicationsGetJoinEligibility } from '$lib/api/generated/sdk.gen';
+import type {
+	MembershipEligibilitySchema,
+	PublicMembershipTierSchema,
+	PublicPlanSchema
+} from '$lib/api/generated/types.gen';
+import * as m from '$lib/paraglide/messages.js';
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { accessToken: 'test-token' }
+}));
+
+vi.mock('$app/navigation', () => ({
+	invalidateAll: vi.fn()
+}));
+
+vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/api/generated/sdk.gen')>()),
+	memembershipapplicationsGetJoinEligibility: vi.fn()
+}));
+
+function mockEligibility(overrides: Partial<MembershipEligibilitySchema> = {}) {
+	vi.mocked(memembershipapplicationsGetJoinEligibility).mockResolvedValue({
+		data: { allowed: true, organization_id: 'org-1', ...overrides },
+		error: undefined,
+		response: { ok: true } as unknown as Response
+	} as unknown as Awaited<ReturnType<typeof memembershipapplicationsGetJoinEligibility>>);
+}
+
+function makePlan(overrides: Partial<PublicPlanSchema> = {}): PublicPlanSchema {
+	return {
+		id: 'plan-1',
+		tier_id: 't-gold',
+		tier_name: 'Gold',
+		name: 'Monthly',
+		description: null,
+		price: '10.00',
+		currency: 'EUR',
+		period_unit: 'month',
+		period_count: 1,
+		payment_method: 'online',
+		sales_status: 'open',
+		sold_out: false,
+		...overrides
+	};
+}
+
+function makeTier(overrides: Partial<PublicMembershipTierSchema> = {}): PublicMembershipTierSchema {
+	return {
+		id: 't-gold',
+		name: 'Gold',
+		description: null,
+		display_order: 0,
+		requires_approval: false,
+		questionnaire_id: null,
+		plans: [],
+		is_free: true,
+		...overrides
+	};
+}
+
+describe('TierCard', () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+		});
+		vi.clearAllMocks();
+		mockEligibility();
+	});
+
+	function renderCard(props: Record<string, unknown> = {}) {
+		return render(QueryClientTestWrapper, {
+			props: {
+				client: queryClient,
+				component: TierCard,
+				componentProps: {
+					tier: makeTier(),
+					organizationSlug: 'acme',
+					organizationName: 'Acme',
+					isAuthenticated: true,
+					onSubscribe: vi.fn(),
+					...props
+				}
+			}
+		});
+	}
+
+	// The cards are peers in a grid, so each has to announce which tier it is
+	// before anything inside it makes sense (WCAG 1.3.1).
+	it('names itself after its tier', () => {
+		renderCard({ tier: makeTier({ name: 'Supporter' }) });
+
+		expect(screen.getByRole('article', { name: 'Supporter' })).toBeInTheDocument();
+	});
+
+	it('renders the tier description as markdown', () => {
+		renderCard({ tier: makeTier({ description: 'Access to **everything**.' }) });
+
+		expect(screen.getByText('everything').tagName).toBe('STRONG');
+	});
+
+	// Not colour: an icon plus its own words, so the state survives greyscale and
+	// every form of colour blindness.
+	it('states the approval gate in words', () => {
+		renderCard({ tier: makeTier({ requires_approval: true }) });
+
+		expect(screen.getByText(m['membershipTiers.requiresApproval']())).toBeInTheDocument();
+	});
+
+	it('links the questionnaire gate at the questionnaire itself', () => {
+		renderCard({ tier: makeTier({ name: 'Gold', questionnaire_id: 'q-42' }) });
+
+		expect(
+			screen.getByRole('link', {
+				name: m['membershipTiers.questionnaireLinkAria']({ tier: 'Gold' })
+			})
+		).toHaveAttribute('href', '/org/acme/questionnaire/q-42');
+	});
+
+	it('marks a plan-less tier as free and still offers a join CTA', async () => {
+		renderCard({ tier: makeTier({ name: 'Supporter', is_free: true, plans: [] }) });
+
+		expect(screen.getByText(m['membershipTiers.freeBadge']())).toBeInTheDocument();
+		expect(await screen.findByRole('button', { name: 'Join Supporter' })).toBeInTheDocument();
+	});
+
+	it('renders the plans of a paid tier and drops the free badge', () => {
+		renderCard({
+			tier: makeTier({
+				is_free: false,
+				plans: [makePlan({ id: 'p-1', name: 'Monthly' })]
+			})
+		});
+
+		expect(screen.getByRole('heading', { level: 4, name: 'Monthly' })).toBeInTheDocument();
+		expect(screen.queryByText(m['membershipTiers.freeBadge']())).toBeNull();
+	});
+
+	// Owner/staff: the page is configuration to them. Suppressed here rather than
+	// in the CTA so no eligibility request is made at all.
+	it('asks nothing and offers nothing when the join CTA is suppressed', async () => {
+		renderCard({ showJoinCta: false });
+
+		await waitFor(() => {
+			expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalled();
+		});
+		expect(screen.queryByRole('button', { name: /^join /i })).toBeNull();
+	});
+
+	// A tier the backend serialized without an id cannot be applied to (there is no
+	// `tier_id` to post), so it must not grow a button that could only fail.
+	it('omits the CTA for a tier with no id', async () => {
+		renderCard({ tier: makeTier({ id: null }) });
+
+		await waitFor(() => {
+			expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalled();
+		});
+		expect(screen.queryByRole('button', { name: /^join /i })).toBeNull();
+	});
+});

--- a/src/lib/components/tickets/PurchaseErrorAlert.svelte
+++ b/src/lib/components/tickets/PurchaseErrorAlert.svelte
@@ -37,15 +37,10 @@
 		(tier.restricted_to_membership_tiers ?? []).map((t) => t.name).filter(Boolean)
 	);
 
-	// The org's membership plans: the only surface where a qualifying tier can be
-	// obtained. Deliberately not "Join organization" — a plain membership request
-	// grants no tier and would dead-end, which is why the backend refuses to send
-	// this case down the become_member path at all.
-	const membershipPlansHref = $derived(
-		organizationSlug
-			? `${resolve('/(public)/org/[slug]', { slug: organizationSlug })}#membership`
-			: null
-	);
+	// The link below points at the org's membership page — the only surface where
+	// a qualifying tier can be obtained. Deliberately not "Join organization": a
+	// plain membership request grants no tier and would dead-end, which is why the
+	// backend refuses to send this case down the become_member path at all.
 </script>
 
 {#if message}
@@ -59,15 +54,13 @@
 					{m['tierCardAdmin.requiresMembership']({ tiers: requiredTierNames.join(', ') })}
 				</p>
 			{/if}
-			{#if membershipGateRefused && membershipPlansHref}
-				<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the route id; the appended #membership fragment cannot be expressed through resolve() -->
+			{#if membershipGateRefused && organizationSlug}
 				<a
-					href={membershipPlansHref}
+					href={resolve('/(public)/org/[slug]/membership', { slug: organizationSlug })}
 					class="mt-2 inline-block text-sm font-medium underline underline-offset-4"
 				>
 					{m['membershipPlans.viewMembership']()}
 				</a>
-				<!-- eslint-enable svelte/no-navigation-without-resolve -->
 			{/if}
 		</AlertDescription>
 	</Alert>

--- a/src/lib/components/tickets/PurchaseErrorAlert.test.ts
+++ b/src/lib/components/tickets/PurchaseErrorAlert.test.ts
@@ -78,10 +78,12 @@ describe('PurchaseErrorAlert', () => {
 		);
 	});
 
-	it("links at the organization's membership plans", () => {
+	// The dedicated tier page since #720: the old `/org/acme#membership` fragment
+	// pointed at a plan grid that no longer lives on the landing page.
+	it("links at the organization's membership page", () => {
 		renderAlert({ error: refusalError });
 		const link = screen.getByRole('link', { name: m['membershipPlans.viewMembership']() });
-		expect(link).toHaveAttribute('href', '/org/acme#membership');
+		expect(link).toHaveAttribute('href', '/org/acme/membership');
 	});
 
 	it('omits the link when the organization slug is unknown', () => {

--- a/src/lib/utils/membership-eligibility.test.ts
+++ b/src/lib/utils/membership-eligibility.test.ts
@@ -49,6 +49,24 @@ describe('getMembershipCtaKind', () => {
 		expect(getMembershipCtaKind({ ...base, reason_code: 'membership_paused' })).toBe('info');
 	});
 
+	// BE #831 made gated and monetized tiers coexist, so this step is the positive
+	// end of a tier's gate chain: everything else is satisfied and only the charge
+	// is left. Folded into `info` before #720, where it rendered policy prose and
+	// no control — the exact dead end this issue is about.
+	it('maps proceed_to_payment to payment, not to info', () => {
+		expect(getMembershipCtaKind({ ...base, next_step: 'proceed_to_payment' })).toBe('payment');
+		// Also when the verdict is refused-but-payable: the block IS the payment.
+		expect(
+			getMembershipCtaKind({
+				...base,
+				allowed: false,
+				next_step: 'proceed_to_payment',
+				reason_code: 'tier_requires_subscription',
+				plan_id: 'plan-1'
+			})
+		).toBe('payment');
+	});
+
 	// BE #812, pinned field-for-field as `MembershipQuestionnaireGate._handle_rejected`
 	// emits it: refused, no next_step, and a `questionnaire_id` still attached (the
 	// gate passes it for context). `info` is the whole point — the previous verdict

--- a/src/lib/utils/membership-eligibility.ts
+++ b/src/lib/utils/membership-eligibility.ts
@@ -9,15 +9,16 @@ import * as m from '$lib/paraglide/messages.js';
  * The shape of call-to-action a membership eligibility verdict implies.
  *
  * - `join` — allowed, free path → open the apply dialog
+ * - `payment` — every gate is cleared; what is left is paying for a plan
  * - `questionnaire` — the user must submit the membership questionnaire first
  * - `waiting` — something is pending review (questionnaire, approval, whitelist)
  * - `retry_later` — the questionnaire can be retaken after `retry_on`
  * - `reapply` — a previous application ended; the user may apply again
  * - `member` — the user is already a member
- * - `info` — nothing actionable: invitation-only, payment-gated, or a plain denial
+ * - `info` — nothing actionable: invitation-only or a plain denial
  */
 export type MembershipCtaKind =
-	'join' | 'questionnaire' | 'waiting' | 'retry_later' | 'reapply' | 'member' | 'info';
+	'join' | 'payment' | 'questionnaire' | 'waiting' | 'retry_later' | 'reapply' | 'member' | 'info';
 
 /**
  * Map a membership eligibility verdict to the CTA the UI should render.
@@ -40,8 +41,14 @@ export function getMembershipCtaKind(e: MembershipEligibilitySchema): Membership
 		case 'reapply':
 			return 'reapply';
 		case 'requires_invitation':
-		case 'proceed_to_payment':
 			return 'info';
+		case 'proceed_to_payment':
+			// BE #831: gated and monetized are no longer mutually exclusive, so this
+			// step is the *positive* end of a tier's gate chain — approval and
+			// questionnaire (if any) are satisfied and only the charge is left. It
+			// used to fold into `info`, which rendered the org's policy prose next to
+			// nothing to press; the caller now sends the user at the plans instead.
+			return 'payment';
 	}
 	// No next_step: `allowed` decides. Since BE #788 a pending tier-less
 	// application arrives with an explicit `wait_for_approval`, so it is caught by

--- a/src/routes/(public)/org/[slug]/+page.server.ts
+++ b/src/routes/(public)/org/[slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { error, isHttpError } from '@sveltejs/kit';
+import { error, isHttpError, redirect } from '@sveltejs/kit';
 import { buildSeo } from '$lib/seo';
 import { resolveLang } from '$lib/seo/server';
 import {
@@ -21,6 +21,20 @@ import { canPerformAction } from '$lib/utils/permissions';
 
 export const load: PageServerLoad = async ({ params, locals, fetch, url, request }) => {
 	const { slug } = params;
+
+	// Stripe hands the member back to this URL — the success/cancel URLs are built
+	// server-side by the BACKEND (`subscription_stripe_service.py`, `/org/{slug}?
+	// membership_success=true`), so the frontend cannot re-point them. The card
+	// that explains the outcome now lives on the membership page, so forward the
+	// flag there. Outside the try below: a `redirect` is not an `HttpError`, and
+	// the catch would swallow it into a 500.
+	const isCheckoutReturn =
+		url.searchParams.has('membership_success') || url.searchParams.has('membership_cancelled');
+	if (isCheckoutReturn) {
+		// The whole query string travels: `?ot=` may be riding along on a private
+		// org, and the membership page reads it the same way this one does.
+		throw redirect(303, `/org/${encodeURIComponent(slug)}/membership${url.search}`);
+	}
 
 	try {
 		// Prepare headers with authentication if user is logged in

--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -26,7 +26,6 @@
 		eventseriesListEventSeries
 	} from '$lib/api/generated/sdk.gen';
 	import MembershipCta from '$lib/components/organization/membership/MembershipCta.svelte';
-	import MembershipSection from '$lib/components/organization/membership/MembershipSection.svelte';
 	import OrgContactButton from '$lib/components/organization/OrgContactButton.svelte';
 	import ClaimMembershipButton from '$lib/components/organizations/ClaimMembershipButton.svelte';
 	import OrgMembershipInline from '$lib/components/account/OrgMembershipInline.svelte';
@@ -371,12 +370,30 @@
 			/>
 		</div>
 
-		<!-- Membership Section (plans, checkout return, refund policy) -->
-		<MembershipSection
-			{organization}
-			plans={data.membershipPlans}
-			isAuthenticated={data.isAuthenticated}
-		/>
+		<!-- Membership entry point.
+
+		     The plan grid used to live here, above the resources, series and
+		     events this page exists to show. It moved to /org/[slug]/membership
+		     (#720) — a tier can only be *chosen* there — and what is left is the
+		     pointer at it. The `id="membership"` stays so the deep links that
+		     predate the move still land on something that explains itself. -->
+		{#if organization.accept_membership_requests || data.membershipPlans.length > 0}
+			<section id="membership" aria-labelledby="membership-heading" class="mb-12">
+				<h2 id="membership-heading" class="text-2xl font-bold">
+					{m['membershipPlans.heading']()}
+				</h2>
+				<p class="mt-1 text-sm text-muted-foreground">
+					{m['membershipTiers.landingBlurb']({ organizationName: organization.name })}
+				</p>
+				<a
+					href={resolve('/(public)/org/[slug]/membership', { slug: organization.slug })}
+					class="mt-3 inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				>
+					{m['membershipPlans.viewMembership']()}
+					<ArrowRight class="h-4 w-4" aria-hidden="true" />
+				</a>
+			</section>
+		{/if}
 
 		<!-- Resources Section -->
 		{#if displayedResources.length > 0}

--- a/src/routes/(public)/org/[slug]/membership/+page.server.ts
+++ b/src/routes/(public)/org/[slug]/membership/+page.server.ts
@@ -1,0 +1,138 @@
+import { error, isHttpError } from '@sveltejs/kit';
+import { buildSeo } from '$lib/seo';
+import { resolveLang } from '$lib/seo/server';
+import {
+	organizationGetOrganization,
+	organizationListMembershipTiers,
+	permissionMyPermissions
+} from '$lib/api';
+import { log } from '$lib/server/logger';
+import type { PageServerLoad } from './$types';
+import type {
+	MembershipStatus,
+	MembershipTierSchema,
+	OrganizationPermissionsSchema,
+	PublicMembershipTierSchema
+} from '$lib/api/generated/types.gen';
+
+/**
+ * SSR is on (the SvelteKit default, restated because it is a decision here):
+ * "become a member of X" is an indexable, linkable page, and the tier grid is
+ * its entire content — rendering it only on the client would leave crawlers and
+ * shared links with an empty box.
+ */
+export const ssr = true;
+
+export const load: PageServerLoad = async ({ params, locals, fetch, url, request }) => {
+	const { slug } = params;
+
+	try {
+		const headers: HeadersInit = {};
+		if (locals.user?.accessToken) {
+			headers['Authorization'] = `Bearer ${locals.user.accessToken}`;
+		}
+		// Same private-org escape hatch the org landing page honours, so a token
+		// link that reaches the profile also reaches its membership offer.
+		const orgToken = url.searchParams.get('ot');
+		if (orgToken) {
+			headers['X-Org-Token'] = orgToken;
+		}
+
+		const orgResponse = await organizationGetOrganization({ fetch, path: { slug }, headers });
+
+		if (!orgResponse.data) {
+			if (orgResponse.response?.status === 410) {
+				throw error(410, 'This invitation link is no longer valid');
+			}
+			throw error(404, 'Organization not found');
+		}
+
+		const organization = orgResponse.data;
+
+		// Non-fatal: an org with no reachable tier listing still gets a page that
+		// says so, rather than a 500 on a public URL people may have shared.
+		const tiers = await (async (): Promise<PublicMembershipTierSchema[]> => {
+			try {
+				const response = await organizationListMembershipTiers({ fetch, path: { slug }, headers });
+				return response.data ?? [];
+			} catch (err) {
+				log.warning('org_membership_tiers_fetch_failed', { error: err, slug });
+				return [];
+			}
+		})();
+
+		// The viewer's standing. It decides whether the page shows a badge instead
+		// of N join CTAs, so it is worth the extra round trip — but never worth a
+		// failed page: a permissions outage degrades to "logged in, no standing".
+		let isMember = false;
+		let membershipTier: MembershipTierSchema | null = null;
+		let membershipStatus: MembershipStatus | null = null;
+		let isOwner = false;
+		let isStaff = false;
+		if (locals.user) {
+			try {
+				const permissionsResponse = await permissionMyPermissions({ fetch, headers });
+				if (permissionsResponse.data) {
+					const userPermissions: OrganizationPermissionsSchema = permissionsResponse.data;
+					const membership = userPermissions.memberships?.[organization.id];
+					if (membership) {
+						isMember = true;
+						membershipTier = membership.tier || null;
+						membershipStatus = (membership.status as MembershipStatus) || null;
+					}
+
+					const orgPermissions = userPermissions.organization_permissions?.[organization.id];
+					if (orgPermissions === 'owner') {
+						isOwner = true;
+					} else if (orgPermissions && typeof orgPermissions === 'object') {
+						isStaff = true;
+					}
+				}
+			} catch (err) {
+				log.error('org_membership_permissions_fetch_failed', { error: err, slug });
+			}
+		}
+
+		const lang = resolveLang(request);
+		// Canonical without the query string: `?ot=` and the Stripe return flags
+		// are per-visit, and each would otherwise mint a distinct canonical URL
+		// for the same page.
+		const canonicalUrl = new URL(url.pathname, url.origin);
+		const orgSeo = buildSeo({ kind: 'org', url: canonicalUrl, lang, org: organization });
+		// The org SEO carries the right image, locale alternates and JSON-LD; only
+		// the wording has to say what THIS page is. Overridden here rather than by
+		// adding a `kind` to `buildSeo`, so the membership route owns its own copy.
+		const title = `Membership | ${organization.name} | Revel`;
+		const description = `Become a member of ${organization.name} on Revel — membership tiers, what each one includes, and how to join.`;
+		const seo = {
+			...orgSeo,
+			title,
+			description,
+			og: { ...orgSeo.og, title: `Membership | ${organization.name}`, description },
+			twitter: { ...orgSeo.twitter, title: `Membership | ${organization.name}`, description }
+		};
+
+		return {
+			seo,
+			organization,
+			tiers,
+			isMember,
+			membershipTier,
+			membershipStatus,
+			isOwner,
+			isStaff,
+			isAuthenticated: !!locals.user
+		};
+	} catch (err) {
+		if (isHttpError(err)) throw err;
+
+		if (typeof err === 'object' && err !== null && 'status' in err) {
+			const status = (err as { status: number }).status;
+			if (status === 404) throw error(404, 'Organization not found');
+			if (status === 403) throw error(403, 'You do not have permission to view this organization');
+		}
+
+		log.error('org_membership_load_error', { error: err, slug });
+		throw error(500, 'Failed to load membership options');
+	}
+};

--- a/src/routes/(public)/org/[slug]/membership/+page.svelte
+++ b/src/routes/(public)/org/[slug]/membership/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { ArrowLeft } from '@lucide/svelte';
+	import MembershipSection from '$lib/components/organization/membership/MembershipSection.svelte';
+	import { SeoHead } from '$lib/seo';
+	import * as m from '$lib/paraglide/messages.js';
+	import type { PageData } from './$types';
+
+	const { data }: { data: PageData } = $props();
+
+	const organization = $derived(data.organization);
+</script>
+
+<SeoHead config={data.seo} />
+
+<div class="space-y-6">
+	<a
+		href={resolve('/(public)/org/[slug]', { slug: organization.slug })}
+		class="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+	>
+		<ArrowLeft class="h-4 w-4" aria-hidden="true" />
+		{m['membershipTiers.backToOrg']({ organizationName: organization.name })}
+	</a>
+
+	<MembershipSection
+		{organization}
+		tiers={data.tiers}
+		isAuthenticated={data.isAuthenticated}
+		isMember={data.isMember}
+		membershipTier={data.membershipTier}
+		membershipStatus={data.membershipStatus}
+		isOwner={data.isOwner}
+		isStaff={data.isStaff}
+	/>
+</div>


### PR DESCRIPTION
Closes #720

Base is `integration/membership-tier-unlock`, **not** `main`.

## The hole

A user could never choose a membership tier anywhere in the product:

- `ApplyDialog` posted `{ notes }` only; `MembershipCta` asked `join-eligibility` with no `tier_id`. **Every application the UI ever created was tier-less.**
- `MembershipSection` built its grid by grouping the *plans* endpoint by tier, so a tier with no plan rendered zero cards — precisely the free, questionnaire-gated tier.
- With no tier on the request the backend resolved only the org-wide policy, so `MembershipTier.membership_questionnaire` and `requires_membership_approval` were dead configuration.

## What changed

### A new route: `/org/[slug]/membership`

SSR on, own SEO (title/description overridden on top of the org SEO so it keeps the org's og:image, locale alternates and JSON-LD; canonical is built from `url.pathname` only, so `?ot=` and the Stripe flags don't mint variants). Loads the org, the new public `membership-tiers` endpoint (non-fatal — an unreachable listing renders the empty state, not a 500) and the viewer's standing.

`MembershipSection` was repurposed as this page's body: heading, checkout-return card, tier grid, refund policy, `SubscribeDialog`. New `TierCard.svelte` renders one tier — `<article aria-labelledby>`, h3 name, markdown description, `Free` badge, gate list (icon **plus words**, never colour), plans as `PlanCard`s, and the per-tier CTA. Mobile-first: one column, `sm:grid-cols-2`.

**Gated and paid are not treated as exclusive** (BE #831): a tier can show an approval line, a questionnaire link *and* its plans at once.

### Sending the tier

- `MembershipCta` gains `tierId` / `tierName` / `plansInline`. Query key is `['org', slug, 'join-eligibility', tierId ?? null]` — the existing 3-element invalidations in `ApplyDialog` and `CheckoutReturnCard` still reach every entry, because TanStack matches by prefix. The request carries `query: { tier_id }`.
- Without a `tierId` the component is now a **summary**: `join` / `reapply` / `payment` become a link to the tier grid instead of opening a dialog that could only create another tier-less application. That is why the org landing hero CTA no longer opens `ApplyDialog`. `ApplyDialog` is not even mounted in summary mode.
- `ApplyDialog` accepts and posts `tier_id`, and titles itself after the tier ("Join Gold").
- CTAs say what they join ("Join Gold"), never N bare "Join"s.

### `proceed_to_payment`

`getMembershipCtaKind` folded it into `info`, which rendered policy prose next to nothing to press. It now maps to a new `payment` kind: with the tier's plans on screen it renders the "choose a plan below" note, elsewhere it links to the membership page. (`submit_application` was left alone — it still falls through to `allowed ? 'join' : 'info'`, unchanged.)

### Stripe return

Traced first: the success/cancel URLs are built **server-side by the backend** (`revel-backend/src/events/service/subscription_stripe_service.py:142-143` → `/org/{slug}?membership_success=true`), so the frontend cannot re-point them. The org landing load therefore `303`s any `?membership_success` / `?membership_cancelled` (whole query string preserved, `?ot=` included) to `/org/[slug]/membership`, which renders `CheckoutReturnCard` exactly as before and strips the flag with the same raw `history.replaceState` idiom. The redirect sits *outside* the load's try/catch — a redirect is not an `HttpError` and the catch would have turned it into a 500.

**Optional backend follow-up:** point `success_url`/`cancel_url` straight at `/org/{slug}/membership` and the hop disappears. Not required — the hop is correct either way.

### `#membership` deep links

All three sites repointed at the real route (no fragment, so the `eslint-disable svelte/no-navigation-without-resolve` blocks came out):

- `tickets/PurchaseErrorAlert.svelte`
- `events/OrganizationInfo.svelte`
- `events/IneligibilityActionButton.svelte` (`upgrade_membership`) — a third site the issue didn't list

A stale `/org/[slug]#membership` still lands on something sensible: the landing page keeps a compact `id="membership"` section (heading + one line + "View membership options") in the plan grid's old slot, rendered when the org accepts members or has plans.

## Props I wanted but did not add

None. `PlanCard` and `SubscribeDialog` are composed exactly as they are (#724 owns them). `QuestionnaireCard` (#721) and the admin questionnaire routes (#722) are untouched.

## New i18n keys (all four locales)

Predictable conflict surface for the parallel branches:

- `membershipEligibility.joinTier`, `membershipEligibility.choosePlan`
- `membershipApply.titleTier`, `membershipApply.reapplyTitleTier`
- new namespace `membershipTiers.*`: `heading`, `subtitle`, `tiersHeading`, `empty`, `backToOrg`, `freeBadge`, `requiresApproval`, `questionnaireRequired`, `questionnaireLink`, `questionnaireLinkAria`, `landingBlurb`

`membershipTiers` is inserted after `membershipApply` in each catalog; the other two are appended inside existing namespaces.

## Tests (written, not run — house rule)

- `TierCard.test.ts` (new): accessible name, markdown description, both gate affordances, free badge + join CTA on a plan-less tier, plans on a paid tier, no request at all when the CTA is suppressed or the tier has no id.
- `MembershipSection.test.ts` (rewritten for tiers): empty state, **a plan-less tier renders a joinable card**, backend `display_order` preserved, plans cheapest-first, gated+paid on one card, per-tier verdicts producing different CTAs, owner badge with zero eligibility round trips, the existing subscriber cases, refund policy.
- `MembershipCta.test.ts`: tier-named join button, `tier_id` on the request, per-tier cache isolation, both `proceed_to_payment` shapes, summary-mode link, both guest paths.
- `ApplyDialog.test.ts`: posts the tier, titles itself after the tier.
- `membership-eligibility.test.ts`: `proceed_to_payment` → `payment`.
- `PurchaseErrorAlert.test.ts`: href is now `/org/acme/membership`.

## E2E — for #723, out of scope here

These specs navigate to `/org/{slug}` expecting the plan grid and will need repointing at `/org/{slug}/membership`:

- `tests/e2e/journeys/j23-subscriptions/{subscribe-online,plan-states,manage-subscription}.spec.ts`
- `tests/e2e/journeys/j27-applications/eligibility-states.spec.ts` (asserts `Join {org.name}` on the org page; that button is now the summary link, and the per-tier button reads `Join {tier}`)

## Gate

`make fix` then `make check`: **0 errors**, 374 warnings (the accepted #361 baseline), i18n 7829 keys × 4 aligned, file lengths within caps, type gate armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP
