### PR TITLE
fix(membership): let members apply for an approval-gated PAID tier (#735)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -5172,7 +5172,13 @@
 		"loginToJoin": "Zum Beitreten anmelden",
 		"freeHelper": "Keine Zahlung nötig — du kannst sofort beitreten.",
 		"gatedSubscribeHelper": "Du kannst abonnieren, sobald die Voraussetzungen dieser Stufe erfüllt sind.",
-		"gatedJoinHelper": "Du kannst beitreten, sobald die Voraussetzungen dieser Stufe erfüllt sind."
+		"gatedJoinHelper": "Du kannst beitreten, sobald die Voraussetzungen dieser Stufe erfüllt sind.",
+		"applyCta": "Beitritt beantragen",
+		"applyCtaAria": "Beitritt mit {plan} beantragen",
+		"reapplyCta": "Erneut beantragen",
+		"reapplyCtaAria": "Erneut mit {plan} beantragen",
+		"applySubscribeHelper": "Die Organisation prüft Anträge — du zahlst erst nach der Zusage.",
+		"applyJoinHelper": "Die Organisation prüft Anträge — du trittst erst nach der Zusage bei."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Du musst eingeloggt sein, um eine Verifizierung anzufordern",
@@ -6806,7 +6812,8 @@
 			"approval": "Deine Bewerbung liegt der Organisation zur Prüfung vor. Du hörst von uns, sobald entschieden ist."
 		},
 		"joinTier": "{tier} beitreten",
-		"choosePlan": "Du erfüllst die Voraussetzungen – wähle unten einen Tarif, um beizutreten."
+		"choosePlan": "Du erfüllst die Voraussetzungen – wähle unten einen Tarif, um beizutreten.",
+		"applyChoosePlan": "Wähle einen Tarif, um einen Antrag zu stellen — die Organisation prüft Anträge vor der Zahlung."
 	},
 	"membershipApply": {
 		"title": "{orgName} beitreten",
@@ -6826,7 +6833,8 @@
 		"trackLink": "Deine Bewerbung verfolgen",
 		"error": "Deine Bewerbung konnte nicht gesendet werden. Bitte versuch es noch einmal.",
 		"titleTier": "{tier} beitreten",
-		"reapplyTitleTier": "Erneut für {tier} bewerben"
+		"reapplyTitleTier": "Erneut für {tier} bewerben",
+		"forPlan": "{orgName} — Antrag mit dem Tarif {plan}."
 	},
 	"membershipTiers": {
 		"heading": "Mitgliedschaft",

--- a/messages/en.json
+++ b/messages/en.json
@@ -5172,7 +5172,13 @@
 		"loginToJoin": "Log in to join",
 		"freeHelper": "No payment needed — you can join right away.",
 		"gatedSubscribeHelper": "You can subscribe once this tier's requirements are met.",
-		"gatedJoinHelper": "You can join once this tier's requirements are met."
+		"gatedJoinHelper": "You can join once this tier's requirements are met.",
+		"applyCta": "Apply to join",
+		"applyCtaAria": "Apply to join with {plan}",
+		"reapplyCta": "Apply again",
+		"reapplyCtaAria": "Apply again with {plan}",
+		"applySubscribeHelper": "The organization reviews applications — you'll pay once you're approved.",
+		"applyJoinHelper": "The organization reviews applications — you'll join once you're approved."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "You must be logged in to request verification",
@@ -6806,7 +6812,8 @@
 			"approval": "Your application is with the organization for review. You'll hear back once they decide."
 		},
 		"joinTier": "Join {tier}",
-		"choosePlan": "You're eligible — choose a plan below to join."
+		"choosePlan": "You're eligible — choose a plan below to join.",
+		"applyChoosePlan": "Choose a plan to apply — the organization reviews applications before payment."
 	},
 	"membershipApply": {
 		"title": "Join {orgName}",
@@ -6826,7 +6833,8 @@
 		"trackLink": "Track your application",
 		"error": "Could not send your application. Please try again.",
 		"titleTier": "Join {tier}",
-		"reapplyTitleTier": "Re-apply to {tier}"
+		"reapplyTitleTier": "Re-apply to {tier}",
+		"forPlan": "{orgName} — applying with the {plan} plan."
 	},
 	"membershipTiers": {
 		"heading": "Membership",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -5143,7 +5143,13 @@
 		"loginToJoin": "Se connecter pour rejoindre",
 		"freeHelper": "Aucun paiement requis — vous pouvez rejoindre immédiatement.",
 		"gatedSubscribeHelper": "Vous pourrez vous abonner une fois les conditions de ce niveau remplies.",
-		"gatedJoinHelper": "Vous pourrez rejoindre une fois les conditions de ce niveau remplies."
+		"gatedJoinHelper": "Vous pourrez rejoindre une fois les conditions de ce niveau remplies.",
+		"applyCta": "Demander à adhérer",
+		"applyCtaAria": "Demander à adhérer avec {plan}",
+		"reapplyCta": "Refaire une demande",
+		"reapplyCtaAria": "Refaire une demande avec {plan}",
+		"applySubscribeHelper": "L'organisation examine les demandes — vous paierez une fois votre demande acceptée.",
+		"applyJoinHelper": "L'organisation examine les demandes — vous adhérerez une fois votre demande acceptée."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Tu dois être connecté pour demander une vérification",
@@ -6777,7 +6783,8 @@
 			"approval": "Ta candidature est en cours d'examen par l'organisation. Tu auras une réponse dès qu'elle aura décidé."
 		},
 		"joinTier": "Rejoindre {tier}",
-		"choosePlan": "Vous êtes éligible : choisissez une formule ci-dessous pour adhérer."
+		"choosePlan": "Vous êtes éligible : choisissez une formule ci-dessous pour adhérer.",
+		"applyChoosePlan": "Choisissez une formule pour faire une demande — l'organisation examine les demandes avant le paiement."
 	},
 	"membershipApply": {
 		"title": "Rejoindre {orgName}",
@@ -6797,7 +6804,8 @@
 		"trackLink": "Suivre ta demande",
 		"error": "Impossible d'envoyer ta demande. Réessaie.",
 		"titleTier": "Rejoindre {tier}",
-		"reapplyTitleTier": "Postuler à nouveau pour {tier}"
+		"reapplyTitleTier": "Postuler à nouveau pour {tier}",
+		"forPlan": "{orgName} — demande avec la formule {plan}."
 	},
 	"membershipTiers": {
 		"heading": "Adhésion",

--- a/messages/it.json
+++ b/messages/it.json
@@ -5172,7 +5172,13 @@
 		"loginToJoin": "Accedi per iscriverti",
 		"freeHelper": "Nessun pagamento richiesto: puoi iscriverti subito.",
 		"gatedSubscribeHelper": "Potrai abbonarti quando avrai soddisfatto i requisiti di questo livello.",
-		"gatedJoinHelper": "Potrai iscriverti quando avrai soddisfatto i requisiti di questo livello."
+		"gatedJoinHelper": "Potrai iscriverti quando avrai soddisfatto i requisiti di questo livello.",
+		"applyCta": "Richiedi di iscriverti",
+		"applyCtaAria": "Richiedi di iscriverti con {plan}",
+		"reapplyCta": "Richiedi di nuovo",
+		"reapplyCtaAria": "Richiedi di nuovo con {plan}",
+		"applySubscribeHelper": "L'organizzazione esamina le richieste: pagherai una volta approvata.",
+		"applyJoinHelper": "L'organizzazione esamina le richieste: entrerai una volta approvata."
 	},
 	"requestWhitelistButton": {
 		"mustBeLoggedIn": "Devi essere loggato per richiedere la verifica",
@@ -6806,7 +6812,8 @@
 			"approval": "La tua candidatura è in fase di revisione da parte dell'organizzazione. Riceverai una risposta appena avranno deciso."
 		},
 		"joinTier": "Iscriviti a {tier}",
-		"choosePlan": "Hai i requisiti: scegli un piano qui sotto per iscriverti."
+		"choosePlan": "Hai i requisiti: scegli un piano qui sotto per iscriverti.",
+		"applyChoosePlan": "Scegli un piano per fare richiesta: l'organizzazione esamina le richieste prima del pagamento."
 	},
 	"membershipApply": {
 		"title": "Unisciti a {orgName}",
@@ -6826,7 +6833,8 @@
 		"trackLink": "Segui la tua richiesta",
 		"error": "Non è stato possibile inviare la tua richiesta. Riprova.",
 		"titleTier": "Iscriviti a {tier}",
-		"reapplyTitleTier": "Invia una nuova richiesta per {tier}"
+		"reapplyTitleTier": "Invia una nuova richiesta per {tier}",
+		"forPlan": "{orgName} — richiesta con il piano {plan}."
 	},
 	"membershipTiers": {
 		"heading": "Iscrizione",

--- a/src/lib/components/organization/membership/ApplyDialog.svelte
+++ b/src/lib/components/organization/membership/ApplyDialog.svelte
@@ -41,6 +41,24 @@
 		tierId?: string | null;
 		/** Names the tier in the dialog heading. */
 		tierName?: string | null;
+		/**
+		 * The plan this application is for, which is what makes it a PAID
+		 * application (BE #831: *"A `plan_id` makes this a paid application"*).
+		 *
+		 * Not an optimization — on a tier that carries an active plan it is the
+		 * only application the backend will accept. `TierAvailabilityGate` (#6)
+		 * refuses a plan-less `/apply` there with `tier_requires_subscription` and
+		 * never reaches the approval gate below it, so without this the dialog can
+		 * only ever mint FREE applications and manual-approval gating on a
+		 * monetized tier is unreachable through the UI (#735).
+		 *
+		 * The row carries the plan through to settlement: it advances to APPROVED
+		 * when staff decide, and COMPLETED once the subscription bought with this
+		 * plan activates.
+		 */
+		planId?: string | null;
+		/** Names the plan in the dialog, so the applicant sees which one they chose. */
+		planName?: string | null;
 	}
 
 	const {
@@ -50,7 +68,9 @@
 		organizationName,
 		mode,
 		tierId = null,
-		tierName = null
+		tierName = null,
+		planId = null,
+		planName = null
 	}: Props = $props();
 
 	const accessToken = $derived(authStore.accessToken);
