### PR TITLE
test(e2e): repoint the last membership CTAs at the tier grid

### DIFF
--- a/tests/e2e/journeys/j01-guest/organizations.spec.ts
+++ b/tests/e2e/journeys/j01-guest/organizations.spec.ts
@@ -42,16 +42,16 @@ test.describe('J1 guest browses organizations @p0', () => {
 		).toBeVisible();
 		// Public org page exposes follow/membership CTAs and its events.
 		await expect(page.getByRole('button', { name: 'Follow' })).toBeVisible();
-		// The guest membership CTA is a real LINK into login carrying a returnUrl
-		// back to this org (MembershipCta's anonymous branch — it replaced the
-		// legacy "Request Membership" button), so it survives no-JS and
-		// middle-click.
+		// The guest membership CTA is a real LINK (MembershipCta's anonymous
+		// branch — it replaced the legacy "Request Membership" button), so it
+		// survives no-JS and middle-click. Since #720 the landing page carries the
+		// SUMMARY CTA — no tier to apply to from here — so it points at the public
+		// tier grid rather than straight at login: a guest gets to see what they
+		// would be joining before being asked for an account. The login round trip
+		// (with its returnUrl) is the tier cards' job, and is asserted there.
 		const joinLink = page.getByRole('link', { name: 'Join Revel Events Collective' });
 		await expect(joinLink).toBeVisible();
-		await expect(joinLink).toHaveAttribute(
-			'href',
-			/\/login\?returnUrl=%2Forg%2Frevel-events-collective$/
-		);
+		await expect(joinLink).toHaveAttribute('href', '/org/revel-events-collective/membership');
 		await expect(page.getByRole('heading', { name: 'Events', exact: true })).toBeVisible();
 	});
 });

