### PR TITLE
fix(ticket-admin): rename-holder Save never enables — dead $page.data.user token source (#757)

### DIFF
--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.svelte
@@ -34,6 +34,7 @@
 		type CheckInDialogTicket
 	} from '$lib/components/tickets/checkin-adapter';
 	import { createTicketMemberAdmin } from '$lib/components/tickets/ticket-member-admin.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import QRScannerModal from '$lib/components/tickets/QRScannerModal.svelte';
 	import CheckInDialog from '$lib/components/tickets/CheckInDialog.svelte';
@@ -74,7 +75,7 @@
 	// Membership + blacklist admin actions (state, mutations, handlers).
 	const memberAdmin = createTicketMemberAdmin({
 		getSlug: () => data.event.organization.slug,
-		getAccessToken: () => $page.data.user?.accessToken
+		getAccessToken: () => authStore.accessToken
 	});
 
 	// Unconfirm payment confirmation state
@@ -110,7 +111,7 @@
 			const response = await eventadminticketsConfirmTicketPayment({
 				path: { event_id: data.event.id, ticket_id: ticketId },
 				body: pricePaid ? { price_paid: pricePaid } : undefined,
-				headers: { Authorization: `Bearer ${$page.data.user?.accessToken}` }
+				headers: { Authorization: `Bearer ${authStore.accessToken}` }
 			});
 
 			if (response.error) {
@@ -134,7 +135,7 @@
 		mutationFn: async (ticketId: string) => {
 			const response = await eventadminticketsUnconfirmTicketPayment({
 				path: { event_id: data.event.id, ticket_id: ticketId },
-				headers: { Authorization: `Bearer ${$page.data.user?.accessToken}` }
+				headers: { Authorization: `Bearer ${authStore.accessToken}` }
 			});
 
 			if (response.error) {
@@ -161,7 +162,7 @@
 		mutationFn: async (ticketId: string) => {
 			const response = await eventadminticketsCancelTicket({
 				path: { event_id: data.event.id, ticket_id: ticketId },
-				headers: { Authorization: `Bearer ${$page.data.user?.accessToken}` }
+				headers: { Authorization: `Bearer ${authStore.accessToken}` }
 			});
 
 			if (response.error) {
@@ -187,7 +188,7 @@
 			const response = await eventadminticketsCheckInTicket({
 				path: { event_id: data.event.id, code },
 				body: pricePaid ? { price_paid: pricePaid } : undefined,
-				headers: { Authorization: `Bearer ${$page.data.user?.accessToken}` }
+				headers: { Authorization: `Bearer ${authStore.accessToken}` }
 			});
 
 			if (response.error) {
@@ -401,7 +402,7 @@
 			// Fetch ticket details
 			const response = await eventadminticketsGetTicket({
 				path: { event_id: data.event.id, ticket_id: code },
-				headers: { Authorization: `Bearer ${$page.data.user?.accessToken}` }
+				headers: { Authorization: `Bearer ${authStore.accessToken}` }
 			});
 
 			if (response.error || !response.data) {
@@ -436,7 +437,7 @@
 	async function handleExportAttendees(): Promise<string> {
 		const response = await eventadminticketsExportAttendees({
 			path: { event_id: data.event.id },
-			headers: { Authorization: `Bearer ${$page.data.user?.accessToken}` }
+			headers: { Authorization: `Bearer ${authStore.accessToken}` }
 		});
 		if (response.error || !response.data?.id) {
 			throw new Error('Export failed');
@@ -502,7 +503,7 @@
 				<ExportButton
 					label={m['exportButton.exportAttendees']()}
 					onExport={handleExportAttendees}
-					accessToken={$page.data.user?.accessToken ?? null}
+					accessToken={authStore.accessToken}
 				/>
 			</div>
 		</div>
@@ -683,7 +684,7 @@
 	open={showReseatDialog}
 	ticket={ticketToReseat}
 	eventId={data.event.id}
-	accessToken={$page.data.user?.accessToken ?? null}
+	accessToken={authStore.accessToken}
 	onClose={() => {
 		showReseatDialog = false;
 		ticketToReseat = null;
@@ -698,7 +699,7 @@
 		ticketId={ticketToRename.id}
 		eventId={data.event.id}
 		currentName={ticketToRename.guest_name?.trim() ?? ''}
-		accessToken={$page.data.user?.accessToken ?? null}
+		accessToken={authStore.accessToken}
 		onClose={() => {
 			showRenameDialog = false;
 			ticketToRename = null;


### PR DESCRIPTION
## Root cause

The admin tickets page read the bearer token from `$page.data.user?.accessToken` — a source that is **never populated**: no load function anywhere returns `user` into page data, and the root layout deliberately keeps tokens out of the SSR payload (they live only in the client-side in-memory `authStore`). It only type-checked because SvelteKit types `page.data` loosely.

The dead read was invisible until now because all consumers passed the token as an `Authorization` header, which the API client's request interceptor overwrites with the real in-memory token on every request — so `Bearer undefined` was silently repaired. The #754 wave added the first consumers that **gate UI** on the token value:

- `RenameTicketHolderDialog` — `disabled={isPending || !accessToken}` plus an early return in `submit()` → Save permanently disabled, zero network calls (the exact #757 symptom)
- `ExportButton` on the same page — same `!accessToken` gate, so Export attendees was also silently broken there (the attendees and questionnaires pages already used `authStore` correctly)

## Fix

One file: the tickets admin page now sources the token from `authStore.accessToken` (the established pattern in `MyTicketModal` and the attendees page) at all ten former `$page.data.user` sites — the two gated consumers plus the header-only mutations. Those were the only ten occurrences of `$page.data.user` in the codebase, so the trap is gone entirely.

## Verification

- Reproduced the deterministic E2E red pre-fix (`rename-holder.spec.ts`, overlay-blocked Save)
- Post-fix: `rename-holder.spec.ts` green on chromium + mobile-chrome, first attempt
- Full `j10-event-admin` directory: **42/42 passed** (check-in, cancel, payments, tiers, waitlist, seat overrides all exercise the changed token paths)
- `make check` fully green; dialog unit tests 6/6 (the component itself was never the bug)

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for ticket management actions, including ticket updates, lookups, exports, reseating, and renaming ticket holders.
  * Resolved authorization issues that could prevent these actions from completing successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->