### PR TITLE
feat(membership): give the offline plan card a way to reach the organizers

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -4304,6 +4304,7 @@
 	"orgContactButton": {
 		"contactOrganizer": "Organisator*innen kontaktieren",
 		"emailAriaLabel": "E-Mail an {organizationName}",
+		"contactAriaLabel": "{organizationName} kontaktieren",
 		"dialogTitle": "{organizationName} kontaktieren",
 		"dialogDesc": "Sende eine Nachricht an {organizationName}. Die E-Mail-Adresse deines Kontos wird mit den Organisator*innen geteilt, damit sie antworten können.",
 		"subjectLabel": "Betreff",
@@ -5165,7 +5166,7 @@
 		"soldOutHelper": "Alle Plätze sind vergeben — einer wird eventuell frei, wenn eine Mitgliedschaft endet.",
 		"paused": "Anmeldung pausiert",
 		"pausedHelper": "Die Organisation hat die Anmeldung vorübergehend geschlossen.",
-		"offlineManaged": "Wird von der Organisation verwaltet — melde dich bei ihr, um diesen Plan zu buchen.",
+		"offlineManaged": "Wird von der Organisation manuell verwaltet.",
 		"refundPolicy": "Rückerstattungsrichtlinie",
 		"viewMembership": "Mitgliedschaftsoptionen ansehen",
 		"joinFreeCta": "Kostenlos beitreten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4304,6 +4304,7 @@
 	"orgContactButton": {
 		"contactOrganizer": "Contact organizer",
 		"emailAriaLabel": "Email {organizationName}",
+		"contactAriaLabel": "Contact {organizationName}",
 		"dialogTitle": "Contact {organizationName}",
 		"dialogDesc": "Send a message to {organizationName}. Your account email will be shared with the organizer so they can reply.",
 		"subjectLabel": "Subject",
@@ -5165,7 +5166,7 @@
 		"soldOutHelper": "All spots are taken — one may free up if a membership ends.",
 		"paused": "Sales paused",
 		"pausedHelper": "The organization has temporarily closed sign-ups.",
-		"offlineManaged": "Managed by the organization — contact them to join this plan.",
+		"offlineManaged": "Managed manually by the organization.",
 		"refundPolicy": "Refund policy",
 		"viewMembership": "View membership options",
 		"joinFreeCta": "Join for free",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -4275,6 +4275,7 @@
 	"orgContactButton": {
 		"contactOrganizer": "Contacter l'organisateur·rice",
 		"emailAriaLabel": "Envoyer un e-mail à {organizationName}",
+		"contactAriaLabel": "Contacter {organizationName}",
 		"dialogTitle": "Contacter {organizationName}",
 		"dialogDesc": "Envoie un message à {organizationName}. L'adresse e-mail de ton compte sera partagée avec l'organisateur·rice afin qu'il/elle puisse te répondre.",
 		"subjectLabel": "Objet",
@@ -5136,7 +5137,7 @@
 		"soldOutHelper": "Toutes les places sont prises — une peut se libérer si une adhésion prend fin.",
 		"paused": "Inscriptions en pause",
 		"pausedHelper": "L'organisation a temporairement fermé les inscriptions.",
-		"offlineManaged": "Géré par l'organisation — contacte-la pour rejoindre ce forfait.",
+		"offlineManaged": "Géré manuellement par l'organisation.",
 		"refundPolicy": "Politique de remboursement",
 		"viewMembership": "Voir les options d'adhésion",
 		"joinFreeCta": "Rejoindre gratuitement",

--- a/messages/it.json
+++ b/messages/it.json
@@ -4304,6 +4304,7 @@
 	"orgContactButton": {
 		"contactOrganizer": "Contatta organizzatore",
 		"emailAriaLabel": "Invia email a {organizationName}",
+		"contactAriaLabel": "Contatta {organizationName}",
 		"dialogTitle": "Contatta {organizationName}",
 		"dialogDesc": "Invia un messaggio a {organizationName}. L'email del tuo account sarà condivisa con l'organizzatore per poterti rispondere.",
 		"subjectLabel": "Oggetto",
@@ -5165,7 +5166,7 @@
 		"soldOutHelper": "Tutti i posti sono occupati — potrebbe liberarsene uno se un'iscrizione termina.",
 		"paused": "Iscrizioni in pausa",
 		"pausedHelper": "L'organizzazione ha temporaneamente chiuso le iscrizioni.",
-		"offlineManaged": "Gestito dall'organizzazione — contattala per aderire a questo piano.",
+		"offlineManaged": "Gestito manualmente dall'organizzazione.",
 		"refundPolicy": "Politica di rimborso",
 		"viewMembership": "Vedi le opzioni di iscrizione",
 		"joinFreeCta": "Iscriviti gratis",

--- a/src/lib/components/organization/OrgContactButton.svelte
+++ b/src/lib/components/organization/OrgContactButton.svelte
@@ -18,6 +18,16 @@
 		isAuthenticated: boolean;
 		variant?: 'primary' | 'outline';
 		class?: string;
+		/**
+		 * Overrides the control's accessible name, for callers that place this
+		 * button where "Contact organizer" alone does not say *who* (the offline
+		 * plan card, where the button sits among several plan-level CTAs).
+		 *
+		 * Opt-in rather than a new default: the `form` branch's name is its own
+		 * visible text everywhere else, and silently renaming it would rename it
+		 * for the org and event pages too.
+		 */
+		ariaLabel?: string | null;
 	}
 
 	const {
@@ -27,7 +37,8 @@
 		contactEmail = null,
 		isAuthenticated,
 		variant = 'outline',
-		class: className = ''
+		class: className = '',
+		ariaLabel = null
 	}: Props = $props();
 
 	const accessToken = $derived(authStore.accessToken);
@@ -98,14 +109,16 @@
 	<a
 		href="mailto:{contactEmail}"
 		class={buttonClasses}
-		aria-label={m['orgContactButton.emailAriaLabel']({ organizationName })}
+		aria-label={ariaLabel ?? m['orgContactButton.emailAriaLabel']({ organizationName })}
 	>
 		<Mail class="h-4 w-4" aria-hidden="true" />
 		{m['orgContactButton.contactOrganizer']()}
 	</a>
 {:else if contactMethod === 'form'}
 	<Dialog.Root open={showDialog} onOpenChange={handleOpenChange}>
-		<Dialog.Trigger class={buttonClasses}>
+		<!-- No aria-label by default: the visible text IS the name. Supplied only
+		     where the caller needs it to say who is being contacted. -->
+		<Dialog.Trigger class={buttonClasses} aria-label={ariaLabel ?? undefined}>
 			<Mail class="h-4 w-4" aria-hidden="true" />
 			{m['orgContactButton.contactOrganizer']()}
 		</Dialog.Trigger>

--- a/src/lib/components/organization/membership/MembershipSection.svelte
+++ b/src/lib/components/organization/membership/MembershipSection.svelte
@@ -193,6 +193,8 @@
 						organizationSlug={organization.slug}
 						organizationName={organization.name}
 						{isAuthenticated}
+						contactMethod={organization.contact_method}
+						contactEmail={organization.contact_email}
 						{subscription}
 						{subscriptionLoading}
 						onSubscribe={handleSubscribe}

--- a/src/lib/components/organization/membership/PlanCard.svelte
+++ b/src/lib/components/organization/membership/PlanCard.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import type { MySubscriptionSchema, PublicPlanSchema } from '$lib/api/generated/types.gen';
+	import type {
+		ContactMethod,
+		MySubscriptionSchema,
+		PublicPlanSchema
+	} from '$lib/api/generated/types.gen';
 	import type { MembershipGateAction } from '$lib/utils/membership-eligibility';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
+	import OrgContactButton from '$lib/components/organization/OrgContactButton.svelte';
 	import {
 		canSwitchToPlan,
 		formatPlanPrice,
@@ -20,6 +25,17 @@
 		onSubscribe: (plan: PublicPlanSchema & { id: string }) => void;
 		/** Where the login round trip should come back to. */
 		organizationSlug: string;
+		/** Names the org in the offline plan's contact CTA. */
+		organizationName: string;
+		/**
+		 * How this organization accepts messages, straight off the org record. An
+		 * OFFLINE plan is settled with them directly, so this is the only place the
+		 * card can point a would-be member at — and `none`, or `email` with
+		 * no address on file, means there is nowhere to point, which the copy then
+		 * has to stop promising.
+		 */
+		contactMethod?: ContactMethod;
+		contactEmail?: string | null;
 		/**
 		 * The viewer's live subscription in this organization, or `null` when they
 		 * have none. The backend only ever hands back a *non-terminal* row here,
@@ -68,6 +84,9 @@
 		isAuthenticated,
 		onSubscribe,
 		organizationSlug,
+		organizationName,
+		contactMethod = 'none',
+		contactEmail = null,
 		subscription = null,
 		subscriptionLoading = false,
 		gateAction = null,
@@ -165,6 +184,24 @@
 	 */
 	const isPendingCheckout = $derived(subscription?.status === 'pending');
 
+	/**
+	 * Whether `OrgContactButton` would really render something for this org.
+	 *
+	 * Deliberately stricter than the `method !== 'none'` test used elsewhere: the
+	 * button's own `email` branch also requires an address, so a method of
+	 * `email` with none on file renders NOTHING. Gating the copy on the looser
+	 * test would leave the offline card promising a button that never arrives —
+	 * the same dead end this replaces, one step further along.
+	 */
+	const canContactOrganization = $derived.by(() => {
+		// Both operands read unconditionally: `&&`/`||` inside a `$derived` would
+		// leave the skipped one untracked.
+		const method = contactMethod;
+		const hasEmail = !!contactEmail;
+		if (method === 'email') return hasEmail;
+		return method === 'form';
+	});
+
 	const isFree = $derived(isFreePlan(plan));
 	/** A non-renewing term — said in words, because the price line no longer
 	    carries a cadence to imply it. */
@@ -254,7 +291,34 @@
 					</a>
 				{/if}
 			{:else if action === 'offline'}
+				<!-- The one branch with no self-serve path at all: the plan is settled
+				     with the organizers, so the sentence states that constraint and
+				     the CTA beneath it is how you reach them. The sentence stands
+				     alone when there is nobody to reach — it says what is true of the
+				     plan and stops, rather than telling the viewer to make contact
+				     they have no means of making.
+
+				     A whole button rather than a link spliced into the sentence: the
+				     org's two contact channels (mailto and a dialog) already live in
+				     OrgContactButton, and splicing would mean cutting a translated
+				     string around an anchor. -->
 				<p class="text-sm text-muted-foreground">{m['membershipPlans.offlineManaged']()}</p>
+				{#if canContactOrganization}
+					<!-- Named for the org, not just "Contact organizer": these buttons
+					     repeat down a page of plans and a screen-reader user hears them
+					     out of context. Full width on mobile like every other CTA here,
+					     so it cannot overflow a narrow card. -->
+					<OrgContactButton
+						{organizationSlug}
+						{organizationName}
+						{contactMethod}
+						{contactEmail}
+						{isAuthenticated}
+						variant="outline"
+						ariaLabel={m['orgContactButton.contactAriaLabel']({ organizationName })}
+						class="mt-2 w-full justify-center sm:w-auto"
+					/>
+				{/if}
 			{:else if isApplyAction}
 				<!-- #735. The one branch where a blocked gate still leaves the member
 				     something to press: the backend is waiting for an application that

--- a/src/lib/components/organization/membership/PlanCard.test.ts
+++ b/src/lib/components/organization/membership/PlanCard.test.ts
@@ -1,9 +1,17 @@
 import { render, screen } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
 import PlanCard from './PlanCard.svelte';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
 import type { MySubscriptionSchema, PublicPlanSchema } from '$lib/api/generated/types.gen';
 import * as m from '$lib/paraglide/messages.js';
+
+// The offline branch mounts OrgContactButton, which reads the token for its
+// contact-form mutation.
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { accessToken: 'test-token' }
+}));
 
 function makePlan(overrides: Partial<PublicPlanSchema> = {}): PublicPlanSchema {
 	return {
@@ -64,23 +72,42 @@ function makeSub(overrides: Partial<MySubscriptionSchema> = {}): MySubscriptionS
 	};
 }
 
+let queryClient: QueryClient;
+
+/**
+ * Wrapped in a real QueryClientProvider: the offline branch mounts
+ * `OrgContactButton`, whose contact-form mutation resolves its client from
+ * Svelte context.
+ */
 function renderCard(props: Record<string, unknown> = {}) {
 	const onSubscribe = vi.fn();
 	const onApply = vi.fn();
-	const result = render(PlanCard, {
+	const result = render(QueryClientTestWrapper, {
 		props: {
-			plan: makePlan(),
-			isAuthenticated: true,
-			onSubscribe,
-			onApply,
-			organizationSlug: 'acme',
-			...props
+			client: queryClient,
+			component: PlanCard,
+			componentProps: {
+				plan: makePlan(),
+				isAuthenticated: true,
+				onSubscribe,
+				onApply,
+				organizationSlug: 'acme',
+				organizationName: 'Acme',
+				...props
+			}
 		}
 	});
 	return { ...result, onSubscribe, onApply };
 }
 
 describe('PlanCard', () => {
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+		});
+		vi.clearAllMocks();
+	});
+
 	it('shows the plan name, price and description', () => {
 		renderCard({ plan: makePlan({ description: 'Two lines\nof perks' }) });
 
@@ -90,14 +117,75 @@ describe('PlanCard', () => {
 	});
 
 	// Offline plans are settled with the organizers directly — there is no
-	// checkout to send the member to.
-	it('explains an offline plan instead of offering a CTA', () => {
-		const { onSubscribe } = renderCard({ plan: makePlan({ payment_method: 'offline' }) });
+	// checkout to send the member to, so the card states the constraint and, when
+	// the org has somewhere to be reached, offers a way to reach them.
+	describe('an offline plan', () => {
+		const offlinePlan = () => makePlan({ payment_method: 'offline' });
 
-		expect(screen.getByText(/managed by the organization/i)).toBeInTheDocument();
-		expect(screen.queryByRole('button')).toBeNull();
-		expect(screen.queryByRole('link')).toBeNull();
-		expect(onSubscribe).not.toHaveBeenCalled();
+		it('offers the contact form when the org takes messages that way', () => {
+			const { onSubscribe } = renderCard({
+				plan: offlinePlan(),
+				contactMethod: 'form'
+			});
+
+			expect(screen.getByText(m['membershipPlans.offlineManaged']())).toBeInTheDocument();
+			// Named for the org: "Contact organizer" alone does not say who, and
+			// these repeat down a page of plans.
+			expect(
+				screen.getByRole('button', {
+					name: m['orgContactButton.contactAriaLabel']({ organizationName: 'Acme' })
+				})
+			).toBeInTheDocument();
+			// Still no checkout — the CTA contacts, it does not subscribe.
+			expect(screen.queryByRole('button', { name: /subscribe/i })).toBeNull();
+			expect(onSubscribe).not.toHaveBeenCalled();
+		});
+
+		it('offers a mailto link when the org publishes an address', () => {
+			renderCard({
+				plan: offlinePlan(),
+				contactMethod: 'email',
+				contactEmail: 'hello@acme.test'
+			});
+
+			expect(screen.getByText(m['membershipPlans.offlineManaged']())).toBeInTheDocument();
+			const link = screen.getByRole('link', {
+				name: m['orgContactButton.contactAriaLabel']({ organizationName: 'Acme' })
+			});
+			expect(link).toHaveAttribute('href', 'mailto:hello@acme.test');
+		});
+
+		// The trap this guards: `contact_method === 'email'` with no address on
+		// file renders nothing at all, so gating the copy on the method alone
+		// would promise a button that never arrives.
+		it('says only what is true when the email method has no address on file', () => {
+			renderCard({
+				plan: offlinePlan(),
+				contactMethod: 'email',
+				contactEmail: null
+			});
+
+			expect(screen.getByText(m['membershipPlans.offlineManaged']())).toBeInTheDocument();
+			expect(screen.queryByRole('button')).toBeNull();
+			expect(screen.queryByRole('link')).toBeNull();
+		});
+
+		it('states the constraint alone when the org accepts no contact', () => {
+			const { onSubscribe } = renderCard({ plan: offlinePlan(), contactMethod: 'none' });
+
+			expect(screen.getByText(m['membershipPlans.offlineManaged']())).toBeInTheDocument();
+			expect(screen.queryByRole('button')).toBeNull();
+			expect(screen.queryByRole('link')).toBeNull();
+			expect(onSubscribe).not.toHaveBeenCalled();
+		});
+
+		// The copy must not tell anybody to make contact it cannot offer — the
+		// dead end the CTA replaced.
+		it('never instructs the viewer to make contact in the sentence itself', () => {
+			renderCard({ plan: offlinePlan(), contactMethod: 'none' });
+
+			expect(screen.queryByText(/contact them/i)).toBeNull();
+		});
 	});
 
 	it('labels a sold-out plan in text and withdraws the CTA', () => {
@@ -443,7 +531,7 @@ describe('PlanCard', () => {
 			expect(screen.getByText('Free')).toBeInTheDocument();
 			expect(screen.getByText('Never expires')).toBeInTheDocument();
 			expect(screen.queryByText(/€0\.00/)).toBeNull();
-			expect(screen.queryByText(/managed by the organization/i)).toBeNull();
+			expect(screen.queryByText(m['membershipPlans.offlineManaged']())).toBeNull();
 		});
 
 		it('offers a join CTA that hands the plan to the caller', async () => {

--- a/src/lib/components/organization/membership/TierCard.svelte
+++ b/src/lib/components/organization/membership/TierCard.svelte
@@ -3,6 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { createQuery } from '@tanstack/svelte-query';
 	import type {
+		ContactMethod,
 		MySubscriptionSchema,
 		PublicMembershipTierSchema,
 		PublicPlanSchema
@@ -27,6 +28,13 @@
 		organizationName: string;
 		isAuthenticated: boolean;
 		/**
+		 * The org's contact channel, forwarded to the plan cards — only an OFFLINE
+		 * plan has anything to do with it. Carried as two fields rather than the
+		 * whole org record: these cards are handed exactly what they render.
+		 */
+		contactMethod?: ContactMethod;
+		contactEmail?: string | null;
+		/**
 		 * The viewer's live subscription in this org, forwarded untouched to every
 		 * PlanCard — see that component for why a non-null value withdraws the
 		 * subscribe CTA everywhere.
@@ -49,6 +57,8 @@
 		organizationSlug,
 		organizationName,
 		isAuthenticated,
+		contactMethod = 'none',
+		contactEmail = null,
 		subscription = null,
 		subscriptionLoading = false,
 		onSubscribe,
@@ -334,6 +344,9 @@
 							{subscription}
 							{subscriptionLoading}
 							{organizationSlug}
+							{organizationName}
+							{contactMethod}
+							{contactEmail}
 							{onSubscribe}
 							{gateAction}
 							{gateReason}


### PR DESCRIPTION
## The dead end

An OFFLINE membership plan renders no CTA — the plan is settled with the organization directly, so there is no checkout to send anybody to. What it said instead was:

> Managed by the organization — contact them to join this plan.

…with nothing behind the instruction. No address, no form, nothing to press. And most organizations *do* have a contact channel configured: it was already rendered on their org page and on every event page, just not here.

## What the card does now

The offline branch states the constraint and, when the org really has a reachable channel, offers the existing contact CTA beneath it:

> **Managed manually by the organization.**
> `[✉ Contact organizer]`

When there is no channel, the sentence stands alone. It says what is true of the plan and stops — it no longer tells a viewer to make contact they have no means of making.

A whole button after the sentence rather than a link spliced into it: the org's two channels (a `mailto:` anchor and the contact-form dialog) already live in `OrgContactButton`, so this reuses them wholesale, and no translated string has to be cut around an `<a>` marker — the pattern `GuestTicketFooter.svelte` avoids on purpose ("latent XSS channel").

## "Really has a channel" is stricter than the usual test

`OrganizationInfo.svelte` gates on `contact_method !== 'none'`. That is looser than what the button actually renders: its `email` branch *also* requires an address, so `contact_method === 'email'` with none on file renders **nothing**. Gating the copy on the method alone would have promised a button that never arrives — the same dead end, one step further along. The predicate here is therefore `(method === 'email' && !!contactEmail) || method === 'form'`.

That combination turns out to be unreachable through the API today: the backend maintains the invariant "non-NONE contact method ⇒ verified email", refusing to enable a method without one and resetting `contact_method` to `NONE` when the contact email changes to an unverified address (`organization_service/contact.py:57`). So this is defence in depth rather than a live bug — but the component would still render the broken promise if the invariant ever moved, and there is a component test pinning it.

## Accessibility

The CTA is named for the organization, not left as a bare "Contact organizer": several plan cards can carry one on a single page and a screen-reader user hears them out of context. The `email` branch already did this (`Email {organizationName}`); the `form` branch had only its visible text.

Rather than renaming that trigger by default — which would rename it on the org and event pages too, where the visible text *is* the name (and where `j01-guest/contact-org.spec.ts` targets it by that name) — `OrgContactButton` gains an opt-in `ariaLabel` prop that only this caller passes.

Mobile-first: `w-full justify-center sm:w-auto`, matching every other CTA on the card. Verified at 375px — the button sits inside the card and the document does not scroll horizontally.

## Prop threading

`MembershipSection` already holds the `OrganizationRetrieveSchema`, so it passes two fields down:

```
MembershipSection  →  TierCard            →  PlanCard
  contact_method       contactMethod?         contactMethod?  (default 'none')
  contact_email        contactEmail?          contactEmail?   (default null)
                                              organizationName (already on TierCard)
```

Two fields rather than the whole org object: that is all these cards render. Both default to the honest no-contact state, so no existing call site changes behaviour.

The offline short-circuit in `PlanCard`'s `action` derived is untouched — it still returns `'offline'` above every gate branch.

## i18n

| key | change |
| --- | --- |
| `membershipPlans.offlineManaged` | **reworded** in en/it/de/fr — the "contact them" instruction is gone |
| `orgContactButton.contactAriaLabel` | **new** in en/it/de/fr — "Contact {organizationName}" |

No key retired. Recompiled with `pnpm paraglide:compile`.

## Verification

- **Component tests** on `PlanCard` for all four states: `form` (dialog trigger, named for the org), `email` **with** an address (mailto anchor, same name), `email` **without** one (sentence only, no button, no link), and `none` (sentence only) — plus a test that the sentence itself never instructs the viewer to make contact. `PlanCard.test.ts` now renders under a real `QueryClientProvider`, since the offline branch mounts a component with a mutation.
- **Smoked** against a throwaway public org with one offline plan, flipping `contact_method` between the three reachable states. Playwright accessibility snapshots:

```yaml
# contact_method: form
- paragraph: Managed manually by the organization.
- button "Contact Offline CTA Smoke …": Contact organizer

# contact_method: email (verified address)
- paragraph: Managed manually by the organization.
- link "Contact Offline CTA Smoke …":
  - /url: mailto:offline-cta-smoke-…@example.com
  - text: Contact organizer

# contact_method: none
- paragraph: Managed manually by the organization.
```

  The throwaway org and its owner were deleted afterwards.
- `make fix` && `make check` green: **0 errors**, 374 warnings (the accepted #361 baseline), type gate armed, i18n and file-length clean.

No E2E in this PR — that decision was deferred deliberately.

Base is `integration/membership-tier-unlock`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ry6Begq3ssvJEasNLQiP