--- a/tests/e2e/journeys/j03-account/follow-org.spec.ts
+++ b/tests/e2e/journeys/j03-account/follow-org.spec.ts
@@ -79,14 +79,42 @@ test.describe('J3 follow org & request membership @p1', () => {
 		// The CTA follows the refreshed eligibility verdict.
 		await expect(generalTier.getByRole('button', { name: 'Application pending' })).toBeDisabled();
 
-		// Both are server-side: a fresh load of the LANDING page still shows
-		// Following, and its summary CTA reports the pending application…
+		// Both survive a round trip to the server: a fresh load of the LANDING page
+		// still shows Following, and it still points at the grid.
+		//
+		// The landing CTA is MembershipCta's SUMMARY mode (no tier), and it does
+		// NOT report the pending application — deliberately, and asserted here so
+		// the difference is a decision rather than a hole. Eligibility is
+		// tier-scoped on the backend, and this application names a tier; a
+		// tier-less verdict cannot see it, and with N tiers there is no single
+		// state for a summary to honestly report anyway. So the landing page keeps
+		// the pointer at the grid…
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
 		await expect(page.getByRole('button', { name: 'Following' })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Application pending' })).toBeVisible({
-			timeout: 15_000
-		});
+		// Scoped to the Membership landmark: the hero CTA and this section link
+		// carry the SAME words, and `.first()` would quietly pick whichever came
+		// out on top.
+		await expect(
+			page.getByRole('region', { name: 'Membership' }).getByRole('link', {
+				name: 'View membership options'
+			})
+		).toHaveAttribute('href', membershipPath(org.slug));
+		// The absence is the point, so it is asserted on TEXT rather than on a
+		// role: #720 turned several membership CTAs from buttons into links, and a
+		// `getByRole('button', …).toHaveCount(0)` would pass for the wrong reason
+		// against any of them.
+		await expect(page.getByText('Application pending')).toHaveCount(0);
+		// …and the pending state is asserted where it lives: a fresh, cold load of
+		// the GRID, which is what proves the application was persisted rather than
+		// just optimistically rendered by the dialog that created it. Named on the
+		// tier card, not page-globally: `toBeDisabled()` on a wrong element would
+		// pass for the wrong reason.
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+		await expect(
+			tierCard(page, 'General membership').getByRole('button', { name: 'Application pending' })
+		).toBeDisabled({ timeout: 15_000 });
 
 		// …and the org admin's request queue lists the applicant + message.
 		const ownerContext = await browser.newContext();

--- a/tests/e2e/journeys/j23-subscriptions/plan-states.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/plan-states.spec.ts
@@ -129,13 +129,16 @@ test.describe('J23 plan availability states @p2', () => {
 		// A real link, not a scripted redirect — it carries the return trip.
 		const loginCta = card.getByRole('link', { name: 'Log in to subscribe' });
 		await expect(loginCta).toBeVisible({ timeout: 15_000 });
-		// PlanCard's return trip still points at the org LANDING page, not at the
-		// page the button was pressed on — deliberate on its side (`loginHref` in
-		// PlanCard.svelte), and asserted here so a change to it is a decision
-		// somebody makes rather than a silent drift.
+		// The return trip comes back to THIS page — the tier grid — not to the org
+		// landing page it used to name (`loginHref` in PlanCard.svelte, corrected
+		// alongside #720: plan cards moved here, so returning a visitor to a page
+		// that no longer shows the plan they were about to take is exactly what a
+		// returnUrl is for). Asserted here so a change to it is a decision somebody
+		// makes rather than a silent drift, and so it stays in step with
+		// TierCard's own CTA, which resolves to the same route.
 		await expect(loginCta).toHaveAttribute(
 			'href',
-			`/login?returnUrl=${encodeURIComponent(`/org/${ORG_SLUG}`)}`
+			`/login?returnUrl=${encodeURIComponent(membershipPath(ORG_SLUG))}`
 		);
 		await expect(card.getByRole('button', { name: 'Subscribe' })).toHaveCount(0);
 

--- a/tests/e2e/journeys/j27-applications/apply-flows.spec.ts
+++ b/tests/e2e/journeys/j27-applications/apply-flows.spec.ts
@@ -27,21 +27,27 @@ import { closeDialog } from '../../support/ui';
 // auto-created "General membership" tier) and its own applicant, so parallel
 // projects/workers and a `retries: 1` re-run never share an application.
 //
-// Two backend behaviours the specs are built on, verified live against this
+// Three backend behaviours the specs are built on, verified live against this
 // branch:
 //   * a TIER-BEARING apply on an ungated org completes on the spot — the
 //     membership exists before any UI is opened;
 //   * a TIER-LESS apply stays PENDING for staff, whatever the org's approval
 //     policy, because the backend never resolves a default tier on the
-//     member's behalf.
+//     member's behalf;
+//   * eligibility is TIER-SCOPED: `MembershipEligibilityService` buckets a
+//     user's applications by `tier_id` (tier-less rows live in their own
+//     `None` bucket), so an application only ever colours the verdict for the
+//     tier it names. An arrange whose row must be visible on a tier CARD has
+//     to name that tier — see the re-apply test.
 //
 // The second bullet used to read "all the UI ever sends, since ApplyDialog
 // posts no tier". That is no longer true and was the blind spot #723 was filed
 // about: since #720/#727 a member picks a tier on /org/[slug]/membership and
 // ApplyDialog posts its `tier_id`, so the UI path is the TIER-BEARING one.
-// Tier-less applies survive only as ARRANGE steps (`applyViaApi` with no
-// tier) and as the legacy rows staff still have to name a tier for. The
-// member-facing tier selection itself is covered by tier-selection.spec.ts.
+// Tier-less applies survive only as ARRANGE steps for the account-hub surfaces
+// (which list applications whatever their tier) and as the legacy rows staff
+// still have to name a tier for. The member-facing tier selection itself is
+// covered by tier-selection.spec.ts.
 //
 // Approval alone does NOT create the membership: the state machine advances
 // when the MEMBER reads the application, which the account hub's Applications
@@ -197,9 +203,18 @@ test.describe('j27 application flows @p2', () => {
 		// would land in "Closed", where they are indistinguishable.
 		await setOrgMembershipPolicy(org.owner, org.slug, { requiresApproval: true });
 
-		// Tier-less ARRANGE — the legacy shape a staff-decided application has —
-		// so the rejection under test is not itself produced by the UI.
-		const first = await applyViaApi(applicant, org.slug, { notes: 'E2E: first try' });
+		// API ARRANGE, so the rejection under test is not itself produced by the
+		// UI — but it names the TIER, and that is load-bearing. Applications are
+		// tier-scoped on the backend (`MembershipEligibilityService` keys them by
+		// `tier_id`, with `None` its own bucket), so a tier-less rejection is
+		// invisible to every tier card's verdict and the grid would keep offering
+		// a plain Join. This arrange used to be tier-less and passed only while
+		// the CTA lived on the org landing page, where the verdict was tier-less
+		// too; #720 moved it onto the tier.
+		const first = await applyViaApi(applicant, org.slug, {
+			tierId: org.defaultTierId,
+			notes: 'E2E: first try'
+		});
 		expect(first.status).toBe('pending');
 		await rejectApplication(org.owner, org.slug, first.applicationId);
 
@@ -208,8 +223,8 @@ test.describe('j27 application flows @p2', () => {
 		await waitForClientAuth(page);
 
 		// The verdict turns the join CTA into a re-apply one — a rejection is not
-		// a dead end. Scoped to the tier: the rejection is org-wide, so every tier
-		// card carries the same offer and a page-global lookup is ambiguous.
+		// a dead end. Scoped to the tier because the verdict is: only the card for
+		// the tier that was rejected carries the offer.
 		const generalTier = tierCard(page, DEFAULT_TIER);
 		const reapplyButton = generalTier.getByRole('button', { name: 'Re-apply for membership' });
 		await expect(reapplyButton).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
Four journey specs still asserted pre-#720 behaviour and failed the full-suite run (12 failures = 6 tests × 2 projects; these are 4 of the 6). **The product is correct in all four cases — only the specs changed. No product code is touched.**

## What was stale

**1. `j23-subscriptions/plan-states.spec.ts` — guest login CTA**
Asserted `returnUrl=/org/{slug}`. `PlanCard`'s `loginHref` was deliberately corrected in `99d8479b` to return to `/org/{slug}/membership`: plan cards moved there with #720, and returning a guest to a page that no longer shows the plan they wanted was the bug. Expectation updated (and now built from the shared `membershipPath()` helper, so the next move updates one place).

**2. `j01-guest/organizations.spec.ts` — public org profile (@p0)**
Asserted the hero `Join {org}` link went to `/login?returnUrl=/org/{slug}`. Since #720 `MembershipCta` without a `tierId` is a *summary*: it links to the public tier grid, so a guest sees what they would be joining before being asked for an account. The login round trip belongs to the tier cards and is asserted there (j23). **This spec was outside the set #732 repointed.**

**3. `j27-applications/apply-flows.spec.ts` — rejected → re-apply**
Not a locator problem. Eligibility is **tier-scoped** on the backend: `MembershipEligibilityService` buckets a user's applications by `tier_id`, with tier-less rows in their own `None` bucket, and `current_application` reads only the bucket for the tier being asked about. The arrange rejected a **tier-less** application, so no tier card's verdict could see it and the grid correctly kept offering a plain `Join General membership` (confirmed in the failure snapshot). The arrange now names `org.defaultTierId`. It is still an API arrange, so the rejection under test is still not produced by the UI — the reason the spec gave for going tier-less in the first place is preserved.

**4. `j03-account/follow-org.spec.ts` — follow + apply (@p1)**
Same root cause, on the landing page. The application the UI creates carries a tier; the landing hero is summary mode (tier-less verdict) and cannot see it — and with N tiers there is no single state a summary could honestly report. The spec now asserts:
- the landing page still points at the grid (scoped to the `Membership` landmark — the hero CTA and the section link carry identical words, so `.first()` would silently pick either);
- the pending wording is absent **on text, not on a role** — #720 turned several membership CTAs from buttons into links, so `getByRole('button', …).toHaveCount(0)` would pass for the wrong reason;
- the pending state itself on a **cold load of the grid**, which is a stronger persistence check than the in-place assertion it replaces.

## Verification

```
j03 follow-org + j27 apply-flows   chromium       5 passed
j03 follow-org + j27 apply-flows   mobile-chrome  5 passed
j01 organizations + j23 plan-states  chromium + mobile-chrome  8 passed
```

`make fix` && `make check` green (exit 0).

## Not in scope

`j05-rsvp/eligibility-matrix.spec.ts` (the other 2 × 2 failures, sold-out/waitlist) is triaged separately — this branch touches none of `EventBadges`, `IneligibilityMessage` or `eligibility.ts`.

Follow-up to #723.

Base is `integration/membership-tier-unlock`, not `main`. Branch is named `feature/*` so `push` CI actually runs (#731).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP