### PR TITLE
test(e2e): drive tier selection through the UI, repoint the moved surfaces

### DIFF
--- a/tests/e2e/journeys/j03-account/follow-org.spec.ts
+++ b/tests/e2e/journeys/j03-account/follow-org.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '../../support/fixtures';
-import { createOrganization, createVerifiedUser } from '../../support/factories';
+import {
+	createOrganization,
+	createVerifiedUser,
+	setOrgMembershipPolicy
+} from '../../support/factories';
 import { authenticateContext } from '../../support/session';
+import { membershipPath, tierCard } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 import { closeDialog } from '../../support/ui';
 
@@ -9,9 +14,13 @@ import { closeDialog } from '../../support/ui';
 // land in the org admin's queue; unfollow at the end.
 //
 // The join flow is the eligibility CTA + ApplyDialog (PR② of the membership
-// subscriptions work); the legacy "Request Membership" button is gone. A UI
-// apply carries no tier, so the backend leaves the application PENDING for
-// staff — hence the "Application received" outcome and the approve leg below.
+// subscriptions work); the legacy "Request Membership" button is gone. Since
+// #720 the CTA that opens that dialog lives on /org/[slug]/membership, next to
+// the tier being joined — the landing page keeps only a pointer at the grid —
+// and the apply carries that tier. The org therefore has to REQUIRE APPROVAL
+// for the application to stay pending; a tier-bearing apply on an ungated org
+// completes on the spot, and there would be no request for the admin queue leg
+// below to show.
 //
 // Isolation: throwaway-owned org (accepting requests) + throwaway follower —
 // seeded follow relationships (hannah→Alpha, ivan→Beta) stay untouched, and
@@ -27,6 +36,7 @@ test.describe('J3 follow org & request membership @p1', () => {
 			createVerifiedUser('Follower')
 		]);
 		const followerName = `${follower.firstName} ${follower.lastName}`;
+		await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: true });
 
 		const context = await browser.newContext();
 		await authenticateContext(context, follower);
