### PR TITLE
fix(checkout): never default guest_name from email — mirror BE 8b12be6c

### DIFF
--- a/src/lib/components/events/event-checkout-controller.svelte.ts
+++ b/src/lib/components/events/event-checkout-controller.svelte.ts
@@ -68,7 +68,7 @@ export interface CheckoutControllerDeps {
 	// Buyer's name for guest_name defaulting. MUST be name fields only
 	// (getUserRealName), never display_name — that bottoms out at
 	// username = email, which must not be written onto tickets.
-	getUserDisplayName: () => string;
+	getTicketHolderDefaultName: () => string;
 	/** Whether the event demands a holder name on every ticket. */
 	getRequireTicketNames: () => boolean;
 	/** Push a refreshed user status into the host component state. */
@@ -91,7 +91,7 @@ export function createCheckoutController(deps: CheckoutControllerDeps) {
 		eventId,
 		queryClient,
 		getUserTickets,
-		getUserDisplayName,
+		getTicketHolderDefaultName,
 		getRequireTicketNames,
 		setUserStatus,
 		onCloseTicketTierModal,
@@ -308,7 +308,7 @@ export function createCheckoutController(deps: CheckoutControllerDeps) {
 
 	/** Single-ticket fallback when a caller supplied no items (purchase-items.ts). */
 	function defaultTicketItems(): TicketPurchaseItem[] {
-		return defaultPurchaseItems(getRequireTicketNames(), getUserDisplayName());
+		return defaultPurchaseItems(getRequireTicketNames(), getTicketHolderDefaultName());
 	}
 
 	/**

--- a/src/lib/components/events/event-checkout-controller.svelte.ts
+++ b/src/lib/components/events/event-checkout-controller.svelte.ts
@@ -65,7 +65,9 @@ export interface CheckoutControllerDeps {
 	queryClient: QueryClient;
 	/** Current user's tickets (used to locate a pending payment to resume). */
 	getUserTickets: () => EventTicketSchemaActual[];
-	/** Logged-in user's display name (fallback for guest_name). */
+	// Buyer's name for guest_name defaulting. MUST be name fields only
+	// (getUserRealName), never display_name — that bottoms out at
+	// username = email, which must not be written onto tickets.
 	getUserDisplayName: () => string;
 	/** Whether the event demands a holder name on every ticket. */
 	getRequireTicketNames: () => boolean;

--- a/src/lib/utils/user-display.test.ts
+++ b/src/lib/utils/user-display.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { getUserDisplayName, getUserRealName } from './user-display';
+
+const base = { preferred_name: '', first_name: '', last_name: '', email: 'ann@example.com' };
+
+describe('getUserRealName', () => {
+	it('prefers the preferred name', () => {
+		expect(getUserRealName({ ...base, preferred_name: 'Annie', first_name: 'Ann' })).toBe('Annie');
+	});
+
+	it('falls back to first + last name', () => {
+		expect(getUserRealName({ ...base, first_name: 'Ann', last_name: 'Attendee' })).toBe(
+			'Ann Attendee'
+		);
+	});
+
+	it('falls back to first name alone', () => {
+		expect(getUserRealName({ ...base, first_name: 'Ann' })).toBe('Ann');
+	});
+
+	it('never falls back to email — returns empty for a nameless user', () => {
+		expect(getUserRealName(base)).toBe('');
+	});
+
+	it('stays empty when only null-ish fields are present', () => {
+		expect(getUserRealName({ preferred_name: null, first_name: null, last_name: null })).toBe('');
+	});
+});
+
+describe('getUserDisplayName', () => {
+	it('still bottoms out at email for pure display purposes', () => {
+		expect(getUserDisplayName(base)).toBe('ann@example.com');
+	});
+});

--- a/src/lib/utils/user-display.test.ts
+++ b/src/lib/utils/user-display.test.ts
@@ -25,6 +25,15 @@ describe('getUserRealName', () => {
 	it('stays empty when only null-ish fields are present', () => {
 		expect(getUserRealName({ preferred_name: null, first_name: null, last_name: null })).toBe('');
 	});
+
+	it('treats whitespace-only fields as empty and trims composites', () => {
+		expect(getUserRealName({ ...base, preferred_name: '   ' })).toBe('');
+		expect(getUserRealName({ ...base, preferred_name: '  Annie  ' })).toBe('Annie');
+		expect(getUserRealName({ ...base, first_name: ' Ann ', last_name: ' Attendee ' })).toBe(
+			'Ann Attendee'
+		);
+		expect(getUserRealName({ ...base, first_name: '   ', last_name: 'Attendee' })).toBe('');
+	});
 });
 
 describe('getUserDisplayName', () => {

--- a/src/lib/utils/user-display.ts
+++ b/src/lib/utils/user-display.ts
@@ -39,8 +39,10 @@ export function getUserEmail(user: UserDisplayInfo): string | undefined {
  * placeholder.
  */
 export function getUserRealName(user: UserDisplayInfo): string {
-	if (user.preferred_name) return user.preferred_name;
-	if (user.first_name && user.last_name) return `${user.first_name} ${user.last_name}`;
-	if (user.first_name) return user.first_name;
-	return '';
+	const preferred = user.preferred_name?.trim();
+	if (preferred) return preferred;
+	const first = user.first_name?.trim();
+	const last = user.last_name?.trim();
+	if (first && last) return `${first} ${last}`;
+	return first || '';
 }

--- a/src/lib/utils/user-display.ts
+++ b/src/lib/utils/user-display.ts
@@ -28,3 +28,19 @@ export function getUserDisplayName(user: UserDisplayInfo, fallback = 'Unknown Us
 export function getUserEmail(user: UserDisplayInfo): string | undefined {
 	return user.email ?? undefined;
 }
+
+/**
+ * Name-fields-only variant for values that get WRITTEN somewhere (ticket
+ * holder names, payment descriptions): preferred_name > first+last > first,
+ * else ''. Never falls back to email/username — registration sets
+ * username = email for every account, so an email fallback would stamp the
+ * buyer's address onto tickets and invoices (the leak BE 8b12be6c fixed
+ * server-side). Callers needing a non-empty value supply their own
+ * placeholder.
+ */
+export function getUserRealName(user: UserDisplayInfo): string {
+	if (user.preferred_name) return user.preferred_name;
+	if (user.first_name && user.last_name) return `${user.first_name} ${user.last_name}`;
+	if (user.first_name) return user.first_name;
+	return '';
+}

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -236,7 +236,7 @@
 		eventId: event.id,
 		queryClient,
 		getUserTickets: () => userTickets,
-		getUserDisplayName: () => ticketHolderDefaultName,
+		getTicketHolderDefaultName: () => ticketHolderDefaultName,
 		getRequireTicketNames: () => event.require_ticket_names,
 		setUserStatus: (status) => {
 			userStatus = status;

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -42,6 +42,7 @@
 	import type { TierRemainingTicketsSchema } from '$lib/api/generated/types.gen';
 	import { getPotluckPermissions } from '$lib/utils/permissions';
 	import { formatEventLocation } from '$lib/utils/event';
+	import { getUserRealName } from '$lib/utils/user-display';
 	import { formatDateTime } from '$lib/utils/date';
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
@@ -139,8 +140,10 @@
 		return undefined;
 	});
 
-	// Get user's display name for ticket purchase forms
-	const userDisplayName = $derived(authStore.user?.display_name ?? '');
+	// Holder-name default for ticket purchase forms. Name fields only — the
+	// backend's display_name bottoms out at username (= email), which must
+	// never be written into guest_name (BE 8b12be6c).
+	const ticketHolderDefaultName = $derived(authStore.user ? getUserRealName(authStore.user) : '');
 
 	// Active waitlist offer (eligibility-shaped userStatus with allowed=true + expiry)
 	const activeOfferExpiresAt = $derived.by((): string | null => {
@@ -233,7 +236,7 @@
 		eventId: event.id,
 		queryClient,
 		getUserTickets: () => userTickets,
-		getUserDisplayName: () => userDisplayName,
+		getUserDisplayName: () => ticketHolderDefaultName,
 		getRequireTicketNames: () => event.require_ticket_names,
 		setUserStatus: (status) => {
 			userStatus = status;
@@ -619,7 +622,7 @@
 	timezone={event.timezone}
 	capacityDisclosed={viewerVisibility.show_capacity}
 	eventMaxTicketsPerUser={event.max_tickets_per_user}
-	userName={userDisplayName}
+	userName={ticketHolderDefaultName}
 	requireTicketNames={event.require_ticket_names}
 	{preSelectedTier}
 	{initialDiscountCode}


### PR DESCRIPTION
## Summary

Follow-up to #754, prompted by the late backend change in letsrevel/revel-backend#847 (commit `8b12be6c`): the backend's holder-name fallback no longer bottoms out at username/email. This PR closes the same leak on the frontend side.

**The problem:** on events that *require* ticket names, the hidden single-ticket default (and the holder-name input prefill) fed `authStore.user.display_name` into `guest_name`. Backend `display_name` bottoms out at `username`, and registration sets `username = email` — so a buyer with no name fields set would get their **email** stamped onto the ticket, Stripe description, and invoice. Exactly the class of leak `8b12be6c` fixed server-side for the flag-off path.

**The fix:**
- New `getUserRealName()` in `user-display.ts`: name fields only (`preferred_name` → first+last → first → `''`), never email. Unit-tested, including the "nameless user returns empty" case. `getUserDisplayName()` is unchanged for pure display purposes.
- The event page now feeds `getUserRealName(authStore.user)` into both the checkout controller dep and the `TicketTierModal` `userName` prop. For a nameless buyer the flag-on default therefore falls through to the localized "Guest" placeholder instead of their email.
- Flag-off behavior is untouched: no `guest_name` is sent at all (backend applies its own safe fallback, which may now be blank).

Blank holder names (now a normal state for any registered buyer without name fields, per the BE change) already render gracefully everywhere — my-tickets, admin table, and check-in all fall back to purchaser identity via the hardened `getGuestNameIfDifferent`, and the owner modal offers "Add holder name". No API contract change; no regen.

## Tests

- New `user-display.test.ts` (6 tests) pinning the never-email guarantee.
- `make check` fully green; ticket-surface suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket purchase forms now use the attendee’s actual name by default, avoiding email usernames being saved as guest names.
  * Improved handling for users with preferred names, full names, first names, or no available name information.

* **Tests**
  * Added coverage for name selection, fallbacks, and nameless users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->