### PR TITLE
fix(membership): withdraw Subscribe while a tier's gates are unsatisfied (#733)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -5170,7 +5170,9 @@
 		"viewMembership": "Mitgliedschaftsoptionen ansehen",
 		"joinFreeCta": "Kostenlos beitreten",
 		"loginToJoin": "Zum Beitreten anmelden",
-		"freeHelper": "Keine Zahlung nötig — du kannst sofort beitreten."
+		"freeHelper": "Keine Zahlung nötig — du kannst sofort beitreten.",
+		"gatedSubscribeHelper": "Du kannst abonnieren, sobald die Voraussetzungen dieser Stufe erfüllt sind.",
+		"gatedJoinHelper": "Du kannst beitreten, sobald die Voraussetzungen dieser Stufe erfüllt sind."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Du musst eingeloggt sein, um eine Verifizierung anzufordern",

--- a/messages/en.json
+++ b/messages/en.json
@@ -5170,7 +5170,9 @@
 		"viewMembership": "View membership options",
 		"joinFreeCta": "Join for free",
 		"loginToJoin": "Log in to join",
-		"freeHelper": "No payment needed — you can join right away."
+		"freeHelper": "No payment needed — you can join right away.",
+		"gatedSubscribeHelper": "You can subscribe once this tier's requirements are met.",
+		"gatedJoinHelper": "You can join once this tier's requirements are met."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "You must be logged in to request verification",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -5141,7 +5141,9 @@
 		"viewMembership": "Voir les options d'adhésion",
 		"joinFreeCta": "Rejoindre gratuitement",
 		"loginToJoin": "Se connecter pour rejoindre",
-		"freeHelper": "Aucun paiement requis — vous pouvez rejoindre immédiatement."
+		"freeHelper": "Aucun paiement requis — vous pouvez rejoindre immédiatement.",
+		"gatedSubscribeHelper": "Vous pourrez vous abonner une fois les conditions de ce niveau remplies.",
+		"gatedJoinHelper": "Vous pourrez rejoindre une fois les conditions de ce niveau remplies."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Tu dois être connecté pour demander une vérification",

--- a/messages/it.json
+++ b/messages/it.json
@@ -5170,7 +5170,9 @@
 		"viewMembership": "Vedi le opzioni di iscrizione",
 		"joinFreeCta": "Iscriviti gratis",
 		"loginToJoin": "Accedi per iscriverti",
-		"freeHelper": "Nessun pagamento richiesto: puoi iscriverti subito."
+		"freeHelper": "Nessun pagamento richiesto: puoi iscriverti subito.",
+		"gatedSubscribeHelper": "Potrai abbonarti quando avrai soddisfatto i requisiti di questo livello.",
+		"gatedJoinHelper": "Potrai iscriverti quando avrai soddisfatto i requisiti di questo livello."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Devi essere loggato per richiedere la verifica",

--- a/src/lib/components/organization/membership/MembershipCta.svelte
+++ b/src/lib/components/organization/membership/MembershipCta.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { memembershipapplicationsGetJoinEligibility } from '$lib/api/generated/sdk.gen';
-	import type {
-		MembershipEligibilitySchema,
-		MembershipStatus,
-		MembershipTierSchema
-	} from '$lib/api/generated/types.gen';
+	import type { MembershipStatus, MembershipTierSchema } from '$lib/api/generated/types.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { joinEligibilityQueryOptions } from '$lib/queries/join-eligibility';
 	import {
 		getMembershipCtaKind,
 		getMembershipStatusMessage
@@ -107,29 +103,19 @@
 		return authed && !settled && token;
 	});
 
-	const eligibilityQuery = createQuery(() => ({
-		// The tier is part of the key, not just the request: verdicts are per tier
-		// (one may be joinable while its neighbour wants a questionnaire) and a
-		// shared key would serve whichever card asked first to all of them. The
-		// existing `['org', slug, 'join-eligibility']` invalidations still reach
-		// every entry — TanStack matches keys by prefix.
-		queryKey: ['org', organizationSlug, 'join-eligibility', tierId ?? null],
-		queryFn: async (): Promise<MembershipEligibilitySchema> => {
-			const res = await memembershipapplicationsGetJoinEligibility({
-				path: { slug: organizationSlug },
-				query: tierId ? { tier_id: tierId } : undefined,
-				headers: { Authorization: `Bearer ${accessToken}` }
-			});
-			// hey-api resolves rather than throws — a missing payload is a failure
-			// even when no error body came back.
-			if (res.error || !res.data) {
-				throw new Error('Failed to load membership eligibility');
-			}
-			return res.data;
-		},
-		enabled: queryEnabled,
-		retry: false
-	}));
+	// The tier is part of the key, not just the request: verdicts are per tier
+	// (one may be joinable while its neighbour wants a questionnaire) and a
+	// shared key would serve whichever card asked first to all of them. The
+	// existing `['org', slug, 'join-eligibility']` invalidations still reach
+	// every entry — TanStack matches keys by prefix.
+	const eligibilityQuery = createQuery(() =>
+		joinEligibilityQueryOptions({
+			organizationSlug,
+			tierId,
+			accessToken,
+			enabled: queryEnabled
+		})
+	);
 
 	const eligibility = $derived(eligibilityQuery.data ?? null);
 	const ctaKind = $derived(eligibility ? getMembershipCtaKind(eligibility) : null);

--- a/src/lib/components/organization/membership/PlanCard.svelte
+++ b/src/lib/components/organization/membership/PlanCard.svelte
@@ -29,6 +29,29 @@
 		subscription?: MySubscriptionSchema | null;
 		/** The subscription lookup is still in flight — the answer is not known yet. */
 		subscriptionLoading?: boolean;