@@ -46,26 +56,31 @@ test.describe('J3 follow org & request membership @p1', () => {
 		await page.getByRole('menuitemcheckbox', { name: 'Notify me about new events' }).click();
 		await expect(page.getByText('Preferences updated')).toBeVisible({ timeout: 15_000 });
 
-		// Apply for membership with a message.
-		await page.getByRole('button', { name: `Join ${org.name}` }).click();
-		const applyDialog = page.getByRole('dialog', { name: `Join ${org.name}` });
+		// Apply for membership with a message — on the tier grid, the only surface
+		// that can name the tier the application will carry.
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+		const generalTier = tierCard(page, 'General membership');
+		await expect(generalTier).toBeVisible({ timeout: 15_000 });
+		await generalTier.getByRole('button', { name: 'Join General membership' }).click();
+		const applyDialog = page.getByRole('dialog', { name: 'Join General membership' });
 		await expect(applyDialog).toBeVisible();
 		await applyDialog.getByLabel('Message (optional)').fill('E2E: please let me in');
 		await applyDialog.getByRole('button', { name: 'Send application' }).click();
 
 		// The outcome replaces the form in place, so the dialog is RE-TITLED —
-		// a tier-less apply stays PENDING, hence "Application received" (an
-		// auto-granted membership would title it "You're in!").
+		// approval is still owed, hence "Application received" (an auto-granted
+		// membership would title it "You're in!").
 		const outcomeDialog = page.getByRole('dialog', { name: 'Application received' });
 		await expect(outcomeDialog).toBeVisible({ timeout: 15_000 });
 		await expect(outcomeDialog.getByRole('link', { name: 'Track your application' })).toBeVisible();
 		await closeDialog(page, outcomeDialog);
 
 		// The CTA follows the refreshed eligibility verdict.
-		await expect(page.getByRole('button', { name: 'Application pending' })).toBeDisabled();
+		await expect(generalTier.getByRole('button', { name: 'Application pending' })).toBeDisabled();
 
-		// Both are server-side: a fresh load still shows Following + the pending
-		// application…
+		// Both are server-side: a fresh load of the LANDING page still shows
+		// Following, and its summary CTA reports the pending application…
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
 		await expect(page.getByRole('button', { name: 'Following' })).toBeVisible();

--- a/tests/e2e/journeys/j23-subscriptions/plan-states.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/plan-states.spec.ts
@@ -9,12 +9,16 @@ import {
 	uniqueName
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
-import { planCard } from '../../support/membership-locators';
+import { membershipPath, planCard } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 
 // J23 (USER_JOURNEYS.md) — member-facing plan AVAILABILITY states on the public
-// org page: sold out (cap occupied), sales paused, offline (staff-managed) and
-// the guest CTA. No payment happens anywhere in this file.
+// membership page: sold out (cap occupied), sales paused, offline
+// (staff-managed) and the guest CTA. No payment happens anywhere in this file.
+//
+// The plan grid moved off the org landing page onto /org/[slug]/membership
+// (#720) — the landing page keeps only a pointer at it — so every navigation
+// here goes to `membershipPath()`.
 //
 // Everything is arranged on Org Alpha (`revel-events-collective`): it is the
 // only Stripe-connected seeded org, and ONLINE plans cannot exist anywhere
@@ -71,7 +75,7 @@ test.describe('J23 plan availability states @p2', () => {
 		const context = await browser.newContext();
 		await authenticateContext(context, viewer);
 		const page = await context.newPage();
-		await gotoHydrated(page, `/org/${ORG_SLUG}`);
+		await gotoHydrated(page, membershipPath(ORG_SLUG));
 		await waitForClientAuth(page);
 
 		// Control: an open ONLINE plan offers the CTA to this very user.
@@ -119,12 +123,16 @@ test.describe('J23 plan availability states @p2', () => {
 		// an explicit unauthenticated context says so.
 		const context = await browser.newContext();
 		const page = await context.newPage();
-		await gotoHydrated(page, `/org/${ORG_SLUG}`);
+		await gotoHydrated(page, membershipPath(ORG_SLUG));
 
 		const card = planCard(page, plan.name);
 		// A real link, not a scripted redirect — it carries the return trip.
 		const loginCta = card.getByRole('link', { name: 'Log in to subscribe' });
 		await expect(loginCta).toBeVisible({ timeout: 15_000 });
+		// PlanCard's return trip still points at the org LANDING page, not at the
+		// page the button was pressed on — deliberate on its side (`loginHref` in
+		// PlanCard.svelte), and asserted here so a change to it is a decision
+		// somebody makes rather than a silent drift.
 		await expect(loginCta).toHaveAttribute(
 			'href',
 			`/login?returnUrl=${encodeURIComponent(`/org/${ORG_SLUG}`)}`

--- a/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
@@ -7,19 +7,23 @@ import {
 	uniqueName
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
-import { membershipCard, planCard } from '../../support/membership-locators';
+import { membershipCard, membershipPath, planCard } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 import { completeStripeCheckout } from '../../support/stripe';
 
 // J23.3 / J23.4 (USER_JOURNEYS.md) — the member-initiated hosted-checkout
 // journey: Subscribe → SubscribeDialog → checkout.stripe.com → pay → back on
-// the org page, where CheckoutReturnCard polls until the `stripe listen`
+// the membership page, where CheckoutReturnCard polls until the `stripe listen`
 // webhook flips the subscription ACTIVE.
 //
-// MUST-COVER here and nowhere else: the `?membership_success=true` flag is
-// consumed in onMount with the RAW history API (see MembershipSection —
-// $app/navigation's replaceState throws during hydration). jsdom cannot
-// exercise that, so this spec is the only proof it happens.
+// MUST-COVER here and nowhere else, TWO server-side hops jsdom cannot exercise:
+//   * Stripe's return URLs are built by the BACKEND and still point at the org
+//     LANDING page (`/org/{slug}?membership_success=true`), which 303-redirects
+//     the flag on to `/org/{slug}/membership` (#720/#726). This spec drives the
+//     real backend-built URL, so it is the only proof that hop happens.
+//   * the flag is then consumed in onMount with the RAW history API (see
+//     MembershipSection — $app/navigation's replaceState throws during
+//     hydration).
 //
 // Requires the full Stripe test-mode setup from tests/e2e/README.md (backend
 // bootstrapped with CONNECTED_TEST_STRIPE_ID + the `stripe listen` forwarder).
@@ -31,7 +35,10 @@ import { completeStripeCheckout } from '../../support/stripe';
 // backend refuses a second non-terminal subscription per user per org).
 
 const ORG_SLUG = 'revel-events-collective';
+/** Where Stripe is sent back to — backend-owned, and still the LANDING page. */
 const ORG_PATH = `/org/${ORG_SLUG}`;
+/** Where the plans live, and where the checkout return actually lands. */
+const MEMBERSHIP_PATH = membershipPath(ORG_SLUG);
 
 /** An online €15/month plan on a fresh tier of Org Alpha, plus its subscriber. */
 async function arrangeOnlinePlan(label: string) {
@@ -91,13 +98,13 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		const context = await browser.newContext();
 		await authenticateContext(context, user);
 		const page = await context.newPage();
-		await gotoHydrated(page, ORG_PATH);
+		await gotoHydrated(page, MEMBERSHIP_PATH);
 		await waitForClientAuth(page);
 
 		await subscribeThroughDialog(page, plan.name);
 		await completeStripeCheckout(page);
 
-		// Back on the org page at the backend-built success URL. NOTE: no
+		// Back on the membership page at the backend-built success URL. NOTE: no
 		// waitForClientAuth here — its stall fallback reloads, and a reload would
 		// drop the (already consumed) flag and unmount the card under us.
 		const confirming = page
@@ -113,19 +120,30 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await expect(welcome).toBeVisible({ timeout: 120_000 });
 		await expect(page.getByText('Your subscription is active.')).toBeVisible();
 
-		// MUST-COVER: the flag was consumed in onMount via the raw history API,
-		// so a reload or a back-navigation cannot replay the card.
-		await expect(page).toHaveURL(new RegExp(`${ORG_PATH}(?:$|[?#])`));
+		// MUST-COVER, both hops at once: Stripe returned to the LANDING path, the
+		// server load forwarded it to the membership page (#726), and the flag was
+		// then consumed in onMount via the raw history API — so a reload or a
+		// back-navigation cannot replay the card.
+		await expect(page).toHaveURL(new RegExp(`${MEMBERSHIP_PATH}(?:$|[?#])`));
 		expect(page.url()).not.toContain('membership_success');
 
-		// The card invalidates the stale verdicts it invalidates precisely so the
-		// rest of the page agrees with it — no reload needed.
+		// The card invalidates the stale verdicts precisely so the rest of the page
+		// agrees with it — no reload needed. The plan's own card in the tier grid
+		// is the nearest consumer of that invalidation.
+		const boughtPlan = planCard(page, plan.name);
+		await expect(boughtPlan.getByText('Your plan')).toBeVisible({ timeout: 30_000 });
+		await expect(boughtPlan.getByText("You're subscribed to this plan.")).toBeVisible();
+		// …and the grid's join CTAs are replaced by the member status pill (this
+		// one rides on invalidateAll() re-running the server load).
+		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 30_000 });
+
+		// The org landing page — which keeps the inline membership card — tells the
+		// same story on a fresh server load.
+		await gotoHydrated(page, ORG_PATH);
+		await waitForClientAuth(page);
 		const inlineCard = page.locator('.bg-card').filter({ hasText: 'Your membership' });
 		await expect(inlineCard.getByText(plan.name)).toBeVisible({ timeout: 30_000 });
 		await expect(inlineCard.getByLabel('Active')).toBeVisible();
-		// …and the join CTA is replaced by the member status pill (this one rides
-		// on invalidateAll() re-running the server load).
-		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 30_000 });
 
 		// The account hub tells the same story.
 		await gotoHydrated(page, '/account/memberships');
@@ -183,24 +201,15 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		const context = await browser.newContext();
 		await authenticateContext(context, user);
 		const page = await context.newPage();
-		await gotoHydrated(page, ORG_PATH);
+		await gotoHydrated(page, MEMBERSHIP_PATH);
 		await waitForClientAuth(page);
 
 		await subscribeThroughDialog(page, plan.name);
 
-		// Abandon: walk away from the hosted page onto the backend-built cancel
-		// URL instead of paying. The PENDING subscription (and its open Checkout
-		// session) survives.
-		await gotoHydrated(page, `${ORG_PATH}?membership_cancelled=true`);
-		await expect(page.getByRole('heading', { name: 'Checkout not completed' })).toBeVisible({
-			timeout: 20_000
-		});
-		await expect(
-			page.getByText("Your payment wasn't completed. You can resume it whenever you're ready.")
-		).toBeVisible();
-
-		// Pre-payment state elsewhere on the page: the member's own subscription
-		// card says the first payment is still outstanding.
+		// Pre-payment state, on the org LANDING page: the inline membership card
+		// lives there and nowhere else, so this leg is a detour by construction.
+		// The member's own subscription card says the first payment is still
+		// outstanding.
 		//
 		// Deliberately asserted HERE and not on /account/memberships: that page
 		// lists OrganizationMember rows, and an ONLINE plan creates none until the
@@ -208,9 +217,24 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		// syncs the member row for OFFLINE plans). Probed: `/api/me/memberships`
 		// answers `count: 0` at this point, while `/api/me/…/subscription` — what
 		// this card reads — already returns the PENDING row.
+		await gotoHydrated(page, ORG_PATH);
+		await waitForClientAuth(page);
 		const inlineCard = page.locator('.bg-card').filter({ hasText: 'Your membership' });
 		await expect(inlineCard.getByLabel('Pending')).toBeVisible({ timeout: 20_000 });
 		await expect(inlineCard.getByText('Awaiting first payment')).toBeVisible();
+
+		// Abandon: walk away from the hosted page onto the backend-built cancel
+		// URL instead of paying. The PENDING subscription (and its open Checkout
+		// session) survives. That URL is the LANDING page, which forwards the flag
+		// to the membership page where the card that reads it now lives (#726).
+		await gotoHydrated(page, `${ORG_PATH}?membership_cancelled=true`);
+		await expect(page).toHaveURL(new RegExp(`${MEMBERSHIP_PATH}(?:$|[?#])`));
+		await expect(page.getByRole('heading', { name: 'Checkout not completed' })).toBeVisible({
+			timeout: 20_000
+		});
+		await expect(
+			page.getByText("Your payment wasn't completed. You can resume it whenever you're ready.")
+		).toBeVisible();
 
 		// Resume: the backend hands back a payable session for the same pending
 		// subscription, and the browser leaves for Stripe again.

--- a/tests/e2e/journeys/j27-applications/apply-flows.spec.ts
+++ b/tests/e2e/journeys/j27-applications/apply-flows.spec.ts
@@ -1,16 +1,21 @@
 import { test, expect } from '../../support/fixtures';
-import { ApiClient } from '../../support/api';
 import {
 	applyViaApi,
 	approveApplication,
 	createOrganization,
 	createVerifiedUser,
+	myApplicationFor,
 	rejectApplication,
 	setOrgMembershipPolicy,
 	type ThrowawayUser
 } from '../../support/factories';
 import { pageAs } from '../../support/session';
-import { applicationRow, membershipCard } from '../../support/membership-locators';
+import {
+	applicationRow,
+	membershipCard,
+	membershipPath,
+	tierCard
+} from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 import { closeDialog } from '../../support/ui';
 
@@ -26,26 +31,36 @@ import { closeDialog } from '../../support/ui';
 // branch:
 //   * a TIER-BEARING apply on an ungated org completes on the spot — the
 //     membership exists before any UI is opened;
-//   * a TIER-LESS apply (all the UI ever sends, since ApplyDialog posts no
-//     tier) stays PENDING for staff, whatever the org's approval policy.
+//   * a TIER-LESS apply stays PENDING for staff, whatever the org's approval
+//     policy, because the backend never resolves a default tier on the
+//     member's behalf.
+//
+// The second bullet used to read "all the UI ever sends, since ApplyDialog
+// posts no tier". That is no longer true and was the blind spot #723 was filed
+// about: since #720/#727 a member picks a tier on /org/[slug]/membership and
+// ApplyDialog posts its `tier_id`, so the UI path is the TIER-BEARING one.
+// Tier-less applies survive only as ARRANGE steps (`applyViaApi` with no
+// tier) and as the legacy rows staff still have to name a tier for. The
+// member-facing tier selection itself is covered by tier-selection.spec.ts.
+//
 // Approval alone does NOT create the membership: the state machine advances
 // when the MEMBER reads the application, which the account hub's Applications
 // section does on every mount.
 
 /** The member's own application id, for admin-side arranges after a UI apply.
- *  The LIST endpoint is a plain read — unlike GET /me/applications/{id}, which
- *  advances the state machine and would do the very work under test. */
+ *  `myApplicationFor` reads the LIST endpoint, which is a plain read — unlike
+ *  GET /me/applications/{id}, which advances the state machine and would do the
+ *  very work under test. */
 async function findApplicationId(user: ThrowawayUser, orgSlug: string): Promise<string> {
-	const api = await ApiClient.login(user.email, user.password);
-	const page = await api.get<{ results: Array<{ id?: string | null; organization_slug: string }> }>(
-		'/api/me/applications'
-	);
-	const application = page.results.find((a) => a.organization_slug === orgSlug);
+	const application = await myApplicationFor(user, orgSlug);
 	if (!application?.id) {
 		throw new Error(`No application for ${user.email} at ${orgSlug}`);
 	}
 	return application.id;
 }
+
+/** The tier a post-save signal gives every new org — the one the UI applies to. */
+const DEFAULT_TIER = 'General membership';
 
 test.describe('j27 application flows @p2', () => {
 	test('tier-bearing apply completes instantly and shows up as a membership', async ({
@@ -69,8 +84,18 @@ test.describe('j27 application flows @p2', () => {
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
 		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel('Membership tier: General membership')).toBeVisible();
-		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+		await expect(page.getByLabel(`Membership tier: ${DEFAULT_TIER}`)).toBeVisible();
+
+		// The membership grid withdraws the offer tier by tier. The per-tier member
+		// badge is the settle signal: those CTAs resolve asynchronously, so
+		// asserting the absence of a Join button without it would pass while the
+		// verdicts were still in flight.
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+		await expect(
+			tierCard(page, DEFAULT_TIER).getByLabel('You are a member of this organization')
+		).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByRole('button', { name: /^Join / })).toHaveCount(0);
 
 		// …and the account hub lists both halves: the membership card, and the
 		// application itself already settled under "Closed".
@@ -100,11 +125,16 @@ test.describe('j27 application flows @p2', () => {
 		await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: true });
 
 		const page = await pageAs(browser, applicant);
-		await gotoHydrated(page, `/org/${org.slug}`);
+		// The membership grid is where a tier — and therefore a join — is chosen;
+		// the org landing page only points at it (#720).
+		await gotoHydrated(page, membershipPath(org.slug));
 		await waitForClientAuth(page);
 
-		await page.getByRole('button', { name: `Join ${org.name}` }).click();
-		const applyDialog = page.getByRole('dialog', { name: `Join ${org.name}` });
+		const generalTier = tierCard(page, DEFAULT_TIER);
+		await expect(generalTier).toBeVisible({ timeout: 15_000 });
+		await generalTier.getByRole('button', { name: `Join ${DEFAULT_TIER}` }).click();
+		// The tier, not the org, names the dialog once there is one.
+		const applyDialog = page.getByRole('dialog', { name: `Join ${DEFAULT_TIER}` });
 		await expect(applyDialog).toBeVisible();
 		await applyDialog.getByLabel('Message (optional)').fill('E2E: approval pipeline');
 		await applyDialog.getByRole('button', { name: 'Send application' }).click();
@@ -119,7 +149,7 @@ test.describe('j27 application flows @p2', () => {
 			)
 		).toBeVisible();
 		await closeDialog(page, outcomeDialog);
-		await expect(page.getByRole('button', { name: 'Application pending' })).toBeDisabled();
+		await expect(generalTier.getByRole('button', { name: 'Application pending' })).toBeDisabled();
 
 		// The account hub tracks it as in-progress.
 		await gotoHydrated(page, '/account/memberships');
@@ -129,9 +159,13 @@ test.describe('j27 application flows @p2', () => {
 		).toBeVisible({ timeout: 15_000 });
 		await expect(membershipCard(page, org.name)).toBeHidden();
 
-		// Staff approve. A UI apply carries no tier, so the approval must name one.
+		// Staff approve, WITHOUT naming a tier — and that is the assertion. Since
+		// #727 the UI's apply carries `tier_id`, so the application resolves its
+		// own; the backend only makes staff pick for a tier-less (legacy) row.
+		// Were ApplyDialog to stop sending the tier, this approve would have
+		// nothing to resolve and the completion below would never arrive.
 		const applicationId = await findApplicationId(applicant, org.slug);
-		await approveApplication(org.owner, org.slug, applicationId, org.defaultTierId);
+		await approveApplication(org.owner, org.slug, applicationId);
 
 		// Approval is not the membership: the row only completes when the member
 		// reads it, and each remount of the Applications section re-fires that
@@ -148,29 +182,40 @@ test.describe('j27 application flows @p2', () => {
 		await page.context().close();
 	});
 
-	test('a rejected application can be re-applied for from the org page', async ({ browser }) => {
+	test('a rejected application can be re-applied for from the membership page', async ({
+		browser
+	}) => {
 		test.setTimeout(180_000);
 		const [org, applicant] = await Promise.all([
 			createOrganization({ acceptMembershipRequests: true }),
 			createVerifiedUser('Applicant')
 		]);
 
-		// Tier-less (what the UI sends) so the application is staff's to decide.
+		// Approval required, so the RE-apply — which now carries a tier, since the
+		// UI sends one (#727) — parks as pending instead of completing outright.
+		// Without it the second application would settle instantly and both rows
+		// would land in "Closed", where they are indistinguishable.
+		await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: true });
+
+		// Tier-less ARRANGE — the legacy shape a staff-decided application has —
+		// so the rejection under test is not itself produced by the UI.
 		const first = await applyViaApi(applicant, org.slug, { notes: 'E2E: first try' });
 		expect(first.status).toBe('pending');
 		await rejectApplication(org.owner, org.slug, first.applicationId);
 
 		const page = await pageAs(browser, applicant);
-		await gotoHydrated(page, `/org/${org.slug}`);
+		await gotoHydrated(page, membershipPath(org.slug));
 		await waitForClientAuth(page);
 
 		// The verdict turns the join CTA into a re-apply one — a rejection is not
-		// a dead end.
-		const reapplyButton = page.getByRole('button', { name: 'Re-apply for membership' });
+		// a dead end. Scoped to the tier: the rejection is org-wide, so every tier
+		// card carries the same offer and a page-global lookup is ambiguous.
+		const generalTier = tierCard(page, DEFAULT_TIER);
+		const reapplyButton = generalTier.getByRole('button', { name: 'Re-apply for membership' });
 		await expect(reapplyButton).toBeVisible({ timeout: 15_000 });
 		await reapplyButton.click();
 
-		const reapplyDialog = page.getByRole('dialog', { name: `Re-apply to ${org.name}` });
+		const reapplyDialog = page.getByRole('dialog', { name: `Re-apply to ${DEFAULT_TIER}` });
 		await expect(reapplyDialog).toBeVisible();
 		await reapplyDialog.getByLabel('Message (optional)').fill('E2E: second try');
 		await reapplyDialog.getByRole('button', { name: 'Send application' }).click();

--- a/tests/e2e/journeys/j27-applications/eligibility-states.spec.ts
+++ b/tests/e2e/journeys/j27-applications/eligibility-states.spec.ts
@@ -8,7 +8,7 @@ import {
 	setOrgMembershipPolicy
 } from '../../support/factories';
 import { pageAs } from '../../support/session';
-import { applicationRow, membershipCard } from '../../support/membership-locators';
+import { applicationRow, membershipCard, membershipPath } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 
 // J27 eligibility states — the verdicts that are NOT an application in flight:
@@ -16,11 +16,13 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 // policy that outranks the org default.
 //
 // Live-verified behaviours these specs are built on:
-//   * `accept_membership_requests: false` renders NO membership CTA at all —
-//     the org page gates the whole <MembershipCta> block on that flag
-//     (src/routes/(public)/org/[slug]/+page.svelte), so the eligibility
+//   * `accept_membership_requests: false` renders NO membership CTA at all on
+//     the org LANDING page — it gates the whole <MembershipCta> block on that
+//     flag (src/routes/(public)/org/[slug]/+page.svelte), so the eligibility
 //     verdict's own copy ("not accepting new members" / "by invitation") never
-//     reaches the DOM. Test 1 asserts the absence, not the copy.
+//     reaches the DOM there. Test 1 asserts the absence, not the copy. The tier
+//     grid at /org/[slug]/membership (#720) does NOT read the flag — it asks
+//     the backend per tier — so test 1 checks that surface separately.
 //   * `requires_membership_approval` is TRI-STATE on a tier: `true`/`false`
 //     override the org default, `null` inherits it. Test 3 pins all three
 //     against both org defaults.
@@ -55,6 +57,29 @@ test.describe('j27 membership eligibility states @p2', () => {
 		await expect(
 			page.getByText('Joining is by invitation — ask the organization for an invite link.')
 		).toBeHidden();
+
+		// The tier grid is a SECOND public way in since #720, and it is not gated
+		// on `accept_membership_requests` the way the landing hero is — it asks the
+		// backend per tier instead. So the closed door has to hold there too.
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+		await expect(page.getByRole('heading', { name: 'Membership', level: 1 })).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Each tier's CTA is a client query, so a bare absence check would pass
+		// while the verdicts were still in flight (the slot is an empty skeleton
+		// until they land). The settled refusal is a `role="note"` explanation —
+		// MembershipCta's `info` branch — so waiting for one is the settle signal.
+		// The `.or()` covers the org publishing no tiers at all, where there is no
+		// verdict to wait for and nothing to press either way.
+		await expect(
+			page
+				.getByRole('note')
+				.first()
+				.or(page.getByText(`${org.name} hasn't published any membership tiers yet.`))
+		).toBeVisible({ timeout: 20_000 });
+		await expect(page.getByRole('button', { name: /^Join / })).toHaveCount(0);
 
 		await page.context().close();
 	});

--- a/tests/e2e/journeys/j27-applications/questionnaire-flow.spec.ts
+++ b/tests/e2e/journeys/j27-applications/questionnaire-flow.spec.ts
@@ -8,13 +8,22 @@ import {
 	MEMBERSHIP_QUESTION
 } from '../../support/factories';
 import { pageAs } from '../../support/session';
-import { membershipCard } from '../../support/membership-locators';
+import { membershipCard, membershipPath, tierCard } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 
-// J27.1–27.3 (USER_JOURNEYS.md) — the membership QUESTIONNAIRE gate: the org
-// page's `submit_questionnaire` CTA, the org-scoped fill route it points at,
+// J27.1–27.3 (USER_JOURNEYS.md) — the ORG-DEFAULT membership QUESTIONNAIRE
+// gate: the `submit_questionnaire` CTA, the org-scoped fill route it points at,
 // and the two evaluation modes' outcomes (auto-graded → gate clears; manual →
 // the member waits).
+//
+// Scope note: everything here rides on the ORG default
+// (`default_membership_questionnaire_id`), so it passes whether or not
+// per-TIER overrides work. That gap is tier-selection.spec.ts's subject.
+//
+// The two tests deliberately enter from different surfaces: test 1 from the
+// membership grid (where the gate replaces a tier's Join button) and test 2
+// from the org landing page (whose summary CTA must still route to the
+// questionnaire). Both are member-facing entry points and both have to work.
 //
 // Isolation: each test arranges its own org (throwaway owner), its own
 // questionnaire and its own applicant, so parallel projects/workers and a
@@ -37,6 +46,9 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 //   * clearing the questionnaire gate is not joining. It only turns the CTA
 //     back into a plain "Join" — the application is still owed.
 
+/** The tier a post-save signal gives every new org — the one the UI applies to. */
+const DEFAULT_TIER = 'General membership';
+
 test.describe('j27 membership questionnaire @p2', () => {
 	test('an auto-graded questionnaire clears the join gate and the applicant becomes a member', async ({
 		browser
@@ -54,16 +66,19 @@ test.describe('j27 membership questionnaire @p2', () => {
 		await setOrgMembershipPolicy(org.owner, org.slug, { defaultQuestionnaireId: wrapper.id });
 
 		const page = await pageAs(browser, applicant);
-		await gotoHydrated(page, `/org/${org.slug}`);
+		await gotoHydrated(page, membershipPath(org.slug));
 		await waitForClientAuth(page);
 
-		// The gate replaces the join CTA outright: there is nothing to apply for
-		// until the questionnaire is on file.
-		const questionnaireCta = page.getByRole('link', {
+		// The gate replaces the tier's join CTA outright: there is nothing to apply
+		// for until the questionnaire is on file. Asserted on the tier card, where
+		// the two are alternatives in one slot — so the absence below is the gate
+		// talking and not an unsettled verdict.
+		const generalTier = tierCard(page, DEFAULT_TIER);
+		const questionnaireCta = generalTier.getByRole('link', {
 			name: 'Fill in the membership questionnaire'
 		});
 		await expect(questionnaireCta).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+		await expect(generalTier.getByRole('button', { name: `Join ${DEFAULT_TIER}` })).toHaveCount(0);
 
 		await questionnaireCta.click();
 		await page.waitForURL('**/questionnaire/**');
@@ -102,26 +117,25 @@ test.describe('j27 membership questionnaire @p2', () => {
 		// by re-reading the page, not by waiting in place. "Join" reappearing IS
 		// the pass verdict — a failed one would leave a waiting/retry CTA.
 		await expect(async () => {
-			await gotoHydrated(page, `/org/${org.slug}`);
+			await gotoHydrated(page, membershipPath(org.slug));
 			await waitForClientAuth(page);
-			await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeVisible({
-				timeout: 10_000
-			});
+			await expect(
+				tierCard(page, DEFAULT_TIER).getByRole('button', { name: `Join ${DEFAULT_TIER}` })
+			).toBeVisible({ timeout: 10_000 });
 		}).toPass({ timeout: 45_000 });
 
-		// Clearing the gate is not membership — the application is still owed, and
-		// the ApplyDialog sends no tier, so a UI apply can only ever park as
-		// pending (apply-flows.spec.ts owns that path). Here the apply is the
-		// arrange for the last leg: with the questionnaire passed and no approval
-		// requirement left, a tier-bearing apply completes on the spot.
+		// Clearing the gate is not membership — the application is still owed.
+		// The apply itself is arranged here rather than clicked: driving
+		// ApplyDialog is tier-selection.spec.ts's subject, and this test is about
+		// the questionnaire. With the gate passed and no approval requirement
+		// left, a tier-bearing apply completes on the spot.
 		const outcome = await applyViaApi(applicant, org.slug, { tierId: org.defaultTierId });
 		expect(outcome.status).toBe('completed');
 
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
 		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel('Membership tier: General membership')).toBeVisible();
-		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+		await expect(page.getByLabel(`Membership tier: ${DEFAULT_TIER}`)).toBeVisible();
 
 		await gotoHydrated(page, '/account/memberships');
 		await waitForClientAuth(page);
@@ -149,6 +163,9 @@ test.describe('j27 membership questionnaire @p2', () => {
 		await setOrgMembershipPolicy(org.owner, org.slug, { defaultQuestionnaireId: wrapper.id });
 
 		const page = await pageAs(browser, applicant);
+		// From the org LANDING page this time: its summary CTA carries no tier, but
+		// a questionnaire verdict is still actionable from there and must route to
+		// the fill page rather than punting to the grid.
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
 
@@ -176,7 +193,9 @@ test.describe('j27 membership questionnaire @p2', () => {
 		await expect(
 			page.getByRole('link', { name: 'Fill in the membership questionnaire' })
 		).toBeHidden();
-		await expect(page.getByRole('button', { name: `Join ${org.name}` })).toBeHidden();
+		// No `Join …` counter-assertion here on purpose: since #720 the landing
+		// hero never renders one for anybody, so its absence would prove nothing.
+		// The tier grid's version of this check is in test 1.
 
 		// …and yet there is nothing to track YET: a questionnaire submission is not
 		// an application, so the hub stays empty on both halves. (The waiting CTA

--- a/tests/e2e/journeys/j27-applications/tier-selection.spec.ts
+++ b/tests/e2e/journeys/j27-applications/tier-selection.spec.ts
@@ -1,0 +1,246 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createMembershipQuestionnaire,
+	createMembershipTier,
+	createOrganization,
+	createSubscriptionPlan,
+	createVerifiedUser,
+	myApplicationFor,
+	patchTierPolicy,
+	uniqueName,
+	MEMBERSHIP_QUESTION
+} from '../../support/factories';
+import { pageAs } from '../../support/session';
+import { membershipPath, tierCard } from '../../support/membership-locators';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import { closeDialog } from '../../support/ui';
+
+// J27 (USER_JOURNEYS.md) — choosing a TIER, through the UI, on
+// /org/[slug]/membership. Filed as #723: the suite was green over a feature
+// that had no user interface, and said so in a comment.
+//
+// Until #720/#727 every tier-bearing apply in this suite was arranged with
+// `applyViaApi`, because `ApplyDialog` posted no tier and `MembershipCta`
+// asked for eligibility without one. Two things follow from that, and both are
+// what these tests exist to hold down:
+//
+//   * an application created through the UI could not carry a tier, so staff
+//     had to guess one at approval time;
+//   * a tier's own questionnaire/approval OVERRIDES were dead configuration —
+//     with no `tier_id` on the eligibility request the backend resolved the org
+//     default, so a gated tier looked exactly like an ungated one. j23
+//     tier-policy.spec.ts round-trips those overrides through the admin form,
+//     and j27 questionnaire-flow.spec.ts exercises the gate via the ORG
+//     default; neither could fail when the tier half was missing. Test 2 is
+//     that missing half, and it is the case that broke in production.
+//
+// The ARRANGE steps stay on the API (orgs, tiers, questionnaires, plans) —
+// what has to go through the UI is the ACT.
+//
+// Isolation, the j27 house rule: every test arranges its OWN throwaway org and
+// its own applicant, so parallel projects/workers and a `retries: 1` re-run
+// never share an application (one per user per org).
+//
+// Backend behaviours these tests are built on, all of them already relied on
+// elsewhere in j27: a new org requires no approval and sets no questionnaire,
+// so a TIER-BEARING apply has nothing left to gate on and completes on the
+// spot — which is why every act below ends in "You're in!" rather than
+// "Application received".
+
+/** The tier a post-save signal gives every new org. */
+const DEFAULT_TIER = 'General membership';
+/** ApplyDialog's completed-outcome title. */
+const JOINED = "You're in!";
+
+test.describe('j27 tier selection @p2', () => {
+	test('applying from a named tier puts THAT tier on the application', async ({ browser }) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('TierApplicant')
+		]);
+		// A second, NAMED tier beside the auto-created default. Picking the one
+		// that is NOT the fallback is what gives the assertion teeth: a dropped
+		// `tier_id` does not fail loudly, it silently resolves to something else.
+		const goldName = uniqueName('Gold Tier');
+		const gold = await createMembershipTier(org.owner, org.slug, goldName);
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+
+		// Both tiers are on offer; the applicant chooses.
+		const goldCard = tierCard(page, goldName);
+		await expect(goldCard).toBeVisible({ timeout: 15_000 });
+		await expect(tierCard(page, DEFAULT_TIER)).toBeVisible();
+		// The CTA names its tier — N cards must not all read "Join".
+		await goldCard.getByRole('button', { name: `Join ${goldName}` }).click();
+
+		// …and so does the dialog it opens.
+		const dialog = page.getByRole('dialog', { name: `Join ${goldName}` });
+		await expect(dialog).toBeVisible();
+		await dialog.getByLabel('Message (optional)').fill('E2E: gold, please');
+		await dialog.getByRole('button', { name: 'Send application' }).click();
+
+		const outcome = page.getByRole('dialog', { name: JOINED });
+		await expect(outcome).toBeVisible({ timeout: 15_000 });
+		await expect(outcome.getByText(`You're now a member of ${org.name}.`)).toBeVisible();
+		await closeDialog(page, outcome);
+
+		// THE assertion (#723): read back from the MEMBER's own applications list,
+		// not from the apply response the dialog just consumed. Fails the moment
+		// ApplyDialog stops sending `tier_id`.
+		const application = await myApplicationFor(applicant, org.slug);
+		expect(application?.status).toBe('completed');
+		expect(application?.tier_id).toBe(gold.id);
+		expect(application?.tier_name).toBe(goldName);
+
+		// …and the membership it produced sits at that tier, not at the default the
+		// backend would have fallen back to.
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+		await expect(page.getByLabel(`Membership tier: ${goldName}`)).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByLabel(`Membership tier: ${DEFAULT_TIER}`)).toHaveCount(0);
+
+		await page.context().close();
+	});
+
+	test('a tier-level questionnaire override gates that tier and leaves its neighbour open', async ({
+		browser
+	}) => {
+		test.setTimeout(240_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('TierGate')
+		]);
+		// Deliberately NO org-level default questionnaire: whatever gates below is
+		// the TIER's own override and nothing else. (questionnaire-flow.spec.ts
+		// owns the org-default path, and passes whether or not overrides work.)
+		const gatedName = uniqueName('Gated Tier');
+		const openName = uniqueName('Open Tier');
+		const [gated, questionnaire] = await Promise.all([
+			createMembershipTier(org.owner, org.slug, gatedName),
+			createMembershipQuestionnaire(org.owner, org.slug, { evaluationMode: 'manual' }),
+			// The ungated control. Its id is never needed — the grid addresses it
+			// by name — so it is created and left unnamed here.
+			createMembershipTier(org.owner, org.slug, openName)
+		]);
+		await patchTierPolicy(org.owner, org.slug, gated.id, {
+			membership_questionnaire: questionnaire.id
+		});
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+
+		const gatedCard = tierCard(page, gatedName);
+		const openCard = tierCard(page, openName);
+
+		// Server-rendered, straight off the tier listing: the requirement is stated
+		// on the card before any verdict is asked for, and only on the card that
+		// carries the override.
+		await expect(gatedCard.getByText('A membership questionnaire is required.')).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(openCard.getByText('A membership questionnaire is required.')).toHaveCount(0);
+
+		// …and the per-tier VERDICT agrees. This is the assertion #723 is about:
+		// the eligibility request carries `tier_id`, so one tier's Join button is
+		// replaced by the gate while its neighbour's is untouched. Drop the
+		// `tier_id` and both cards resolve the org default — no questionnaire —
+		// and both offer Join, which is exactly what shipped to production.
+		const gateCta = gatedCard.getByRole('link', {
+			name: 'Fill in the membership questionnaire'
+		});
+		await expect(gateCta).toBeVisible({ timeout: 15_000 });
+		await expect(gatedCard.getByRole('button', { name: `Join ${gatedName}` })).toHaveCount(0);
+		await expect(openCard.getByRole('button', { name: `Join ${openName}` })).toBeVisible({
+			timeout: 15_000
+		});
+		await expect(
+			openCard.getByRole('link', { name: 'Fill in the membership questionnaire' })
+		).toHaveCount(0);
+
+		// The gated tier's CTA routes to the questionnaire the override names.
+		await gateCta.click();
+		await page.waitForURL('**/questionnaire/**');
+		await expect(page.getByRole('heading', { name: 'Membership questionnaire' })).toBeVisible();
+		await expect(page.getByLabel(MEMBERSHIP_QUESTION.manual.question)).toBeVisible();
+		// The route takes the INNER Questionnaire id, never the
+		// OrganizationQuestionnaire wrapper id the override stores — linking the
+		// wrapper would 404 the fill page.
+		const routeId = new URL(page.url()).pathname.split('/').pop();
+		expect(routeId).toBeTruthy();
+		expect(routeId).not.toBe(questionnaire.id);
+
+		// The neighbour stays joinable with that questionnaire still unfilled: the
+		// override is a fact about one tier, not about the organization.
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+		await openCard.getByRole('button', { name: `Join ${openName}` }).click();
+		const dialog = page.getByRole('dialog', { name: `Join ${openName}` });
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole('button', { name: 'Send application' }).click();
+		await expect(page.getByRole('dialog', { name: JOINED })).toBeVisible({ timeout: 15_000 });
+
+		const application = await myApplicationFor(applicant, org.slug);
+		expect(application?.status).toBe('completed');
+		expect(application?.tier_name).toBe(openName);
+
+		await page.context().close();
+	});
+
+	test('a free, plan-less tier is offered on the grid and can be joined', async ({ browser }) => {
+		test.setTimeout(180_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('FreeTier')
+		]);
+		const freeName = uniqueName('Free Tier');
+		// Its id is never needed — the grid addresses it by name.
+		await createMembershipTier(org.owner, org.slug, freeName);
+		// A PRICED neighbour, so "the free tier is on the page" means more than
+		// "every tier is on the page". The grid is built from the TIER listing
+		// rather than the PLAN listing precisely so a tier with nothing to sell is
+		// not filtered out of existence (#720, letsrevel/revel-backend#830) — with
+		// only free tiers around, a plan-grouped grid would render nothing at all
+		// and the difference would be invisible.
+		//
+		// The plan is OFFLINE (the factory default): an ONLINE one needs Stripe
+		// Connect, which a throwaway org does not have.
+		const paidName = uniqueName('Paid Tier');
+		const paid = await createMembershipTier(org.owner, org.slug, paidName);
+		const plan = await createSubscriptionPlan(org.owner, org.slug, paid.id, {
+			name: uniqueName('Paid Plan')
+		});
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+
+		const freeCard = tierCard(page, freeName);
+		await expect(freeCard).toBeVisible({ timeout: 15_000 });
+		// `is_free` is "this tier has no active plan", said in words beside an icon
+		// — never by colour alone.
+		await expect(freeCard.getByText('Free', { exact: true })).toBeVisible();
+		// The priced neighbour is on the same page, is not free, and shows what it
+		// costs — the discriminator that makes the badge above mean something.
+		const paidCard = tierCard(page, paidName);
+		await expect(paidCard.getByText('Free', { exact: true })).toHaveCount(0);
+		await expect(paidCard.getByRole('heading', { level: 4, name: plan.name })).toBeVisible();
+
+		// A plan-less tier is joined outright: there is no plan, so there is no
+		// checkout to send anybody to.
+		await freeCard.getByRole('button', { name: `Join ${freeName}` }).click();
+		const dialog = page.getByRole('dialog', { name: `Join ${freeName}` });
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole('button', { name: 'Send application' }).click();
+		await expect(page.getByRole('dialog', { name: JOINED })).toBeVisible({ timeout: 15_000 });
+
+		const application = await myApplicationFor(applicant, org.slug);
+		expect(application?.status).toBe('completed');
+		expect(application?.tier_name).toBe(freeName);
+
+		await page.context().close();
+	});
+});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1277,9 +1277,12 @@ export async function getSeededBestAvailableEvent(
  * The outcome depends entirely on the org/tier policy, so specs read the
  * returned `status`: a TIER-BEARING apply against an org with no gate (no
  * approval requirement, no questionnaire) comes back `completed` — the
- * membership exists already. A TIER-LESS apply (what the UI's ApplyDialog
- * sends) stays `pending` for staff, because the backend never resolves a
- * default tier on the member's behalf.
+ * membership exists already. A TIER-LESS apply stays `pending` for staff,
+ * because the backend never resolves a default tier on the member's behalf.
+ *
+ * NOTE (#720/#727): the UI's ApplyDialog now posts `tier_id` too, so the
+ * tier-BEARING branch is the one a member actually walks. Tier-less applies
+ * survive here as the ARRANGE shape for legacy/staff-decided rows.
  *
  * `nextStep` is the eligibility verdict's `next_step` (null once there is
  * nothing left to do) — the same field MembershipCta switches its CTA on.
@@ -1315,6 +1318,36 @@ export async function applyViaApi(
 		status: response.application.status,
 		nextStep: response.eligibility.next_step ?? null
 	};
+}
+
+/** One row of the caller's own applications list, as far as specs read it. */
+export interface MyApplication {
+	id?: string | null;
+	organization_slug: string;
+	status: string;
+	tier_id?: string | null;
+	tier_name?: string | null;
+}
+
+/**
+ * The caller's OWN application row for an org, or null if they have none.
+ *
+ * Deliberately the LIST endpoint and never GET /me/applications/{id}: the
+ * detail read ADVANCES the application state machine (an approved row completes
+ * on it), which is the very behaviour several specs assert on. The list is a
+ * plain read and changes nothing.
+ *
+ * This is an ASSERTION helper, not an arrange one — it exists so a spec can ask
+ * what the member's own account says about an application it created through
+ * the UI, rather than trusting the apply response the UI itself consumed.
+ */
+export async function myApplicationFor(
+	user: ThrowawayUser,
+	orgSlug: string
+): Promise<MyApplication | null> {
+	const api = await ApiClient.login(user.email, user.password);
+	const page = await api.get<{ results: MyApplication[] }>('/api/me/applications');
+	return page.results.find((a) => a.organization_slug === orgSlug) ?? null;
 }
 
 /** Withdraw one of the caller's own applications (idempotent server-side). */

--- a/tests/e2e/support/membership-locators.ts
+++ b/tests/e2e/support/membership-locators.ts
@@ -44,21 +44,56 @@ export function applicationRow(
 }
 
 /**
- * A subscription plan's card on the public org page.
+ * The public membership grid: the only surface on which a TIER can be chosen.
  *
- * Plan cards carry no ARIA role, so this matches the shadcn Card surface class
- * and narrows by the (unique, `uniqueName`-generated) plan name. The cards are
- * grid SIBLINGS, never nested inside one another, so exactly one resolves.
+ * Since #720 the org landing page (`/org/[slug]`) keeps a compact pointer and
+ * nothing else — the plan/tier cards live here. A function rather than a
+ * template literal at each call site so the move is expressed in one place.
+ */
+export function membershipPath(slug: string): string {
+	return `/org/${slug}/membership`;
+}
+
+/**
+ * One membership TIER's card on the public membership page.
  *
- * Deliberately NO `.first()` — neither source copy had one, and strictness is
- * the feature here: `.first()` would downgrade a would-be strict-mode error
- * (loud, immediate) into a silent first-match, and this helper's consumers
- * include `toHaveCount(0)` assertions, precisely the class that false-PASSES
- * against a wrongly-picked element. If the markup ever does nest these cards,
- * the loud failure is what we want.
+ * `TierCard` renders an `<article aria-labelledby>` pointing at its own `<h3>`,
+ * so the accessible name is exactly the tier name. `exact: true` is required,
+ * not cosmetic: Playwright matches accessible names as SUBSTRINGS, and
+ * "General membership" would otherwise also select a spec-created
+ * "General membership (gated)".
+ *
+ * SCOPING CAVEAT, same shape as `requestCard`: the lookup is page-global, which
+ * is safe only because `TierCard` is the only `<article>` in the membership
+ * page's component tree. Should another article-bearing card land there, scope
+ * this to the grid rather than reaching for `.first()`.
+ */
+export function tierCard(page: Page, tierName: string): Locator {
+	return page.getByRole('article', { name: tierName, exact: true });
+}
+
+/**
+ * A subscription plan's card, inside its tier's card on the membership page.
+ *
+ * Anchored on the plan's own `<h4>` and walked up to the NEAREST `.bg-card`
+ * ancestor, which is the plan's shadcn Card. The older `.bg-card` +
+ * `hasText(planName)` form died with #720: plan cards used to be grid siblings,
+ * and are now NESTED inside their `TierCard`'s Card — which carries `.bg-card`
+ * and contains the plan name too, so the filter matched two elements.
+ *
+ * Deliberately NO `.first()` — strictness is the feature here: `.first()` would
+ * downgrade a would-be strict-mode error (loud, immediate) into a silent
+ * first-match, and this helper's consumers include `toHaveCount(0)` assertions,
+ * precisely the class that false-PASSES against a wrongly-picked element.
+ * `exact: true` on the heading is what keeps it single-valued; plan names come
+ * from `uniqueName()`, so nothing but the intended card can answer.
  */
 export function planCard(page: Page, planName: string): Locator {
-	return page.locator('.bg-card').filter({ hasText: planName });
+	return page
+		.getByRole('heading', { level: 4, name: planName, exact: true })
+		.locator(
+			'xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " bg-card ")][1]'
+		);
 }
 
 /**


### PR DESCRIPTION
Closes #723

## Why

#725–#728 unlocked membership tiers: the grid moved off the org landing page onto `/org/[slug]/membership`, `ApplyDialog` now posts `tier_id`, `MembershipCta` asks for eligibility *per tier*, and the landing hero keeps only a summary CTA that links to the grid.

Two consequences, and this PR is both of them.

## Part 1 — repointing the specs the move broke

Found by grepping the suite for public-`/org/` navigations and membership assertions, then reading the component source for each affected selector. **Five** specs broke, not the four named in the issue:

| Spec | What broke |
| --- | --- |
| `j23-subscriptions/plan-states.spec.ts` | both tests navigated to the landing page for the plan grid |
| `j23-subscriptions/subscribe-online.spec.ts` | ditto, plus the post-checkout URL assertion and the inline "Your membership" card, which stayed on the landing page |
| `j27-applications/apply-flows.spec.ts` | tests 2 and 3 clicked `Join {org}` / `Re-apply for membership` — the hero's join CTA is now a *link* to the grid, so `getByRole('button', …)` no longer resolves |
| `j27-applications/questionnaire-flow.spec.ts` | test 1's "Join reappears after grading" loop asserted a hero button that no longer exists |
| **`j03-account/follow-org.spec.ts`** (@p1, not in the issue) | clicked `Join {org}` on the hero |

`j23-subscriptions/manage-subscription.spec.ts` and `j27-applications/eligibility-states.spec.ts` were named in the issue but **do not break** — both only read the member-status/tier badges, which the hero still renders in summary mode. `eligibility-states` was extended anyway: its "offers no way in" claim was materially incomplete, because the tier grid is a second public surface and (unlike the hero) does *not* read `accept_membership_requests`.

Two arrange changes were forced by the new behaviour, not cosmetic: `follow-org` and `apply-flows`' re-apply test now set `requiresApproval: true`, because a **tier-bearing** apply on an ungated org completes on the spot and there would be no pending application for the admin-queue / two-rows legs to assert on.

### Shared locators
- `planCard` re-anchored on the plan's own `<h4>` + nearest `.bg-card` ancestor. Plan cards used to be grid siblings and are now **nested inside** their `TierCard`'s Card — both carry `.bg-card` and both contain the plan name, so the old `.filter({ hasText })` form matched two elements.
- New `membershipPath(slug)` and `tierCard(page, tierName)` (`<article>` labelled by the tier's `<h3>`, `exact: true`).

`apply-flows`' local `findApplicationId` is hoisted onto a new `myApplicationFor` factory, which several tests here need for assertions.

## Part 2 — the missing coverage (`j27-applications/tier-selection.spec.ts`, @p2)

Three tests, each arranging its own throwaway org + applicant (j27 isolation rule), API for the arrange, UI for the **act**:

1. **`applying from a named tier puts THAT tier on the application`** — picks a `uniqueName()`d tier beside the auto-created default, applies through `ApplyDialog`, then reads back `tier_id` / `tier_name` **from the member's own `/api/me/applications` list**, not from the apply response the dialog consumed. Also asserts the resulting membership badge names that tier and not the default. → *fails if `ApplyDialog` stops sending `tier_id`.*
2. **`a tier-level questionnaire override gates that tier and leaves its neighbour open`** — one org, two tiers, no org-level default questionnaire at all. Asserts the requirement line is server-rendered on the gated card only, that the gated tier's CTA is the questionnaire link while the neighbour's is a live Join button, that the route takes the *inner* Questionnaire id, and that the neighbour is joinable with the questionnaire still unfilled. → *this is the case that broke in production; drop `tier_id` from the eligibility query and both cards resolve the org default and both offer Join.*
3. **`a free, plan-less tier is offered on the grid and can be joined`** — a plan-less tier next to a priced one, so "it's on the page" means more than "everything is on the page". Asserts the `Free` badge on one and not the other, and joins it with no checkout.

`apply-flows.spec.ts`'s misleading comment block ("all the UI ever sends, since ApplyDialog posts no tier") is corrected in place, with a pointer to the new spec. Related scope notes added to `questionnaire-flow.spec.ts` (it rides on the **org default**, so it passed whether or not tier overrides worked) and `eligibility-states.spec.ts`.

## Not covered

**Gated + paid** (issue item 4, BE #831). A questionnaire-gated *and* priced tier needs an ONLINE plan, which needs Stripe Connect, which only the seeded Org Alpha has — and putting a tier-policy override on a shared org would leak state into every other worker's run of j23. It also has an open product question this spec should not silently pin: `PlanCard` does not consult eligibility, so a gated tier's plan currently offers Subscribe / Join-for-free next to a CTA saying the questionnaire is required. Worth its own issue.

## Verification

- `pnpm exec playwright test --list` clean — **519 tests in 129 files** (+6: 3 new tests × 2 projects).
- `make fix` && `make check` green.
- **Nothing was executed.** Per the house rule, the E2E suite was not run — no `make test-e2e`, no `make test`. Every selector in this PR was read off the component source (`src/lib/components/organization/membership/`, `src/routes/(public)/org/[slug]/membership/`) rather than probed live, so the specs are unverified and want a full-suite run before merge.

## CI note

Branch is named `feature/…` deliberately: `.github/workflows/ci.yml` only runs on `push` to `[main, develop, feature/*]` and `pull_request` targeting `[main, develop]`, so a PR into an integration branch gets checks *only* via the branch-name path. Tracked as #731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP
