### PR TITLE
fix(membership): report the viewer's questionnaire state on a gated tier (#740)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -6796,6 +6796,7 @@
 			"not_accepting_requests": "Diese Organisation nimmt derzeit keine neuen Mitglieder auf.",
 			"tier_unavailable": "Diese Mitgliedschaftsstufe ist derzeit nicht verfügbar.",
 			"plan_unavailable": "Dieser Plan ist derzeit nicht verfügbar.",
+			"plan_not_online": "Dieser Plan wird von der Organisation verwaltet — melde dich bei ihr, um beizutreten.",
 			"application_rejected": "Dein vorheriger Antrag wurde nicht genehmigt.",
 			"membership_questionnaire_missing": "Diese Organisation bittet neue Mitglieder, zuerst einen Fragebogen auszufüllen.",
 			"membership_questionnaire_failed": "Dein Fragebogen wurde nicht genehmigt.",
@@ -6844,7 +6845,9 @@
 		"backToOrg": "Zurück zu {organizationName}",
 		"freeBadge": "Kostenlos",
 		"requiresApproval": "Die Organisation prüft und genehmigt jede Anfrage.",
+		"approvalCleared": "Die Organisation hat deine Anfrage genehmigt.",
 		"questionnaireRequired": "Ein Mitgliedschaftsfragebogen ist erforderlich.",
+		"questionnaireCleared": "Du hast den Mitgliedschaftsfragebogen ausgefüllt.",
 		"questionnaireLink": "Fragebogen öffnen",
 		"questionnaireLinkAria": "Mitgliedschaftsfragebogen für {tier} öffnen",
 		"landingBlurb": "Sieh dir die Mitgliedschaftsstufen von {organizationName} an und wie du beitreten kannst."

--- a/messages/en.json
+++ b/messages/en.json
@@ -6796,6 +6796,7 @@
 			"not_accepting_requests": "This organization isn't accepting new members right now.",
 			"tier_unavailable": "This membership tier isn't available right now.",
 			"plan_unavailable": "This plan isn't available right now.",
+			"plan_not_online": "This plan is managed by the organization — contact them to join.",
 			"application_rejected": "Your previous application wasn't approved.",
 			"membership_questionnaire_missing": "This organization asks new members to fill in a questionnaire first.",
 			"membership_questionnaire_failed": "Your questionnaire wasn't approved.",
@@ -6844,7 +6845,9 @@
 		"backToOrg": "Back to {organizationName}",
 		"freeBadge": "Free",
 		"requiresApproval": "The organization reviews and approves each application.",
+		"approvalCleared": "The organization has approved your application.",
 		"questionnaireRequired": "A membership questionnaire is required.",
+		"questionnaireCleared": "You've completed the membership questionnaire.",
 		"questionnaireLink": "Open the questionnaire",
 		"questionnaireLinkAria": "Open the membership questionnaire for {tier}",
 		"landingBlurb": "See the membership tiers {organizationName} offers and how to join."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -6767,6 +6767,7 @@
 			"not_accepting_requests": "Cette organisation n'accepte pas de nouveaux membres pour le moment.",
 			"tier_unavailable": "Ce niveau d'adhésion n'est pas disponible pour le moment.",
 			"plan_unavailable": "Ce forfait n'est pas disponible pour le moment.",
+			"plan_not_online": "Ce forfait est géré par l'organisation — contacte-la pour adhérer.",
 			"application_rejected": "Ta demande précédente n'a pas été approuvée.",
 			"membership_questionnaire_missing": "Cette organisation demande aux nouveaux membres de remplir d'abord un questionnaire.",
 			"membership_questionnaire_failed": "Ton questionnaire n'a pas été approuvé.",
@@ -6815,7 +6816,9 @@
 		"backToOrg": "Retour à {organizationName}",
 		"freeBadge": "Gratuit",
 		"requiresApproval": "L'organisation examine et approuve chaque demande.",
+		"approvalCleared": "L'organisation a approuvé ta demande.",
 		"questionnaireRequired": "Un questionnaire d'adhésion est requis.",
+		"questionnaireCleared": "Tu as rempli le questionnaire d'adhésion.",
 		"questionnaireLink": "Ouvrir le questionnaire",
 		"questionnaireLinkAria": "Ouvrir le questionnaire d'adhésion pour {tier}",
 		"landingBlurb": "Découvrez les niveaux d'adhésion proposés par {organizationName} et comment adhérer."

--- a/messages/it.json
+++ b/messages/it.json
@@ -6796,6 +6796,7 @@
 			"not_accepting_requests": "Questa organizzazione al momento non accetta nuovi membri.",
 			"tier_unavailable": "Questo livello di iscrizione non è disponibile al momento.",
 			"plan_unavailable": "Questo piano non è disponibile al momento.",
+			"plan_not_online": "Questo piano è gestito dall'organizzazione — contattala per aderire.",
 			"application_rejected": "La tua richiesta precedente non è stata approvata.",
 			"membership_questionnaire_missing": "Questa organizzazione chiede a chi si iscrive di compilare prima un questionario.",
 			"membership_questionnaire_failed": "Il tuo questionario non è stato approvato.",
@@ -6844,7 +6845,9 @@
 		"backToOrg": "Torna a {organizationName}",
 		"freeBadge": "Gratuito",
 		"requiresApproval": "L'organizzazione esamina e approva ogni richiesta.",
+		"approvalCleared": "L'organizzazione ha approvato la tua richiesta.",
 		"questionnaireRequired": "È richiesto un questionario di iscrizione.",
+		"questionnaireCleared": "Hai completato il questionario di iscrizione.",
 		"questionnaireLink": "Apri il questionario",
 		"questionnaireLinkAria": "Apri il questionario di iscrizione per {tier}",
 		"landingBlurb": "Scopri i livelli di iscrizione offerti da {organizationName} e come iscriverti."

--- a/src/lib/components/organization/membership/TierCard.svelte
+++ b/src/lib/components/organization/membership/TierCard.svelte
@@ -11,6 +11,7 @@
 	import { joinEligibilityQueryOptions } from '$lib/queries/join-eligibility';
 	import {
 		getMembershipGateAction,
+		getMembershipRequirementState,
 		getMembershipStatusMessage
 	} from '$lib/utils/membership-eligibility';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
@@ -108,34 +109,54 @@
 	});
 
 	/**
-	 * The plan the gate verdict is asked about, and why one plan can answer for
-	 * all of them.
+	 * The cheapest plan whose card could offer a CTA at all — the one a blocked
+	 * gate has something to WITHDRAW (#733/#734). Offline, sold-out and paused
+	 * cards never render a Subscribe button in the first place (`PlanCard` stops
+	 * at each of those above its gate branches), so they are not candidates.
 	 *
-	 * A plan is REQUIRED: with no `plan_id` the backend's gate #6 short-circuits
-	 * any monetized tier with `tier_requires_subscription` and never reaches the
-	 * questionnaire and approval gates at all — which is exactly why the CTA's
-	 * own tier-only verdict cannot answer this question. Given a plan, the gates
-	 * that do run above the payment one are facts about the (viewer, tier) pair,
-	 * identical for every plan on the card; `isBlockedByMembershipGate` keeps only
-	 * those, so the choice of plan below cannot leak into the answer.
-	 *
-	 * Cheapest first (the list is already sorted) among the plans that could
-	 * offer a CTA at all: an offline, sold-out or paused plan card shows no
-	 * Subscribe for the gate to withdraw, so a tier with nothing else on it asks
-	 * nothing.
+	 * Kept as the FIRST choice of plan to ask about, not merely as a filter: for
+	 * every tier that has one, the question below is byte-identical to the one
+	 * asked before #740, so no existing card's verdict — or cache key — moves.
 	 */