+		/**
+		 * The tier's membership gates are known to be UNSATISFIED for this viewer
+		 * (#733). Resolved by `TierCard` from a plan-bearing eligibility verdict —
+		 * never from the tier's static `questionnaire_id` / `requires_approval`,
+		 * which say the tier is gated, not that this viewer is behind the gate.
+		 *
+		 * Defaults to false, and stays false whenever the verdict is unknown
+		 * (guest, ungated tier, request in flight or failed). Withdrawing the CTA
+		 * from somebody who is in fact eligible is a worse failure than the dead
+		 * button this flag exists to remove, and `POST …/subscribe` runs the whole
+		 * gate stack itself (BE #831) — so an unknown answer costs a 400 at worst,
+		 * never an unreachable plan.
+		 */
+		gateBlocked?: boolean;
+		/** Localized explanation of that block, rendered where the CTA was. */
+		gateReason?: string | null;
+		/** The verdict is still in flight: hold the CTA rather than offer it. */
+		gatePending?: boolean;
+		/**
+		 * Id of the tier's requirement list, so the withheld-CTA note points at the
+		 * full requirements rather than relying on them merely being nearby.
+		 */
+		gateRequirementsId?: string | null;
 	}
 
 	const {
@@ -37,12 +60,16 @@
 		onSubscribe,
 		organizationSlug,
 		subscription = null,
-		subscriptionLoading = false
+		subscriptionLoading = false,
+		gateBlocked = false,
+		gateReason = null,
+		gatePending = false,
+		gateRequirementsId = null
 	}: Props = $props();
 
 	/**
 	 * What the card offers, in precedence order:
-	 * already subscribed → offline → sold out → paused → subscribe/login → nothing.
+	 * already subscribed → offline → sold out → paused → gated → subscribe/login.
 	 *
 	 * The membership check comes first because it is a fact about the *viewer*,
 	 * and it outranks every fact about the plan: an existing member cannot buy
@@ -55,6 +82,18 @@
 	 * *member* self-serve — `POST …/subscribe` accepts it and activates the
 	 * subscription on the spot — so it takes the ordinary join path, with the
 	 * label and dialog copy adjusted for the absent charge.
+	 *
+	 * `gated` sits second-to-last, below every plan-level stop and above the
+	 * viewer's own CTA (#733). Since BE #831 a tier can be gated AND priced, and
+	 * a questionnaire the viewer has not passed makes Subscribe an action that
+	 * cannot succeed: `/subscribe` runs the same gate stack and refuses with a
+	 * 400 — after the member has committed to a concrete charge. The CTA is
+	 * *removed* rather than disabled, so the tier's questionnaire/approval
+	 * affordance is the only thing left to press; the price stays on the card
+	 * above, so what they are working toward is still visible.
+	 *
+	 * A guest is untouched: nobody has asked the backend about them, and "Log in
+	 * to subscribe" is true whatever their eligibility turns out to be.
 	 */
 	const action = $derived.by(() => {
 		if (subscription) {
@@ -64,7 +103,20 @@
 		if (plan.sold_out) return 'none';
 		if (plan.sales_status === 'paused') return 'none';
 		if (!plan.id) return 'none';
-		return isAuthenticated ? 'subscribe' : 'login';
+		if (!isAuthenticated) return 'login';
+		return gateBlocked ? 'gated' : 'subscribe';
+	});
+
+	/**
+	 * Held while either lookup is unsettled: until the subscription AND the gate
+	 * verdict answer, we do not know whether this button would 400. Transient,
+	 * on a control that keeps its label and its box, so nothing shifts and
+	 * nothing is conveyed by colour alone.
+	 */
+	const ctaHeld = $derived.by(() => {
+		const subLoading = subscriptionLoading;
+		const gateLoading = gatePending;
+		return subLoading || gateLoading;
 	});
 
 	/**
@@ -172,12 +224,26 @@
 				{/if}
 			{:else if action === 'offline'}
 				<p class="text-sm text-muted-foreground">{m['membershipPlans.offlineManaged']()}</p>
+			{:else if action === 'gated'}
+				<!-- What replaces the CTA carries the reason itself, rather than
+				     leaving a bare gap next to a requirement stated elsewhere on the
+				     card: the note IS the explanation, and `aria-describedby` ties it
+				     to the tier's full requirement list so the association is
+				     programmatic and not merely visual (WCAG 1.3.1). -->
+				<p
+					role="note"
+					class="text-sm text-muted-foreground"
+					aria-describedby={gateRequirementsId ?? undefined}
+				>
+					{isFree
+						? m['membershipPlans.gatedJoinHelper']()
+						: m['membershipPlans.gatedSubscribeHelper']()}
+					{#if gateReason}
+						<span class="block">{gateReason}</span>
+					{/if}
+				</p>
 			{:else if action === 'subscribe'}
-				<!-- Disabled only while the membership lookup is in flight: until it
-				     answers we do not know whether this button would 400. It is a
-				     transient state on a control that keeps its label and its box, so
-				     nothing shifts and nothing is conveyed by colour alone. -->
-				<Button class="w-full sm:w-auto" onclick={handleSubscribe} disabled={subscriptionLoading}>
+				<Button class="w-full sm:w-auto" onclick={handleSubscribe} disabled={ctaHeld}>
 					{isFree ? m['membershipPlans.joinFreeCta']() : m['membershipPlans.subscribeCta']()}
 				</Button>
 				{#if isFree}

--- a/src/lib/components/organization/membership/PlanCard.test.ts
+++ b/src/lib/components/organization/membership/PlanCard.test.ts
@@ -3,6 +3,7 @@ import { userEvent } from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import PlanCard from './PlanCard.svelte';
 import type { MySubscriptionSchema, PublicPlanSchema } from '$lib/api/generated/types.gen';
+import * as m from '$lib/paraglide/messages.js';
 
 function makePlan(overrides: Partial<PublicPlanSchema> = {}): PublicPlanSchema {
 	return {
@@ -235,6 +236,99 @@ describe('PlanCard', () => {
 		renderCard({ subscriptionLoading: true });
 
 		expect(screen.getByRole('button', { name: /subscribe/i })).toBeDisabled();
+	});
+
+	// #733: since BE #831 a tier can be gated AND priced. `POST …/subscribe` runs
+	// the whole eligibility gate stack, so a Subscribe button offered beside "a
+	// membership questionnaire is required" can only ever collect a 400 — after
+	// quoting the member a concrete charge.
+	describe("when the tier's gates are unsatisfied for this viewer", () => {
+		it('withdraws Subscribe and explains why, with the price still on the card', () => {
+			const { onSubscribe } = renderCard({
+				gateBlocked: true,
+				gateReason: 'This organization asks new members to fill in a questionnaire first.'
+			});
+
+			expect(screen.queryByRole('button', { name: /subscribe/i })).toBeNull();
+			expect(
+				screen.getByText(m['membershipPlans.gatedSubscribeHelper'](), { exact: false })
+			).toBeInTheDocument();
+			expect(
+				screen.getByText('This organization asks new members to fill in a questionnaire first.')
+			).toBeInTheDocument();
+			// What they are working toward stays visible.
+			expect(screen.getByText('€10.00 / month')).toBeInTheDocument();
+			expect(onSubscribe).not.toHaveBeenCalled();
+		});
+
+		// Not merely adjacent to the reason: the note that replaces the CTA carries
+		// it, and points at the tier's full requirement list (WCAG 1.3.1).
+		it('associates the withheld CTA with the tier requirements programmatically', () => {
+			renderCard({
+				gateBlocked: true,
+				gateReason: 'Membership requests are approved by the organization.',
+				gateRequirementsId: 'tier-1-requirements'
+			});
+
+			const note = screen.getByRole('note');
+			expect(note).toHaveAttribute('aria-describedby', 'tier-1-requirements');
+			expect(note).toHaveTextContent('Membership requests are approved by the organization.');
+		});
+
+		// Manual approval has the same shape as the questionnaire: apply, be
+		// approved, then pay. Nothing to press until the first two happen.
+		it('withdraws the free-join CTA too, in join wording', () => {
+			renderCard({
+				plan: makePlan({ payment_method: 'free', price: '0.00', period_unit: 'lifetime' }),
+				gateBlocked: true,
+				gateReason: 'Membership requests are approved by the organization.'
+			});
+
+			expect(screen.queryByRole('button', { name: /join for free/i })).toBeNull();
+			expect(
+				screen.getByText(m['membershipPlans.gatedJoinHelper'](), { exact: false })
+			).toBeInTheDocument();
+			expect(screen.queryByText(m['membershipPlans.gatedSubscribeHelper']())).toBeNull();
+		});
+
+		// The crux: "the tier is gated" is not "this viewer is blocked". A member
+		// who has already passed the questionnaire comes back allowed, and hiding
+		// the plan from them would be a worse bug than the one being fixed.
+		it('offers Subscribe untouched once the gates are satisfied', async () => {
+			const user = userEvent.setup();
+			const { onSubscribe } = renderCard({ gateBlocked: false });
+
+			await user.click(screen.getByRole('button', { name: /subscribe/i }));
+			expect(onSubscribe).toHaveBeenCalledTimes(1);
+			expect(screen.queryByRole('note')).toBeNull();
+		});
+
+		// Until the verdict lands we do not know which of the two it is, so the
+		// button keeps its label and its box but cannot be pressed — the same
+		// treatment the membership lookup already gets.
+		it('holds the Subscribe button while the verdict is in flight', () => {
+			renderCard({ gatePending: true });
+
+			expect(screen.getByRole('button', { name: /subscribe/i })).toBeDisabled();
+		});
+
+		// Nobody asked the backend about a guest, and "Log in to subscribe" is true
+		// whatever their eligibility turns out to be.
+		it('leaves a guest with the login CTA', () => {
+			renderCard({ isAuthenticated: false, gateBlocked: true });
+
+			expect(screen.getByRole('link', { name: /log in to subscribe/i })).toBeInTheDocument();
+			expect(screen.queryByRole('note')).toBeNull();
+		});
+
+		// Plan-level stops still outrank the gate: a sold-out plan says so, rather
+		// than blaming the questionnaire for a card nobody could take anyway.
+		it('keeps plan-level stops ahead of the gate', () => {
+			renderCard({ plan: makePlan({ sold_out: true }), gateBlocked: true });
+
+			expect(screen.getByText('Sold out')).toBeInTheDocument();
+			expect(screen.queryByRole('note')).toBeNull();
+		});
 	});
 
 	// A FREE plan is un-billed like an OFFLINE one but, unlike it, members take it

--- a/src/lib/components/organization/membership/TierCard.svelte
+++ b/src/lib/components/organization/membership/TierCard.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { resolve } from '$app/paths';
+	import { createQuery } from '@tanstack/svelte-query';
 	import type {
 		MySubscriptionSchema,
 		PublicMembershipTierSchema,
 		PublicPlanSchema
 	} from '$lib/api/generated/types.gen';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import { joinEligibilityQueryOptions } from '$lib/queries/join-eligibility';
+	import {
+		getMembershipStatusMessage,
+		isBlockedByMembershipGate
+	} from '$lib/utils/membership-eligibility';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { ClipboardList, Gift, ShieldCheck } from '@lucide/svelte';
@@ -50,6 +57,8 @@
 	// its own accessible name.
 	const uid = $props.id();
 	const headingId = `${uid}-tier-name`;
+	/** Referenced by a plan card whose CTA the gates withheld. */
+	const requirementsId = `${uid}-tier-requirements`;
 
 	/**
 	 * `id` is optional in the generated schema (it is a model field with a
@@ -79,6 +88,82 @@
 	 * by colour (WCAG 1.4.1).
 	 */
 	const isFree = $derived(tier.is_free);
+
+	const accessToken = $derived(authStore.accessToken);
+
+	/**
+	 * Does this tier carry a gate AT ALL? A static fact about the tier, straight
+	 * off the public listing — it decides whether to ASK the backend, never
+	 * whether to withhold anything. Only a verdict can say that this viewer is
+	 * behind the gate; an ungated tier asks nothing and its plan cards behave
+	 * exactly as they did before #733.
+	 */
+	const isGated = $derived.by(() => {
+		// Read unconditionally: `||` inside a `$derived` would leave the skipped
+		// operand untracked by the query options below.
+		const questionnaire = !!tier.questionnaire_id;
+		const approval = !!tier.requires_approval;
+		return questionnaire || approval;
+	});
+
+	/**
+	 * The plan the gate verdict is asked about, and why one plan can answer for
+	 * all of them.
+	 *
+	 * A plan is REQUIRED: with no `plan_id` the backend's gate #6 short-circuits
+	 * any monetized tier with `tier_requires_subscription` and never reaches the
+	 * questionnaire and approval gates at all — which is exactly why the CTA's
+	 * own tier-only verdict cannot answer this question. Given a plan, the gates
+	 * that do run above the payment one are facts about the (viewer, tier) pair,
+	 * identical for every plan on the card; `isBlockedByMembershipGate` keeps only
+	 * those, so the choice of plan below cannot leak into the answer.
+	 *
+	 * Cheapest first (the list is already sorted) among the plans that could
+	 * offer a CTA at all: an offline, sold-out or paused plan card shows no
+	 * Subscribe for the gate to withdraw, so a tier with nothing else on it asks
+	 * nothing.
+	 */
+	const gatePlanId = $derived(
+		plans.find(
+			(p) => !!p.id && p.payment_method !== 'offline' && !p.sold_out && p.sales_status !== 'paused'
+		)?.id ?? null
+	);
+
+	const gateQueryEnabled = $derived.by(() => {
+		// Every operand read unconditionally, for the reason given above.
+		const authed = isAuthenticated;
+		const gated = isGated;
+		const hasTier = !!tierId;
+		const hasPlan = !!gatePlanId;
+		const token = !!accessToken;
+		// Owners and staff pass the gate stack by definition (gate #1), and the
+		// grid already suppresses their per-tier CTA; asking would be N round
+		// trips for a question they never posed.
+		const asks = showJoinCta;
+		// A viewer with a live subscription gets the member branch on every card,
+		// so no verdict could change what they see.
+		const subscribed = !!subscription;
+		return authed && gated && hasTier && hasPlan && token && asks && !subscribed;
+	});
+
+	const gateQuery = createQuery(() =>
+		joinEligibilityQueryOptions({
+			organizationSlug,
+			tierId,
+			planId: gatePlanId,
+			accessToken,
+			enabled: gateQueryEnabled
+		})
+	);
+
+	const gateVerdict = $derived(gateQuery.data ?? null);
+	const gateBlocked = $derived(gateVerdict ? isBlockedByMembershipGate(gateVerdict) : false);
+	const gateReason = $derived(
+		gateBlocked && gateVerdict ? getMembershipStatusMessage(gateVerdict) : null
+	);
+	// `isLoading`, not `isPending`: a disabled query stays pending forever, and
+	// that would hold the Subscribe button of every ungated tier hostage.
+	const gatePending = $derived(gateQuery.isLoading);
 </script>
 
 <!-- `<article>` + `aria-labelledby`, not a labelled `region`: the cards are peers
@@ -108,7 +193,7 @@
 			<!-- What it takes to get in. Rendered for everyone, member or not: it is a
 		     description of the tier, not of the viewer's progress through it. -->
 			{#if tier.requires_approval || tier.questionnaire_id}
-				<ul class="space-y-1.5 text-sm">
+				<ul id={requirementsId} class="space-y-1.5 text-sm">
 					{#if tier.requires_approval}
 						<li class="flex items-start gap-2">
 							<ShieldCheck
@@ -156,6 +241,10 @@
 							{subscriptionLoading}
 							{organizationSlug}
 							{onSubscribe}
+							{gateBlocked}
+							{gateReason}
+							{gatePending}
+							gateRequirementsId={requirementsId}
 						/>
 					{/each}
 				</div>

--- a/src/lib/components/organization/membership/TierCard.test.ts
+++ b/src/lib/components/organization/membership/TierCard.test.ts
@@ -164,4 +164,131 @@ describe('TierCard', () => {
 		});
 		expect(screen.queryByRole('button', { name: /^join /i })).toBeNull();
 	});
+
+	// #733. The tier's own fields say the tier IS GATED; only a verdict says this
+	// VIEWER is behind the gate — and for a monetized tier that verdict has to
+	// name a plan, because the backend's TierAvailabilityGate short-circuits a
+	// plan-less check on any tier that sells something, long before the
+	// questionnaire and approval gates run.
+	describe('a gated, priced tier', () => {
+		const gatedPaidTier = () =>
+			makeTier({
+				is_free: false,
+				questionnaire_id: 'q-42',
+				plans: [makePlan({ id: 'p-1', name: 'Monthly', price: '10.00' })]
+			});
+
+		it('asks about a plan, not just the tier', async () => {
+			mockEligibility({ allowed: false, reason_code: 'membership_questionnaire_missing' });
+			renderCard({ tier: gatedPaidTier() });
+
+			await waitFor(() => {
+				expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalledWith(
+					expect.objectContaining({ query: { tier_id: 't-gold', plan_id: 'p-1' } })
+				);
+			});
+		});
+
+		it('withdraws Subscribe and leaves the questionnaire as the only thing to press', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'membership_questionnaire_missing',
+				next_step: 'submit_questionnaire',
+				questionnaire_id: 'q-42'
+			});
+			renderCard({ tier: gatedPaidTier() });
+
+			await waitFor(() => {
+				expect(screen.queryByRole('button', { name: /subscribe/i })).toBeNull();
+			});
+			// The plan card says, in its own words, why its CTA is gone…
+			const note = screen.getByText(m['membershipPlans.gatedSubscribeHelper'](), { exact: false });
+			expect(note).toHaveTextContent(
+				m['membershipEligibility.reason.membership_questionnaire_missing']()
+			);
+			// The price the member is working toward is still on the card…
+			expect(screen.getByText('€10.00 / month')).toBeInTheDocument();
+			// …and the way forward is the gate's own link.
+			expect(
+				screen.getByRole('link', {
+					name: m['membershipTiers.questionnaireLinkAria']({ tier: 'Gold' })
+				})
+			).toHaveAttribute('href', '/org/acme/questionnaire/q-42');
+		});
+
+		// The crux, in the direction that matters most: a member who has already
+		// passed the questionnaire must still be able to pay.
+		it('keeps Subscribe for a viewer who has cleared the gate', async () => {
+			mockEligibility({ allowed: true, next_step: 'proceed_to_payment', plan_id: 'p-1' });
+			renderCard({ tier: gatedPaidTier() });
+
+			expect(await screen.findByRole('button', { name: /subscribe/i })).toBeEnabled();
+		});
+
+		// Manual approval is the same shape, and it arrives from PaymentReadyGate
+		// as `submit_application`: apply and be approved before there is anything
+		// to pay for.
+		it('withdraws Subscribe when the tier is approval-gated and nothing is on file', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'requires_approval',
+				next_step: 'submit_application'
+			});
+			renderCard({
+				tier: makeTier({
+					is_free: false,
+					requires_approval: true,
+					plans: [makePlan({ id: 'p-1' })]
+				})
+			});
+
+			await waitFor(() => {
+				expect(screen.queryByRole('button', { name: /subscribe/i })).toBeNull();
+			});
+			expect(
+				screen.getByText(m['membershipPlans.gatedSubscribeHelper'](), { exact: false })
+			).toHaveTextContent(m['membershipEligibility.reason.requires_approval']());
+		});
+
+		// A refusal about the PLAN rather than about the viewer: the plan card
+		// already models sold-out, paused and offline itself, and a Stripe-less org
+		// is not something the member can fill in a form to fix.
+		it('does not read a payment-readiness refusal as a gate', async () => {
+			mockEligibility({ allowed: false, reason_code: 'org_not_stripe_connected' });
+			renderCard({ tier: gatedPaidTier() });
+
+			expect(await screen.findByRole('button', { name: /subscribe/i })).toBeEnabled();
+		});
+	});
+
+	// An ungated tier is exactly as it was: no verdict is asked for on its plans'
+	// behalf, and nothing about the CTA changes.
+	it('asks no plan-level question about an ungated tier', async () => {
+		renderCard({
+			tier: makeTier({ is_free: false, plans: [makePlan({ id: 'p-1' })] })
+		});
+
+		expect(await screen.findByRole('button', { name: /subscribe/i })).toBeEnabled();
+		expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalledWith(
+			expect.objectContaining({ query: expect.objectContaining({ plan_id: 'p-1' }) })
+		);
+	});
+
+	// Every plan on the tier is a dead end already, so there is no CTA for a
+	// verdict to withdraw — and no reason to spend a round trip finding out.
+	it('asks nothing when the tier sells only offline plans', async () => {
+		renderCard({
+			tier: makeTier({
+				is_free: false,
+				questionnaire_id: 'q-42',
+				plans: [makePlan({ id: 'p-1', payment_method: 'offline' })]
+			})
+		});
+
+		await waitFor(() => {
+			expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalledWith(
+				expect.objectContaining({ query: expect.objectContaining({ plan_id: 'p-1' }) })
+			);
+		});
+	});
 });