@@ -92,10 +112,14 @@
 			const res = await memembershipapplicationsApply({
 				path: { slug: organizationSlug },
 				// An empty note is no note: sending `''` would store a blank message
-				// on the application. `tier_id` is likewise omitted rather than sent
-				// as null when the caller has no tier, so the backend keeps its
-				// org-default resolution for the legacy tier-less path.
-				body: { tier_id: tierId ?? undefined, notes: notes || undefined },
+				// on the application. `tier_id` and `plan_id` are likewise omitted
+				// rather than sent as null when the caller has neither, so the backend
+				// keeps its org-default resolution for the legacy tier-less path.
+				body: {
+					tier_id: tierId ?? undefined,
+					plan_id: planId ?? undefined,
+					notes: notes || undefined
+				},
 				headers: { Authorization: `Bearer ${accessToken}` }
 			});
 			// hey-api resolves rather than throws — a missing payload is a failure
@@ -211,6 +235,12 @@
 					{completed
 						? m['membershipApply.completedBody']({ orgName: organizationName })
 						: m['membershipApply.pendingBody']()}
+				{:else if planName}
+					<!-- Which plan the application will carry. The applicant pressed Apply
+					     on one specific card and the row's `plan` FK is set from it, so the
+					     dialog says so rather than leaving them to infer it from whichever
+					     button they happened to press. -->
+					{m['membershipApply.forPlan']({ orgName: organizationName, plan: planName })}
 				{:else}
 					{organizationName}
 				{/if}

--- a/src/lib/components/organization/membership/ApplyDialog.test.ts
+++ b/src/lib/components/organization/membership/ApplyDialog.test.ts
@@ -12,6 +12,7 @@ import type {
 	MembershipApplicationSchema,
 	MembershipEligibilitySchema
 } from '$lib/api/generated/types.gen';
