### PR TITLE
feat(rebrand): foundations — tokens, tone system, six shared primitives (PR 1/10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1045,6 +1045,46 @@ Source PDF: `Revel_Digital-Styleguide.pdf` at this repo's root (**local-only, gi
 - **Fonts:** Nata Sans is the main brand font, universal on web and social; all weights in the family are allowed. **BBH Bartle** (open-source Google Font) is the additional display face **for social-media designs only** — do not ship it in the app. Both upper- and lowercase allowed, tracking 0.
 - **Picture style:** DO — colourful, warm image language; closeness and a sense of community; "real"-looking portraits. DON'T — classic stock imagery, people who read as actors/models, cold or distanced shots, corporate casual. (The landing page deliberately uses no photography; these rules bind social assets, OG images, and any future photo use.)
 
+### Rebrand volumes & shared primitives (2026-08 platform rebrand)
+
+The poster language extends app-wide at three volumes (master spec:
+`docs/superpowers/specs/2026-08-04-platform-rebrand-design.md`, local-only):
+
+- **Poster** (landing only): color-block panels, diagonal cuts, stickers. Frozen.
+- **Celebration** (public discovery, auth, error pages, user dashboard, ALL empty
+  states): display typography + kickers + sparing `Sticker` accents. Surfaces stay
+  on theme tokens; only decorative accents keep the fixed poster palette
+  (**imagery rule** — identical in dark mode, like the landing panels).
+- **Studio** (admin, dense forms/tables): heavy typography + tone tokens only.
+  No tilts, no cuts, no stickers — except empty states, which stay warm everywhere.
+
+**Shared primitives** (always prefer these over hand-rolled equivalents):
+`common/PageHeader` (page h1: kicker/title/subtitle/actions, `volume` prop),
+`common/SectionHeader`, `common/EmptyState` (poster-tinted tilted chip),
+`common/StatusBadge` (solid, tone-mapped — wrap domain enums in thin mappers),
+`common/ToneTile` (soft icon tile), `brand/Sticker` (celebration only, rotation
+clamped [-3, 3]). Tone vocabulary: `common/tones.ts` (`brand | info | success |
+warning | danger | neutral`).
+
+**Typography scale** (encoded in the primitives; use the same classes when
+composing manually):
+
+| Role | Classes |
+| --- | --- |
+| Display title (celebration h1) | `text-3xl font-black leading-[1.12] sm:text-4xl` |
+| Studio title (admin h1) | `text-2xl font-extrabold tracking-tight sm:text-3xl` |
+| Kicker | `text-sm font-extrabold uppercase tracking-[0.12em]` (`text-xs` in dense admin) |
+| Section heading | celebration `text-xl font-extrabold` · studio `text-lg font-bold` |
+| Card title | `font-bold` |
+
+**Raw-hue sweep rule:** in any file you touch, replace raw Tailwind palette color
+utilities (`bg-blue-50`, `text-emerald-600`, `dark:bg-indigo-950`, ...) with
+semantic tokens / `StatusBadge` / `ToneTile`. Exemptions: JS color objects for
+QR/canvas libraries, user-configurable data colors (e.g. seat categories), and
+`--brand-telegram`. New tokens `--success`/`--info` and the first-class
+`poster.*` Tailwind colors (`bg-poster-amber`, ...) exist for this. Never
+introduce new raw palette hues.
+
 ### Theme rules
 
 - **Use tokens, never raw hexes** in components (`bg-primary`, `text-muted-foreground`, …). Palette hexes appear only in `app.css`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1064,7 +1064,12 @@ The poster language extends app-wide at three volumes (master spec:
 `common/StatusBadge` (solid, tone-mapped — wrap domain enums in thin mappers),
 `common/ToneTile` (soft icon tile), `brand/Sticker` (celebration only, rotation
 clamped [-3, 3]). Tone vocabulary: `common/tones.ts` (`brand | info | success |
-warning | danger | neutral`).
+warning | danger | neutral`). `StatusBadge` is solid-fill only by design (audit-
+enforced pairs; no soft variant) — sizes `sm | md | lg`. `ToneTile`'s `tone` axis
+is semantic only; the admin quick-actions identity-color grid gets an additive
+poster-tint axis when PR 7 lands — don't overload `tone` for identity.
+`PageHeader`'s `decoration` slot is aria-hidden ornament only — status text
+goes through `actions` or `StatusBadge`, never `decoration`.
 
 **Typography scale** (encoded in the primitives; use the same classes when
 composing manually):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1081,7 +1081,7 @@ composing manually):
 utilities (`bg-blue-50`, `text-emerald-600`, `dark:bg-indigo-950`, ...) with
 semantic tokens / `StatusBadge` / `ToneTile`. Exemptions: JS color objects for
 QR/canvas libraries, user-configurable data colors (e.g. seat categories), and
-`--brand-telegram`. New tokens `--success`/`--info` and the first-class
+the `--brand-telegram`/`--brand-telegram-text` pair. New tokens `--success`/`--info` and the first-class
 `poster.*` Tailwind colors (`bg-poster-amber`, ...) exist for this. Never
 introduce new raw palette hues.
 

--- a/scripts/audit-brand-themes.py
+++ b/scripts/audit-brand-themes.py
@@ -117,6 +117,12 @@ TEXT_PAIRS = [  # (fg, bg, min_ratio, note)
     ("accent-foreground", "accent", 4.5, "accent label"),
     ("highlight-foreground", "highlight", 4.5, "highlight label"),
     ("destructive-foreground", "destructive", 4.5, "destructive label"),
+    ("success-foreground", "success", 4.5, "success badge label"),
+    ("info-foreground", "info", 4.5, "info badge label"),
+    ("success", "background", 3.0, "success as icon/accent on page"),
+    ("success", "card", 3.0, "success as icon/accent on card"),
+    ("info", "background", 3.0, "info as icon/accent on page"),
+    ("info", "card", 3.0, "info as icon/accent on card"),
     ("primary", "background", 3.0, "primary as text-primary/link on page"),
     ("primary", "card", 3.0, "primary on card"),
     ("ring", "background", 3.0, "focus ring visibility"),
@@ -132,7 +138,7 @@ TEXT_PAIRS = [  # (fg, bg, min_ratio, note)
     ("poster-crimson-deep", "poster-white", 4.5, "sticker text on white sticker"),
 ]
 
-SEMANTIC = ["primary", "secondary", "accent", "destructive", "highlight"]
+SEMANTIC = ["primary", "secondary", "accent", "destructive", "highlight", "success", "info"]
 
 failures = 0
 confusables = 0

--- a/src/app.css
+++ b/src/app.css
@@ -42,6 +42,16 @@
 		--highlight-foreground: 30 55% 12%;
 		--destructive: 350 78% 30%; /* maroon, never brand crimson */
 		--destructive-foreground: 0 0% 100%;
+		/* Rebrand additions (2026-08 platform rebrand): success/info join the
+		   semantic set — values tuned so audit-brand-themes.py passes both the
+		   AA pairs and the color-blind (lightness) separation. */
+		--success: 145 65% 28%; /* confirmations; deep green, white label */
+		--success-foreground: 0 0% 100%;
+		--info: 226 70% 32%; /* informational; periwinkle family, deepened for AA */
+		--info-foreground: 0 0% 100%;
+		/* Third-party brand identity (Telegram #0088cc) — centralized so the
+		   literal appears once; deliberately NOT part of the semantic audit. */
+		--brand-telegram: 200 100% 40%;
 		--border: 268 35% 84%;
 		--input: 268 35% 84%;
 		--ring: 270 70% 48%;
@@ -83,6 +93,10 @@
 		--highlight-foreground: 30 60% 10%;
 		--destructive: 0 70% 45%;
 		--destructive-foreground: 0 0% 100%;
+		--success: 145 55% 65%; /* glow green, ink label — mirrors the dark primary pattern */
+		--success-foreground: 173 40% 8%;
+		--info: 226 100% 82%; /* periwinkle glow, ink label */
+		--info-foreground: 173 40% 8%;
 		--border: 270 25% 20%;
 		--input: 270 25% 20%;
 		--ring: 268 60% 72%;

--- a/src/app.css
+++ b/src/app.css
@@ -49,9 +49,10 @@
 		--success-foreground: 0 0% 100%;
 		--info: 226 70% 32%; /* informational; periwinkle family, deepened for AA */
 		--info-foreground: 0 0% 100%;
-		/* Third-party brand identity (Telegram #0088cc) — centralized so the
-		   literal appears once; deliberately NOT part of the semantic audit. */
-		--brand-telegram: 200 100% 40%;
+		/* Third-party brand identity (Telegram, reference #0088cc) — centralized so
+		   the literal appears once; deliberately NOT part of the semantic audit. */
+		--brand-telegram: 200 100% 33%; /* fill: white labels measure ~5.4:1 (hand-verified; audit-exempt) — deliberately darker than Telegram's #0088cc so text-sm white labels pass AA in both modes (fill is NOT redefined in .dark) */
+		--brand-telegram-text: 200 100% 33%; /* text-on-surface: ~4.9:1 on --background, ~5.4:1 on card (hand-verified) */
 		--border: 268 35% 84%;
 		--input: 268 35% 84%;
 		--ring: 270 70% 48%;
@@ -100,6 +101,7 @@
 		--border: 270 25% 20%;
 		--input: 270 25% 20%;
 		--ring: 268 60% 72%;
+		--brand-telegram-text: 200 85% 60%; /* ~8.0:1 on dark background, ~6.7:1 on dark popover (hand-verified) */
 	}
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -52,7 +52,7 @@
 		/* Third-party brand identity (Telegram, reference #0088cc) — centralized so
 		   the literal appears once; deliberately NOT part of the semantic audit. */
 		--brand-telegram: 200 100% 33%; /* fill: white labels measure ~5.4:1 (hand-verified; audit-exempt) — deliberately darker than Telegram's #0088cc so text-sm white labels pass AA in both modes (fill is NOT redefined in .dark) */
-		--brand-telegram-text: 200 100% 33%; /* text-on-surface: ~4.9:1 on --background, ~5.4:1 on card (hand-verified) */
+		--brand-telegram-text: 200 100% 33%; /* text-on-surface: 4.8:1 on --background, 5.4:1 on card (hand-verified) */
 		--border: 268 35% 84%;
 		--input: 268 35% 84%;
 		--ring: 270 70% 48%;
@@ -101,7 +101,7 @@
 		--border: 270 25% 20%;
 		--input: 270 25% 20%;
 		--ring: 268 60% 72%;
-		--brand-telegram-text: 200 85% 60%; /* ~8.0:1 on dark background, ~6.7:1 on dark popover (hand-verified) */
+		--brand-telegram-text: 200 85% 60%; /* 8.0:1 on dark background, 7.3:1 on dark popover (hand-verified) */
 	}
 }
 

--- a/src/lib/components/brand/Sticker.svelte
+++ b/src/lib/components/brand/Sticker.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * App-facing twin of landing/poster/PosterSticker.svelte (kept separate on
+	 * purpose: the landing is frozen and owns its marker classes). Same look:
+	 * white sticker with brand-tinted text, ink variant inverts. Fixed poster
+	 * palette in BOTH modes (imagery rule) — text/tint pairs are audited token
+	 * pairs ("sticker text on white sticker") in audit-brand-themes.py.
+	 */
+	interface Props {
+		/** Text color on the white sticker; 'ink' inverts to ink bg + white text. */
+		tint?: 'purple' | 'crimson' | 'ink';
+		/** Degrees, clamped to [-3, 3] (tilt discipline, see rebrand spec). */
+		rotate?: number;
+		class?: string;
+		children: Snippet;
+	}
+	const { tint = 'purple', rotate = -2, class: className = '', children }: Props = $props();
+	const clamped = $derived(Math.max(-3, Math.min(3, rotate)));
+</script>
+
+<span
+	class="inline-block rounded-[0.55em] px-[0.55em] py-[0.18em] font-extrabold shadow-[0_4px_12px_hsl(var(--poster-ink)/0.25)]
+		{tint === 'ink' ? 'bg-poster-ink text-poster-white' : 'bg-poster-white'}
+		{tint === 'purple' ? 'text-poster-purple' : ''}
+		{tint === 'crimson' ? 'text-poster-crimson-deep' : ''}
+		{className}"
+	style="transform: rotate({clamped}deg)"
+>
+	{@render children()}
+</span>

--- a/src/lib/components/brand/Sticker.svelte
+++ b/src/lib/components/brand/Sticker.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { cn } from '$lib/utils';
 
 	/**
 	 * App-facing twin of landing/poster/PosterSticker.svelte (kept separate on
@@ -21,11 +22,13 @@
 </script>
 
 <span
-	class="inline-block rounded-[0.55em] px-[0.55em] py-[0.18em] font-extrabold shadow-[0_4px_12px_hsl(var(--poster-ink)/0.25)]
-		{tint === 'ink' ? 'bg-poster-ink text-poster-white' : 'bg-poster-white'}
-		{tint === 'purple' ? 'text-poster-purple' : ''}
-		{tint === 'crimson' ? 'text-poster-crimson-deep' : ''}
-		{className}"
+	class={cn(
+		'inline-block rounded-[0.55em] px-[0.55em] py-[0.18em] font-extrabold shadow-[0_4px_12px_hsl(var(--poster-ink)/0.25)]',
+		tint === 'ink' ? 'bg-poster-ink text-poster-white' : 'bg-poster-white',
+		tint === 'purple' && 'text-poster-purple',
+		tint === 'crimson' && 'text-poster-crimson-deep',
+		className
+	)}
 	style="transform: rotate({clamped}deg)"
 >
 	{@render children()}

--- a/src/lib/components/brand/Sticker.test.ts
+++ b/src/lib/components/brand/Sticker.test.ts
@@ -17,6 +17,12 @@ describe('Sticker', () => {
 		expect(el.style.transform).toBe('rotate(3deg)');
 	});
 
+	it('clamps rotation at the lower bound', () => {
+		const { container } = render(Sticker, { props: { rotate: -45, children: text('x') } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.style.transform).toBe('rotate(-3deg)');
+	});
+
 	it('ink tint inverts to ink background with white text', () => {
 		const { container } = render(Sticker, { props: { tint: 'ink', children: text('Live') } });
 		const el = container.querySelector('span') as HTMLElement;

--- a/src/lib/components/brand/Sticker.test.ts
+++ b/src/lib/components/brand/Sticker.test.ts
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import Sticker from './Sticker.svelte';
+
+const text = (s: string) => createRawSnippet(() => ({ render: () => `<span>${s}</span>` }));
+
+describe('Sticker', () => {
+	it('renders its content', () => {
+		render(Sticker, { props: { children: text('Sold out') } });
+		expect(screen.getByText('Sold out')).toBeInTheDocument();
+	});
+
+	it('clamps rotation to [-3, 3]', () => {
+		const { container } = render(Sticker, { props: { rotate: 45, children: text('x') } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.style.transform).toBe('rotate(3deg)');
+	});
+
+	it('ink tint inverts to ink background with white text', () => {
+		const { container } = render(Sticker, { props: { tint: 'ink', children: text('Live') } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('bg-poster-ink');
+		expect(el.className).toContain('text-poster-white');
+	});
+
+	it('default tint is purple text on a white sticker', () => {
+		const { container } = render(Sticker, { props: { children: text('New') } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('bg-poster-white');
+		expect(el.className).toContain('text-poster-purple');
+	});
+});

--- a/src/lib/components/common/EmptyState.svelte
+++ b/src/lib/components/common/EmptyState.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import type { Component, Snippet } from 'svelte';
+	import type { Tone } from './tones';
+
+	interface Props {
+		icon: Component;
+		/** Already-translated strings — i18n stays at the call site. */
+		title: string;
+		body?: string;
+		tone?: Exclude<Tone, 'danger'>;
+		action?: Snippet;
+		class?: string;
+	}
+	const { icon: Icon, title, body, tone = 'brand', action, class: className = '' }: Props = $props();
+
+	// Imagery rule: the chip is decorative art, so it keeps the FIXED poster
+	// palette in both modes (like the landing's stickers). Every solid pair
+	// below is an audited token pair in audit-brand-themes.py (poster section),
+	// except success, which has no poster hue and uses the theme success pair
+	// (also audited, flips in dark).
+	const chipClasses: Record<Exclude<Tone, 'danger'>, string> = {
+		brand: 'bg-poster-purple text-poster-white',
+		info: 'bg-poster-periwinkle text-poster-ink',
+		warning: 'bg-poster-amber text-poster-ink',
+		neutral: 'bg-poster-paper text-poster-ink',
+		success: 'bg-success text-success-foreground'
+	};
+</script>
+
+<div
+	class="flex flex-col items-center rounded-lg border bg-card px-6 py-10 text-center {className}"
+>
+	<span
+		aria-hidden="true"
+		class="flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl shadow-sm {chipClasses[
+			tone
+		]}"
+	>
+		<Icon class="h-7 w-7" />
+	</span>
+	<h3 class="mt-4 text-lg font-extrabold">{title}</h3>
+	{#if body}
+		<p class="mt-1.5 max-w-sm text-sm text-muted-foreground">{body}</p>
+	{/if}
+	{#if action}
+		<div class="mt-5 flex flex-wrap justify-center gap-2">{@render action()}</div>
+	{/if}
+</div>

--- a/src/lib/components/common/EmptyState.svelte
+++ b/src/lib/components/common/EmptyState.svelte
@@ -11,7 +11,14 @@
 		action?: Snippet;
 		class?: string;
 	}
-	const { icon: Icon, title, body, tone = 'brand', action, class: className = '' }: Props = $props();
+	const {
+		icon: Icon,
+		title,
+		body,
+		tone = 'brand',
+		action,
+		class: className = ''
+	}: Props = $props();
 
 	// Imagery rule: the chip is decorative art, so it keeps the FIXED poster
 	// palette in both modes (like the landing's stickers). Every solid pair

--- a/src/lib/components/common/EmptyState.svelte
+++ b/src/lib/components/common/EmptyState.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Component, Snippet } from 'svelte';
+	import { cn } from '$lib/utils';
 	import type { Tone } from './tones';
 
 	interface Props {
@@ -8,6 +9,8 @@
 		title: string;
 		body?: string;
 		tone?: Exclude<Tone, 'danger'>;
+		/** Heading level for the title; use 2 on pages whose only heading is this one. */
+		level?: 2 | 3;
 		action?: Snippet;
 		class?: string;
 	}
@@ -16,6 +19,7 @@
 		title,
 		body,
 		tone = 'brand',
+		level = 3,
 		action,
 		class: className = ''
 	}: Props = $props();
@@ -32,20 +36,30 @@
 		neutral: 'bg-poster-paper text-poster-ink',
 		success: 'bg-success text-success-foreground'
 	};
+
+	const headingClass = 'mt-4 text-lg font-extrabold';
 </script>
 
 <div
-	class="flex flex-col items-center rounded-lg border bg-card px-6 py-10 text-center {className}"
+	class={cn(
+		'flex flex-col items-center rounded-lg border bg-card px-6 py-10 text-center',
+		className
+	)}
 >
 	<span
 		aria-hidden="true"
-		class="flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl shadow-sm {chipClasses[
-			tone
-		]}"
+		class={cn(
+			'flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl shadow-sm',
+			chipClasses[tone]
+		)}
 	>
 		<Icon class="h-7 w-7" />
 	</span>
-	<h3 class="mt-4 text-lg font-extrabold">{title}</h3>
+	{#if level === 2}
+		<h2 class={headingClass}>{title}</h2>
+	{:else}
+		<h3 class={headingClass}>{title}</h3>
+	{/if}
 	{#if body}
 		<p class="mt-1.5 max-w-sm text-sm text-muted-foreground">{body}</p>
 	{/if}

--- a/src/lib/components/common/EmptyState.test.ts
+++ b/src/lib/components/common/EmptyState.test.ts
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import { CalendarX } from '@lucide/svelte';
+import EmptyState from './EmptyState.svelte';
+
+const snip = (s: string) => createRawSnippet(() => ({ render: () => `<span>${s}</span>` }));
+
+describe('EmptyState', () => {
+	it('renders title as a heading and the body', () => {
+		render(EmptyState, {
+			props: { icon: CalendarX, title: 'No events yet', body: 'Create your first one.' }
+		});
+		expect(screen.getByRole('heading', { level: 3, name: 'No events yet' })).toBeInTheDocument();
+		expect(screen.getByText('Create your first one.')).toBeInTheDocument();
+	});
+
+	it('the icon chip is decorative (aria-hidden) and tilted', () => {
+		const { container } = render(EmptyState, { props: { icon: CalendarX, title: 'Empty' } });
+		const chip = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+		expect(chip).not.toBeNull();
+		expect(chip.className).toContain('-rotate-2');
+	});
+
+	it('brand tone (default) uses the fixed poster palette (imagery rule)', () => {
+		const { container } = render(EmptyState, { props: { icon: CalendarX, title: 'Empty' } });
+		const chip = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+		expect(chip.className).toContain('bg-poster-purple');
+		expect(chip.className).toContain('text-poster-white');
+	});
+
+	it('renders an action snippet', () => {
+		render(EmptyState, {
+			props: { icon: CalendarX, title: 'Empty', action: snip('Create event') }
+		});
+		expect(screen.getByText('Create event')).toBeInTheDocument();
+	});
+});

--- a/src/lib/components/common/EmptyState.test.ts
+++ b/src/lib/components/common/EmptyState.test.ts
@@ -35,4 +35,11 @@ describe('EmptyState', () => {
 		});
 		expect(screen.getByText('Create event')).toBeInTheDocument();
 	});
+
+	it('renders an h2 when level=2', () => {
+		render(EmptyState, {
+			props: { icon: CalendarX, title: 'No events yet', level: 2 }
+		});
+		expect(screen.getByRole('heading', { level: 2, name: 'No events yet' })).toBeInTheDocument();
+	});
 });

--- a/src/lib/components/common/PageHeader.svelte
+++ b/src/lib/components/common/PageHeader.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		/** Already-translated strings — i18n stays at the call site. */
+		title: string;
+		kicker?: string;
+		subtitle?: string;
+		/** 'celebration' = display scale (public/user surfaces); 'studio' = admin/dense. */
+		volume?: 'celebration' | 'studio';
+		/** Right-aligned on sm+, wraps under the title on mobile. */
+		actions?: Snippet;
+		/** Celebration-only decorative slot (e.g. a brand Sticker). Ignored in studio. */
+		decoration?: Snippet;
+		class?: string;
+	}
+	const {
+		title,
+		kicker,
+		subtitle,
+		volume = 'studio',
+		actions,
+		decoration,
+		class: className = ''
+	}: Props = $props();
+</script>
+
+<header class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between {className}">
+	<div class="min-w-0">
+		{#if kicker}
+			<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">{kicker}</p>
+		{/if}
+		<div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+			<h1
+				class="mt-1 {volume === 'celebration'
+					? 'text-3xl font-black leading-[1.12] sm:text-4xl'
+					: 'text-2xl font-extrabold tracking-tight sm:text-3xl'}"
+			>
+				{title}
+			</h1>
+			{#if decoration && volume === 'celebration'}
+				<span aria-hidden="true">{@render decoration()}</span>
+			{/if}
+		</div>
+		{#if subtitle}
+			<p class="mt-2 max-w-prose text-muted-foreground">{subtitle}</p>
+		{/if}
+	</div>
+	{#if actions}
+		<div class="flex shrink-0 flex-wrap items-center gap-2">{@render actions()}</div>
+	{/if}
+</header>

--- a/src/lib/components/common/PageHeader.svelte
+++ b/src/lib/components/common/PageHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { cn } from '$lib/utils';
 
 	interface Props {
 		/** Already-translated strings — i18n stays at the call site. */
@@ -25,16 +26,19 @@
 	}: Props = $props();
 </script>
 
-<header class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between {className}">
+<header class={cn('flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between', className)}>
 	<div class="min-w-0">
 		{#if kicker}
 			<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">{kicker}</p>
 		{/if}
 		<div class="flex flex-wrap items-center gap-x-3 gap-y-1">
 			<h1
-				class="mt-1 {volume === 'celebration'
-					? 'text-3xl font-black leading-[1.12] sm:text-4xl'
-					: 'text-2xl font-extrabold tracking-tight sm:text-3xl'}"
+				class={cn(
+					'mt-1',
+					volume === 'celebration'
+						? 'text-3xl font-black leading-[1.12] sm:text-4xl'
+						: 'text-2xl font-extrabold tracking-tight sm:text-3xl'
+				)}
 			>
 				{title}
 			</h1>

--- a/src/lib/components/common/PageHeader.test.ts
+++ b/src/lib/components/common/PageHeader.test.ts
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import PageHeader from './PageHeader.svelte';
+
+const snip = (s: string) => createRawSnippet(() => ({ render: () => `<span>${s}</span>` }));
+
+describe('PageHeader', () => {
+	it('renders title as the page h1', () => {
+		render(PageHeader, { props: { title: 'Your events' } });
+		expect(screen.getByRole('heading', { level: 1, name: 'Your events' })).toBeInTheDocument();
+	});
+
+	it('studio volume (default) uses the studio scale', () => {
+		render(PageHeader, { props: { title: 'Settings' } });
+		const h1 = screen.getByRole('heading', { level: 1 });
+		expect(h1.className).toContain('font-extrabold');
+		expect(h1.className).not.toContain('font-black');
+	});
+
+	it('celebration volume uses the display scale', () => {
+		render(PageHeader, { props: { title: 'Party time', volume: 'celebration' } });
+		const h1 = screen.getByRole('heading', { level: 1 });
+		expect(h1.className).toContain('font-black');
+	});
+
+	it('renders kicker, subtitle, and actions', () => {
+		render(PageHeader, {
+			props: {
+				title: 'Members',
+				kicker: 'Organization',
+				subtitle: 'Manage who belongs.',
+				actions: snip('Invite')
+			}
+		});
+		expect(screen.getByText('Organization')).toBeInTheDocument();
+		expect(screen.getByText('Manage who belongs.')).toBeInTheDocument();
+		expect(screen.getByText('Invite')).toBeInTheDocument();
+	});
+
+	it('decoration renders in celebration and is decorative; ignored in studio', () => {
+		const { container, unmount } = render(PageHeader, {
+			props: { title: 'Hey', volume: 'celebration', decoration: snip('New!') }
+		});
+		const deco = screen.getByText('New!').closest('[aria-hidden="true"]');
+		expect(deco).not.toBeNull();
+		expect(container.textContent).toContain('New!');
+		unmount();
+		render(PageHeader, { props: { title: 'Hey', volume: 'studio', decoration: snip('New!') } });
+		expect(screen.queryByText('New!')).toBeNull();
+	});
+});

--- a/src/lib/components/common/PageHeader.test.ts
+++ b/src/lib/components/common/PageHeader.test.ts
@@ -24,6 +24,24 @@ describe('PageHeader', () => {
 		expect(h1.className).toContain('font-black');
 	});
 
+	it('celebration volume applies the full typography contract', () => {
+		render(PageHeader, { props: { title: 'Party time', volume: 'celebration' } });
+		const h1 = screen.getByRole('heading', { level: 1 });
+		expect(h1.className).toContain('text-3xl');
+		expect(h1.className).toContain('font-black');
+		expect(h1.className).toContain('leading-[1.12]');
+		expect(h1.className).toContain('sm:text-4xl');
+	});
+
+	it('studio volume applies the full typography contract', () => {
+		render(PageHeader, { props: { title: 'Settings', volume: 'studio' } });
+		const h1 = screen.getByRole('heading', { level: 1 });
+		expect(h1.className).toContain('text-2xl');
+		expect(h1.className).toContain('font-extrabold');
+		expect(h1.className).toContain('tracking-tight');
+		expect(h1.className).toContain('sm:text-3xl');
+	});
+
 	it('renders kicker, subtitle, and actions', () => {
 		render(PageHeader, {
 			props: {

--- a/src/lib/components/common/SectionHeader.svelte
+++ b/src/lib/components/common/SectionHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { cn } from '$lib/utils';
 
 	interface Props {
 		/** Already-translated strings — i18n stays at the call site. */
@@ -8,6 +9,8 @@
 		level?: 2 | 3;
 		/** 'celebration' = public/user surfaces; 'studio' = admin/dense. */
 		volume?: 'celebration' | 'studio';
+		/** Applied to the heading element so callers can keep existing aria-labelledby wiring. */
+		id?: string;
 		actions?: Snippet;
 		class?: string;
 	}
@@ -16,6 +19,7 @@
 		kicker,
 		level = 2,
 		volume = 'studio',
+		id,
 		actions,
 		class: className = ''
 	}: Props = $props();
@@ -23,17 +27,23 @@
 	const headingClass = $derived(
 		volume === 'celebration' ? 'text-xl font-extrabold' : 'text-lg font-bold'
 	);
+	const kickerClass = $derived(
+		cn(
+			'font-extrabold uppercase tracking-[0.12em] text-primary',
+			volume === 'celebration' ? 'text-sm' : 'text-xs'
+		)
+	);
 </script>
 
-<div class="flex flex-wrap items-end justify-between gap-2 {className}">
+<div class={cn('flex flex-wrap items-end justify-between gap-2', className)}>
 	<div class="min-w-0">
 		{#if kicker}
-			<p class="text-xs font-extrabold uppercase tracking-[0.12em] text-primary">{kicker}</p>
+			<p class={kickerClass}>{kicker}</p>
 		{/if}
 		{#if level === 2}
-			<h2 class={headingClass}>{title}</h2>
+			<h2 class={headingClass} {id}>{title}</h2>
 		{:else}
-			<h3 class={headingClass}>{title}</h3>
+			<h3 class={headingClass} {id}>{title}</h3>
 		{/if}
 	</div>
 	{#if actions}

--- a/src/lib/components/common/SectionHeader.svelte
+++ b/src/lib/components/common/SectionHeader.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		/** Already-translated strings — i18n stays at the call site. */
+		title: string;
+		kicker?: string;
+		level?: 2 | 3;
+		/** 'celebration' = public/user surfaces; 'studio' = admin/dense. */
+		volume?: 'celebration' | 'studio';
+		actions?: Snippet;
+		class?: string;
+	}
+	const {
+		title,
+		kicker,
+		level = 2,
+		volume = 'studio',
+		actions,
+		class: className = ''
+	}: Props = $props();
+
+	const headingClass = $derived(
+		volume === 'celebration' ? 'text-xl font-extrabold' : 'text-lg font-bold'
+	);
+</script>
+
+<div class="flex flex-wrap items-end justify-between gap-2 {className}">
+	<div class="min-w-0">
+		{#if kicker}
+			<p class="text-xs font-extrabold uppercase tracking-[0.12em] text-primary">{kicker}</p>
+		{/if}
+		{#if level === 2}
+			<h2 class={headingClass}>{title}</h2>
+		{:else}
+			<h3 class={headingClass}>{title}</h3>
+		{/if}
+	</div>
+	{#if actions}
+		<div class="flex shrink-0 items-center gap-2">{@render actions()}</div>
+	{/if}
+</div>

--- a/src/lib/components/common/SectionHeader.test.ts
+++ b/src/lib/components/common/SectionHeader.test.ts
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import SectionHeader from './SectionHeader.svelte';
+
+const snip = (s: string) => createRawSnippet(() => ({ render: () => `<span>${s}</span>` }));
+
+describe('SectionHeader', () => {
+	it('renders an h2 by default', () => {
+		render(SectionHeader, { props: { title: 'Upcoming' } });
+		expect(screen.getByRole('heading', { level: 2, name: 'Upcoming' })).toBeInTheDocument();
+	});
+
+	it('renders an h3 when level=3', () => {
+		render(SectionHeader, { props: { title: 'Details', level: 3 } });
+		expect(screen.getByRole('heading', { level: 3, name: 'Details' })).toBeInTheDocument();
+	});
+
+	it('renders kicker with the standardized tracking', () => {
+		render(SectionHeader, { props: { title: 'Tickets', kicker: 'This week' } });
+		expect(screen.getByText('This week').className).toContain('tracking-[0.12em]');
+	});
+
+	it('renders actions', () => {
+		render(SectionHeader, { props: { title: 'Polls', actions: snip('See all') } });
+		expect(screen.getByText('See all')).toBeInTheDocument();
+	});
+});

--- a/src/lib/components/common/SectionHeader.test.ts
+++ b/src/lib/components/common/SectionHeader.test.ts
@@ -25,4 +25,29 @@ describe('SectionHeader', () => {
 		render(SectionHeader, { props: { title: 'Polls', actions: snip('See all') } });
 		expect(screen.getByText('See all')).toBeInTheDocument();
 	});
+
+	it('celebration volume uses the display heading scale', () => {
+		render(SectionHeader, { props: { title: 'Highlights', volume: 'celebration' } });
+		const heading = screen.getByRole('heading', { level: 2 });
+		expect(heading.className).toContain('text-xl');
+		expect(heading.className).toContain('font-extrabold');
+	});
+
+	it('kicker is text-xs in studio and text-sm in celebration', () => {
+		const { unmount } = render(SectionHeader, {
+			props: { title: 'Details', kicker: 'Studio', volume: 'studio' }
+		});
+		expect(screen.getByText('Studio').className).toContain('text-xs');
+		unmount();
+
+		render(SectionHeader, {
+			props: { title: 'Details', kicker: 'Celebration', volume: 'celebration' }
+		});
+		expect(screen.getByText('Celebration').className).toContain('text-sm');
+	});
+
+	it('passes id through to the heading element', () => {
+		render(SectionHeader, { props: { title: 'Tickets', id: 'tickets-heading' } });
+		expect(screen.getByRole('heading', { level: 2 }).id).toBe('tickets-heading');
+	});
 });

--- a/src/lib/components/common/StatusBadge.svelte
+++ b/src/lib/components/common/StatusBadge.svelte
@@ -1,15 +1,25 @@
 <script lang="ts">
 	import type { Component } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn } from '$lib/utils';
 	import type { Tone } from './tones';
 
-	interface Props {
+	interface Props extends HTMLAttributes<HTMLSpanElement> {
 		tone: Tone;
 		/** Already-translated label — i18n stays at the call site. */
 		label: string;
 		icon?: Component;
+		size?: 'sm' | 'md' | 'lg';
 		class?: string;
 	}
-	const { tone, label, icon: Icon, class: className = '' }: Props = $props();
+	const {
+		tone,
+		label,
+		icon: Icon,
+		size = 'md',
+		class: className = '',
+		...restProps
+	}: Props = $props();
 
 	// Solid fills only: every fg/bg pair below is a token pair enforced at
 	// >= 4.5:1 by scripts/audit-brand-themes.py in BOTH modes. No alpha here —
@@ -22,15 +32,25 @@
 		danger: 'bg-destructive text-destructive-foreground',
 		neutral: 'bg-muted text-muted-foreground'
 	};
+	const sizeClasses = {
+		sm: 'px-2 py-0.5 text-[11px]',
+		md: 'px-2.5 py-0.5 text-xs',
+		lg: 'px-3 py-1 text-sm'
+	};
+	const iconSizes = { sm: 'h-3 w-3', md: 'h-3 w-3', lg: 'h-3.5 w-3.5' };
 </script>
 
 <span
-	class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-bold {toneClasses[
-		tone
-	]} {className}"
+	class={cn(
+		'inline-flex items-center gap-1 rounded-full font-bold',
+		sizeClasses[size],
+		toneClasses[tone],
+		className
+	)}
+	{...restProps}
 >
 	{#if Icon}
-		<Icon class="h-3 w-3" aria-hidden="true" />
+		<Icon class={iconSizes[size]} aria-hidden="true" />
 	{/if}
 	{label}
 </span>

--- a/src/lib/components/common/StatusBadge.svelte
+++ b/src/lib/components/common/StatusBadge.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import type { Component } from 'svelte';
+	import type { Tone } from './tones';
+
+	interface Props {
+		tone: Tone;
+		/** Already-translated label — i18n stays at the call site. */
+		label: string;
+		icon?: Component;
+		class?: string;
+	}
+	const { tone, label, icon: Icon, class: className = '' }: Props = $props();
+
+	// Solid fills only: every fg/bg pair below is a token pair enforced at
+	// >= 4.5:1 by scripts/audit-brand-themes.py in BOTH modes. No alpha here —
+	// that keeps this component fully covered by the audit, no hand math.
+	const toneClasses: Record<Tone, string> = {
+		brand: 'bg-primary text-primary-foreground',
+		info: 'bg-info text-info-foreground',
+		success: 'bg-success text-success-foreground',
+		warning: 'bg-highlight text-highlight-foreground',
+		danger: 'bg-destructive text-destructive-foreground',
+		neutral: 'bg-muted text-muted-foreground'
+	};
+</script>
+
+<span
+	class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-bold {toneClasses[
+		tone
+	]} {className}"
+>
+	{#if Icon}
+		<Icon class="h-3 w-3" aria-hidden="true" />
+	{/if}
+	{label}
+</span>

--- a/src/lib/components/common/StatusBadge.test.ts
+++ b/src/lib/components/common/StatusBadge.test.ts
@@ -24,4 +24,21 @@ describe('StatusBadge', () => {
 		expect(svg).not.toBeNull();
 		expect(svg?.getAttribute('aria-hidden')).toBe('true');
 	});
+
+	it('passes through title and role via restProps', () => {
+		const { container } = render(StatusBadge, {
+			props: { tone: 'success', label: 'Confirmed', title: 'RSVP confirmed', role: 'status' }
+		});
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.getAttribute('title')).toBe('RSVP confirmed');
+		expect(el.getAttribute('role')).toBe('status');
+	});
+
+	it('lg size applies the larger padding classes', () => {
+		const { container } = render(StatusBadge, {
+			props: { tone: 'brand', label: 'Big', size: 'lg' }
+		});
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('px-3');
+	});
 });

--- a/src/lib/components/common/StatusBadge.test.ts
+++ b/src/lib/components/common/StatusBadge.test.ts
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import { CircleCheck } from '@lucide/svelte';
+import StatusBadge from './StatusBadge.svelte';
+
+describe('StatusBadge', () => {
+	it('renders the label text', () => {
+		render(StatusBadge, { props: { tone: 'success', label: 'Confirmed' } });
+		expect(screen.getByText('Confirmed')).toBeInTheDocument();
+	});
+
+	it('applies the solid token classes for its tone', () => {
+		const { container } = render(StatusBadge, { props: { tone: 'danger', label: 'Cancelled' } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('bg-destructive');
+		expect(el.className).toContain('text-destructive-foreground');
+	});
+
+	it('renders an optional icon as decorative', () => {
+		const { container } = render(StatusBadge, {
+			props: { tone: 'success', label: 'Paid', icon: CircleCheck }
+		});
+		const svg = container.querySelector('svg');
+		expect(svg).not.toBeNull();
+		expect(svg?.getAttribute('aria-hidden')).toBe('true');
+	});
+});

--- a/src/lib/components/common/ToneTile.svelte
+++ b/src/lib/components/common/ToneTile.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import type { Component } from 'svelte';
+	import type { Tone } from './tones';
+
+	interface Props {
+		tone: Tone;
+		icon: Component;
+		size?: 'sm' | 'md' | 'lg';
+		/** Accessible name; omit when the tile sits next to visible text (decorative). */
+		label?: string;
+		class?: string;
+	}
+	const { tone, icon: Icon, size = 'md', label, class: className = '' }: Props = $props();
+
+	// Soft tint + strong icon (replaces the app's hand-picked bg-blue-50
+	// dark:bg-blue-950 tiles). The composited tint is ~the surface color, so the
+	// icon-vs-surface ratio governs; hand-verified >= 3:1 (WCAG 1.4.11, non-text)
+	// in both modes — composited alpha is invisible to audit-brand-themes.py:
+	//   brand 7.0/5.8 · info 10.1/8.0 · success 5.7/8.8 · danger 9.8/3.1
+	//   warning: amber on light is 1.8:1 (fails) -> highlight-foreground ~16:1;
+	//   dark flips to amber itself, 8.4:1. Ratios recomputed if token values move.
+	const toneClasses: Record<Tone, string> = {
+		brand: 'bg-primary/10 text-primary',
+		info: 'bg-info/10 text-info',
+		success: 'bg-success/10 text-success',
+		warning: 'bg-highlight/20 text-highlight-foreground dark:text-highlight',
+		danger: 'bg-destructive/10 text-destructive',
+		neutral: 'bg-muted text-muted-foreground'
+	};
+	const sizeClasses = {
+		sm: 'h-8 w-8 rounded-md',
+		md: 'h-10 w-10 rounded-md',
+		lg: 'h-12 w-12 rounded-lg'
+	};
+	const iconSizes = { sm: 'h-4 w-4', md: 'h-5 w-5', lg: 'h-6 w-6' };
+</script>
+
+<span
+	class="inline-flex shrink-0 items-center justify-center {sizeClasses[size]} {toneClasses[
+		tone
+	]} {className}"
+	role={label ? 'img' : undefined}
+	aria-label={label}
+	aria-hidden={label ? undefined : true}
+>
+	<Icon class={iconSizes[size]} aria-hidden="true" />
+</span>

--- a/src/lib/components/common/ToneTile.svelte
+++ b/src/lib/components/common/ToneTile.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Component } from 'svelte';
+	import { cn } from '$lib/utils';
 	import type { Tone } from './tones';
 
 	interface Props {
@@ -14,17 +15,21 @@
 
 	// Soft tint + strong icon (replaces the app's hand-picked bg-blue-50
 	// dark:bg-blue-950 tiles). The composited tint is ~the surface color, so the
-	// icon-vs-surface ratio governs; hand-verified >= 3:1 (WCAG 1.4.11, non-text)
-	// in both modes — composited alpha is invisible to audit-brand-themes.py:
-	//   brand 7.0/5.8 · info 10.1/8.0 · success 5.7/8.8 · danger 9.8/3.1
-	//   warning: amber on light is 1.8:1 (fails) -> highlight-foreground ~16:1;
-	//   dark flips to amber itself, 8.4:1. Ratios recomputed if token values move.
+	// icon-vs-surface ratio governs; independently recomputed >= 3:1 (WCAG 1.4.11,
+	// non-text) in both modes — composited alpha is invisible to
+	// scripts/audit-brand-themes.py. Ratios as (light page/card | dark page/card):
+	//   brand 5.3/5.9 | 5.9/5.3 · info 8.3/9.3 | 8.0/7.2 · success 4.4/4.9 | 8.7/7.8
+	//   danger 7.2/8.1 | 12.0/11.0 (dark flips to white icon on /25 red tint —
+	//   dark destructive text on the /10 tint measured 2.95:1, under the floor)
+	//   warning 12.6/13.9 | 6.7/6.0 (amber on light is 1.8:1 -> highlight-foreground)
+	// Recompute if any of these token values move.
 	const toneClasses: Record<Tone, string> = {
 		brand: 'bg-primary/10 text-primary',
 		info: 'bg-info/10 text-info',
 		success: 'bg-success/10 text-success',
 		warning: 'bg-highlight/20 text-highlight-foreground dark:text-highlight',
-		danger: 'bg-destructive/10 text-destructive',
+		danger:
+			'bg-destructive/10 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground',
 		neutral: 'bg-muted text-muted-foreground'
 	};
 	const sizeClasses = {
@@ -36,9 +41,12 @@
 </script>
 
 <span
-	class="inline-flex shrink-0 items-center justify-center {sizeClasses[size]} {toneClasses[
-		tone
-	]} {className}"
+	class={cn(
+		'inline-flex shrink-0 items-center justify-center',
+		sizeClasses[size],
+		toneClasses[tone],
+		className
+	)}
 	role={label ? 'img' : undefined}
 	aria-label={label}
 	aria-hidden={label ? undefined : true}

--- a/src/lib/components/common/ToneTile.test.ts
+++ b/src/lib/components/common/ToneTile.test.ts
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import { Calendar } from '@lucide/svelte';
+import ToneTile from './ToneTile.svelte';
+
+describe('ToneTile', () => {
+	it('is aria-hidden when no label is given (decorative next to visible text)', () => {
+		const { container } = render(ToneTile, { props: { tone: 'brand', icon: Calendar } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.getAttribute('aria-hidden')).toBe('true');
+		expect(el.getAttribute('role')).toBeNull();
+	});
+
+	it('is an accessibly named img when a label is given', () => {
+		const { container } = render(ToneTile, {
+			props: { tone: 'info', icon: Calendar, label: 'Events' }
+		});
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.getAttribute('role')).toBe('img');
+		expect(el.getAttribute('aria-label')).toBe('Events');
+	});
+
+	it('maps tones to token classes, never raw palette hues', () => {
+		const { container } = render(ToneTile, { props: { tone: 'success', icon: Calendar } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('bg-success/10');
+		expect(el.className).toContain('text-success');
+	});
+
+	it('warning tone flips its icon color per mode (amber fails AA on light)', () => {
+		const { container } = render(ToneTile, { props: { tone: 'warning', icon: Calendar } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('text-highlight-foreground');
+		expect(el.className).toContain('dark:text-highlight');
+	});
+});

--- a/src/lib/components/common/tones.ts
+++ b/src/lib/components/common/tones.ts
@@ -1,0 +1,6 @@
+/**
+ * Semantic tone vocabulary for the rebrand primitives (StatusBadge, ToneTile,
+ * EmptyState). Tones map to theme tokens, never to raw Tailwind palette hues —
+ * this is what replaces the app's scattered bg-blue-50/text-emerald-600 pattern.
+ */
+export type Tone = 'brand' | 'info' | 'success' | 'warning' | 'danger' | 'neutral';

--- a/src/lib/components/profile/TelegramConnectionManager.svelte
+++ b/src/lib/components/profile/TelegramConnectionManager.svelte
@@ -205,7 +205,7 @@
 			</p>
 			<Button
 				onclick={handleOpenConnectDialog}
-				class="bg-[hsl(var(--brand-telegram))] hover:bg-[hsl(var(--brand-telegram)/0.9)]"
+				class="bg-[hsl(var(--brand-telegram))] text-white hover:bg-[hsl(var(--brand-telegram)/0.9)]"
 			>
 				<MessageCircle class="mr-2 h-4 w-4" aria-hidden="true" />
 				{m['telegram.buttons_connect']()}
@@ -336,7 +336,7 @@
 				type="button"
 				onclick={handleConnectSubmit}
 				disabled={connectMutation.isPending || !otpValue.trim()}
-				class="w-full bg-[hsl(var(--brand-telegram))] hover:bg-[hsl(var(--brand-telegram)/0.9)] sm:w-auto"
+				class="w-full bg-[hsl(var(--brand-telegram))] text-white hover:bg-[hsl(var(--brand-telegram)/0.9)] sm:w-auto"
 			>
 				{#if connectMutation.isPending}
 					<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />

--- a/src/lib/components/profile/TelegramConnectionManager.svelte
+++ b/src/lib/components/profile/TelegramConnectionManager.svelte
@@ -146,7 +146,7 @@
 <div class="space-y-4">
 	<div class="flex items-center justify-between">
 		<div class="flex items-center gap-3">
-			<MessageCircle class="h-6 w-6 text-[hsl(var(--brand-telegram))]" aria-hidden="true" />
+			<MessageCircle class="h-6 w-6 text-[hsl(var(--brand-telegram-text))]" aria-hidden="true" />
 			<div>
 				<h3 class="text-lg font-semibold">{m['telegram.heading']()}</h3>
 				<p class="text-sm text-muted-foreground">
@@ -249,7 +249,7 @@
 							href={botLink}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="inline-flex items-center gap-2 text-sm text-[hsl(var(--brand-telegram))] underline-offset-4 hover:underline"
+							class="inline-flex items-center gap-2 text-sm text-[hsl(var(--brand-telegram-text))] underline-offset-4 hover:underline"
 						>
 							<MessageCircle class="h-4 w-4" aria-hidden="true" />
 							<span>@{botName}</span>

--- a/src/lib/components/profile/TelegramConnectionManager.svelte
+++ b/src/lib/components/profile/TelegramConnectionManager.svelte
@@ -146,7 +146,7 @@
 <div class="space-y-4">
 	<div class="flex items-center justify-between">
 		<div class="flex items-center gap-3">
-			<MessageCircle class="h-6 w-6 text-[#0088cc]" aria-hidden="true" />
+			<MessageCircle class="h-6 w-6 text-[hsl(var(--brand-telegram))]" aria-hidden="true" />
 			<div>
 				<h3 class="text-lg font-semibold">{m['telegram.heading']()}</h3>
 				<p class="text-sm text-muted-foreground">
@@ -203,7 +203,10 @@
 			<p class="mb-3 text-sm text-muted-foreground">
 				{m['telegram.notConnected_description']()}
 			</p>
-			<Button onclick={handleOpenConnectDialog} class="bg-[#0072ab] hover:bg-[#0072ab]/90">
+			<Button
+				onclick={handleOpenConnectDialog}
+				class="bg-[hsl(var(--brand-telegram))] hover:bg-[hsl(var(--brand-telegram)/0.9)]"
+			>
 				<MessageCircle class="mr-2 h-4 w-4" aria-hidden="true" />
 				{m['telegram.buttons_connect']()}
 			</Button>
@@ -246,7 +249,7 @@
 							href={botLink}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="inline-flex items-center gap-2 text-sm text-[#0072ab] underline-offset-4 hover:underline"
+							class="inline-flex items-center gap-2 text-sm text-[hsl(var(--brand-telegram))] underline-offset-4 hover:underline"
 						>
 							<MessageCircle class="h-4 w-4" aria-hidden="true" />
 							<span>@{botName}</span>
@@ -333,7 +336,7 @@
 				type="button"
 				onclick={handleConnectSubmit}
 				disabled={connectMutation.isPending || !otpValue.trim()}
-				class="w-full bg-[#0072ab] hover:bg-[#0072ab]/90 sm:w-auto"
+				class="w-full bg-[hsl(var(--brand-telegram))] hover:bg-[hsl(var(--brand-telegram)/0.9)] sm:w-auto"
 			>
 				{#if connectMutation.isPending}
 					<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -64,6 +64,15 @@ export default {
 					DEFAULT: 'hsl(var(--highlight) / <alpha-value>)',
 					foreground: 'hsl(var(--highlight-foreground) / <alpha-value>)'
 				},
+				// Rebrand additions: success/info complete the semantic set.
+				success: {
+					DEFAULT: 'hsl(var(--success) / <alpha-value>)',
+					foreground: 'hsl(var(--success-foreground) / <alpha-value>)'
+				},
+				info: {
+					DEFAULT: 'hsl(var(--info) / <alpha-value>)',
+					foreground: 'hsl(var(--info-foreground) / <alpha-value>)'
+				},
 				popover: {
 					DEFAULT: 'hsl(var(--popover) / <alpha-value>)',
 					foreground: 'hsl(var(--popover-foreground) / <alpha-value>)'
@@ -71,6 +80,19 @@ export default {
 				card: {
 					DEFAULT: 'hsl(var(--card) / <alpha-value>)',
 					foreground: 'hsl(var(--card-foreground) / <alpha-value>)'
+				},
+				// Poster palette as first-class utilities (bg-poster-amber, ...).
+				// Fixed values, identical in dark mode by design (imagery, not surfaces).
+				poster: {
+					purple: 'hsl(var(--poster-purple) / <alpha-value>)',
+					crimson: 'hsl(var(--poster-crimson) / <alpha-value>)',
+					'crimson-deep': 'hsl(var(--poster-crimson-deep) / <alpha-value>)',
+					lavender: 'hsl(var(--poster-lavender) / <alpha-value>)',
+					periwinkle: 'hsl(var(--poster-periwinkle) / <alpha-value>)',
+					amber: 'hsl(var(--poster-amber) / <alpha-value>)',
+					ink: 'hsl(var(--poster-ink) / <alpha-value>)',
+					paper: 'hsl(var(--poster-paper) / <alpha-value>)',
+					white: 'hsl(var(--poster-white) / <alpha-value>)'
 				}
 			},
 			borderRadius: {


### PR DESCRIPTION
## Platform rebrand, PR 1 of 10 — Foundations

First PR of the platform-wide rebrand program (master spec lives locally at `docs/superpowers/specs/2026-08-04-platform-rebrand-design.md`). Everything here is **purely additive**: no existing token values change, no behavior changes, no copy changes (`messages/` untouched), landing frozen.

### What's in it

**Tokens (`src/app.css` + `tailwind.config.ts` + audit script)**
- `--success` / `--info` (light + dark) join the semantic set — the tokens the app previously faked with raw Tailwind hues (`bg-emerald-*`, `bg-blue-*`). Both are wired into `scripts/audit-brand-themes.py` (`TEXT_PAIRS` + `SEMANTIC` color-blind separation) and pass at 0 failures.
- `--brand-telegram` / `--brand-telegram-text` fill/text pair centralizing the Telegram hex literals (see deviation note below).
- The poster palette is now first-class Tailwind (`bg-poster-amber`, `text-poster-ink`, …) instead of arbitrary-value syntax.

**Six shared primitives** (the interfaces PRs 2–10 adopt)
- `common/PageHeader` — kicker + display/studio h1 + subtitle + actions + celebration-only decoration slot
- `common/SectionHeader` — kicker + h2/h3, volume-aware sizes, `id` passthrough for `aria-labelledby`
- `common/EmptyState` — tilted poster-tinted icon chip (imagery rule: mode-inert), `level` 2|3
- `common/StatusBadge` — solid audit-enforced tone pills, `size` sm/md/lg, restProps for title/aria/role; absorbs the ~12 hand-rolled domain badges via thin mappers in later PRs
- `common/ToneTile` — soft icon tiles replacing hand-picked `bg-blue-50 dark:bg-blue-950` pairs (semantic `tone` axis only; identity `tint` axis lands with PR 7)
- `brand/Sticker` — app-facing twin of the landing's PosterSticker, rotation clamped [-3°, 3°]
- 41 tests incl. typography-contract assertions (the class strings ARE the spec table)

**Docs** — CLAUDE.md gains the "Rebrand volumes & shared primitives" section: the three volumes (Poster/Celebration/Studio), primitive catalog with API rulings, typography table, raw-hue sweep rule.

### Deviation from plan (ruled during review)

The plan's `--brand-telegram: 200 100% 40%` (= Telegram's #0088cc) carried a wrong AA rationale: the button labels are `text-sm font-medium`, so the 4.5:1 normal-text threshold applies, and white on #0088cc measures **3.9:1** (a regression from the old `#0072ab`'s 5.25:1). Shipped instead: fill `200 100% 33%` (white labels **5.39:1**, fixed across modes, with explicit `text-white` since the shadcn Button's dark `text-primary-foreground` is ink) + `--brand-telegram-text` (33% light / `200 85% 60%` dark → 4.8–8.0:1 on all surfaces). WCAG guardrail > plan literal.

### Verification

- `make check` green (svelte-check 0 errors, eslint `--max-warnings 0`, i18n, file-length, canary armed)
- Full unit suite: **202 files / 2426 passed** (baseline 196/2393; all growth = new tests)
- `python3 scripts/audit-brand-themes.py`: 0 WCAG failures, 0 color-blind confusables
- Visual QA on a scratch page (not committed): 375px + 1280px, light + dark — imagery rule verified (poster chips identical across modes, success chip theme-flips by design)
- SDD: 6 tasks, per-task opus reviews, 2 fix rounds total, final whole-branch review clean after one fix wave

### Follow-ups (routed to later PRs / issues)

- `audit-brand-themes.py`: add composited-alpha pair rows so ToneTile's tint ratios get machine-checked instead of hand-verified comments (would have auto-caught the dark-danger defect the review found)
- `members/StatusBadge.svelte` rename (name collision with the new `common/StatusBadge`) — PR 6/10 territory
- ToneTile identity-`tint` axis (poster palette) — ships with PR 7's admin quick-actions grid
- `PosterSticker` → `Sticker` unification when the landing unfreezes
- ToneTile dark-danger comment cell is conservative (says 12.0/11.0, measures 15.3/14.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)