--- a/src/lib/queries/join-eligibility.ts
+++ b/src/lib/queries/join-eligibility.ts
@@ -1,0 +1,84 @@
+import { queryOptions } from '@tanstack/svelte-query';
+import { memembershipapplicationsGetJoinEligibility } from '$lib/api/generated/sdk.gen';
+import type {
+	JoinEligibilityQuery,
+	MembershipEligibilitySchema
+} from '$lib/api/generated/types.gen';
+
+interface JoinEligibilityArgs {
+	organizationSlug: string;
+	/** The tier the question is about; `null` asks about the org as a whole. */
+	tierId: string | null;
+	/**
+	 * Narrows the question to one plan, which is the ONLY way to reach the
+	 * payment half of the backend's gate stack: with no plan, gate #6
+	 * (`TierAvailabilityGate`) short-circuits any monetized tier with
+	 * `tier_requires_subscription` and the questionnaire/approval gates below it
+	 * never run. A verdict about a paid tier's gates therefore has to name a plan.
+	 */
+	planId?: string | null;
+	accessToken: string | null;
+	enabled: boolean;
+}
+
+/**
+ * `['org', slug, 'join-eligibility', tierId]`, plus the plan when there is one.
+ *
+ * The plan is appended rather than always present so the tier-only key keeps its
+ * existing four-element shape. Every invalidation in the app targets the
+ * three-element prefix (`ApplyDialog`, `SubscribeDialog`, `CheckoutReturnCard`,
+ * the questionnaire page), and TanStack matches keys by prefix, so both shapes
+ * are refreshed by all of them.
+ */
+export function joinEligibilityKey(
+	organizationSlug: string,
+	tierId: string | null,
+	planId: string | null = null
+): (string | null)[] {
+	const base = ['org', organizationSlug, 'join-eligibility', tierId ?? null];
+	return planId ? [...base, planId] : base;
+}
+
+/**
+ * What THIS viewer may do with THIS tier (optionally: with this plan).
+ *
+ * Shared so the tier CTA and the tier's plan cards observe the same key and
+ * fetcher — TanStack de-duplicates identical keys into one request, and one
+ * prefix invalidation refreshes every card on the page.
+ *
+ * `retry: false` is deliberate and inherited from the CTA's original inline
+ * query: a refused verdict is a decision, not a blip, and silent retries would
+ * hammer the endpoint once per tier on every org page.
+ */
+export function joinEligibilityQueryOptions({
+	organizationSlug,
+	tierId,
+	planId = null,
+	accessToken,
+	enabled
+}: JoinEligibilityArgs) {
+	return queryOptions({
+		queryKey: joinEligibilityKey(organizationSlug, tierId, planId),
+		queryFn: async (): Promise<MembershipEligibilitySchema> => {
+			// Only the parameters that have a value: the backend treats an absent
+			// `tier_id` as "the org as a whole", and a literal `tier_id=` would be a
+			// different question.
+			const query: JoinEligibilityQuery = {};
+			if (tierId) query.tier_id = tierId;
+			if (planId) query.plan_id = planId;
+			const res = await memembershipapplicationsGetJoinEligibility({
+				path: { slug: organizationSlug },
+				query: tierId || planId ? query : undefined,
+				headers: { Authorization: `Bearer ${accessToken}` }
+			});
+			// hey-api resolves rather than throws — a missing payload is a failure
+			// even when no error body came back.
+			if (res.error || !res.data) {
+				throw new Error('Failed to load membership eligibility');
+			}
+			return res.data;
+		},
+		enabled,
+		retry: false
+	});
+}