+import * as m from '$lib/paraglide/messages.js';
 
 vi.mock('$lib/api/generated/sdk.gen', () => ({
 	memembershipapplicationsApply: vi.fn()
@@ -166,7 +167,7 @@ describe('ApplyDialog', () => {
 			expect(vi.mocked(memembershipapplicationsApply)).toHaveBeenCalledWith(
 				expect.objectContaining({
 					path: { slug: 'acme' },
-					body: { tier_id: undefined, notes: 'hello' }
+					body: { tier_id: undefined, plan_id: undefined, notes: 'hello' }
 				})
 			);
 		});
@@ -181,7 +182,9 @@ describe('ApplyDialog', () => {
 
 		await waitFor(() => {
 			expect(vi.mocked(memembershipapplicationsApply)).toHaveBeenCalledWith(
-				expect.objectContaining({ body: { tier_id: undefined, notes: undefined } })
+				expect.objectContaining({
+					body: { tier_id: undefined, plan_id: undefined, notes: undefined }
+				})
 			);
 		});
 	});
@@ -200,9 +203,55 @@ describe('ApplyDialog', () => {
 			expect(vi.mocked(memembershipapplicationsApply)).toHaveBeenCalledWith(
 				expect.objectContaining({
 					path: { slug: 'acme' },
-					body: { tier_id: 'tier-gold', notes: undefined }
+					body: { tier_id: 'tier-gold', plan_id: undefined, notes: undefined }
 				})
 			);
+		});
+	});
+
+	// #735, and the reason the CTA work above it means anything. BE #831: *"a
+	// `plan_id` makes this a paid application"*. Without it, `TierAvailabilityGate`
+	// (#6) refuses the application outright on a tier that carries an active plan
+	// (`tier_requires_subscription`) and never reaches the approval gate — so the
+	// only applications this dialog could create were FREE ones, and manual
+	// approval on a monetized tier had no way in.
+	describe('applying with a plan', () => {
+		it('posts the plan alongside the tier', async () => {
+			const user = userEvent.setup();
+			mockApplySuccess(makeResult());
+			renderDialog({
+				tierId: 'tier-gold',
+				tierName: 'Gold',
+				planId: 'plan-1',
+				planName: 'Monthly'
+			});
+
+			await user.click(screen.getByRole('button', { name: /send application/i }));
+
+			await waitFor(() => {
+				expect(vi.mocked(memembershipapplicationsApply)).toHaveBeenCalledWith(
+					expect.objectContaining({
+						path: { slug: 'acme' },
+						body: { tier_id: 'tier-gold', plan_id: 'plan-1', notes: undefined }
+					})
+				);
+			});
+		});
+
+		// The applicant pressed one plan's button among several; the row's `plan` FK
+		// comes from that press, so the dialog states which one rather than leaving
+		// them to remember.
+		it('names the plan it is applying with', () => {
+			renderDialog({
+				tierId: 'tier-gold',
+				tierName: 'Gold',
+				planId: 'plan-1',
+				planName: 'Monthly'
+			});
+
+			expect(
+				screen.getByText(m['membershipApply.forPlan']({ orgName: 'Acme', plan: 'Monthly' }))
+			).toBeInTheDocument();
 		});
 	});
 

--- a/src/lib/components/organization/membership/MembershipCta.svelte
+++ b/src/lib/components/organization/membership/MembershipCta.svelte
@@ -298,26 +298,29 @@
 	</Button>
 {:else if eligibility && ctaKind}
 	<div class={cn('flex flex-col items-start gap-2', className)}>
-		{#if ctaKind === 'apply' || (deferToPlans && (ctaKind === 'join' || ctaKind === 'reapply'))}
-			<!-- #735. The gates are waiting on an application, and on a monetized
-			     tier an application has to name a plan or the backend refuses it —
-			     so the affordance lives on the plan cards, one per plan, and this
+		{#if deferToPlans && (ctaKind === 'join' || ctaKind === 'apply' || ctaKind === 'reapply')}
+			<!-- #735. Every step here is per-PLAN — an application on a monetized
+			     tier has to name one or the backend refuses it — so the affordance
+			     lives on the plan cards, which know the id and the name, and this
 			     says where to look and what happens next. `role="note"`, the same
-			     shape the `payment` branch already uses for the same reason. -->
-			{#if deferToPlans}
-				<p role="note" class="text-sm text-muted-foreground">
-					{m['membershipEligibility.applyChoosePlan']()}
-				</p>
-			{:else}
-				<!-- No plan on this CTA, so it cannot mint the paid application the
-				     verdict is asking for: send them to the grid, where the plan cards
-				     can. Unreachable in practice — `submit_application` is emitted by
-				     the payment gate, which only runs for a plan-bearing question. -->
-				<Button href={membershipHref}>
-					<UserPlus class="h-4 w-4" aria-hidden="true" />
-					{m['membershipPlans.viewMembership']()}
-				</Button>
-			{/if}
+			     shape the `payment` branch already uses for the same reason.
+			     `join` is the allowed-but-plan-less shape, which the payment gate
+			     makes unreachable for a plan-bearing question; it keeps the eligible
+			     wording rather than the under-review one. -->
+			<p role="note" class="text-sm text-muted-foreground">
+				{ctaKind === 'join'
+					? m['membershipEligibility.choosePlan']()
+					: m['membershipEligibility.applyChoosePlan']()}
+			</p>
+		{:else if ctaKind === 'apply'}
+			<!-- No plan on this CTA, so it cannot mint the paid application the
+			     verdict is asking for: send them to the grid, where the plan cards
+			     can. Unreachable in practice — `submit_application` is emitted by
+			     the payment gate, which only runs for a plan-bearing question. -->
+			<Button href={membershipHref}>
+				<UserPlus class="h-4 w-4" aria-hidden="true" />
+				{m['membershipPlans.viewMembership']()}
+			</Button>
 		{:else if ctaKind === 'join'}
 			{#if isTierMode}
 				<Button onclick={() => openApply('join')}>

--- a/src/lib/components/organization/membership/MembershipCta.svelte
+++ b/src/lib/components/organization/membership/MembershipCta.svelte
@@ -52,6 +52,24 @@
 		/** Names the tier in the CTA, so N cards do not all read "Join". */
 		tierName?: string | null;
 		/**
+		 * A representative plan of this tier, which changes what the backend is
+		 * ASKED — and on a monetized tier it is the only way to get an answer worth
+		 * rendering (#735).
+		 *
+		 * Without it, gate #6 (`TierAvailabilityGate`) short-circuits any tier
+		 * carrying an active plan with `tier_requires_subscription` and no
+		 * `next_step`, so the CTA rendered the org's policy prose and offered
+		 * nothing — the approval gate below it never even ran. With it the verdict
+		 * names a move (`submit_application`, `submit_questionnaire`,
+		 * `wait_for_approval`, `proceed_to_payment`, …).
+		 *
+		 * `TierCard` supplies it, and only for a GATED tier, so an ungated paid
+		 * tier's CTA is untouched. It is the same plan the tier's plan cards are
+		 * gated on, and the query options are shared — so this is the SAME cache
+		 * key and one request, not a second round trip per tier.
+		 */
+		planId?: string | null;
+		/**
 		 * Tier mode only: this tier's plans are on screen next to the CTA, so a
 		 * `proceed_to_payment` verdict points at them instead of linking away.
 		 */
@@ -70,10 +88,29 @@
 		class: className,
 		tierId = null,
 		tierName = null,
+		planId = null,
 		plansInline = false
 	}: Props = $props();
 
 	const isTierMode = $derived(!!tierId);
+
+	/**
+	 * The verdict was asked WITH a plan and that tier's plan cards are on screen,
+	 * so every step it names that is per-plan — apply, re-apply, pay — belongs to
+	 * those cards, which carry the plan's id and its name. This CTA points at them
+	 * instead of offering a second, plan-less copy of the same button (#735).
+	 *
+	 * Gated on `planId` rather than on `plansInline` alone: a tier whose plans are
+	 * all offline still renders plan cards but gets no plan-bearing verdict, and
+	 * its CTA must keep behaving exactly as it did.
+	 */
+	const deferToPlans = $derived.by(() => {
+		// Both operands read unconditionally: `&&` inside a `$derived` would leave
+		// the skipped one untracked.
+		const plan = !!planId;
+		const inline = plansInline;
+		return plan && inline;
+	});
 
 	// Status badge styling, kept in step with MemberCard.svelte.
 	const statusStyles: Record<MembershipStatus, string> = {
@@ -112,6 +149,7 @@
 		joinEligibilityQueryOptions({
 			organizationSlug,
 			tierId,
+			planId,
 			accessToken,
 			enabled: queryEnabled
 		})
@@ -260,7 +298,27 @@
 	</Button>
 {:else if eligibility && ctaKind}
 	<div class={cn('flex flex-col items-start gap-2', className)}>
-		{#if ctaKind === 'join'}
+		{#if ctaKind === 'apply' || (deferToPlans && (ctaKind === 'join' || ctaKind === 'reapply'))}
+			<!-- #735. The gates are waiting on an application, and on a monetized
+			     tier an application has to name a plan or the backend refuses it —
+			     so the affordance lives on the plan cards, one per plan, and this
+			     says where to look and what happens next. `role="note"`, the same
+			     shape the `payment` branch already uses for the same reason. -->
+			{#if deferToPlans}
+				<p role="note" class="text-sm text-muted-foreground">
+					{m['membershipEligibility.applyChoosePlan']()}
+				</p>
+			{:else}
+				<!-- No plan on this CTA, so it cannot mint the paid application the
+				     verdict is asking for: send them to the grid, where the plan cards
+				     can. Unreachable in practice — `submit_application` is emitted by
+				     the payment gate, which only runs for a plan-bearing question. -->
+				<Button href={membershipHref}>
+					<UserPlus class="h-4 w-4" aria-hidden="true" />
+					{m['membershipPlans.viewMembership']()}
+				</Button>
+			{/if}
+		{:else if ctaKind === 'join'}
 			{#if isTierMode}
 				<Button onclick={() => openApply('join')}>
 					<UserPlus class="h-4 w-4" aria-hidden="true" />
@@ -401,6 +459,7 @@
 		{organizationName}
 		{tierId}
 		{tierName}
+		{planId}
 		mode={applyMode}
 	/>
 {/if}

--- a/src/lib/components/organization/membership/MembershipCta.test.ts
+++ b/src/lib/components/organization/membership/MembershipCta.test.ts
@@ -474,6 +474,133 @@ describe('MembershipCta', () => {
 		expect(await screen.findByRole('dialog')).toHaveTextContent('Re-apply to Gold');
 	});
 
+	// #735, the tier-level half. On a monetized tier a tier-only question is a dead
+	// end — gate #6 answers `tier_requires_subscription` with no next_step, and the
+	// approval gate below it never runs — so `TierCard` now hands this CTA the
+	// representative plan its own plan cards are gated on. What the verdict then
+	// names is per-PLAN, and the plan cards (which know the id and the name) carry
+	// it; this CTA points at them rather than offering a second, plan-less copy.
+	describe('when the tier carries a plan', () => {
+		function renderPaidTierCta(props: Record<string, unknown> = {}) {
+			return renderTierCta({ planId: 'plan-1', plansInline: true, ...props });
+		}
+
+		// The same cache key `TierCard` and its plan cards already observe, so this
+		// is one shared request, not a second round trip per tier.
+		it('asks the backend about the tier AND the plan', async () => {
+			mockEligibility(
+				makeEligibility({
+					allowed: false,
+					next_step: 'submit_application',
+					reason_code: 'requires_approval'
+				})
+			);
+			renderPaidTierCta();
+
+			await screen.findByRole('note');
+			expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalledWith(
+				expect.objectContaining({ query: { tier_id: 'tier-gold', plan_id: 'plan-1' } })
+			);
+		});
+
+		// The verdict this whole issue is about. Before #735 it fell through to
+		// `info` and rendered the org's approval POLICY next to nothing to press.
+		it('points at the plan cards when an application is what is missing', async () => {
+			mockEligibility(
+				makeEligibility({
+					allowed: false,
+					next_step: 'submit_application',
+					reason_code: 'requires_approval'
+				})
+			);
+			renderPaidTierCta();
+
+			expect(await screen.findByRole('note')).toHaveTextContent(
+				m['membershipEligibility.applyChoosePlan']()
+			);
+			// Not a second Join button: it would have no plan to apply with, and the
+			// backend refuses a plan-less application on a monetized tier.
+			expect(screen.queryByRole('button', { name: /join/i })).toBeNull();
+			expect(screen.queryByText(m['membershipEligibility.reason.requires_approval']())).toBeNull();
+		});
+
+		it('points at the plan cards for a re-apply too', async () => {
+			mockEligibility(
+				makeEligibility({
+					allowed: false,
+					next_step: 'reapply',
+					reason_code: 'application_rejected'
+				})
+			);
+			renderPaidTierCta();
+
+			expect(await screen.findByRole('note')).toHaveTextContent(
+				m['membershipEligibility.applyChoosePlan']()
+			);
+			expect(screen.queryByRole('button', { name: /re-apply/i })).toBeNull();
+		});
+
+		// Once staff decide, the approval gate falls through and the payment gate
+		// allows: the plan cards get their Subscribe back and this says so.
+		it('hands the tier back to the plans once the gates clear', async () => {
+			mockEligibility(makeEligibility({ allowed: true, next_step: 'proceed_to_payment' }));
+			renderPaidTierCta();
+
+			expect(await screen.findByRole('note')).toHaveTextContent(
+				m['membershipEligibility.choosePlan']()
+			);
+		});
+
+		// The waiting half. Nothing to press on any plan card, so the tier CTA is
+		// the one place the state and the way to follow it are stated — announced in
+		// words, not by a greyed-out control alone.
+		it('keeps the pending state and the tracking link while staff decide', async () => {
+			mockEligibility(
+				makeEligibility({
+					allowed: false,
+					next_step: 'wait_for_approval',
+					reason_code: 'requires_approval',
+					application_id: 'app-1'
+				})
+			);
+			renderPaidTierCta();
+
+			expect(await screen.findByRole('button', { name: /application pending/i })).toBeDisabled();
+			expect(screen.getByRole('link', { name: /track your application/i })).toHaveAttribute(
+				'href',
+				'/account/memberships'
+			);
+		});
+
+		// A questionnaire is not per-plan: `TierCard` renders its link straight off
+		// the tier, and the CTA keeps its own. Unchanged by this issue.
+		it('still links the questionnaire itself', async () => {
+			mockEligibility(
+				makeEligibility({
+					allowed: false,
+					next_step: 'submit_questionnaire',
+					reason_code: 'membership_questionnaire_missing',
+					questionnaire_id: 'q1'
+				})
+			);
+			renderPaidTierCta();
+
+			expect(
+				await screen.findByRole('link', { name: m['membershipEligibility.questionnaireCta']() })
+			).toHaveAttribute('href', '/org/acme/questionnaire/q1');
+		});
+
+		// The deferral is gated on the PLAN, not on the plans merely being on
+		// screen: a tier whose plans are all offline renders cards but gets no
+		// plan-bearing verdict, and its CTA must keep behaving exactly as before.
+		it('keeps its own join button when no plan was named', async () => {
+			mockEligibility(makeEligibility({ allowed: true }));
+			renderTierCta({ plansInline: true });
+
+			expect(await screen.findByRole('button', { name: 'Join Gold' })).toBeInTheDocument();
+		});
+	});
+
 	// The cache key carries the tier (#720). Without it the first card's verdict
 	// would be served to every other tier on the page — one tier's "you can join"
 	// answering for a tier that wants a questionnaire.

--- a/src/lib/components/organization/membership/PlanCard.svelte
+++ b/src/lib/components/organization/membership/PlanCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import type { MySubscriptionSchema, PublicPlanSchema } from '$lib/api/generated/types.gen';
+	import type { MembershipGateAction } from '$lib/utils/membership-eligibility';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
@@ -30,21 +31,29 @@
 		/** The subscription lookup is still in flight — the answer is not known yet. */
 		subscriptionLoading?: boolean;
 		/**
-		 * The tier's membership gates are known to be UNSATISFIED for this viewer
-		 * (#733). Resolved by `TierCard` from a plan-bearing eligibility verdict —
-		 * never from the tier's static `questionnaire_id` / `requires_approval`,
-		 * which say the tier is gated, not that this viewer is behind the gate.
+		 * What the tier's membership gates leave this viewer to do with this plan
+		 * (#733, #735). Resolved by `TierCard` from a plan-bearing eligibility
+		 * verdict — never from the tier's static `questionnaire_id` /
+		 * `requires_approval`, which say the tier is gated, not that this viewer is
+		 * behind the gate.
 		 *
-		 * Defaults to false, and stays false whenever the verdict is unknown
-		 * (guest, ungated tier, request in flight or failed). Withdrawing the CTA
-		 * from somebody who is in fact eligible is a worse failure than the dead
-		 * button this flag exists to remove, and `POST …/subscribe` runs the whole
-		 * gate stack itself (BE #831) — so an unknown answer costs a 400 at worst,
-		 * never an unreachable plan.
+		 * `null` means "nothing in the way", and that is also what an UNKNOWN
+		 * verdict resolves to (guest, ungated tier, request in flight or failed).
+		 * Withdrawing the CTA from somebody who is in fact eligible is a worse
+		 * failure than the dead button #733 removed, and `POST …/subscribe` runs
+		 * the whole gate stack itself (BE #831) — so an unknown answer costs a 400
+		 * at worst, never an unreachable plan.
 		 */
-		gateBlocked?: boolean;
-		/** Localized explanation of that block, rendered where the CTA was. */
+		gateAction?: MembershipGateAction | null;
+		/** Localized explanation of that gate, rendered where the CTA was. */
 		gateReason?: string | null;
+		/**
+		 * Open the application dialog for THIS plan. Called only from the `apply` /
+		 * `reapply` branches, so the plan has an id by construction — the
+		 * application's `plan` FK is what makes it a paid application, and it must
+		 * be the plan whose card was pressed.
+		 */
+		onApply?: (plan: PublicPlanSchema & { id: string }, mode: 'join' | 'reapply') => void;
 		/** The verdict is still in flight: hold the CTA rather than offer it. */
 		gatePending?: boolean;
 		/**
@@ -61,8 +70,9 @@
 		organizationSlug,
 		subscription = null,
 		subscriptionLoading = false,
-		gateBlocked = false,
+		gateAction = null,
 		gateReason = null,
+		onApply,
 		gatePending = false,
 		gateRequirementsId = null
 	}: Props = $props();
@@ -83,14 +93,24 @@
 	 * subscription on the spot — so it takes the ordinary join path, with the
 	 * label and dialog copy adjusted for the absent charge.
 	 *
-	 * `gated` sits second-to-last, below every plan-level stop and above the
-	 * viewer's own CTA (#733). Since BE #831 a tier can be gated AND priced, and
-	 * a questionnaire the viewer has not passed makes Subscribe an action that
+	 * The gate branches sit second-to-last, below every plan-level stop and above
+	 * the viewer's own CTA (#733). Since BE #831 a tier can be gated AND priced,
+	 * and a questionnaire the viewer has not passed makes Subscribe an action that
 	 * cannot succeed: `/subscribe` runs the same gate stack and refuses with a
-	 * 400 — after the member has committed to a concrete charge. The CTA is
-	 * *removed* rather than disabled, so the tier's questionnaire/approval
-	 * affordance is the only thing left to press; the price stays on the card
-	 * above, so what they are working toward is still visible.
+	 * 400 — after the member has committed to a concrete charge.
+	 *
+	 * What replaces it depends on WHOSE move it is (#735):
+	 *
+	 * - `apply` / `reapply` — the member's. The gate is waiting on an application
+	 *   that only they can create, so the card offers exactly that, carrying this
+	 *   plan's id. Withdrawing the CTA and stopping (the whole of #733) left an
+	 *   approval-gated priced tier with no affordance anywhere: unlike a
+	 *   questionnaire, whose link `TierCard` renders straight off the tier, an
+	 *   application has no other entry point.
+	 * - `gated` — somebody else's, or nothing at all: staff are deciding, the
+	 *   grader is running, the cooldown has not expired. No control, and the
+	 *   reason in its place. The price stays on the card above either way, so what
+	 *   they are working toward stays visible.
 	 *
 	 * A guest is untouched: nobody has asked the backend about them, and "Log in
 	 * to subscribe" is true whatever their eligibility turns out to be.
@@ -104,8 +124,13 @@
 		if (plan.sales_status === 'paused') return 'none';
 		if (!plan.id) return 'none';
 		if (!isAuthenticated) return 'login';
-		return gateBlocked ? 'gated' : 'subscribe';
+		if (gateAction === 'apply') return 'apply';
+		if (gateAction === 'reapply') return 'reapply';
+		return gateAction ? 'gated' : 'subscribe';
 	});
+
+	/** True for both application branches — they differ only in wording and mode. */
+	const isApplyAction = $derived(action === 'apply' || action === 'reapply');
 
 	/**
 	 * Held while either lookup is unsettled: until the subscription AND the gate
@@ -167,6 +192,12 @@
 		if (!plan.id) return;
 		onSubscribe({ ...plan, id: plan.id });
 	}
+
+	function handleApply(): void {
+		// Same re-narrowing as above; the apply branches are equally id-gated.
+		if (!plan.id) return;
+		onApply?.({ ...plan, id: plan.id }, action === 'reapply' ? 'reapply' : 'join');
+	}
 </script>
 
 <Card class="flex h-full flex-col">
@@ -224,6 +255,35 @@
 				{/if}
 			{:else if action === 'offline'}
 				<p class="text-sm text-muted-foreground">{m['membershipPlans.offlineManaged']()}</p>
+			{:else if isApplyAction}
+				<!-- #735. The one branch where a blocked gate still leaves the member
+				     something to press: the backend is waiting for an application that
+				     does not exist yet (`submit_application`), or for a fresh one after
+				     a rejection (`reapply`).
+				     Named with the PLAN, not left as a bare "Apply": several of these
+				     sit on one tier, a screen-reader user hears them out of context,
+				     and the plan is exactly what distinguishes them — it is the id the
+				     application will carry. -->
+				<Button
+					class="w-full sm:w-auto"
+					onclick={handleApply}
+					disabled={ctaHeld}
+					aria-label={action === 'reapply'
+						? m['membershipPlans.reapplyCtaAria']({ plan: plan.name })
+						: m['membershipPlans.applyCtaAria']({ plan: plan.name })}
+				>
+					{action === 'reapply'
+						? m['membershipPlans.reapplyCta']()
+						: m['membershipPlans.applyCta']()}
+				</Button>
+				<!-- The order matters and is not obvious: approval comes BEFORE the
+				     charge (the backend's PaymentReadyGate is last), so this says so
+				     rather than letting the member expect a checkout. -->
+				<p class="mt-2 text-sm text-muted-foreground">
+					{isFree
+						? m['membershipPlans.applyJoinHelper']()
+						: m['membershipPlans.applySubscribeHelper']()}
+				</p>
 			{:else if action === 'gated'}
 				<!-- What replaces the CTA carries the reason itself, rather than
 				     leaving a bare gap next to a requirement stated elsewhere on the

--- a/src/lib/components/organization/membership/PlanCard.test.ts
+++ b/src/lib/components/organization/membership/PlanCard.test.ts
@@ -66,16 +66,18 @@ function makeSub(overrides: Partial<MySubscriptionSchema> = {}): MySubscriptionS
 
 function renderCard(props: Record<string, unknown> = {}) {
 	const onSubscribe = vi.fn();
+	const onApply = vi.fn();
 	const result = render(PlanCard, {
 		props: {
 			plan: makePlan(),
 			isAuthenticated: true,
 			onSubscribe,
+			onApply,
 			organizationSlug: 'acme',
 			...props
 		}
 	});
-	return { ...result, onSubscribe };
+	return { ...result, onSubscribe, onApply };
 }
 
 describe('PlanCard', () => {
@@ -245,7 +247,7 @@ describe('PlanCard', () => {
 	describe("when the tier's gates are unsatisfied for this viewer", () => {
 		it('withdraws Subscribe and explains why, with the price still on the card', () => {
 			const { onSubscribe } = renderCard({
-				gateBlocked: true,
+				gateAction: 'blocked',
 				gateReason: 'This organization asks new members to fill in a questionnaire first.'
 			});
 
@@ -265,7 +267,7 @@ describe('PlanCard', () => {
 		// it, and points at the tier's full requirement list (WCAG 1.3.1).
 		it('associates the withheld CTA with the tier requirements programmatically', () => {
 			renderCard({
-				gateBlocked: true,
+				gateAction: 'blocked',
 				gateReason: 'Membership requests are approved by the organization.',
 				gateRequirementsId: 'tier-1-requirements'
 			});
@@ -280,7 +282,7 @@ describe('PlanCard', () => {
 		it('withdraws the free-join CTA too, in join wording', () => {
 			renderCard({
 				plan: makePlan({ payment_method: 'free', price: '0.00', period_unit: 'lifetime' }),
-				gateBlocked: true,
+				gateAction: 'blocked',
 				gateReason: 'Membership requests are approved by the organization.'
 			});
 
@@ -296,7 +298,7 @@ describe('PlanCard', () => {
 		// the plan from them would be a worse bug than the one being fixed.
 		it('offers Subscribe untouched once the gates are satisfied', async () => {
 			const user = userEvent.setup();
-			const { onSubscribe } = renderCard({ gateBlocked: false });
+			const { onSubscribe } = renderCard({ gateAction: null });
 
 			await user.click(screen.getByRole('button', { name: /subscribe/i }));
 			expect(onSubscribe).toHaveBeenCalledTimes(1);
@@ -315,7 +317,7 @@ describe('PlanCard', () => {
 		// Nobody asked the backend about a guest, and "Log in to subscribe" is true
 		// whatever their eligibility turns out to be.
 		it('leaves a guest with the login CTA', () => {
-			renderCard({ isAuthenticated: false, gateBlocked: true });
+			renderCard({ isAuthenticated: false, gateAction: 'blocked' });
 
 			expect(screen.getByRole('link', { name: /log in to subscribe/i })).toBeInTheDocument();
 			expect(screen.queryByRole('note')).toBeNull();
@@ -324,10 +326,101 @@ describe('PlanCard', () => {
 		// Plan-level stops still outrank the gate: a sold-out plan says so, rather
 		// than blaming the questionnaire for a card nobody could take anyway.
 		it('keeps plan-level stops ahead of the gate', () => {
-			renderCard({ plan: makePlan({ sold_out: true }), gateBlocked: true });
+			renderCard({ plan: makePlan({ sold_out: true }), gateAction: 'blocked' });
 
 			expect(screen.getByText('Sold out')).toBeInTheDocument();
 			expect(screen.queryByRole('note')).toBeNull();
+		});
+	});
+
+	// #735, the other half of #733. A blocked gate is not always somebody else's
+	// move: `submit_application` means the backend is waiting for an application
+	// that does not exist yet, and on a monetized tier only this card can create
+	// one — the application has to name a plan or gate #6 refuses it. Withdrawing
+	// the CTA and stopping there made manual-approval gating unreachable.
+	describe('when the gate is waiting on an application', () => {
+		it('offers an apply CTA in place of Subscribe, named for the plan', async () => {
+			const user = userEvent.setup();
+			const { onApply, onSubscribe } = renderCard({
+				gateAction: 'apply',
+				gateReason: m['membershipEligibility.reason.requires_approval']()
+			});
+
+			// The accessible name carries the plan: several of these sit on one tier
+			// and a screen-reader user hears them out of context.
+			const cta = screen.getByRole('button', {
+				name: m['membershipPlans.applyCtaAria']({ plan: 'Monthly' })
+			});
+			expect(cta).toHaveTextContent(m['membershipPlans.applyCta']());
+			expect(screen.queryByRole('button', { name: /subscribe/i })).toBeNull();
+			// Approval comes BEFORE the charge; the helper says so rather than
+			// letting the member expect a checkout.
+			expect(screen.getByText(m['membershipPlans.applySubscribeHelper']())).toBeInTheDocument();
+
+			await user.click(cta);
+			expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ id: 'plan-1' }), 'join');
+			expect(onSubscribe).not.toHaveBeenCalled();
+		});
+
+		it('says the free plan will be joined, not paid for, once approved', () => {
+			renderCard({
+				plan: makePlan({ payment_method: 'free', price: '0.00', period_unit: 'lifetime' }),
+				gateAction: 'apply'
+			});
+
+			expect(screen.getByText(m['membershipPlans.applyJoinHelper']())).toBeInTheDocument();
+			expect(screen.queryByText(m['membershipPlans.applySubscribeHelper']())).toBeNull();
+		});
+
+		// One step later in the same story: the previous application was rejected
+		// and the backend says a fresh one supersedes it.
+		it('offers an apply-again CTA in re-apply mode', async () => {
+			const user = userEvent.setup();
+			const { onApply } = renderCard({ gateAction: 'reapply' });
+
+			const cta = screen.getByRole('button', {
+				name: m['membershipPlans.reapplyCtaAria']({ plan: 'Monthly' })
+			});
+			expect(cta).toHaveTextContent(m['membershipPlans.reapplyCta']());
+
+			await user.click(cta);
+			expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ id: 'plan-1' }), 'reapply');
+		});
+
+		// The waiting half of the same gate: an application IS on file, staff are
+		// deciding, and there is nothing for the member to press. It must not
+		// collapse into the apply branch and invite a duplicate row.
+		it('keeps a wait state as a note, with no control to press', () => {
+			renderCard({
+				gateAction: 'blocked',
+				gateReason: m['membershipEligibility.wait.approval']()
+			});
+
+			expect(screen.getByRole('note')).toHaveTextContent(
+				m['membershipEligibility.wait.approval']()
+			);
+			expect(screen.queryByRole('button')).toBeNull();
+		});
+
+		// Plan-level stops still outrank the gate, apply branch included: an apply
+		// button on a sold-out plan would be an application for a plan nobody can
+		// take.
+		it('does not offer to apply for a sold-out plan', () => {
+			const { onApply } = renderCard({ plan: makePlan({ sold_out: true }), gateAction: 'apply' });
+
+			expect(screen.getByText('Sold out')).toBeInTheDocument();
+			expect(screen.queryByRole('button')).toBeNull();
+			expect(onApply).not.toHaveBeenCalled();
+		});
+
+		// Same reason the Subscribe button is held: until both lookups answer we do
+		// not know which branch this is.
+		it('holds the apply CTA while the verdict is still settling', () => {
+			renderCard({ gateAction: 'apply', subscriptionLoading: true });
+
+			expect(
+				screen.getByRole('button', { name: m['membershipPlans.applyCtaAria']({ plan: 'Monthly' }) })
+			).toBeDisabled();
 		});
 	});
 

--- a/src/lib/components/organization/membership/TierCard.svelte
+++ b/src/lib/components/organization/membership/TierCard.svelte
@@ -10,12 +10,13 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { joinEligibilityQueryOptions } from '$lib/queries/join-eligibility';
 	import {
-		getMembershipStatusMessage,
-		isBlockedByMembershipGate
+		getMembershipGateAction,
+		getMembershipStatusMessage
 	} from '$lib/utils/membership-eligibility';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { ClipboardList, Gift, ShieldCheck } from '@lucide/svelte';
+	import ApplyDialog from './ApplyDialog.svelte';
 	import MembershipCta from './MembershipCta.svelte';
 	import PlanCard from './PlanCard.svelte';
 
@@ -157,13 +158,47 @@
 	);
 
 	const gateVerdict = $derived(gateQuery.data ?? null);
-	const gateBlocked = $derived(gateVerdict ? isBlockedByMembershipGate(gateVerdict) : false);
+	const gateAction = $derived(gateVerdict ? getMembershipGateAction(gateVerdict) : null);
 	const gateReason = $derived(
-		gateBlocked && gateVerdict ? getMembershipStatusMessage(gateVerdict) : null
+		gateAction && gateVerdict ? getMembershipStatusMessage(gateVerdict) : null
 	);
 	// `isLoading`, not `isPending`: a disabled query stays pending forever, and
 	// that would hold the Subscribe button of every ungated tier hostage.
 	const gatePending = $derived(gateQuery.isLoading);
+
+	/**
+	 * The plan the tier CTA asks about, and the reason it is not simply
+	 * `gatePlanId`.
+	 *
+	 * On a GATED tier the CTA has to name a plan or its verdict is a dead end:
+	 * gate #6 answers a plan-less question about a monetized tier with
+	 * `tier_requires_subscription` (no `next_step`), which is why #735's approval
+	 * gate was unreachable from here. Naming this plan reuses the query ABOVE —
+	 * same key, same fetcher, so TanStack serves both observers from one request —
+	 * and the CTA and the plan cards can no longer disagree about the same viewer.
+	 *
+	 * Held back on an UNGATED tier deliberately: there the tier-only verdict is
+	 * already correct for what that CTA says, and changing the question would
+	 * change every paid tier's CTA for no gain (#735 keeps that blast radius out).
+	 */
+	const ctaPlanId = $derived(isGated ? gatePlanId : null);
+
+	/**
+	 * The plan a pressed Apply button belongs to. One dialog per TIER rather than
+	 * one per card: only one can be open at a time, and mounting it here keeps it
+	 * alive while the verdict behind it moves on (the application's own
+	 * invalidation flips every plan card to the waiting note while the applicant
+	 * is still reading the outcome).
+	 */
+	let applyPlan = $state<(PublicPlanSchema & { id: string }) | null>(null);
+	let applyMode = $state<'join' | 'reapply'>('join');
+	let applyOpen = $state(false);
+
+	function handleApply(plan: PublicPlanSchema & { id: string }, mode: 'join' | 'reapply'): void {
+		applyPlan = plan;
+		applyMode = mode;
+		applyOpen = true;
+	}
 </script>
 
 <!-- `<article>` + `aria-labelledby`, not a labelled `region`: the cards are peers
@@ -241,9 +276,10 @@
 							{subscriptionLoading}
 							{organizationSlug}
 							{onSubscribe}
-							{gateBlocked}
+							{gateAction}
 							{gateReason}
 							{gatePending}
+							onApply={handleApply}
 							gateRequirementsId={requirementsId}
 						/>
 					{/each}
@@ -258,6 +294,7 @@
 						{isAuthenticated}
 						{tierId}
 						tierName={tier.name}
+						planId={ctaPlanId}
 						plansInline={plans.length > 0}
 					/>
 				{/if}
@@ -265,3 +302,26 @@
 		</CardContent>
 	</Card>
 </article>
+
+<!--
+	Outside the <article>, and outside every branch that could disappear beneath it:
+	an application that completes calls `invalidateAll()`, and the reloaded page can
+	re-render this card with a different verdict — a dialog destroyed mid-read is an
+	unannounced context change that drops focus to <body> (WCAG 3.2). Re-keyed by
+	plan so switching plans resets the dialog's own form and mutation state.
+-->
+{#if applyPlan}
+	{#key applyPlan.id}
+		<ApplyDialog
+			open={applyOpen}
+			onOpenChange={(next) => (applyOpen = next)}
+			{organizationSlug}
+			{organizationName}
+			mode={applyMode}
+			{tierId}
+			tierName={tier.name}
+			planId={applyPlan.id}
+			planName={applyPlan.name}
+		/>
+	{/key}
+{/if}

--- a/src/lib/components/organization/membership/TierCard.test.ts
+++ b/src/lib/components/organization/membership/TierCard.test.ts
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { QueryClient } from '@tanstack/svelte-query';
 import TierCard from './TierCard.svelte';
@@ -225,29 +226,102 @@ describe('TierCard', () => {
 			expect(await screen.findByRole('button', { name: /subscribe/i })).toBeEnabled();
 		});
 
-		// Manual approval is the same shape, and it arrives from PaymentReadyGate
-		// as `submit_application`: apply and be approved before there is anything
-		// to pay for.
-		it('withdraws Subscribe when the tier is approval-gated and nothing is on file', async () => {
+		// #735. Manual approval arrives from PaymentReadyGate as
+		// `submit_application` — apply, be approved, then pay. Unlike the
+		// questionnaire above there is no link anywhere on the tier to press, so
+		// withdrawing Subscribe and stopping there (all #733 did) left the tier
+		// with no affordance at all. The plan card now offers the application.
+		const approvalTier = () =>
+			makeTier({
+				is_free: false,
+				requires_approval: true,
+				plans: [makePlan({ id: 'p-1', name: 'Monthly' })]
+			});
+
+		it('offers to apply — with the plan — when approval is outstanding', async () => {
 			mockEligibility({
 				allowed: false,
 				reason_code: 'requires_approval',
 				next_step: 'submit_application'
 			});
-			renderCard({
-				tier: makeTier({
-					is_free: false,
-					requires_approval: true,
-					plans: [makePlan({ id: 'p-1' })]
+			renderCard({ tier: approvalTier() });
+
+			expect(
+				await screen.findByRole('button', {
+					name: m['membershipPlans.applyCtaAria']({ plan: 'Monthly' })
 				})
+			).toBeEnabled();
+			// The dead Subscribe stays gone: `/subscribe` runs the same gates.
+			expect(screen.queryByRole('button', { name: /subscribe/i })).toBeNull();
+			// And the tier CTA below points at the plans rather than offering a
+			// second, plan-less application the backend would refuse.
+			expect(screen.getByRole('note')).toHaveTextContent(
+				m['membershipEligibility.applyChoosePlan']()
+			);
+		});
+
+		// The round trip that made #735 a bug rather than a cosmetic gap: the
+		// dialog the plan card opens has to carry the plan, or the backend refuses
+		// the application on a monetized tier.
+		it('opens the application dialog for the plan that was pressed', async () => {
+			const user = userEvent.setup();
+			mockEligibility({
+				allowed: false,
+				reason_code: 'requires_approval',
+				next_step: 'submit_application'
 			});
+			renderCard({ tier: approvalTier() });
+
+			await user.click(
+				await screen.findByRole('button', {
+					name: m['membershipPlans.applyCtaAria']({ plan: 'Monthly' })
+				})
+			);
+
+			const dialog = await screen.findByRole('dialog');
+			expect(dialog).toHaveTextContent(m['membershipApply.titleTier']({ tier: 'Gold' }));
+			expect(dialog).toHaveTextContent(
+				m['membershipApply.forPlan']({ orgName: 'Acme', plan: 'Monthly' })
+			);
+		});
+
+		// Once staff approve, `ManualApprovalGate` falls through and the payment
+		// gate allows: Subscribe returns with no code of its own. This is the
+		// post-approval half of the journey, asserted rather than assumed.
+		it('hands Subscribe back once the application is approved', async () => {
+			mockEligibility({ allowed: true, next_step: 'proceed_to_payment', plan_id: 'p-1' });
+			renderCard({ tier: approvalTier() });
+
+			expect(await screen.findByRole('button', { name: /subscribe/i })).toBeEnabled();
+			expect(
+				screen.queryByRole('button', {
+					name: m['membershipPlans.applyCtaAria']({ plan: 'Monthly' })
+				})
+			).toBeNull();
+		});
+
+		// While staff decide there is nothing to press: an Apply button here would
+		// mint a duplicate row against a pending application.
+		it('shows a wait state, not a second application, while approval is pending', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'requires_approval',
+				next_step: 'wait_for_approval',
+				application_id: 'app-1'
+			});
+			renderCard({ tier: approvalTier() });
 
 			await waitFor(() => {
-				expect(screen.queryByRole('button', { name: /subscribe/i })).toBeNull();
+				expect(
+					screen.getByText(m['membershipPlans.gatedSubscribeHelper'](), { exact: false })
+				).toHaveTextContent(m['membershipEligibility.wait.approval']());
 			});
 			expect(
-				screen.getByText(m['membershipPlans.gatedSubscribeHelper'](), { exact: false })
-			).toHaveTextContent(m['membershipEligibility.reason.requires_approval']());
+				screen.queryByRole('button', {
+					name: m['membershipPlans.applyCtaAria']({ plan: 'Monthly' })
+				})
+			).toBeNull();
+			expect(screen.getByRole('button', { name: /application pending/i })).toBeDisabled();
 		});
 
 		// A refusal about the PLAN rather than about the viewer: the plan card

--- a/src/lib/utils/membership-eligibility.test.ts
+++ b/src/lib/utils/membership-eligibility.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
 	getApplicationPendingMessage,
 	getMembershipCtaKind,
+	getMembershipGateAction,
 	getMembershipStatusMessage,
 	isBlockedByMembershipGate
 } from './membership-eligibility';
@@ -48,6 +49,23 @@ describe('getMembershipCtaKind', () => {
 	it('maps requires_invitation and bare denials to info', () => {
 		expect(getMembershipCtaKind({ ...base, next_step: 'requires_invitation' })).toBe('info');
 		expect(getMembershipCtaKind({ ...base, reason_code: 'membership_paused' })).toBe('info');
+	});
+
+	// #735. The exact verdict `PaymentReadyGate` (#10) emits for an approval-gated
+	// tier with an active plan and no application on file: refused, but naming its
+	// own remedy. It used to fall off the end of the switch into `info` — a refusal
+	// with no next_step — which is precisely why the approval gate was unreachable
+	// through the UI on a monetized tier.
+	it('maps submit_application to apply, not to info', () => {
+		expect(
+			getMembershipCtaKind({
+				...base,
+				allowed: false,
+				next_step: 'submit_application',
+				reason_code: 'requires_approval',
+				plan_id: 'plan-1'
+			})
+		).toBe('apply');
 	});
 
 	// BE #831 made gated and monetized tiers coexist, so this step is the positive
@@ -384,5 +402,76 @@ describe('isBlockedByMembershipGate', () => {
 	// stays, and the backend refuses it if it really is unreachable.
 	it('does not block a refusal with no reason code', () => {
 		expect(isBlockedByMembershipGate({ ...base, allowed: false, reason_code: null })).toBe(false);
+	});
+});
+
+// #735. Same predicate, one question further on: not "is the CTA withdrawn" but
+// "whose move is it". The distinction is the whole issue — #733 withdrew the
+// button for every gate alike, which left an approval-gated priced tier with
+// nothing on screen to press.
+describe('getMembershipGateAction', () => {
+	it('leaves an unblocked verdict alone', () => {
+		expect(getMembershipGateAction({ ...base, allowed: true })).toBeNull();
+		expect(
+			getMembershipGateAction({ ...base, allowed: true, next_step: 'proceed_to_payment' })
+		).toBeNull();
+	});
+
+	// The member's move: the backend is waiting for an application nobody else can
+	// create. On a monetized tier this is the ONLY affordance — unlike a
+	// questionnaire, whose link the tier card renders from its own metadata.
+	it('asks for an application when the approval gate has nothing on file', () => {
+		expect(
+			getMembershipGateAction({
+				...base,
+				reason_code: 'requires_approval',
+				next_step: 'submit_application',
+				plan_id: 'plan-1'
+			})
+		).toBe('apply');
+	});
+
+	it('asks again after a rejection', () => {
+		expect(
+			getMembershipGateAction({
+				...base,
+				reason_code: 'application_rejected',
+				next_step: 'reapply',
+				application_id: 'app-1'
+			})
+		).toBe('reapply');
+	});
+
+	// Somebody else's move — staff deciding, the grader running, a cooldown
+	// expiring. Offering to apply here would mint a duplicate row against a
+	// pending application.
+	it('keeps every wait and every fill-something-in step blocked', () => {
+		for (const [reason_code, next_step] of [
+			['requires_approval', 'wait_for_approval'],
+			['membership_questionnaire_pending', 'wait_for_questionnaire_evaluation'],
+			['whitelist_pending', 'wait_for_whitelist_approval'],
+			['membership_questionnaire_missing', 'submit_questionnaire'],
+			['membership_questionnaire_retake_cooldown', 'wait_to_retake_questionnaire']
+		] as const) {
+			expect(getMembershipGateAction({ ...base, reason_code, next_step })).toBe('blocked');
+		}
+		// Terminal refusals arrive with no next_step at all.
+		expect(getMembershipGateAction({ ...base, reason_code: 'blacklisted' })).toBe('blocked');
+	});
+
+	// It inherits `isBlockedByMembershipGate`'s allow-list, so a payment-readiness
+	// refusal can never produce an Apply button either — the plan card keeps
+	// deciding those from the plan's own fields.
+	it('offers nothing for a payment-readiness refusal', () => {
+		expect(
+			getMembershipGateAction({ ...base, reason_code: 'tier_requires_subscription' })
+		).toBeNull();
+		expect(
+			getMembershipGateAction({
+				...base,
+				reason_code: 'duplicate_active_subscription',
+				next_step: 'reapply'
+			})
+		).toBeNull();
 	});
 });

--- a/src/lib/utils/membership-eligibility.ts
+++ b/src/lib/utils/membership-eligibility.ts
@@ -9,6 +9,8 @@ import * as m from '$lib/paraglide/messages.js';
  * The shape of call-to-action a membership eligibility verdict implies.
  *
  * - `join` — allowed, free path → open the apply dialog
+ * - `apply` — refused *pending an application*: staff approval is outstanding and
+ *   nothing is on file yet, so submitting one is the move (BE gate #10)
  * - `payment` — every gate is cleared; what is left is paying for a plan
  * - `questionnaire` — the user must submit the membership questionnaire first
  * - `waiting` — something is pending review (questionnaire, approval, whitelist)
@@ -18,7 +20,15 @@ import * as m from '$lib/paraglide/messages.js';
  * - `info` — nothing actionable: invitation-only or a plain denial
  */
 export type MembershipCtaKind =
-	'join' | 'payment' | 'questionnaire' | 'waiting' | 'retry_later' | 'reapply' | 'member' | 'info';
+	| 'join'
+	| 'apply'
+	| 'payment'
+	| 'questionnaire'
+	| 'waiting'
+	| 'retry_later'
+	| 'reapply'
+	| 'member'
+	| 'info';
 
 /**
  * Map a membership eligibility verdict to the CTA the UI should render.
@@ -42,6 +52,17 @@ export function getMembershipCtaKind(e: MembershipEligibilitySchema): Membership
 			return 'reapply';
 		case 'requires_invitation':
 			return 'info';
+		case 'submit_application':
+			// BE #831 / #735. Emitted by `PaymentReadyGate` (#10) alone, and only for
+			// a PLAN-BEARING verdict: manual approval is required and the caller has
+			// no application on file, so `ManualApprovalGate` (#9) deliberately fell
+			// through to let the free path apply and the payment gate refuses instead.
+			// The refusal is therefore not a dead end — it names its own remedy, and
+			// the whole point of #735 is that the UI now offers it. It used to fold
+			// into `info` (the switch had no arm and `allowed` is false), which is why
+			// an approval gate was unreachable on a monetized tier: the CTA rendered
+			// the org's approval POLICY prose next to nothing to press.
+			return 'apply';
 		case 'proceed_to_payment':
 			// BE #831: gated and monetized are no longer mutually exclusive, so this
 			// step is the *positive* end of a tier's gate chain — approval and
@@ -123,6 +144,47 @@ export function isBlockedByMembershipGate(e: MembershipEligibilitySchema): boole
 	if (e.allowed) return false;
 	if (!e.reason_code) return false;
 	return GATE_BLOCKING_REASON_CODES.includes(e.reason_code);
+}
+
+/**
+ * What a PLAN card should put where its Subscribe button was, given the tier's
+ * plan-bearing verdict.
+ *
+ * `null` means "nothing to do": the gates are satisfied (or say nothing about
+ * this viewer) and Subscribe stands, exactly as before #733.
+ *
+ * - `apply` — the gate is waiting on an application that does not exist yet, and
+ *   creating it is a member-side action. This is the hole #735 closes: withdrawing
+ *   the CTA and stopping there left an approval-gated priced tier with no
+ *   affordance at all, because — unlike a questionnaire, whose link `TierCard`
+ *   renders from the tier's own `questionnaire_id` — nothing else on the page can
+ *   offer to apply.
+ * - `reapply` — same shape, one step later: the previous application was rejected
+ *   and the backend says a fresh one supersedes it (`ApplicationStatusGate` #7).
+ * - `blocked` — the remaining gate refusals, including every `wait_*` step. The
+ *   card keeps #733's behaviour: no control, and the reason in its place. A wait
+ *   IS the correct rendering there — there is nothing for the member to press
+ *   while staff (or the grader) decide, and the tier CTA below carries the
+ *   "Application pending" state and the link to track it.
+ *
+ * Keyed off `isBlockedByMembershipGate` first, so the same allow-list that keeps
+ * the CTA from being withdrawn on a payment-readiness refusal also keeps an Apply
+ * button from appearing on one.
+ */
+export type MembershipGateAction = 'apply' | 'reapply' | 'blocked';
+
+export function getMembershipGateAction(
+	e: MembershipEligibilitySchema
+): MembershipGateAction | null {
+	if (!isBlockedByMembershipGate(e)) return null;
+	switch (e.next_step) {
+		case 'submit_application':
+			return 'apply';
+		case 'reapply':
+			return 'reapply';
+		default:
+			return 'blocked';
+	}
 }
 
 /**

--- a/tests/e2e/journeys/j27-applications/gated-paid-tier.spec.ts
+++ b/tests/e2e/journeys/j27-applications/gated-paid-tier.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from '../../support/fixtures';
 import {
+	approveApplication,
 	createMembershipQuestionnaire,
 	createMembershipTier,
 	createOrganization,
 	createSubscriptionPlan,
 	createVerifiedUser,
+	myApplicationFor,
 	patchTierPolicy,
 	uniqueName,
 	MEMBERSHIP_QUESTION
@@ -39,8 +41,8 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 // Why a FREE plan rather than an ONLINE one. `PlanCard`'s CTA precedence stops
 // at `payment_method === 'offline'` two lines ABOVE the gate branch, so an
 // offline plan could never exercise this. FREE is the only other non-online
-// kind, and it reaches the exact same `gateBlocked ? 'gated' : 'subscribe'`
-// line an online plan would — the gate blocks long before Stripe is consulted,
+// kind, and it reaches the exact same `gateAction` branch an online plan would
+// — the gate blocks long before Stripe is consulted,
 // so an ONLINE plan adds no code path, while forcing the test onto the one
 // Stripe-connected seeded org (Org Alpha) whose shared state other j23 workers
 // depend on. A free plan keeps the whole test on a throwaway org.
@@ -61,11 +63,25 @@ import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
 //     in `GATE_BLOCKING_REASON_CODES`, so `PlanCard` renders the gated note.
 //   * the same pair after a passing auto-graded submission → `allowed: true`,
 //     `proceed_to_payment` → the CTA returns.
-//   * tier_id ALONE (which is what `MembershipCta` asks) → blocked at gate #6
-//     with `tier_requires_subscription`, whatever the questionnaire says. So on
-//     a gated+paid tier the tier CTA is never the questionnaire affordance —
-//     the requirements list's own "Open the questionnaire" link is, and that is
-//     what this test clicks.
+//   * tier_id ALONE → blocked at gate #6 with `tier_requires_subscription`,
+//     whatever the questionnaire says. This is why `TierCard` names a plan in
+//     the question it asks on behalf of BOTH the plan cards and the tier CTA
+//     (#735); before that the CTA asked tier-only and rendered a dead end.
+//
+// The SECOND test is the approval half, and #735 is what made it possible to
+// write. A manual-approval gate needs an application for staff to approve, and
+// on a monetized tier the backend only accepts an application that names a plan
+// ("a `plan_id` makes this a paid application", BE #831) — which the UI never
+// sent, so the whole gate was unreachable through the UI and this file's first
+// test had to clear its gate with a questionnaire instead. Live-verified
+// verdicts it is built on:
+//   * approval-gated tier + free plan, nothing on file, tier_id ONLY →
+//     `tier_requires_subscription`, next_step `null`. A dead end.
+//   * the same pair asked WITH the plan → `requires_approval`,
+//     next_step `submit_application`. Actionable — and the plan card offers it.
+//   * after staff approve → `ManualApprovalGate` falls through and
+//     `PaymentReadyGate` allows, so Subscribe returns with no frontend code of
+//     its own. That is asserted here, not assumed.
 //
 // Isolation, the j27 house rule: the test arranges its OWN org, questionnaire,
 // tiers and applicant, so parallel projects/workers and a `retries: 1` re-run
@@ -164,12 +180,12 @@ test.describe('j27 gated + paid tier @p2', () => {
 		await expect(openPlanCard.getByText(GATED_NOTE)).toHaveCount(0);
 
 		// ── Clear the gate ─────────────────────────────────────────────────────
-		// An auto-graded questionnaire rather than a manual-approval gate, because
-		// approval cannot be cleared on a monetized tier from the member side: the
-		// free `/apply` path is refused by gate #6 (`tier_requires_subscription`),
-		// so there would be no application for staff to approve. The questionnaire
-		// gate (#8) needs nothing but the submission, and a passing auto-graded one
-		// takes the viewer straight to `proceed_to_payment`.
+		// An auto-graded questionnaire, which is the gate this test is about; the
+		// manual-approval one has its own test below (it needs the paid-application
+		// path #735 added, and before that could not be cleared from the member
+		// side at all). The questionnaire gate (#8) needs nothing but the
+		// submission, and a passing auto-graded one takes the viewer straight to
+		// `proceed_to_payment`.
 		await questionnaireLink.click();
 		await page.waitForURL('**/questionnaire/**');
 		await expect(page.getByRole('heading', { name: 'Membership questionnaire' })).toBeVisible();
@@ -228,6 +244,152 @@ test.describe('j27 gated + paid tier @p2', () => {
 		await expect(page.getByLabel(`Membership tier: ${gatedTierName}`)).toBeVisible({
 			timeout: 20_000
 		});
+
+		await page.context().close();
+	});
+
+	// #735. The journey the platform always intended for a gated + paid tier and
+	// the UI could not walk: APPLY (with the plan) → staff APPROVE → PAY.
+	//
+	// Every step of it was blocked by one two-line gap. `ApplyDialog` posted
+	// `{tier_id, notes}`, so the only application it could create was a FREE one —
+	// which `TierAvailabilityGate` (#6) refuses on a tier carrying an active plan,
+	// before `ManualApprovalGate` (#9) ever runs. No application, nothing for
+	// staff to approve, and the tier CTA (asking tier-only) rendered the org's
+	// approval POLICY next to nothing to press. Hence the first test above having
+	// to reach for a questionnaire.
+	//
+	// A FREE plan again, for the reason given at the top of this file: it takes
+	// the identical `gateAction` path an ONLINE plan would — every gate here runs
+	// long before Stripe is consulted — while keeping the whole test on a
+	// throwaway org.
+	test('an approval-gated priced tier can be applied for, approved and then paid', async ({
+		browser
+	}) => {
+		test.setTimeout(240_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('ApprovalPaid')
+		]);
+
+		const tierName = uniqueName('Vetted Paid Tier');
+		const tier = await createMembershipTier(org.owner, org.slug, tierName);
+		// A TIER override, not the org default: the org's own default tier stays
+		// ungated, so anything asserted below is this tier's gate talking.
+		await patchTierPolicy(org.owner, org.slug, tier.id, { requires_membership_approval: true });
+		const plan = await createSubscriptionPlan(org.owner, org.slug, tier.id, {
+			name: uniqueName('Vetted Plan'),
+			payment_method: 'free',
+			period_unit: 'lifetime',
+			price: '0.00'
+		});
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+
+		const card = tierCard(page, tierName);
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		// Server-rendered from the tier listing: the requirement is stated, and —
+		// unlike a questionnaire — it comes with no link, which is exactly why the
+		// plan card has to carry the affordance.
+		await expect(
+			card.getByText('The organization reviews and approves each application.')
+		).toBeVisible();
+
+		// ── Apply, from the plan card ──────────────────────────────────────────
+		const vettedPlanCard = planCard(page, plan.name);
+		// Named with the PLAN: the accessible name is what a screen-reader user
+		// hears out of context, and the plan is what the application will carry.
+		const applyCta = vettedPlanCard.getByRole('button', {
+			name: `Apply to join with ${plan.name}`
+		});
+		await expect(applyCta).toBeVisible({ timeout: 15_000 });
+		// The order is stated, because it is not the obvious one: approval comes
+		// BEFORE the charge (`PaymentReadyGate` is the last gate, not the first).
+		await expect(
+			vettedPlanCard.getByText("The organization reviews applications — you'll join once you're")
+		).toBeVisible();
+		// The dead Subscribe stays gone — `/subscribe` runs the same gate stack.
+		await expect(vettedPlanCard.getByText(JOIN_FREE)).toHaveCount(0);
+		// …and the tier CTA points at the plans rather than offering a second,
+		// plan-less application the backend would refuse with a 403.
+		await expect(
+			card.getByText(
+				'Choose a plan to apply — the organization reviews applications before payment.'
+			)
+		).toBeVisible();
+
+		await applyCta.click();
+		// Located by role alone, not by name: the dialog RENAMES itself to its
+		// outcome ("Application received") once the application lands, so a
+		// name-scoped locator would silently stop matching mid-test.
+		const applyDialog = page.getByRole('dialog');
+		await expect(applyDialog.getByRole('heading', { name: `Join ${tierName}` })).toBeVisible();
+		// The dialog says which plan the application will be for.
+		await expect(
+			applyDialog.getByText(`${org.name} — applying with the ${plan.name} plan.`)
+		).toBeVisible();
+		await applyDialog.getByRole('button', { name: 'Send application' }).click();
+		await expect(applyDialog.getByText('Application received')).toBeVisible({ timeout: 20_000 });
+
+		// The crux, read from the member's OWN account rather than from the
+		// response the UI just consumed: the row the UI created is a PAID
+		// application. A row with `plan_id: null` here is the #735 bug exactly —
+		// it would still be pending, staff could still approve it, and the member
+		// would still be refused at gate #6 afterwards.
+		const application = await myApplicationFor(applicant, org.slug);
+		expect(application?.status).toBe('pending');
+		expect(application?.tier_id).toBe(tier.id);
+		expect(application?.plan_id).toBe(plan.id);
+
+		// While staff decide there is nothing to press, and the state is said in
+		// words rather than left to a greyed-out control.
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+		await expect(
+			planCard(page, plan.name).getByText('Your application is with the organization for review.', {
+				exact: false
+			})
+		).toBeVisible({ timeout: 15_000 });
+		await expect(planCard(page, plan.name).getByText(`Apply to join`)).toHaveCount(0);
+		await expect(card.getByRole('button', { name: 'Application pending' })).toBeDisabled();
+
+		// ── Staff approve ──────────────────────────────────────────────────────
+		// No `tier_id`: the application carries its own, so staff are not asked to
+		// guess one — which is the whole reason ApplyDialog posts the tier.
+		await approveApplication(org.owner, org.slug, application?.id as string);
+
+		// ── …and Subscribe comes back, with no frontend code of its own ─────────
+		// `ManualApprovalGate` falls through on an APPROVED row and
+		// `PaymentReadyGate` allows: the verdict flips to `proceed_to_payment` and
+		// `isBlockedByMembershipGate` stops matching. Polled by re-reading the page
+		// because the verdict is a cached client query.
+		await expect(async () => {
+			await gotoHydrated(page, membershipPath(org.slug));
+			await waitForClientAuth(page);
+			await expect(planCard(page, plan.name).getByText(JOIN_FREE)).toBeVisible({
+				timeout: 10_000
+			});
+		}).toPass({ timeout: 60_000 });
+
+		const payableCard = planCard(page, plan.name);
+		await expect(payableCard.getByText(FREE_HELPER)).toBeVisible();
+		await expect(payableCard.getByText(`Apply to join`)).toHaveCount(0);
+
+		// Live, not merely present: finish the round trip the same way the
+		// questionnaire journey above does.
+		await payableCard.getByRole('button', { name: JOIN_FREE }).click();
+		const subscribeDialog = page.getByRole('dialog', { name: `Join ${plan.name}` });
+		await expect(subscribeDialog).toBeVisible();
+		await subscribeDialog.getByRole('button', { name: 'Join now' }).click();
+		await expect(subscribeDialog.getByText('Welcome, member!')).toBeVisible({ timeout: 20_000 });
+
+		// The membership landed on the approval-gated tier, not on the org's
+		// ungated default one.
+		await gotoHydrated(page, `/org/${org.slug}`);
+		await waitForClientAuth(page);
+		await expect(page.getByLabel(`Membership tier: ${tierName}`)).toBeVisible({ timeout: 20_000 });
 
 		await page.context().close();
 	});

--- a/tests/e2e/support/factories.ts
+++ b/tests/e2e/support/factories.ts
@@ -1284,13 +1284,19 @@ export async function getSeededBestAvailableEvent(
  * tier-BEARING branch is the one a member actually walks. Tier-less applies
  * survive here as the ARRANGE shape for legacy/staff-decided rows.
  *
+ * NOTE (#735): the UI also posts `plan_id` when the member applies from a plan
+ * card, which is the only application a MONETIZED tier accepts. This factory
+ * deliberately stays free-only — the paid path is walked through the UI in
+ * j27/gated-paid-tier, where sending it from here would arrange away the very
+ * behaviour under test.
+ *
  * `nextStep` is the eligibility verdict's `next_step` (null once there is
  * nothing left to do) — the same field MembershipCta switches its CTA on.
  *
  * `submissionId` attaches the questionnaire submission that satisfied the
  * gate — the audit pointer the org-admin request card turns into its
  * "View questionnaire submission" link. The UI never sends it (ApplyDialog
- * posts tier + notes only), so specs that need a submission-bearing row
+ * posts tier + plan + notes), so specs that need a submission-bearing row
  * arrange it here. The backend validates it: it must be a READY submission
  * owned by `user` for the questionnaire that actually gates this (org, tier),
  * or the call 422s.
@@ -1327,6 +1333,13 @@ export interface MyApplication {
 	status: string;
 	tier_id?: string | null;
 	tier_name?: string | null;
+	/**
+	 * The plan a PAID application carries (BE #831: *"a `plan_id` makes this a
+	 * paid application"*). Read by j27's approval journey to prove the row the UI
+	 * created is the paid kind — a free application on a monetized tier is exactly
+	 * what gate #6 refuses, and what #735 was.
+	 */
+	plan_id?: string | null;
 }
 
 /**


### PR DESCRIPTION
Closes #735

Base is `integration/membership-tier-unlock`, not `main`.

## The gap

The backend has supported paid membership applications since letsrevel/revel-backend#831 — `POST /me/organizations/{slug}/apply` takes a `plan_id`, and its docstring is explicit: *"A `plan_id` makes this a paid application"*. The frontend never sent it.

That left **two** halves broken, and each one on its own is enough to make the journey impossible:

1. **`ApplyDialog` posted `{tier_id, notes}`.** The only application the UI could create was a FREE one — which `TierAvailabilityGate` (#6) refuses on any tier carrying an active plan. No application, so nothing for staff to approve.
2. **`MembershipCta` asked with `tier_id` only.** Gate #6 answers a plan-less question about a monetized tier with `tier_requires_subscription` and **no `next_step`**, short-circuiting before `ManualApprovalGate` (#9) ever runs. The CTA therefore rendered the org's approval POLICY next to nothing to press.

Net effect: **manual-approval gating was unreachable through the UI on a paid tier.** #738's E2E had to clear its gate with a questionnaire for exactly this reason.

Live-probed, approval-gated tier + free plan, plain applicant:

```
TIER ONLY    : allowed=False reason_code=tier_requires_subscription next_step=None
TIER + PLAN  : allowed=False reason_code=requires_approval          next_step=submit_application
```

Ask with the plan, and act on `next_step`.

## What changed

| File | Change |
| --- | --- |
| `ApplyDialog.svelte` | Accepts and **posts `plan_id`**; `planName` names the plan in the dialog body. |
| `membership-eligibility.ts` | `submit_application` → new `apply` CTA kind (it used to fall off the end of the switch into `info`). New `getMembershipGateAction`. |
| `PlanCard.svelte` | `gateBlocked: boolean` → `gateAction`; new Apply / Apply-again branches with an `onApply(plan, mode)` callback. |
| `TierCard.svelte` | Owns one `ApplyDialog` per tier, opened with the pressed plan; passes `gateAction` down and `planId` to the CTA. |
| `MembershipCta.svelte` | New `planId` prop, threaded into the query and the dialog; defers per-plan steps to the plan cards. |
| `messages/*.json` | 8 new keys × 4 locales. |

### `next_step` → CTA, and why

`getMembershipGateAction` splits #733's single "blocked" verdict by **whose move it is**:

| `next_step` | plan card | tier CTA |
| --- | --- | --- |
| `submit_application` | **Apply to join** (posts `tier_id` + `plan_id`) | "Choose a plan to apply — the organization reviews applications before payment." |
| `reapply` | **Apply again** | same note |
| `submit_questionnaire` | withheld + reason (unchanged) | the questionnaire link (unchanged) |
| `wait_for_approval` / `wait_for_questionnaire_evaluation` / `wait_for_whitelist_approval` | withheld + the wait copy | disabled "Application pending" + "Track your application" |
| `wait_to_retake_questionnaire` | withheld + reason | countdown (unchanged) |
| `proceed_to_payment` / allowed | **Subscribe** | "You're eligible — choose a plan below to join." (unchanged) |
| terminal refusals (no `next_step`) | withheld + reason | prose, no control (unchanged) |

Two decisions worth calling out:

- **The application lives on the plan card, not on the tier CTA.** The row has a `plan` FK, so *the plan whose card was pressed* is the natural granularity — and a tier-level Apply would have to invent a "representative" plan to carry. The tier CTA points at the cards instead of offering a second, plan-less copy the backend would refuse with a 403. That deferral is gated on `planId`, not on `plansInline` alone: a tier whose plans are all offline renders cards but gets no plan-bearing verdict, and its CTA is untouched.
- **A `wait_*` step stays `blocked`, deliberately.** An Apply button while an application is PENDING would mint a duplicate row. The wait is announced in words on the plan card and carries the pending state + tracking link on the tier CTA — never by colour or position.

### One request, not two

`MembershipCta` builds the **same `joinEligibilityQueryOptions`** with the same `(tier, plan)` key that `TierCard` already uses for its plan cards, so TanStack de-duplicates both observers into one request. The plan is passed **only for a gated tier**, so an ungated paid tier's CTA is byte-for-byte unchanged (AC #4).

### "Then pay" needed no new code

Once staff approve, `ManualApprovalGate` falls through on an APPROVED row, `PaymentReadyGate` allows with `proceed_to_payment`, `isBlockedByMembershipGate` returns false on its first line, and Subscribe returns by itself. **Asserted, not assumed** — both in `TierCard.test.ts` and end-to-end.

## Accessibility

- The Apply CTA's accessible name carries the plan (`Apply to join with {plan}`) — several sit on one tier and a screen-reader user hears them out of context.
- A helper states that **approval comes before the charge**, because the backend's order (`PaymentReadyGate` last) is not the obvious one.
- The waiting state is text, not a greyed-out control alone; the pending CTA keeps its label and the tracking link.
- The apply dialog is mounted outside the `<article>`, so a verdict change behind it cannot destroy it mid-read (WCAG 3.2).

## Testing

`make check` green — 0 errors, 374 warnings (the accepted #361 baseline).

Unit: 197 passing across the membership components + the eligibility util, including a branch per `next_step`, the posted `plan_id`, and the post-approval return of Subscribe.

E2E — `j27/gated-paid-tier` gains the whole journey (apply with a plan → read the row back from the member's **own** account to prove `plan_id` is set → staff approve → Subscribe returns → join completes):

```
Running 4 tests using 2 workers

  ✓  1 [chromium] › j27 gated + paid tier @p2 › a gated priced tier withholds its plan CTA, and hands it back once the gate clears (5.8s)
  ✓  2 [chromium] › j27 gated + paid tier @p2 › an approval-gated priced tier can be applied for, approved and then paid (6.8s)
  ✓  3 [mobile-chrome] › j27 gated + paid tier @p2 › a gated priced tier withholds its plan CTA, and hands it back once the gate clears (4.4s)
  ✓  4 [mobile-chrome] › j27 gated + paid tier @p2 › an approval-gated priced tier can be applied for, approved and then paid (5.3s)

  4 passed (37.8s)
```

**Negative control run**: with `plan_id` dropped from the request (and nothing else changed), the new test fails at the apply step — the backend refuses the plan-less application on a monetized tier — so it is decisive rather than vacuously green.

## New i18n keys (en / it / de / fr)

- `membershipPlans.applyCta`, `.applyCtaAria`, `.reapplyCta`, `.reapplyCtaAria`, `.applySubscribeHelper`, `.applyJoinHelper`
- `membershipEligibility.applyChoosePlan`
- `membershipApply.forPlan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP
