### PR TITLE
fix(deps): bump transitive undici to 7.29.0 (GHSA-4cwx-7wf7-3272)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2855,8 +2855,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unplugin@2.3.11:
@@ -4692,7 +4692,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5505,7 +5505,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unplugin@2.3.11:
     dependencies:


### PR DESCRIPTION
## Summary

The `pnpm audit (prod, high+)` gate started failing today on every PR (including release PR #761 and the dependabot minor/patch batch) due to a new high-severity advisory against transitive `undici`:

- **GHSA-4cwx-7wf7-3272** — undici cross-user information disclosure and parse-time crash via degenerate private cache directives (vulnerable `>=7.0.0 <7.29.0`, patched `>=7.29.0`)
- Path: `isomorphic-dompurify > jsdom > undici@7.28.0`

Lockfile-only change: `pnpm update undici` → `undici@7.29.0` (within jsdom's existing range; no manifest or override needed).

## Verification

- `pnpm audit --prod --audit-level=high` exits 0 locally (remaining: 1 low, 1 moderate — below the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