--- a/src/lib/utils/membership-eligibility.test.ts
+++ b/src/lib/utils/membership-eligibility.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
 	getApplicationPendingMessage,
 	getMembershipCtaKind,
-	getMembershipStatusMessage
+	getMembershipStatusMessage,
+	isBlockedByMembershipGate
 } from './membership-eligibility';
 import type { MembershipEligibilitySchema } from '$lib/api/generated/types.gen';
 import * as m from '$lib/paraglide/messages.js';
@@ -308,5 +309,80 @@ describe('getApplicationPendingMessage', () => {
 	it('does not claim approval is pending for a plain denial', () => {
 		const verdict: MembershipEligibilitySchema = { ...base, allowed: false };
 		expect(getApplicationPendingMessage(verdict)).toBe(m['membershipEligibility.reason.generic']());
+	});
+});
+
+// #733. The predicate a plan card's Subscribe button is withdrawn on, so the two
+// directions are not symmetric: a false positive hides a plan from somebody who
+// could have taken it, while a false negative only reproduces today's behaviour
+// (the backend runs the same gates on POST /subscribe and refuses).
+describe('isBlockedByMembershipGate', () => {
+	it('never blocks an allowed verdict, whatever policy context it carries', () => {
+		expect(isBlockedByMembershipGate({ ...base, allowed: true })).toBe(false);
+		// The tier states "approval required" as POLICY while still allowing this
+		// viewer — `check_eligibility`'s annotation. Reading the code alone here
+		// would withdraw the CTA from every eligible member of an approval tier.
+		expect(
+			isBlockedByMembershipGate({ ...base, allowed: true, reason_code: 'requires_approval' })
+		).toBe(false);
+		// The positive end of a gated + priced tier's chain: gates cleared, charge left.
+		expect(
+			isBlockedByMembershipGate({ ...base, allowed: true, next_step: 'proceed_to_payment' })
+		).toBe(false);
+	});
+
+	it('blocks the questionnaire gate in every state it can be in', () => {
+		for (const code of [
+			'membership_questionnaire_missing',
+			'membership_questionnaire_pending',
+			'membership_questionnaire_failed',
+			'membership_questionnaire_retake_cooldown',
+			'membership_questionnaire_attempts_exhausted'
+		] as const) {
+			expect(isBlockedByMembershipGate({ ...base, reason_code: code })).toBe(true);
+		}
+	});
+
+	// `PaymentReadyGate`'s SUBMIT_APPLICATION: approval is required and nothing is
+	// on file yet, so the member must apply before there is anything to pay for.
+	it('blocks manual approval, applied-for or not', () => {
+		expect(
+			isBlockedByMembershipGate({
+				...base,
+				reason_code: 'requires_approval',
+				next_step: 'submit_application'
+			})
+		).toBe(true);
+		expect(
+			isBlockedByMembershipGate({
+				...base,
+				reason_code: 'requires_approval',
+				next_step: 'wait_for_approval',
+				application_id: 'app-1'
+			})
+		).toBe(true);
+	});
+
+	// Payment-readiness refusals are NOT gates: the plan card already models them
+	// from the plan's own fields and the viewer's live subscription, and
+	// `duplicate_active_subscription` is one the backend deliberately lets fall
+	// through to /subscribe so a half-finished checkout can resume.
+	it('leaves payment-readiness refusals to the plan card', () => {
+		for (const code of [
+			'tier_requires_subscription',
+			'plan_not_online',
+			'org_not_stripe_connected',
+			'plan_unavailable',
+			'tier_unavailable',
+			'duplicate_active_subscription'
+		] as const) {
+			expect(isBlockedByMembershipGate({ ...base, reason_code: code })).toBe(false);
+		}
+	});
+
+	// A refusal the frontend cannot classify is not treated as a gate: the CTA
+	// stays, and the backend refuses it if it really is unreachable.
+	it('does not block a refusal with no reason code', () => {
+		expect(isBlockedByMembershipGate({ ...base, allowed: false, reason_code: null })).toBe(false);
 	});
 });