-	const gatePlanId = $derived(
+	const subscribablePlanId = $derived(
 		plans.find(
 			(p) => !!p.id && p.payment_method !== 'offline' && !p.sold_out && p.sales_status !== 'paused'
 		)?.id ?? null
 	);
+
+	/**
+	 * The plan the gate verdict is asked ABOUT, and why one plan can answer for
+	 * all of them.
+	 *
+	 * A plan is REQUIRED whenever the tier sells one: with no `plan_id` the
+	 * backend's gate #6 short-circuits any monetized tier with
+	 * `tier_requires_subscription` and never reaches the questionnaire and
+	 * approval gates at all — the same verdict whether the viewer has never
+	 * started, is awaiting review, or has passed. Given a plan, the gates that do
+	 * run above the payment one are facts about the (viewer, tier) pair,
+	 * identical for every plan on the card; `isBlockedByMembershipGate` keeps only
+	 * those, so the choice of plan cannot leak into what is withdrawn.
+	 *
+	 * Which is why ASKING and WITHDRAWING are no longer the same list. #740: a
+	 * tier whose only plan is OFFLINE has no Subscribe to withdraw, so it asked
+	 * nothing — and then had no verdict with which to report the viewer's own
+	 * state either, which is the whole bug. Any plan on the card will do for the
+	 * question: they are all `is_active` (the public listing only serializes
+	 * those), so gate #6 lets them through, and every plan-specific stop —
+	 * offline, paused, at cap — lives in gate #10, BELOW the gates being read
+	 * here. A plan-less tier keeps asking a tier-only question, which is correct
+	 * there: gate #6 only short-circuits a tier that HAS an active plan.
+	 */
+	const askPlanId = $derived(subscribablePlanId ?? plans.find((p) => !!p.id)?.id ?? null);
 
 	const gateQueryEnabled = $derived.by(() => {
 		// Every operand read unconditionally, for the reason given above.
 		const authed = isAuthenticated;
 		const gated = isGated;
 		const hasTier = !!tierId;
-		const hasPlan = !!gatePlanId;
+		// A plan to name, or no plans at all — see `askPlanId`. A tier whose plans
+		// all lack ids is neither, and cannot be asked about.
+		const hasPlan = !!askPlanId || plans.length === 0;
 		const token = !!accessToken;
 		// Owners and staff pass the gate stack by definition (gate #1), and the
 		// grid already suppresses their per-tier CTA; asking would be N round
@@ -151,7 +172,7 @@
 		joinEligibilityQueryOptions({
 			organizationSlug,
 			tierId,
-			planId: gatePlanId,
+			planId: askPlanId,
 			accessToken,
 			enabled: gateQueryEnabled
 		})
@@ -167,8 +188,22 @@
 	const gatePending = $derived(gateQuery.isLoading);
 
 	/**
+	 * Where this viewer stands against each requirement the tier states (#740).
+	 *
+	 * The list below used to read the TIER — `questionnaire_id` is set, therefore
+	 * "a membership questionnaire is required" — which is a true statement about
+	 * the tier and a false one about anybody who has already filled it in. These
+	 * two say which of the tier's rules the verdict is currently talking about;
+	 * `verdictMessage` is the prose, resolved by the same helper the plan cards
+	 * and the CTA use, so all three cannot drift apart.
+	 */
+	const questionnaireState = $derived(getMembershipRequirementState('questionnaire', gateVerdict));
+	const approvalState = $derived(getMembershipRequirementState('approval', gateVerdict));
+	const verdictMessage = $derived(gateVerdict ? getMembershipStatusMessage(gateVerdict) : null);
+
+	/**
 	 * The plan the tier CTA asks about, and the reason it is not simply
-	 * `gatePlanId`.
+	 * `askPlanId`.
 	 *
 	 * On a GATED tier the CTA has to name a plan or its verdict is a dead end:
 	 * gate #6 answers a plan-less question about a monetized tier with
@@ -181,7 +216,7 @@
 	 * already correct for what that CTA says, and changing the question would
 	 * change every paid tier's CTA for no gain (#735 keeps that blast radius out).
 	 */
-	const ctaPlanId = $derived(isGated ? gatePlanId : null);
+	const ctaPlanId = $derived(isGated ? askPlanId : null);
 
 	/**
 	 * The plan a pressed Apply button belongs to. One dialog per TIER rather than
@@ -225,17 +260,33 @@
 				{/if}
 			</div>
 
-			<!-- What it takes to get in. Rendered for everyone, member or not: it is a
-		     description of the tier, not of the viewer's progress through it. -->
+			<!-- What it takes to get in — and, once a verdict lands, where THIS viewer
+		     stands against it (#740). The tier's own fields decide which lines
+		     exist at all (they are facts about the tier, server-rendered and true
+		     for everyone); the verdict decides what each one says.
+
+		     A polite live region, and pre-mounted rather than injected with its
+		     first message: the lines are server-rendered with the tier's standing
+		     rules, the verdict arrives later over the same DOM, and a text swap
+		     that moves no focus is otherwise silent for a screen-reader user
+		     (WCAG 4.1.3). Every state is words — no colour, no icon-only cue. -->
 			{#if tier.requires_approval || tier.questionnaire_id}
-				<ul id={requirementsId} class="space-y-1.5 text-sm">
+				<ul id={requirementsId} class="space-y-1.5 text-sm" aria-live="polite">
 					{#if tier.requires_approval}
 						<li class="flex items-start gap-2">
 							<ShieldCheck
 								class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
 								aria-hidden="true"
 							/>
-							<span>{m['membershipTiers.requiresApproval']()}</span>
+							<span>
+								{#if approvalState === 'status' && verdictMessage}
+									{verdictMessage}
+								{:else if approvalState === 'satisfied'}
+									{m['membershipTiers.approvalCleared']()}
+								{:else}
+									{m['membershipTiers.requiresApproval']()}
+								{/if}
+							</span>
 						</li>
 					{/if}
 					{#if tier.questionnaire_id}
@@ -245,20 +296,28 @@
 								aria-hidden="true"
 							/>
 							<span>
-								{m['membershipTiers.questionnaireRequired']()}
-								{#if tier.questionnaire_id}
-									<!-- Named with the tier: a screen-reader user tabbing the page
-								     would otherwise hear the same link text on every card. -->
-									<a
-										href={resolve('/(public)/org/[slug]/questionnaire/[id]', {
-											slug: organizationSlug,
-											id: tier.questionnaire_id
-										})}
-										aria-label={m['membershipTiers.questionnaireLinkAria']({ tier: tier.name })}
-										class="font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-									>
-										{m['membershipTiers.questionnaireLink']()}
-									</a>
+								{#if questionnaireState === 'status' && verdictMessage}
+									<!-- Under review, on cooldown, or refused: there is nothing to
+								     open, so the link goes with the copy that offered it. -->
+									{verdictMessage}
+								{:else if questionnaireState === 'satisfied'}
+									{m['membershipTiers.questionnaireCleared']()}
+								{:else}
+									{m['membershipTiers.questionnaireRequired']()}
+									{#if tier.questionnaire_id}
+										<!-- Named with the tier: a screen-reader user tabbing the page
+									     would otherwise hear the same link text on every card. -->
+										<a
+											href={resolve('/(public)/org/[slug]/questionnaire/[id]', {
+												slug: organizationSlug,
+												id: tier.questionnaire_id
+											})}
+											aria-label={m['membershipTiers.questionnaireLinkAria']({ tier: tier.name })}
+											class="font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+										>
+											{m['membershipTiers.questionnaireLink']()}
+										</a>
+									{/if}
 								{/if}
 							</span>
 						</li>

--- a/src/lib/components/organization/membership/TierCard.test.ts
+++ b/src/lib/components/organization/membership/TierCard.test.ts
@@ -348,21 +348,236 @@ describe('TierCard', () => {
 		);
 	});
 
-	// Every plan on the tier is a dead end already, so there is no CTA for a
-	// verdict to withdraw — and no reason to spend a round trip finding out.
-	it('asks nothing when the tier sells only offline plans', async () => {
-		renderCard({
-			tier: makeTier({
+	// #740. Which plan to ASK about and which plan's CTA to WITHDRAW are two
+	// different questions, and conflating them is what made the reported bug
+	// possible: a tier selling only an offline plan has no Subscribe to withdraw,
+	// so it asked nothing — and then had no verdict with which to report the
+	// viewer's own state either.
+	describe('the plan the verdict is asked about', () => {
+		const offlineOnlyTier = () =>
+			makeTier({
 				is_free: false,
 				questionnaire_id: 'q-42',
-				plans: [makePlan({ id: 'p-1', payment_method: 'offline' })]
-			})
+				plans: [makePlan({ id: 'p-off', payment_method: 'offline' })]
+			});
+
+		it('asks about an offline plan when the tier sells nothing else', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'membership_questionnaire_pending',
+				next_step: 'wait_for_questionnaire_evaluation'
+			});
+			renderCard({ tier: offlineOnlyTier() });
+
+			await waitFor(() => {
+				expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalledWith(
+					expect.objectContaining({ query: { tier_id: 't-gold', plan_id: 'p-off' } })
+				);
+			});
 		});
 
-		await waitFor(() => {
+		// The withdrawal half is unchanged, and cheaply so: whenever a subscribable
+		// plan exists it is still the one asked about, so no existing tier's
+		// question — or cache key — moves.
+		it('prefers a subscribable plan over an offline one', async () => {
+			renderCard({
+				tier: makeTier({
+					is_free: false,
+					questionnaire_id: 'q-42',
+					plans: [
+						makePlan({ id: 'p-off', name: 'Offline', price: '5.00', payment_method: 'offline' }),
+						makePlan({ id: 'p-on', name: 'Monthly', price: '10.00' })
+					]
+				})
+			});
+
+			await waitFor(() => {
+				expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalledWith(
+					expect.objectContaining({ query: { tier_id: 't-gold', plan_id: 'p-on' } })
+				);
+			});
 			expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalledWith(
-				expect.objectContaining({ query: expect.objectContaining({ plan_id: 'p-1' }) })
+				expect.objectContaining({ query: expect.objectContaining({ plan_id: 'p-off' }) })
 			);
+		});
+
+		// Gate #6 only short-circuits a tier that HAS an active plan, so a tier
+		// with none is answerable tier-only — and asking is the only way its
+		// requirement lines can report anything.
+		it('asks a tier-only question when the tier sells nothing at all', async () => {
+			renderCard({ tier: makeTier({ questionnaire_id: 'q-42', plans: [] }) });
+
+			await waitFor(() => {
+				expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalledWith(
+					expect.objectContaining({ query: { tier_id: 't-gold' } })
+				);
+			});
+		});
+
+		// The offline plan's own copy is right in every state; the fix must not
+		// disturb it, and the verdict must not withdraw a CTA that was never there.
+		it('leaves the offline plan card exactly as it was', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'membership_questionnaire_pending',
+				next_step: 'wait_for_questionnaire_evaluation'
+			});
+			renderCard({ tier: offlineOnlyTier() });
+
+			expect(await screen.findByText(m['membershipPlans.offlineManaged']())).toBeInTheDocument();
+			expect(
+				screen.queryByText(m['membershipPlans.gatedSubscribeHelper'](), { exact: false })
+			).toBeNull();
+		});
+	});
+
+	// #740, the half the reporter actually saw: the requirement list stated a fact
+	// about the TIER, so it read "required" whether the viewer had never started,
+	// was awaiting review, or had passed.
+	describe('the requirement lines', () => {
+		const questionnaireTier = () =>
+			makeTier({
+				is_free: false,
+				questionnaire_id: 'q-42',
+				plans: [makePlan({ id: 'p-off', payment_method: 'offline' })]
+			});
+
+		const questionnaireLink = () =>
+			screen.queryByRole('link', {
+				name: m['membershipTiers.questionnaireLinkAria']({ tier: 'Gold' })
+			});
+
+		it('states the rule, with the link, for a viewer who has not started', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'membership_questionnaire_missing',
+				next_step: 'submit_questionnaire',
+				questionnaire_id: 'q-42'
+			});
+			renderCard({ tier: questionnaireTier() });
+
+			await waitFor(() => {
+				expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalled();
+			});
+			expect(screen.getByText(m['membershipTiers.questionnaireRequired']())).toBeInTheDocument();
+			expect(questionnaireLink()).toBeInTheDocument();
+		});
+
+		// The bug itself. Nothing to open, so the link goes with the copy that
+		// offered it.
+		it('reports a submission under review instead of asking for one', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'membership_questionnaire_pending',
+				next_step: 'wait_for_questionnaire_evaluation'
+			});
+			renderCard({ tier: questionnaireTier() });
+
+			expect(
+				await screen.findByText(m['membershipEligibility.wait.questionnaire_evaluation']())
+			).toBeInTheDocument();
+			expect(screen.queryByText(m['membershipTiers.questionnaireRequired']())).toBeNull();
+			expect(questionnaireLink()).toBeNull();
+		});
+
+		it('reports a retake cooldown', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'membership_questionnaire_retake_cooldown',
+				next_step: 'wait_to_retake_questionnaire',
+				retry_on: '2026-08-01T00:00:00Z'
+			});
+			renderCard({ tier: questionnaireTier() });
+
+			expect(
+				await screen.findByText(
+					m['membershipEligibility.reason.membership_questionnaire_retake_cooldown']()
+				)
+			).toBeInTheDocument();
+			expect(screen.queryByText(m['membershipTiers.questionnaireRequired']())).toBeNull();
+		});
+
+		it('says so once the viewer has cleared the questionnaire', async () => {
+			mockEligibility({ allowed: true, next_step: 'proceed_to_payment' });
+			renderCard({ tier: questionnaireTier() });
+
+			expect(
+				await screen.findByText(m['membershipTiers.questionnaireCleared']())
+			).toBeInTheDocument();
+			expect(questionnaireLink()).toBeNull();
+		});
+
+		const approvalTier = () =>
+			makeTier({
+				is_free: false,
+				requires_approval: true,
+				plans: [makePlan({ id: 'p-off', payment_method: 'offline' })]
+			});
+
+		it('reports an application with the organization, and its approval', async () => {
+			mockEligibility({
+				allowed: false,
+				reason_code: 'requires_approval',
+				next_step: 'wait_for_approval',
+				application_id: 'app-1'
+			});
+			const { unmount } = renderCard({ tier: approvalTier() });
+
+			expect(
+				await screen.findByText(m['membershipEligibility.wait.approval']())
+			).toBeInTheDocument();
+			expect(screen.queryByText(m['membershipTiers.requiresApproval']())).toBeNull();
+			unmount();
+
+			queryClient.clear();
+			mockEligibility({ allowed: true, next_step: 'proceed_to_payment' });
+			renderCard({ tier: approvalTier() });
+
+			expect(await screen.findByText(m['membershipTiers.approvalCleared']())).toBeInTheDocument();
+		});
+
+		// The fallback that keeps the lines honest for everybody who never asks —
+		// guests, owners, staff, and every viewer before the verdict lands.
+		it('keeps the tier’s own wording when there is no verdict', async () => {
+			renderCard({
+				tier: makeTier({ questionnaire_id: 'q-42', requires_approval: true }),
+				isAuthenticated: false
+			});
+
+			expect(screen.getByText(m['membershipTiers.questionnaireRequired']())).toBeInTheDocument();
+			expect(screen.getByText(m['membershipTiers.requiresApproval']())).toBeInTheDocument();
+			expect(questionnaireLink()).toBeInTheDocument();
+			await waitFor(() => {
+				expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).not.toHaveBeenCalled();
+			});
+		});
+
+		// A refusal about something else entirely: the CTA carries that reason, and
+		// the requirement lines must not claim the gate was cleared.
+		it('states the rules for a refusal that is about neither of them', async () => {
+			mockEligibility({ allowed: false, reason_code: 'blacklisted' });
+			renderCard({
+				tier: makeTier({
+					questionnaire_id: 'q-42',
+					requires_approval: true,
+					plans: [makePlan({ id: 'p-off', payment_method: 'offline' })]
+				})
+			});
+
+			await waitFor(() => {
+				expect(vi.mocked(memembershipapplicationsGetJoinEligibility)).toHaveBeenCalled();
+			});
+			expect(screen.getByText(m['membershipTiers.questionnaireRequired']())).toBeInTheDocument();
+			expect(screen.getByText(m['membershipTiers.requiresApproval']())).toBeInTheDocument();
+		});
+
+		// The state has to reach a screen-reader user who is not looking at the
+		// card when it changes: the list is server-rendered and the verdict lands
+		// over it later, with no focus move to announce it (WCAG 4.1.3).
+		it('announces the change politely', () => {
+			renderCard({ tier: questionnaireTier() });
+
+			expect(screen.getByRole('list')).toHaveAttribute('aria-live', 'polite');
 		});
 	});
 });

--- a/src/lib/utils/membership-eligibility.test.ts
+++ b/src/lib/utils/membership-eligibility.test.ts
@@ -3,6 +3,7 @@ import {
 	getApplicationPendingMessage,
 	getMembershipCtaKind,
 	getMembershipGateAction,
+	getMembershipRequirementState,
 	getMembershipStatusMessage,
 	isBlockedByMembershipGate
 } from './membership-eligibility';
@@ -473,5 +474,160 @@ describe('getMembershipGateAction', () => {
 				next_step: 'reapply'
 			})
 		).toBeNull();
+	});
+
+	// #740 asks about a tier's OFFLINE plan when it has nothing else, so gate #10
+	// now answers a cleared viewer with `plan_not_online`. It is a fact about the
+	// PLAN, not a gate the member can fill something in to clear, so it must not
+	// withdraw anything — the plan card already says "managed by the organization"
+	// on its own, and a false positive here would hide a plan from an eligible
+	// member (the failure `isBlockedByMembershipGate`'s allow-list exists to
+	// prevent).
+	it('offers nothing for an offline plan refusal', () => {
+		expect(getMembershipGateAction({ ...base, reason_code: 'plan_not_online' })).toBeNull();
+		expect(isBlockedByMembershipGate({ ...base, reason_code: 'plan_not_online' })).toBe(false);
+	});
+});
+
+// #740. The tier's requirement lines used to be pure tier metadata, so a member
+// whose submission was under review was still told "A membership questionnaire
+// is required" next to a link to fill it in again. These map a verdict to what
+// each line should say about THIS viewer.
+describe('getMembershipRequirementState', () => {
+	// No verdict is the common case, not an edge one: guests, owners and staff
+	// never ask, and every viewer sees the server-rendered card before the
+	// verdict lands. The line has to degrade to the tier's standing rule.
+	it('states the rule when nothing is known about the viewer', () => {
+		expect(getMembershipRequirementState('questionnaire', null)).toBe('policy');
+		expect(getMembershipRequirementState('approval', undefined)).toBe('policy');
+	});
+
+	// The never-started state keeps the copy it always had — the rule plus the
+	// link to go and satisfy it is exactly right there.
+	it('states the rule for a viewer who has not submitted yet', () => {
+		expect(
+			getMembershipRequirementState('questionnaire', {
+				...base,
+				reason_code: 'membership_questionnaire_missing',
+				next_step: 'submit_questionnaire',
+				questionnaire_id: 'q1'
+			})
+		).toBe('policy');
+	});
+
+	// The reported bug, at its source: this verdict must not resolve to the
+	// "required" copy.
+	it('reports the viewer state while a submission is under review', () => {
+		expect(
+			getMembershipRequirementState('questionnaire', {
+				...base,
+				reason_code: 'membership_questionnaire_pending',
+				next_step: 'wait_for_questionnaire_evaluation'
+			})
+		).toBe('status');
+	});
+
+	it('reports the viewer state on a retake cooldown and on a refusal', () => {
+		expect(
+			getMembershipRequirementState('questionnaire', {
+				...base,
+				reason_code: 'membership_questionnaire_retake_cooldown',
+				next_step: 'wait_to_retake_questionnaire',
+				retry_on: '2026-08-01T00:00:00Z'
+			})
+		).toBe('status');
+		// Terminal codes arrive with no next_step at all (#812), including via
+		// `ApplicationStatusGate`, which re-raises them on a rejected row.
+		for (const reason_code of [
+			'membership_questionnaire_failed',
+			'membership_questionnaire_attempts_exhausted'
+		] as const) {
+			expect(getMembershipRequirementState('questionnaire', { ...base, reason_code })).toBe(
+				'status'
+			);
+		}
+	});
+
+	// Read off the gate ORDER: #9 and #10 run strictly below the questionnaire
+	// gate, so a verdict shaped by either has already been past it.
+	it('marks the questionnaire cleared once a later gate is doing the talking', () => {
+		expect(getMembershipRequirementState('questionnaire', { ...base, allowed: true })).toBe(
+			'satisfied'
+		);
+		for (const next_step of ['submit_application', 'wait_for_approval'] as const) {
+			expect(
+				getMembershipRequirementState('questionnaire', {
+					...base,
+					reason_code: 'requires_approval',
+					next_step
+				})
+			).toBe('satisfied');
+		}
+	});
+
+	// A refusal from somewhere else entirely says nothing about either
+	// requirement — the CTA carries that reason, and the lines keep stating the
+	// rules. Claiming "cleared" off a blacklist verdict would be a lie.
+	it('says nothing about a requirement the verdict is not about', () => {
+		for (const topic of ['questionnaire', 'approval'] as const) {
+			expect(getMembershipRequirementState(topic, { ...base, reason_code: 'blacklisted' })).toBe(
+				'policy'
+			);
+			expect(
+				getMembershipRequirementState(topic, {
+					...base,
+					reason_code: 'not_accepting_requests',
+					next_step: 'requires_invitation'
+				})
+			).toBe('policy');
+		}
+	});
+
+	it('reports the approval state while staff are deciding, and after they decide', () => {
+		expect(
+			getMembershipRequirementState('approval', {
+				...base,
+				reason_code: 'requires_approval',
+				next_step: 'wait_for_approval',
+				application_id: 'app-1'
+			})
+		).toBe('status');
+		expect(
+			getMembershipRequirementState('approval', {
+				...base,
+				reason_code: 'application_rejected',
+				next_step: 'reapply',
+				application_id: 'app-1'
+			})
+		).toBe('status');
+		expect(
+			getMembershipRequirementState('approval', {
+				...base,
+				allowed: true,
+				next_step: 'proceed_to_payment'
+			})
+		).toBe('satisfied');
+	});
+
+	// The trap in the approval half. `requires_approval` on an ALLOWED verdict is
+	// gate #9's annotation for "nothing on file yet, you may apply" — telling that
+	// viewer their application was approved would invent one.
+	it('does not read the approval annotation as an approval', () => {
+		expect(
+			getMembershipRequirementState('approval', {
+				...base,
+				allowed: true,
+				reason_code: 'requires_approval'
+			})
+		).toBe('policy');
+		// Same for the paid path's prompt to apply: the plan cards offer the
+		// button, so the line keeps stating the rule rather than repeating it.
+		expect(
+			getMembershipRequirementState('approval', {
+				...base,
+				reason_code: 'requires_approval',
+				next_step: 'submit_application'
+			})
+		).toBe('policy');
 	});
 });

--- a/src/lib/utils/membership-eligibility.ts
+++ b/src/lib/utils/membership-eligibility.ts
@@ -187,12 +187,138 @@ export function getMembershipGateAction(
 	}
 }
 
+/** One of the two requirements a tier states about itself on its card. */
+export type MembershipRequirementTopic = 'questionnaire' | 'approval';
+
+/**
+ * What a tier's requirement line should say — about the TIER, or about the
+ * VIEWER standing in front of it.
+ *
+ * - `policy` — no news about this viewer: state the tier's standing rule, which
+ *   is what the line has always said, and (for a questionnaire) offer the link.
+ *   Also the answer whenever there is no verdict at all — a guest, an
+ *   owner/staff viewer, a request in flight or failed — so the line degrades to
+ *   exactly its pre-#740 wording rather than to silence.
+ * - `status` — the verdict has something to say about THIS requirement:
+ *   `getMembershipStatusMessage` is the copy, and there is nothing to press
+ *   (a submission under review, a cooldown, a refusal).
+ * - `satisfied` — this viewer is past that gate.
+ */
+export type MembershipRequirementState = 'policy' | 'status' | 'satisfied';
+
+/**
+ * Every reason code the questionnaire gate (#8) can raise, and no others: this
+ * is what decides that a verdict is talking about the QUESTIONNAIRE line rather
+ * than the approval one. Listed rather than prefix-matched so a new code has to
+ * be classified deliberately.
+ */
+const QUESTIONNAIRE_REASON_CODES: readonly MembershipReasonCode[] = [
+	'membership_questionnaire_missing',
+	'membership_questionnaire_pending',
+	'membership_questionnaire_failed',
+	'membership_questionnaire_retake_cooldown',
+	'membership_questionnaire_attempts_exhausted'
+];
+
+const QUESTIONNAIRE_STEPS: readonly MembershipNextStep[] = [
+	'submit_questionnaire',
+	'wait_for_questionnaire_evaluation',
+	'wait_to_retake_questionnaire'
+];
+
+/**
+ * The application/approval half: gates #7 (`ApplicationStatusGate`) and #9
+ * (`ManualApprovalGate`), plus #10's `submit_application`.
+ */
+const APPROVAL_REASON_CODES: readonly MembershipReasonCode[] = [
+	'requires_approval',
+	'application_rejected'
+];
+
+const APPROVAL_STEPS: readonly MembershipNextStep[] = [
+	'submit_application',
+	'wait_for_approval',
+	'reapply'
+];
+
+/**
+ * Where this viewer stands against one of the tier's stated requirements.
+ *
+ * The tier's own `questionnaire_id` / `requires_approval` say the tier IS
+ * GATED; only a verdict says whether this viewer has done anything about it.
+ * Reading the tier alone is why a member whose submission was under review was
+ * still told "A membership questionnaire is required" with a link to fill in a
+ * questionnaire they had already filled in.
+ *
+ * Prose is deliberately NOT returned: the caller renders
+ * `getMembershipStatusMessage` for `status`, so this stays one mapping of
+ * verdicts to copy rather than two that can drift.
+ *
+ * `satisfied` is read off the gate ORDER, which is the only evidence available
+ * — a verdict names one step, not a checklist. The stack is fixed
+ * (`membership_manager/gates.py`): #8 questionnaire, #9 manual approval, #10
+ * payment readiness. So a verdict shaped by #9 or #10 (`wait_for_approval`,
+ * `submit_application`) has necessarily been past #8, and an `allowed` verdict
+ * has been past everything. The one loose end is `already_member` (gate #4,
+ * which short-circuits ABOVE the questionnaire): it reports `satisfied` without
+ * having evaluated the questionnaire, which is the right thing to tell a member
+ * — the gate is moot for them, and the card renders their member badge anyway.
+ *
+ * The approval half has an extra trap. An `allowed` verdict carrying
+ * `requires_approval` is gate #9's ANNOTATION for "nothing on file yet, you may
+ * apply" — not "you were approved" — so it stays `policy`.
+ */
+export function getMembershipRequirementState(
+	topic: MembershipRequirementTopic,
+	e: MembershipEligibilitySchema | null | undefined
+): MembershipRequirementState {
+	if (!e) return 'policy';
+	if (topic === 'approval') {
+		if (e.allowed) return e.reason_code === 'requires_approval' ? 'policy' : 'satisfied';
+		// The move itself lives on the plan cards (#735), which offer the button;
+		// this line keeps stating the rule rather than duplicating the prompt.
+		if (e.next_step === 'submit_application') return 'policy';
+		return speaksAbout(e, APPROVAL_STEPS, APPROVAL_REASON_CODES) ? 'status' : 'policy';
+	}
+	if (e.allowed) return 'satisfied';
+	if (e.next_step === 'submit_application' || e.next_step === 'wait_for_approval') {
+		return 'satisfied';
+	}
+	// `submit_questionnaire` is the never-started state: the standing rule plus
+	// the link to go and satisfy it is exactly the right copy, and it is the copy
+	// this line has always carried.
+	if (e.next_step === 'submit_questionnaire') return 'policy';
+	return speaksAbout(e, QUESTIONNAIRE_STEPS, QUESTIONNAIRE_REASON_CODES) ? 'status' : 'policy';
+}
+
+/**
+ * Is this verdict about the given requirement at all? A refusal from somewhere
+ * else entirely (blacklist, invite-only, a payment-readiness stop) says nothing
+ * about it, so the line keeps stating the rule and the CTA carries the refusal.
+ */
+function speaksAbout(
+	e: MembershipEligibilitySchema,
+	steps: readonly MembershipNextStep[],
+	codes: readonly MembershipReasonCode[]
+): boolean {
+	const byStep = e.next_step ? steps.includes(e.next_step) : false;
+	const byCode = e.reason_code ? codes.includes(e.reason_code) : false;
+	return byStep || byCode;
+}
+
 /**
  * Localized prose per reason code.
  *
- * Deliberately partial: `org_not_visible`, `tier_requires_subscription`,
- * `plan_not_online` and `org_not_stripe_connected` are gate codes a plain join
- * CTA never surfaces, so they fall through to the backend `reason` string.
+ * Deliberately partial: `org_not_visible`, `tier_requires_subscription` and
+ * `org_not_stripe_connected` are gate codes a plain join CTA never surfaces, so
+ * they fall through to the backend `reason` string.
+ *
+ * `plan_not_online` is the exception that joined the list with #740. It became
+ * reachable when `TierCard` started asking about a tier's OFFLINE plan (the only
+ * way to get a verdict at all for a tier that sells nothing else), and gate #10
+ * answers a cleared offline plan with exactly that code — so the CTA renders
+ * this string, and it must say the same thing the plan card already says rather
+ * than the backend's "not configured for online checkout".
  *
  * `membership_questionnaire_pending` is absent for a stronger reason: it is
  * UNREACHABLE here. The backend raises it from exactly one place
@@ -214,6 +340,7 @@ const REASON_MESSAGES: Partial<Record<MembershipReasonCode, () => string>> = {
 	not_accepting_requests: () => m['membershipEligibility.reason.not_accepting_requests'](),
 	tier_unavailable: () => m['membershipEligibility.reason.tier_unavailable'](),
 	plan_unavailable: () => m['membershipEligibility.reason.plan_unavailable'](),
+	plan_not_online: () => m['membershipEligibility.reason.plan_not_online'](),
 	application_rejected: () => m['membershipEligibility.reason.application_rejected'](),
 	membership_questionnaire_missing: () =>
 		m['membershipEligibility.reason.membership_questionnaire_missing'](),

--- a/tests/e2e/journeys/j27-applications/gated-paid-tier.spec.ts
+++ b/tests/e2e/journeys/j27-applications/gated-paid-tier.spec.ts
@@ -93,6 +93,13 @@ const JOIN_FREE = 'Join for free';
 const GATED_NOTE = "You can join once this tier's requirements are met.";
 /** The free-plan helper that rides along with the CTA, and only with it. */
 const FREE_HELPER = 'No payment needed — you can join right away.';
+/** `TierCard`'s requirement line while the viewer has submitted nothing. */
+const QUESTIONNAIRE_POLICY = 'A membership questionnaire is required.';
+/** …and what it says once their submission is with the organization. */
+const QUESTIONNAIRE_PENDING =
+	"Your questionnaire is being reviewed — we'll let you know once it's evaluated.";
+/** `PlanCard`'s offline branch — correct in every state, and left alone. */
+const OFFLINE_MANAGED = 'Managed by the organization — contact them to join this plan.';
 
 test.describe('j27 gated + paid tier @p2', () => {
 	test('a gated priced tier withholds its plan CTA, and hands it back once the gate clears', async ({
@@ -390,6 +397,109 @@ test.describe('j27 gated + paid tier @p2', () => {
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
 		await expect(page.getByLabel(`Membership tier: ${tierName}`)).toBeVisible({ timeout: 20_000 });
+
+		await page.context().close();
+	});
+
+	// The state the two tests above never reach, and the one a real user reported:
+	// a gated tier whose ONLY plan is OFFLINE. Both halves of the bug live here.
+	//
+	// 1. No verdict was fetched at all. `TierCard` picked the plan to ask about
+	//    from the SUBSCRIBABLE ones — right for its original job (#733/#734 only
+	//    needed to withdraw a Subscribe button, which an offline plan never shows)
+	//    but it also suppressed the verdict used to REPORT state. With no plan,
+	//    gate #6 answers `tier_requires_subscription` for any monetized tier —
+	//    identical before and after the submission, which is precisely why the
+	//    member's own state was invisible.
+	// 2. The requirement line read the TIER (`questionnaire_id`), never the
+	//    viewer, so it said "required" whether they had never started, were
+	//    awaiting review, or had passed.
+	//
+	// An OFFLINE plan, not a free or online one, because that is the shape that
+	// fetched nothing — and the shape whose plan card can carry no state of its
+	// own either ("Managed by the organization" is all it ever says), leaving the
+	// tier's requirement line as the ONLY place the member's standing can appear.
+	//
+	// A MANUAL questionnaire because it parks: manual mode enqueues no evaluation
+	// at all, so the submission sits READY with no evaluation row forever — the
+	// backend's `membership_questionnaire_pending` /
+	// `wait_for_questionnaire_evaluation` verdict, with no grader race to poll.
+	test('a gated tier selling only an offline plan reports the viewer’s questionnaire state', async ({
+		browser
+	}) => {
+		test.setTimeout(240_000);
+		const [org, applicant] = await Promise.all([
+			createOrganization({ acceptMembershipRequests: true }),
+			createVerifiedUser('OfflineGated')
+		]);
+
+		const tierName = uniqueName('Offline Gated Tier');
+		const [tier, questionnaire] = await Promise.all([
+			createMembershipTier(org.owner, org.slug, tierName),
+			createMembershipQuestionnaire(org.owner, org.slug, { evaluationMode: 'manual' })
+		]);
+		// A TIER override, so the org's default tier stays ungated on the same page.
+		await patchTierPolicy(org.owner, org.slug, tier.id, {
+			membership_questionnaire: questionnaire.id
+		});
+		const plan = await createSubscriptionPlan(org.owner, org.slug, tier.id, {
+			name: uniqueName('Offline Plan'),
+			payment_method: 'offline',
+			price: '10.00',
+			currency: 'EUR',
+			period_unit: 'month'
+		});
+
+		const page = await pageAs(browser, applicant);
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+
+		const card = tierCard(page, tierName);
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		const offlinePlanCard = planCard(page, plan.name);
+		await expect(offlinePlanCard.getByText(OFFLINE_MANAGED)).toBeVisible();
+
+		// ── Nothing submitted: the tier's standing rule, and the way in ────────
+		await expect(card.getByText(QUESTIONNAIRE_POLICY)).toBeVisible();
+		const questionnaireLink = card.getByRole('link', {
+			name: `Open the membership questionnaire for ${tierName}`
+		});
+		await expect(questionnaireLink).toBeVisible();
+		// The verdict now names the move instead of dead-ending on gate #6's
+		// "This tier requires a paid subscription. Subscribe to a plan to join." —
+		// which was doubly wrong here: the only plan cannot be subscribed to.
+		await expect(
+			card.getByRole('link', { name: 'Fill in the membership questionnaire' })
+		).toBeVisible({ timeout: 15_000 });
+		await expect(card.getByText('This tier requires a paid subscription')).toHaveCount(0);
+
+		// ── Submit, and leave it with the organization ─────────────────────────
+		await questionnaireLink.click();
+		await page.waitForURL('**/questionnaire/**');
+		await expect(page.getByRole('heading', { name: 'Membership questionnaire' })).toBeVisible();
+		await page.getByLabel(MEMBERSHIP_QUESTION.manual.question).fill('E2E: I like this org.');
+		await page.getByRole('button', { name: 'Submit Questionnaire' }).click();
+		await expect(
+			page.getByText("Questionnaire submitted — we'll let you know once it's been evaluated.")
+		).toBeVisible({ timeout: 15_000 });
+		await page.waitForURL(`**/org/${org.slug}`, { timeout: 15_000 });
+
+		// ── …and the card says so, in the place that used to deny it ───────────
+		await gotoHydrated(page, membershipPath(org.slug));
+		await waitForClientAuth(page);
+		const pendingCard = tierCard(page, tierName);
+		await expect(pendingCard.getByText(QUESTIONNAIRE_PENDING)).toBeVisible({ timeout: 15_000 });
+		// The bug, asserted as an absence: the "you have not started" copy and its
+		// link are what the reporter saw on top of a submission under review.
+		await expect(pendingCard.getByText(QUESTIONNAIRE_POLICY)).toHaveCount(0);
+		await expect(
+			pendingCard.getByRole('link', {
+				name: `Open the membership questionnaire for ${tierName}`
+			})
+		).toHaveCount(0);
+		await expect(pendingCard.getByRole('button', { name: 'Application pending' })).toBeDisabled();
+		// The offline plan's own copy is correct in every state and stays put.
+		await expect(planCard(page, plan.name).getByText(OFFLINE_MANAGED)).toBeVisible();
 
 		await page.context().close();
 	});


### PR DESCRIPTION
Closes #740

A member who had submitted a gated tier's membership questionnaire and was awaiting review still saw **"A membership questionnaire is required. Open the questionnaire"**, as if they had never started. Two independent causes, both fixed here.

## 1. No verdict was fetched at all when every plan was offline

`TierCard` picked the plan to ask about from the **subscribable** ones — right for its original job (#733/#734 only needed to *withdraw a Subscribe button*, which an offline plan never shows) but it also suppressed the verdict used to *report state*. With no `plan_id`, gate #6 answers `tier_requires_subscription` for any monetized tier, **identically before and after the submission** — which is precisely why the member's own state was invisible.

Asking and withdrawing are now two questions:

- **ask** → any plan on the card. They are all `is_active` (the public listing serializes nothing else), so gate #6 lets them through, and every plan-specific stop — offline, paused, at cap — lives in gate #10, *below* the gates being read. A tier with no plans keeps its tier-only question, which gate #6 answers correctly.
- **withdraw** → subscribable only, exactly as before. A subscribable plan is still *preferred* for the question, so every tier that has one asks a byte-identical question: no existing verdict, and no cache key, moves.

## 2. The requirement lines were pure tier metadata

`questionnaire_id` is set, therefore "required" — a true statement about the tier and a false one about anybody who had already filled it in. `getMembershipRequirementState(topic, verdict)` now maps a verdict to what each line should say:

| verdict | questionnaire line | approval line |
| --- | --- | --- |
| no verdict (guest / owner / staff / in flight / failed) | `policy` — the tier's rule + link | `policy` |
| `submit_questionnaire` + `membership_questionnaire_missing` | `policy` — the rule + link (today's copy) | — |
| `wait_for_questionnaire_evaluation` | `status` — "Your questionnaire is being reviewed…", no link | — |
| `wait_to_retake_questionnaire` / `_failed` / `_attempts_exhausted` | `status` | — |
| `wait_for_approval` | `satisfied` (gate #9 runs below #8) | `status` — "Your application is with the organization for review." |
| `submit_application` + `requires_approval` | `satisfied` | `policy` — the plan cards carry the button (#735) |
| `reapply` + `application_rejected` | `policy` (gate #7 runs *above* #8) | `status` |
| `allowed` / `proceed_to_payment` | `satisfied` — "You've completed the membership questionnaire." | `satisfied` — "The organization has approved your application." |
| `allowed` + `requires_approval` (gate #9's *annotation*) | `satisfied` | `policy` — **not** an approval |
| a refusal about neither (blacklist, invite-only, payment readiness) | `policy` | `policy` |

`getMembershipStatusMessage` supplies all the `status` prose, so the requirement lines, the plan cards and the CTA cannot drift apart. `satisfied` is read off the fixed gate ORDER, which is the only evidence a verdict carries.

The list is now a **pre-mounted polite live region**: it is server-rendered with the tier's standing rules and the verdict lands over it later with no focus move to announce it (WCAG 4.1.3). Every state is words — never colour, never icon-only.

## 3. The CTA stops dead-ending

With a plan-bearing verdict the CTA names the move instead of rendering gate #6's "This tier requires a paid subscription. Subscribe to a plan to join." — which was doubly wrong here, since the only plan cannot be subscribed to. Gate #10 answers a *cleared* offline plan with `plan_not_online`, which now carries FE copy saying what the plan card already says. It stays out of `GATE_BLOCKING_REASON_CODES`, so it can never withdraw a CTA from an eligible member — #734's fail-open property is untouched, and #735's blast-radius limit (a `planId` only for GATED tiers) is unchanged.

## Evidence

Playwright accessibility snapshots of the reported shape — gated tier, single €10/month **offline** plan, questionnaire submission READY with no evaluation row — taken from the same fixture before and after.

**Before** — the two states are byte-identical; that is the bug:

```
=== A: nothing submitted ===
- article "…Gated Tier":
  - heading "…Gated Tier" [level=3]
  - list:
    - listitem:
      - text: A membership questionnaire is required.
      - link "Open the membership questionnaire for …Gated Tier"
  - heading "…Offline Plan" [level=4]
  - paragraph: €10.00 / month
  - paragraph: Managed by the organization — contact them to join this plan.
  - note: This tier requires a paid subscription. Subscribe to a plan to join.

=== B: submitted, awaiting review ===
- article "…Gated Tier":
  - heading "…Gated Tier" [level=3]
  - list:
    - listitem:
      - text: A membership questionnaire is required.
      - link "Open the membership questionnaire for …Gated Tier"
  - heading "…Offline Plan" [level=4]
  - paragraph: €10.00 / month
  - paragraph: Managed by the organization — contact them to join this plan.
  - note: This tier requires a paid subscription. Subscribe to a plan to join.
```

**After**:

```
=== A: nothing submitted ===
- article "…Gated Tier":
  - heading "…Gated Tier" [level=3]
  - list:
    - listitem:
      - text: A membership questionnaire is required.
      - link "Open the membership questionnaire for …Gated Tier"
  - heading "…Offline Plan" [level=4]
  - paragraph: €10.00 / month
  - paragraph: Managed by the organization — contact them to join this plan.
  - link "Fill in the membership questionnaire"

=== B: submitted, awaiting review ===
- article "…Gated Tier":
  - heading "…Gated Tier" [level=3]
  - list:
    - listitem: Your questionnaire is being reviewed — we'll let you know once it's evaluated.
  - heading "…Offline Plan" [level=4]
  - paragraph: €10.00 / month
  - paragraph: Managed by the organization — contact them to join this plan.
  - button "Application pending" [disabled]
  - link "Track your application"
```

## Tests

- **Unit** — 10 new cases over `getMembershipRequirementState` (every verdict state, both topics, the annotation trap, the gate-order reasoning) plus one holding `plan_not_online` out of the gate allow-list.
- **Component** — the ask-plan/withdraw-plan split (offline-only asks; a subscribable plan is preferred; a plan-less tier asks tier-only; the offline plan card is untouched) and every requirement-line state, including the live region.
- **E2E** — `j27-applications/gated-paid-tier.spec.ts` gains the offline-only gated tier walking never-started → submitted → awaiting review. Green on both journey projects:

```
Running 6 tests using 2 workers
  ✓ [chromium] … withholds its plan CTA, and hands it back once the gate clears (4.5s)
  ✓ [chromium] … can be applied for, approved and then paid (5.3s)
  ✓ [chromium] … selling only an offline plan reports the viewer's questionnaire state (3.1s)
  ✓ [mobile-chrome] … withholds its plan CTA, and hands it back once the gate clears (4.1s)
  ✓ [mobile-chrome] … selling only an offline plan reports the viewer's questionnaire state (3.2s)
  ✓ [mobile-chrome] … can be applied for, approved and then paid (5.0s)
  6 passed (13.6s)
```

`make check` green: 0 errors, 374 warnings (the accepted #361 baseline), type gate armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