--- a/src/lib/utils/membership-eligibility.ts
+++ b/src/lib/utils/membership-eligibility.ts
@@ -70,6 +70,62 @@ export function getMembershipCtaKind(e: MembershipEligibilitySchema): Membership
 }
 
 /**
+ * The refusals that mean "a membership GATE is unsatisfied for this viewer".
+ *
+ * Deliberately an allow-list rather than "anything not allowed", because the
+ * caller (`PlanCard`, via `TierCard`) uses it to WITHDRAW a Subscribe button:
+ * a false positive hides a plan from somebody who could have taken it, which is
+ * worse than the dead Subscribe button #733 is about. Every code here is
+ * decided by gates #3–#9 of the backend stack
+ * (`events/service/membership_manager/gates.py`) — blacklist, whitelist,
+ * accept-requests, application status, questionnaire, manual approval — all of
+ * which are facts about the (viewer, tier) pair and are therefore identical for
+ * every plan on the tier.
+ *
+ * Excluded on purpose, all of them PAYMENT-READINESS refusals from gate #6 /
+ * #10 rather than gates the member can clear by filling something in:
+ * `tier_requires_subscription`, `plan_not_online`, `org_not_stripe_connected`,
+ * `plan_unavailable`, `tier_unavailable`, `duplicate_active_subscription`,
+ * `org_not_visible`. They are per-PLAN (or already modelled by the plan's own
+ * `payment_method` / `sold_out` / `sales_status` fields, and by the viewer's
+ * live subscription), so the plan card keeps deciding those for itself.
+ * `duplicate_active_subscription` in particular is one the backend deliberately
+ * lets fall THROUGH to `/subscribe` (`subscription_eligibility.
+ * _ensure_plan_eligibility`), where a pending checkout resumes instead of
+ * dead-ending.
+ */
+const GATE_BLOCKING_REASON_CODES: readonly MembershipReasonCode[] = [
+	'blacklisted',
+	'requires_verification',
+	'whitelist_pending',
+	'whitelist_rejected',
+	'not_accepting_requests',
+	'application_rejected',
+	'membership_questionnaire_missing',
+	'membership_questionnaire_pending',
+	'membership_questionnaire_failed',
+	'membership_questionnaire_retake_cooldown',
+	'membership_questionnaire_attempts_exhausted',
+	'requires_approval',
+	'membership_paused'
+];
+
+/**
+ * Is this viewer blocked by one of the tier's membership gates?
+ *
+ * The distinction that matters: a tier's `questionnaire_id` / `requires_approval`
+ * say the tier IS GATED; only a verdict says whether THIS viewer is still behind
+ * the gate. A member who has already passed the questionnaire comes back
+ * `allowed` (with `proceed_to_payment` for a plan-bearing check) and must keep
+ * every CTA a member of an ungated tier would get — hence the first line.
+ */
+export function isBlockedByMembershipGate(e: MembershipEligibilitySchema): boolean {
+	if (e.allowed) return false;
+	if (!e.reason_code) return false;
+	return GATE_BLOCKING_REASON_CODES.includes(e.reason_code);
+}
+
+/**
  * Localized prose per reason code.
  *
  * Deliberately partial: `org_not_visible`, `tier_requires_subscription`,


### PR DESCRIPTION
Closes #733

On a tier that is both eligibility-gated and priced (possible since
letsrevel/revel-backend#831), `TierCard` rendered the gate affordance
("A membership questionnaire is required" + a link) and the plan cards as
independent siblings, and `PlanCard`'s CTA decision consulted only the plan. An
authenticated non-member was therefore offered **Subscribe** next to a message
telling them a questionnaire had to come first.

This is a UX defect, not a hole: `POST /me/organizations/{org_id}/subscribe`
runs the full gate stack (`subscription_eligibility._ensure_plan_eligibility`)
before creating a Checkout session and refuses an ineligible caller with a 400
carrying the verdict. Nobody can pay past a gate — but the refusal arrived only
*after* the member committed to a concrete charge, on a screen that had already
told them what the real next step was.

## Where the verdict comes from, and why

`TierCard` runs one eligibility query per gated tier and passes the result down;
`PlanCard` stays query-free and takes plain props (its test file needs no query
client, and the component stays reusable).

**The verdict has to name a plan.** This is the finding that shaped the whole
change: the CTA's existing tier-only query *cannot* answer this question. With
no `plan_id`, gate #6 (`TierAvailabilityGate`) short-circuits any tier carrying
an active plan with `tier_requires_subscription` — **before** the questionnaire
(#8) and manual-approval (#9) gates ever run. So on a paid tier the tier-scoped
verdict is structurally incapable of saying whether the questionnaire is
satisfied. `TierCard` therefore asks with `tier_id` **and** a `plan_id`.

One plan can answer for all of them because the gates that run above the payment
one are facts about the *(viewer, tier)* pair, identical for every plan on the
card. The representative plan is the cheapest one that could show a CTA at all
(not offline, not sold out, not paused) — a tier with nothing else on it asks
nothing at all.

### "Tier is gated" vs "this viewer is blocked"

The distinction the issue calls the crux, held in two places:

- `tier.questionnaire_id` / `tier.requires_approval` decide **whether to ask**.
  An ungated tier asks nothing and behaves exactly as before.
- Only the verdict decides **whether to withhold** — via a new
  `isBlockedByMembershipGate()` in `membership-eligibility.ts`.

That predicate is a deliberate *allow-list* of gate reason codes, not
"anything not allowed", because the two error directions are not symmetric:
hiding Subscribe from someone eligible is worse than the dead button being
fixed. So:

- `allowed` is never blocked — including `allowed` + `reason_code:
  requires_approval` (that is `check_eligibility`'s policy annotation, not a
  blocker) and `proceed_to_payment` (gates cleared, only the charge left). A
  member who has already passed the questionnaire keeps Subscribe.
- Blocked: questionnaire (missing / pending / failed / cooldown / attempts
  exhausted), manual approval (`submit_application` **and** `wait_for_approval`),
  blacklist/whitelist, not-accepting-requests, rejected application, paused
  membership.
- **Not** blocked: payment-readiness refusals — `tier_requires_subscription`,
  `plan_not_online`, `org_not_stripe_connected`, `plan_unavailable`,
  `tier_unavailable`, `duplicate_active_subscription`. The plan card already
  models those from the plan's own fields and the viewer's live subscription,
  and the backend deliberately lets `duplicate_active_subscription` fall through
  to `/subscribe` so a half-finished checkout can resume. Keeping them out also
  means the representative-plan choice cannot leak into the answer.

Any unknown answer (guest, ungated tier, request in flight, request failed,
verdict the FE cannot classify) leaves the CTA exactly as it is today — worst
case a 400, never an unreachable plan.

## Removed, not disabled

Removed, with the price still on the card. A disabled primary button with no
path forward is its own dead end (and the "why" would live in a tooltip nobody
reads); removing it leaves the tier's questionnaire/approval affordance as the
single call to action, while the price keeps saying what the member is working
toward. The only *disabled* state is transient: while either lookup (membership
or verdict) is in flight, matching the existing `subscriptionLoading` treatment.

**Manual approval gets the same treatment** — `PaymentReadyGate` answers
`submit_application` when approval is required and nothing is on file, and
`wait_for_approval` while it is under review; both withdraw the CTA.

**Guests are untouched:** they keep "Log in to subscribe" / "Log in to join".
Nobody has asked the backend about them, and the sentence is true whatever their
eligibility turns out to be — the query is not even enabled for them (nor for
owners/staff, who pass gate #1 by definition, nor for a viewer who already has a
live subscription).

## Accessibility

What replaces the CTA *is* the explanation: a `role="note"` in the CTA slot
carrying the localized reason, plus `aria-describedby` pointing at the tier's
requirement list (which now carries an id). Nothing is conveyed by colour;
mobile-first (the note occupies the same block the button did, so nothing
reflows).

## Also in here

`MembershipCta`'s inline eligibility query moved into a shared
`$lib/queries/join-eligibility.ts` so the CTA and the plan cards use one key
builder and one fetcher. The tier-only key keeps its existing four-element
shape (the plan is appended only when there is one), and every invalidation in
the app targets the three-element `['org', slug, 'join-eligibility']` prefix, so
both shapes are still refreshed by `ApplyDialog`, `SubscribeDialog`,
`CheckoutReturnCard` and the questionnaire page.

## Tests

Component/unit tests written, **not run** (house rule — please run `make test`):

- `membership-eligibility.test.ts` — `isBlockedByMembershipGate`: allowed
  verdicts (incl. the `requires_approval` annotation and `proceed_to_payment`),
  every questionnaire state, both approval shapes, payment-readiness refusals
  left alone, unclassifiable refusal left alone.
- `PlanCard.test.ts` — gated + blocked (no Subscribe, price still shown, reason
  present), the `aria-describedby` association, free-plan wording, gated +
  eligible (Subscribe unchanged), verdict in flight (held), guest (login CTA),
  plan-level stops still outranking the gate.
- `TierCard.test.ts` — asks with `plan_id`, withdraws Subscribe and leaves the
  questionnaire link as the way forward, keeps Subscribe for a cleared viewer,
  approval-gated, payment-readiness refusal not read as a gate, ungated tier
  asks nothing, offline-only tier asks nothing.

`make fix` + `make check` are green (0 errors; the 374 svelte-check warnings are
the accepted #361 baseline).

**No E2E changes.** `j27 tier-selection.spec.ts` / `eligibility-states.spec.ts`
assert on a *plan-less* gated tier and on an *ungated* tier with an offline plan
— neither reaches the new code path, and no affordance they assert on moved.

## Note for the product question the issue raises

The UI now tells the backend's story: apply → approved → pay, with
`PaymentReadyGate` last. One gap remains and is deliberately out of scope: on an
approval-gated **paid** tier, the tier CTA still renders the org's
"this tier requires a paid subscription" prose rather than an Apply button,
because `MembershipCta`'s own verdict is tier-scoped and hits the same gate #6
short-circuit described above. The questionnaire case has a path forward (the
tier's own link); the approval case says why it cannot subscribe but has nowhere
to apply from. Fixing that means giving the CTA a plan-aware verdict too, which
changes what every paid tier's CTA renders — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP
