### PR TITLE
feat(rebrand): user dashboard — celebration pass, ticket brand moment, badge mappers (PR 5/10)

### DIFF
--- a/src/lib/components/calendar/CalendarControls.svelte
+++ b/src/lib/components/calendar/CalendarControls.svelte
@@ -215,7 +215,7 @@
 	}
 
 	.calendar-controls-title {
-		@apply flex-1 text-xl font-semibold;
+		@apply flex-1 text-xl font-extrabold;
 	}
 
 	.calendar-controls-nav {

--- a/src/lib/components/calendar/CalendarView.svelte
+++ b/src/lib/components/calendar/CalendarView.svelte
@@ -100,7 +100,7 @@
 	}
 
 	.calendar-header-cell {
-		@apply p-2 text-center text-sm font-semibold text-muted-foreground;
+		@apply p-2 text-center text-xs font-extrabold uppercase tracking-[0.08em] text-muted-foreground;
 	}
 
 	.calendar-body {

--- a/src/lib/components/calendar/CalendarWeekView.svelte
+++ b/src/lib/components/calendar/CalendarWeekView.svelte
@@ -115,7 +115,7 @@
 	}
 
 	.week-day-weekday {
-		@apply text-sm font-medium text-muted-foreground;
+		@apply text-xs font-extrabold uppercase tracking-[0.08em] text-muted-foreground;
 	}
 
 	.week-day-number {

--- a/src/lib/components/calendar/CalendarYearView.svelte
+++ b/src/lib/components/calendar/CalendarYearView.svelte
@@ -85,7 +85,7 @@
 	}
 
 	.year-month-name {
-		@apply text-lg font-semibold;
+		@apply text-lg font-bold;
 	}
 
 	.year-month-events {

--- a/src/lib/components/dashboard/DashboardActivityCards.svelte
+++ b/src/lib/components/dashboard/DashboardActivityCards.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { ChevronRight, Ticket, Mail, CheckCircle2 } from '@lucide/svelte';
 	import * as m from '$lib/paraglide/messages.js';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 
 	interface Props {
 		activeTicketsCount: number;
@@ -22,9 +23,7 @@
 			>
 				<div class="flex items-start justify-between">
 					<div class="flex items-center gap-3">
-						<div class="rounded-full bg-blue-100 p-3 dark:bg-blue-950">
-							<Ticket class="h-6 w-6 text-blue-600 dark:text-blue-400" aria-hidden="true" />
-						</div>
+						<ToneTile tone="info" icon={Ticket} size="lg" />
 						<div>
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['dashboard.activityCards.activeTickets']()}
@@ -56,9 +55,7 @@
 			>
 				<div class="flex items-start justify-between">
 					<div class="flex items-center gap-3">
-						<div class="rounded-full bg-green-100 p-3 dark:bg-green-950">
-							<CheckCircle2 class="h-6 w-6 text-green-600 dark:text-green-400" aria-hidden="true" />
-						</div>
+						<ToneTile tone="success" icon={CheckCircle2} size="lg" />
 						<div>
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['dashboard.activityCards.upcomingRsvps']()}
@@ -90,9 +87,7 @@
 			>
 				<div class="flex items-start justify-between">
 					<div class="flex items-center gap-3">
-						<div class="rounded-full bg-purple-100 p-3 dark:bg-purple-950">
-							<Mail class="h-6 w-6 text-purple-600 dark:text-purple-400" aria-hidden="true" />
-						</div>
+						<ToneTile tone="brand" icon={Mail} size="lg" />
 						<div>
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['dashboard.activityCards.pendingInvitations']()}

--- a/src/lib/components/dashboard/DashboardOrganizationsSection.svelte
+++ b/src/lib/components/dashboard/DashboardOrganizationsSection.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import OrganizationCardSkeleton from '$lib/components/common/OrganizationCardSkeleton.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import { getImageUrl } from '$lib/utils/url';
 	import { stripMarkdown } from '$lib/seo';
 	import { Building2, Sparkles, Shield, Check, Award, Crown } from '@lucide/svelte';
@@ -15,7 +18,7 @@
 		getMembershipTier,
 		isOwner,
 		isStaff,
-		statusStyles
+		statusTones
 	} from './dashboard-permissions';
 
 	interface Props {
@@ -32,13 +35,24 @@
 	);
 </script>
 
+{#snippet discoverEventsAction()}
+	<a
+		href={resolve('/(public)/events', {})}
+		class="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+	>
+		<Sparkles class="h-4 w-4" aria-hidden="true" />
+		<span>{m['dashboard.sections.discoverEvents']()}</span>
+	</a>
+{/snippet}
+
 <!-- My Organizations Section -->
 <section id="organizations-section" aria-labelledby="organizations-heading">
-	<div class="mb-4 flex items-center justify-between">
-		<h2 id="organizations-heading" class="flex items-center gap-2 text-xl font-semibold">
-			<Building2 class="h-5 w-5 text-primary" aria-hidden="true" />
-			<span>{m['dashboard.sections.myOrganizations']()}</span>
-		</h2>
+	<div class="mb-4">
+		<SectionHeader
+			title={m['dashboard.sections.myOrganizations']()}
+			volume="celebration"
+			id="organizations-heading"
+		/>
 	</div>
 
 	{#if isLoading}
@@ -49,22 +63,12 @@
 		</div>
 	{:else if organizations.length === 0}
 		<!-- Empty State -->
-		<div class="rounded-lg border bg-card p-8 text-center">
-			<Building2 class="mx-auto mb-4 h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mb-2 text-lg font-semibold">{m['dashboard.emptyStates.noOrganizations']()}</h3>
-			<p class="mb-4 text-sm text-muted-foreground">
-				{m['dashboard.emptyStates.noOrganizationsHint']()}
-			</p>
-			<div class="flex flex-wrap justify-center gap-3">
-				<a
-					href={resolve('/(public)/events', {})}
-					class="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-				>
-					<Sparkles class="h-4 w-4" aria-hidden="true" />
-					<span>{m['dashboard.sections.discoverEvents']()}</span>
-				</a>
-			</div>
-		</div>
+		<EmptyState
+			icon={Building2}
+			title={m['dashboard.emptyStates.noOrganizations']()}
+			body={m['dashboard.emptyStates.noOrganizationsHint']()}
+			action={discoverEventsAction}
+		/>
 	{:else}
 		<!-- Organization Cards -->
 		<div id="dashboard-organizations-list" class="space-y-3">
@@ -90,25 +94,25 @@
 
 						<div class="min-w-0 flex-1">
 							<div class="flex items-center gap-2">
-								<h3 class="font-semibold">{org.name}</h3>
+								<h3 class="font-bold">{org.name}</h3>
 								<!-- Owner Badge -->
 								{#if isOwner(permissions, org.id)}
-									<span
-										class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+									<StatusBadge
+										tone="brand"
+										label={m['dashboardPage.ownerBadge']()}
+										icon={Crown}
+										size="sm"
 										aria-label={m['dashboardPage.ownerBadgeLabel']()}
-									>
-										<Crown class="h-3 w-3" aria-hidden="true" />
-										{m['dashboardPage.ownerBadge']()}
-									</span>
+									/>
 								{:else if isStaff(permissions, org.id)}
 									<!-- Staff Badge -->
-									<span
-										class="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-100"
+									<StatusBadge
+										tone="info"
+										label={m['dashboardPage.staffBadge']()}
+										icon={Shield}
+										size="sm"
 										aria-label={m['dashboardPage.staffBadgeLabel']()}
-									>
-										<Shield class="h-3 w-3" aria-hidden="true" />
-										{m['dashboardPage.staffBadge']()}
-									</span>
+									/>
 								{/if}
 							</div>
 
@@ -125,30 +129,28 @@
 								<div class="mt-2 flex flex-wrap items-center gap-2">
 									<!-- Status Badge -->
 									{#if membershipStatus}
-										<span
-											class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium {statusStyles[
-												membershipStatus
-											]}"
+										<StatusBadge
+											tone={statusTones[membershipStatus]}
+											label={m[`memberStatus.${membershipStatus}`]()}
+											icon={Check}
+											size="sm"
 											aria-label={m['dashboardPage.membershipStatusLabel']({
 												status: membershipStatus
 											})}
-										>
-											<Check class="h-3 w-3" aria-hidden="true" />
-											{m[`memberStatus.${membershipStatus}`]()}
-										</span>
+										/>
 									{/if}
 
 									<!-- Tier Badge -->
 									{#if membershipTier}
-										<span
-											class="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-100"
+										<StatusBadge
+											tone="info"
+											label={membershipTier.name}
+											icon={Award}
+											size="sm"
 											aria-label={m['dashboardPage.membershipTierLabel']({
 												tier: membershipTier.name
 											})}
-										>
-											<Award class="h-3 w-3" aria-hidden="true" />
-											{membershipTier.name}
-										</span>
+										/>
 									{/if}
 								</div>
 							{/if}

--- a/src/lib/components/dashboard/DashboardUpcomingEvents.svelte
+++ b/src/lib/components/dashboard/DashboardUpcomingEvents.svelte
@@ -2,7 +2,9 @@
 	import { resolve } from '$app/paths';
 	import { EventCard } from '$lib/components/events';
 	import EventCardSkeleton from '$lib/components/common/EventCardSkeleton.svelte';
-	import { Calendar, Sparkles, ChevronRight } from '@lucide/svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import { Calendar, ChevronRight } from '@lucide/svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import type { EventInListSchema } from '$lib/api/generated/types.gen';
 
@@ -13,22 +15,25 @@
 	let { upcomingEvents, isLoading }: Props = $props();
 </script>
 
+{#snippet seeAllAction()}
+	<a
+		href={resolve('/(public)/events', {})}
+		class="flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+	>
+		<span>{m['dashboard.activityCards.seeAll']()}</span>
+		<ChevronRight class="h-4 w-4" aria-hidden="true" />
+	</a>
+{/snippet}
+
 <!-- Upcoming Events Section -->
 <section aria-labelledby="upcoming-events-heading">
-	<div class="mb-4 flex items-center justify-between">
-		<h2 id="upcoming-events-heading" class="flex items-center gap-2 text-xl font-semibold">
-			<Sparkles class="h-5 w-5 text-primary" aria-hidden="true" />
-			<span>{m['dashboard.sections.discoverEvents']()}</span>
-		</h2>
-		{#if upcomingEvents.length > 0}
-			<a
-				href={resolve('/(public)/events', {})}
-				class="flex items-center gap-1 text-sm font-medium text-primary hover:underline"
-			>
-				<span>{m['dashboard.activityCards.seeAll']()}</span>
-				<ChevronRight class="h-4 w-4" aria-hidden="true" />
-			</a>
-		{/if}
+	<div class="mb-4">
+		<SectionHeader
+			title={m['dashboard.sections.discoverEvents']()}
+			volume="celebration"
+			id="upcoming-events-heading"
+			actions={upcomingEvents.length > 0 ? seeAllAction : undefined}
+		/>
 	</div>
 
 	{#if isLoading}
@@ -39,15 +44,12 @@
 		</div>
 	{:else if upcomingEvents.length === 0}
 		<!-- Empty State -->
-		<div class="rounded-lg border bg-card p-8 text-center">
-			<Calendar class="mx-auto mb-4 h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mb-2 text-lg font-semibold">
-				{m['dashboard.emptyStates.noEventsAvailable']()}
-			</h3>
-			<p class="mb-4 text-sm text-muted-foreground">
-				{m['dashboard.emptyStates.noEventsHint']()}
-			</p>
-		</div>
+		<EmptyState
+			icon={Calendar}
+			title={m['dashboard.emptyStates.noEventsAvailable']()}
+			body={m['dashboard.emptyStates.noEventsHint']()}
+			tone="neutral"
+		/>
 	{:else}
 		<!-- Event Cards -->
 		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/lib/components/dashboard/dashboard-permissions.ts
+++ b/src/lib/components/dashboard/dashboard-permissions.ts
@@ -3,6 +3,7 @@ import type {
 	MembershipStatus,
 	MembershipTierSchema
 } from '$lib/api/generated/types.gen';
+import type { Tone } from '$lib/components/common/tones';
 
 /**
  * Permission helpers for the dashboard, derived from the auth store's
@@ -106,10 +107,12 @@ export function ownsOrganization(permissions: OrganizationPermissionsSchema | nu
 	return Object.values(permissions.organization_permissions).some((perms) => perms === 'owner');
 }
 
-// Status badge styling (matching MemberCard.svelte)
-export const statusStyles: Record<MembershipStatus, string> = {
-	active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100',
-	paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100',
-	cancelled: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100',
-	banned: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100'
+// Membership status → StatusBadge tone mapping (rebrand: replaces the
+// hand-picked bg-green-100/dark:bg-green-900-style pairs with the shared
+// semantic tone system).
+export const statusTones: Record<MembershipStatus, Tone> = {
+	active: 'success',
+	paused: 'warning',
+	cancelled: 'neutral',
+	banned: 'danger'
 };

--- a/src/lib/components/invitations/InvitationCard.svelte
+++ b/src/lib/components/invitations/InvitationCard.svelte
@@ -7,6 +7,7 @@
 	import { getImageUrl } from '$lib/utils/url';
 	import { formatEventDateRange, formatDate } from '$lib/utils/date';
 	import { getEventLogo, getEventLogoThumbnail } from '$lib/utils/event';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 
 	interface Props {
 		invitation: MyEventInvitationSchema;
@@ -79,7 +80,7 @@
 			<!-- Event Details -->
 			<div class="min-w-0 flex-1">
 				<div class="mb-2">
-					<h3 class="text-lg font-semibold">
+					<h3 class="text-lg font-bold">
 						<a
 							href={resolve('/(public)/events/[id]', { id: invitation.event.id })}
 							class="hover:underline focus:underline focus:outline-none"
@@ -87,12 +88,13 @@
 							{invitation.event.name}
 						</a>
 					</h3>
-					<div
-						class="mt-1 inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300"
-					>
-						<CheckCircle2 class="h-3 w-3" aria-hidden="true" />
-						{m['invitationCard.specialInvitation']()}
-					</div>
+					<StatusBadge
+						tone="success"
+						label={m['invitationCard.specialInvitation']()}
+						icon={CheckCircle2}
+						size="sm"
+						class="mt-1"
+					/>
 				</div>
 
 				<!-- Event Metadata -->
@@ -150,7 +152,7 @@
 				<ul class="space-y-1">
 					{#each privileges as privilege (privilege)}
 						<li class="flex items-center gap-2 text-sm">
-							<CheckCircle2 class="h-4 w-4 shrink-0 text-green-600" aria-hidden="true" />
+							<CheckCircle2 class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
 							{privilege}
 						</li>
 					{/each}

--- a/src/lib/components/invitations/InvitationRequestCard.svelte
+++ b/src/lib/components/invitations/InvitationRequestCard.svelte
@@ -10,6 +10,8 @@
 	import { eventpublicdiscoveryDeleteInvitationRequest } from '$lib/api/generated/sdk.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { toast } from 'svelte-sonner';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		request: EventInvitationRequestSchema;
@@ -39,37 +41,28 @@
 	// Format created date
 	const createdDate = $derived(formatDate(request.created_at));
 
-	// Status display
-	const statusDisplay = $derived.by(() => {
+	// Status display — thin mapper onto the shared StatusBadge tone system
+	// (same visible labels as before, solid-fill tokens instead of hand-picked hues).
+	const statusDisplay = $derived.by((): { label: string; tone: Tone; icon: typeof Clock } => {
 		switch (request.status) {
 			case 'pending':
-				return {
-					label: m['invitationRequestCard.statusPending'](),
-					class: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
-					icon: Clock
-				};
+				return { label: m['invitationRequestCard.statusPending'](), tone: 'warning', icon: Clock };
 			case 'approved':
 				return {
 					label: m['invitationRequestCard.statusApproved'](),
-					class: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+					tone: 'success',
 					icon: CheckCircle2
 				};
 			case 'rejected':
 				return {
 					label: m['invitationRequestCard.statusRejected'](),
-					class: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+					tone: 'danger',
 					icon: XCircle
 				};
 			default:
-				return {
-					label: request.status,
-					class: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300',
-					icon: Clock
-				};
+				return { label: request.status ?? '', tone: 'neutral', icon: Clock };
 		}
 	});
-
-	const StatusIcon = $derived(statusDisplay.icon);
 
 	// Cancel mutation
 	const cancelMutation = createMutation(() => ({
@@ -127,7 +120,7 @@
 			<div class="min-w-0 flex-1">
 				<div class="mb-2 flex items-start justify-between gap-2">
 					<div class="min-w-0">
-						<h3 class="truncate text-lg font-semibold">
+						<h3 class="truncate text-lg font-bold">
 							<a
 								href={resolve('/(public)/events/[id]', { id: request.event.id })}
 								class="hover:underline focus:underline focus:outline-none"
@@ -136,12 +129,13 @@
 							</a>
 						</h3>
 					</div>
-					<div
-						class="inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium {statusDisplay.class}"
-					>
-						<StatusIcon class="h-3 w-3" aria-hidden="true" />
-						{statusDisplay.label}
-					</div>
+					<StatusBadge
+						tone={statusDisplay.tone}
+						label={statusDisplay.label}
+						icon={statusDisplay.icon}
+						size="sm"
+						class="shrink-0"
+					/>
 				</div>
 
 				<!-- Event Metadata -->

--- a/src/lib/components/notifications/NotificationDropdown.svelte
+++ b/src/lib/components/notifications/NotificationDropdown.svelte
@@ -80,7 +80,7 @@
 	>
 		<!-- Header -->
 		<div class="flex shrink-0 items-center justify-between border-b px-4 py-3">
-			<DropdownMenu.Label class="p-0 text-base font-semibold">
+			<DropdownMenu.Label class="p-0 text-base font-bold">
 				{m['notificationDropdown.notifications']()}
 			</DropdownMenu.Label>
 			<Button

--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -334,10 +334,12 @@
 	class={cn(
 		'group cursor-pointer overflow-hidden transition-all hover:shadow-md',
 		!isRead && 'border-l-4 border-l-primary bg-primary/5',
+		// bg-highlight/20 mirrors ToneTile's audited warning tokens (hand-verified
+		// 12.6:1 light / 6.7:1 dark — see ToneTile.svelte).
 		isWaitlistSpot &&
 			waitlistSpotData &&
 			!waitlistSpotData.expired &&
-			'border-l-4 border-l-amber-500 bg-amber-50 dark:bg-amber-950/30',
+			'border-l-4 border-l-highlight bg-highlight/20',
 		isWaitlistSpot && waitlistSpotData?.expired && 'border-l-4 border-l-muted bg-muted/30',
 		compact ? 'p-3' : 'p-4 md:p-6',
 		className
@@ -408,8 +410,8 @@
 							size={compact ? 'sm' : 'default'}
 							class={cn(
 								'min-h-11 w-full sm:w-auto',
-								'bg-amber-600 text-white hover:bg-amber-700',
-								'focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2'
+								'bg-highlight text-highlight-foreground hover:bg-highlight/90',
+								'focus-visible:ring-2 focus-visible:ring-highlight focus-visible:ring-offset-2'
 							)}
 							onclick={handleClaim}
 						>

--- a/src/lib/components/notifications/NotificationList.svelte
+++ b/src/lib/components/notifications/NotificationList.svelte
@@ -11,6 +11,7 @@
 	import { cn } from '$lib/utils/cn';
 	import { toast } from 'svelte-sonner';
 	import NotificationItem from './NotificationItem.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		authToken: string;
@@ -255,46 +256,37 @@
 			</div>
 		{:else if isError}
 			<!-- Error state -->
-			<Card class="p-8 text-center">
-				<div class="flex flex-col items-center gap-3">
-					<BellOff class="h-12 w-12 text-muted-foreground" aria-hidden="true" />
-					<div>
-						<h3 class="text-lg font-semibold">{m['notificationList.errorTitle']()}</h3>
-						<p class="mt-1 text-sm text-muted-foreground">
-							{m['notificationList.errorBody']()}
-						</p>
-					</div>
-					<Button
-						variant="outline"
-						size="sm"
-						onclick={() => queryClient.invalidateQueries({ queryKey: ['notifications'] })}
-					>
-						{m['notificationList.tryAgain']()}
-					</Button>
-				</div>
-			</Card>
+			{#snippet retryAction()}
+				<Button
+					variant="outline"
+					size="sm"
+					onclick={() => queryClient.invalidateQueries({ queryKey: ['notifications'] })}
+				>
+					{m['notificationList.tryAgain']()}
+				</Button>
+			{/snippet}
+			<EmptyState
+				icon={BellOff}
+				title={m['notificationList.errorTitle']()}
+				body={m['notificationList.errorBody']()}
+				tone="neutral"
+				action={retryAction}
+			/>
 		{:else if notifications.length === 0}
 			<!-- Empty state -->
-			<Card class="p-8 text-center">
-				<div class="flex flex-col items-center gap-3">
-					<BellOff class="h-12 w-12 text-muted-foreground" aria-hidden="true" />
-					<div>
-						<h3 class="text-lg font-semibold">{emptyMessage}</h3>
-						<p class="mt-1 text-sm text-muted-foreground">
-							{#if unreadOnly}
-								{m['notificationList.emptyUnreadBody']()}
-							{:else}
-								{m['notificationList.emptyAllBody']()}
-							{/if}
-						</p>
-					</div>
-					{#if unreadOnly}
-						<Button variant="outline" size="sm" onclick={handleFilterToggle}>
-							{m['notificationList.showAllNotifications']()}
-						</Button>
-					{/if}
-				</div>
-			</Card>
+			{#snippet showAllAction()}
+				<Button variant="outline" size="sm" onclick={handleFilterToggle}>
+					{m['notificationList.showAllNotifications']()}
+				</Button>
+			{/snippet}
+			<EmptyState
+				icon={BellOff}
+				title={emptyMessage}
+				body={unreadOnly
+					? m['notificationList.emptyUnreadBody']()
+					: m['notificationList.emptyAllBody']()}
+				action={unreadOnly ? showAllAction : undefined}
+			/>
 		{:else}
 			<!-- Notifications -->
 			<div

--- a/src/lib/components/notifications/NotificationTypeSettings.svelte
+++ b/src/lib/components/notifications/NotificationTypeSettings.svelte
@@ -124,7 +124,7 @@
 		<div class="flex items-center justify-between">
 			<div class="flex items-center gap-2">
 				<Settings class="h-5 w-5" aria-hidden="true" />
-				<h3 class="text-lg font-semibold">{m['notificationPreferences.advancedSettings']()}</h3>
+				<h3 class="text-lg font-bold">{m['notificationPreferences.advancedSettings']()}</h3>
 			</div>
 			<ChevronDown
 				class="h-5 w-5 transition-transform duration-200 {advancedOpen ? 'rotate-180' : ''}"

--- a/src/lib/components/rsvps/RSVPCard.svelte
+++ b/src/lib/components/rsvps/RSVPCard.svelte
@@ -12,6 +12,8 @@
 		getEventCoverArt,
 		getEventCoverArtThumbnail
 	} from '$lib/utils/event';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		rsvp: UserRsvpSchema;
@@ -53,33 +55,18 @@
 	// Format created date
 	const createdDate = $derived(formatDate(rsvp.created_at));
 
-	// Get RSVP status info
-	const statusInfo = $derived.by(() => {
+	// Get RSVP status info — thin mapper onto the shared StatusBadge tone system
+	// (same visible labels as before, solid-fill tokens instead of hand-picked hues).
+	const statusInfo = $derived.by((): { label: string; icon: typeof CheckCircle2; tone: Tone } => {
 		switch (rsvp.status) {
 			case 'yes':
-				return {
-					label: m['rsvpCard.going'](),
-					icon: CheckCircle2,
-					colorClass: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-				};
+				return { label: m['rsvpCard.going'](), icon: CheckCircle2, tone: 'success' };
 			case 'no':
-				return {
-					label: m['rsvpCard.notGoing'](),
-					icon: XCircle,
-					colorClass: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
-				};
+				return { label: m['rsvpCard.notGoing'](), icon: XCircle, tone: 'danger' };
 			case 'maybe':
-				return {
-					label: m['rsvpCard.maybe'](),
-					icon: HelpCircle,
-					colorClass: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
-				};
+				return { label: m['rsvpCard.maybe'](), icon: HelpCircle, tone: 'warning' };
 			default:
-				return {
-					label: m['rsvpCard.unknown'](),
-					icon: HelpCircle,
-					colorClass: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300'
-				};
+				return { label: m['rsvpCard.unknown'](), icon: HelpCircle, tone: 'neutral' };
 		}
 	});
 
@@ -108,7 +95,7 @@
 			<!-- Event Details -->
 			<div class="min-w-0 flex-1">
 				<div class="mb-2">
-					<h3 class="text-lg font-semibold">
+					<h3 class="text-lg font-bold">
 						<a
 							href={resolve('/(public)/events/[id]', { id: rsvp.event.id })}
 							class="hover:underline focus:underline focus:outline-none"
@@ -116,12 +103,13 @@
 							{rsvp.event.name}
 						</a>
 					</h3>
-					<div
-						class="mt-1 inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium {statusInfo.colorClass}"
-					>
-						<StatusIcon class="h-3 w-3" aria-hidden="true" />
-						{statusInfo.label}
-					</div>
+					<StatusBadge
+						tone={statusInfo.tone}
+						label={statusInfo.label}
+						icon={StatusIcon}
+						size="sm"
+						class="mt-1"
+					/>
 				</div>
 
 				<!-- Event Metadata -->

--- a/src/lib/components/series-passes/HeldPassCard.svelte
+++ b/src/lib/components/series-passes/HeldPassCard.svelte
@@ -65,7 +65,7 @@
 			<div class="min-w-0 flex-1">
 				<div class="mb-2 flex items-start justify-between gap-2">
 					<div class="min-w-0 flex-1">
-						<h3 class="text-lg font-semibold">{heldPass.series_pass.name}</h3>
+						<h3 class="text-lg font-bold">{heldPass.series_pass.name}</h3>
 						{#if seriesOrgSlug}
 							<a
 								href={resolve('/(public)/events/[org_slug]/series/[series_slug]', {

--- a/src/lib/components/tickets/MyTicket.svelte
+++ b/src/lib/components/tickets/MyTicket.svelte
@@ -5,7 +5,7 @@
 	import TicketStatusBadge from './TicketStatusBadge.svelte';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import DownloadPdfButton from './DownloadPdfButton.svelte';
-	import { Ticket, Calendar, MapPin, User, Armchair, Banknote } from '@lucide/svelte';
+	import { Ticket, Calendar, MapPin, User, Armchair, Banknote, AlertCircle } from '@lucide/svelte';
 	import { formatDateTime } from '$lib/utils/date';
 	import { formatMoney } from '$lib/utils/format';
 	import QRCode from 'qrcode';
@@ -137,21 +137,26 @@
 	);
 </script>
 
-<Card class="p-6">
+<Card class="overflow-hidden p-6">
 	<div class="space-y-6">
-		<!-- Header -->
-		<div class="flex items-start justify-between">
-			<div class="flex items-center gap-3">
-				<div class="rounded-full bg-primary/10 p-3">
-					<Ticket class="h-6 w-6 text-primary" aria-hidden="true" />
-				</div>
-				<div>
-					<h2 class="text-xl font-bold">{eventName}</h2>
-					<p class="text-sm text-muted-foreground">
-						{ticket.tier?.name || m['myTicket.generalAdmission']()}
-					</p>
-				</div>
-			</div>
+		<!-- Header band — the brand moment (what people screenshot at the door).
+		     Bleeds to the card edges on the logo gradient (--logo-from -> --logo-to,
+		     the same pair RevelMark uses). Only large/bold text and icons sit on the
+		     gradient: white on the purple end measures ~5.5:1, white on the crimson
+		     end ~4.3:1 — that clears the WCAG AA *large-text* floor (3:1) at both
+		     ends but not the 4.5:1 normal-text floor, so smaller metadata (tier
+		     name, status) stays off the gradient, on the card surface below. -->
+		<div
+			class="-mx-6 -mt-6 mb-2 flex items-center gap-3 rounded-t-lg px-6 py-5"
+			style="background: linear-gradient(135deg, hsl(var(--logo-from)), hsl(var(--logo-to)));"
+		>
+			<Ticket class="h-7 w-7 shrink-0 text-poster-white" aria-hidden="true" />
+			<h2 class="text-2xl font-black leading-[1.12] text-poster-white sm:text-3xl">{eventName}</h2>
+		</div>
+		<div class="flex items-start justify-between gap-2">
+			<p class="text-sm font-extrabold uppercase tracking-[0.1em] text-muted-foreground">
+				{ticket.tier?.name || m['myTicket.generalAdmission']()}
+			</p>
 			<TicketStatusBadge status={ticket.status} />
 		</div>
 
@@ -185,30 +190,22 @@
 			</ul>
 		{/if}
 
-		<!-- Pending Payment Banner -->
+		<!-- Pending Payment Banner. Tint/text pair mirrors ToneTile's audited
+		     warning tokens (bg-highlight/20, text-highlight-foreground light /
+		     text-highlight dark — see ToneTile.svelte for the hand-verified
+		     ratios: 12.6:1 light, 6.7:1 dark). -->
 		{#if ticket.status === 'pending'}
-			<div
-				class="rounded-lg border border-orange-200 bg-orange-50 p-4 dark:border-orange-800 dark:bg-orange-950"
-				role="alert"
-			>
+			<div class="rounded-lg border border-highlight/40 bg-highlight/20 p-4" role="alert">
 				<div class="flex items-start gap-3">
-					<svg
-						class="h-5 w-5 shrink-0 text-orange-600 dark:text-orange-400"
-						fill="currentColor"
-						viewBox="0 0 20 20"
+					<AlertCircle
+						class="h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
 						aria-hidden="true"
-					>
-						<path
-							fill-rule="evenodd"
-							d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z"
-							clip-rule="evenodd"
-						/>
-					</svg>
+					/>
 					<div class="flex-1">
-						<p class="font-medium text-orange-900 dark:text-orange-100">
+						<p class="font-bold text-highlight-foreground dark:text-highlight">
 							{m['myTicket.pendingPayment']()}
 						</p>
-						<p class="mt-1 text-sm text-orange-800 dark:text-orange-200">
+						<p class="mt-1 text-sm text-highlight-foreground dark:text-highlight">
 							{#if ticket.tier?.payment_method === 'online'}
 								{m['myTicket.pendingOnline']()}
 							{:else if ticket.tier?.payment_method === 'offline'}
@@ -220,15 +217,13 @@
 
 						<!-- Manual Payment Instructions -->
 						{#if ticket.tier?.payment_method !== 'online' && ticket.tier?.manual_payment_instructions}
-							<div
-								class="mt-3 rounded-md border border-orange-300 bg-orange-100 p-3 dark:border-orange-700 dark:bg-orange-900"
-							>
-								<p class="text-sm font-medium text-orange-900 dark:text-orange-100">
+							<div class="mt-3 rounded-md border border-highlight/40 bg-card p-3">
+								<p class="text-sm font-bold text-foreground">
 									{m['myTicket.paymentInstructions']()}
 								</p>
 								<MarkdownContent
 									content={ticket.tier.manual_payment_instructions}
-									class="mt-1 text-sm text-orange-800 dark:text-orange-200"
+									class="mt-1 text-sm text-muted-foreground"
 								/>
 							</div>
 						{/if}
@@ -237,11 +232,11 @@
 							<button
 								onclick={onResumePayment}
 								disabled={isResumingPayment}
-								class="mt-3 inline-flex items-center gap-2 rounded-md bg-orange-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-orange-500 dark:hover:bg-orange-600"
+								class="mt-3 inline-flex items-center gap-2 rounded-md bg-highlight px-4 py-2 text-sm font-medium text-highlight-foreground shadow-sm hover:bg-highlight/90 focus:outline-none focus:ring-2 focus:ring-highlight focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 							>
 								{#if isResumingPayment}
 									<div
-										class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+										class="h-4 w-4 animate-spin rounded-full border-2 border-highlight-foreground border-t-transparent"
 										aria-hidden="true"
 									></div>
 									{m['myTicket.processing']()}
@@ -302,10 +297,12 @@
 			</div>
 		{/if}
 
-		<!-- Checked In Info -->
+		<!-- Checked In Info. bg-info/10 + text-info mirrors ToneTile's audited
+		     info tokens (hand-verified 8.3:1 light / 8.0:1 dark — see
+		     ToneTile.svelte). -->
 		{#if ticket.status === 'checked_in' && checkedInDate}
-			<div class="rounded-lg bg-blue-50 p-4 text-sm">
-				<p class="font-medium text-blue-900">{m['myTicket.checkedInAt']()} {checkedInDate}</p>
+			<div class="rounded-lg bg-info/10 p-4 text-sm">
+				<p class="font-bold text-info">{m['myTicket.checkedInAt']()} {checkedInDate}</p>
 			</div>
 		{/if}
 

--- a/src/lib/components/tickets/MyTicket.svelte
+++ b/src/lib/components/tickets/MyTicket.svelte
@@ -141,14 +141,20 @@
 	<div class="space-y-6">
 		<!-- Header band — the brand moment (what people screenshot at the door).
 		     Bleeds to the card edges on the logo gradient (--logo-from -> --logo-to,
-		     the same pair RevelMark uses). Only large/bold text and icons sit on the
-		     gradient: white on the purple end measures ~5.5:1, white on the crimson
-		     end ~4.3:1 — that clears the WCAG AA *large-text* floor (3:1) at both
-		     ends but not the 4.5:1 normal-text floor, so smaller metadata (tier
-		     name, status) stays off the gradient, on the card surface below. -->
+		     the same pair RevelMark uses). NOTE: --logo-from/--logo-to are already
+		     COMPLETE hsl(...) values (see app.css) — do not wrap them in another
+		     hsl() (see RevelMark.svelte:36 for the correct var()-only usage); doing
+		     so produces hsl(hsl(...)), an invalid value that drops the whole
+		     declaration and leaves the band transparent. Only large/bold text and
+		     icons sit on the gradient: white on the purple end measures ~5.5:1,
+		     white on the crimson end ~4.3:1 — that clears the WCAG AA *large-text*
+		     floor (3:1) at both ends but NOT the 4.5:1 normal-text floor. Do not
+		     shrink this text below the large-text threshold (effectively
+		     `font-black`/`sm:text-3xl` here). Smaller metadata (tier name, status)
+		     stays off the gradient, on the card surface below. -->
 		<div
-			class="-mx-6 -mt-6 mb-2 flex items-center gap-3 rounded-t-lg px-6 py-5"
-			style="background: linear-gradient(135deg, hsl(var(--logo-from)), hsl(var(--logo-to)));"
+			class="-mx-6 -mt-6 flex items-center gap-3 rounded-t-lg px-6 py-5"
+			style="background: linear-gradient(135deg, var(--logo-from), var(--logo-to));"
 		>
 			<Ticket class="h-7 w-7 shrink-0 text-poster-white" aria-hidden="true" />
 			<h2 class="text-2xl font-black leading-[1.12] text-poster-white sm:text-3xl">{eventName}</h2>
@@ -192,8 +198,11 @@
 
 		<!-- Pending Payment Banner. Tint/text pair mirrors ToneTile's audited
 		     warning tokens (bg-highlight/20, text-highlight-foreground light /
-		     text-highlight dark — see ToneTile.svelte for the hand-verified
-		     ratios: 12.6:1 light, 6.7:1 dark). -->
+		     text-highlight dark). Hand-verified on THIS surface (bg-highlight/20
+		     composited over --card, the Card this banner sits in): 13.93:1 light,
+		     5.96:1 dark. Recompute if this banner is ever moved onto a different
+		     surface (ToneTile.svelte's own comment is for its icon tile on
+		     page/card, not this banner). -->
 		{#if ticket.status === 'pending'}
 			<div class="rounded-lg border border-highlight/40 bg-highlight/20 p-4" role="alert">
 				<div class="flex items-start gap-3">
@@ -298,8 +307,8 @@
 		{/if}
 
 		<!-- Checked In Info. bg-info/10 + text-info mirrors ToneTile's audited
-		     info tokens (hand-verified 8.3:1 light / 8.0:1 dark — see
-		     ToneTile.svelte). -->
+		     info tokens. Hand-verified on THIS surface (bg-info/10 composited over
+		     --card, the Card this banner sits in): 9.31:1 light, 7.15:1 dark. -->
 		{#if ticket.status === 'checked_in' && checkedInDate}
 			<div class="rounded-lg bg-info/10 p-4 text-sm">
 				<p class="font-bold text-info">{m['myTicket.checkedInAt']()} {checkedInDate}</p>

--- a/src/lib/components/tickets/MyTicketModal.svelte
+++ b/src/lib/components/tickets/MyTicketModal.svelte
@@ -19,7 +19,8 @@
 		ChevronLeft,
 		ChevronRight,
 		Pencil,
-		X
+		X,
+		AlertCircle
 	} from '@lucide/svelte';
 	import { formatMoney } from '$lib/utils/format';
 	import QRCode from 'qrcode';
@@ -304,13 +305,13 @@
 						<div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
 							{#if activeTicketCount > 0}
 								<span class="flex items-center gap-1.5">
-									<span class="h-2 w-2 rounded-full bg-green-500"></span>
+									<span class="h-2 w-2 rounded-full bg-success"></span>
 									<span>{m['myTicketModal.activeCount']({ count: activeTicketCount })}</span>
 								</span>
 							{/if}
 							{#if pendingTicketCount > 0}
 								<span class="flex items-center gap-1.5">
-									<span class="h-2 w-2 rounded-full bg-orange-500"></span>
+									<span class="h-2 w-2 rounded-full bg-highlight"></span>
 									<span>{m['myTicketModal.pendingCount']({ count: pendingTicketCount })}</span>
 								</span>
 							{/if}
@@ -347,19 +348,26 @@
 					</div>
 				{/if}
 
-				<!-- Header -->
-				<div class="flex items-start justify-between">
-					<div class="flex items-center gap-3">
-						<div class="rounded-full bg-primary/10 p-3">
-							<Ticket class="h-6 w-6 text-primary" aria-hidden="true" />
-						</div>
-						<div>
-							<h2 class="text-xl font-bold">{eventName}</h2>
-							<p class="text-sm text-muted-foreground">
-								{ticket.tier?.name || m['myTicketModal.generalAdmission']()}
-							</p>
-						</div>
-					</div>
+				<!-- Header band — the brand moment (what people screenshot at the door).
+				     On the logo gradient (--logo-from -> --logo-to, the same pair
+				     RevelMark uses); inset (not bled to the dialog edge) so it never
+				     collides with the dialog's close button. Only large/bold text and
+				     icons sit on the gradient: white on the purple end measures
+				     ~5.5:1, white on the crimson end ~4.3:1 — that clears the WCAG AA
+				     *large-text* floor (3:1) at both ends but not the 4.5:1
+				     normal-text floor, so smaller metadata (tier name, status) stays
+				     off the gradient, on the dialog surface below. -->
+				<div
+					class="flex items-center gap-3 rounded-lg px-5 py-4"
+					style="background: linear-gradient(135deg, hsl(var(--logo-from)), hsl(var(--logo-to)));"
+				>
+					<Ticket class="h-6 w-6 shrink-0 text-poster-white" aria-hidden="true" />
+					<h2 class="text-xl font-black leading-tight text-poster-white">{eventName}</h2>
+				</div>
+				<div class="flex items-start justify-between gap-2">
+					<p class="text-sm font-extrabold uppercase tracking-[0.1em] text-muted-foreground">
+						{ticket.tier?.name || m['myTicketModal.generalAdmission']()}
+					</p>
 					<TicketStatusBadge status={ticket.status} />
 				</div>
 
@@ -414,36 +422,28 @@
 					</dl>
 				{/if}
 
-				<!-- Pending Payment Banner -->
+				<!-- Pending Payment Banner. Tint/text pair mirrors ToneTile's audited
+				     warning tokens (bg-highlight/20, text-highlight-foreground light /
+				     text-highlight dark — see ToneTile.svelte for the hand-verified
+				     ratios: 12.6:1 light, 6.7:1 dark). -->
 				{#if ticket.status === 'pending'}
 					{@const paymentGroup = currentTicketPaymentGroup}
 					{@const ticketsInGroup = paymentGroup?.tickets.length ?? 1}
-					<div
-						class="rounded-lg border border-orange-200 bg-orange-50 p-4 dark:border-orange-800 dark:bg-orange-950"
-						role="alert"
-					>
+					<div class="rounded-lg border border-highlight/40 bg-highlight/20 p-4" role="alert">
 						<div class="flex items-start gap-3">
-							<svg
-								class="h-5 w-5 shrink-0 text-orange-600 dark:text-orange-400"
-								fill="currentColor"
-								viewBox="0 0 20 20"
+							<AlertCircle
+								class="h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
 								aria-hidden="true"
-							>
-								<path
-									fill-rule="evenodd"
-									d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z"
-									clip-rule="evenodd"
-								/>
-							</svg>
+							/>
 							<div class="flex-1">
-								<p class="font-medium text-orange-900 dark:text-orange-100">
+								<p class="font-bold text-highlight-foreground dark:text-highlight">
 									{#if ticketsInGroup > 1}
 										{m['myTicketModal.ticketsPendingPayment']({ count: ticketsInGroup })}
 									{:else}
 										{m['myTicketModal.pendingPayment']()}
 									{/if}
 								</p>
-								<p class="mt-1 text-sm text-orange-800 dark:text-orange-200">
+								<p class="mt-1 text-sm text-highlight-foreground dark:text-highlight">
 									{#if ticket.tier?.payment_method === 'online'}
 										{ticketsInGroup > 1
 											? m['myTicketModal.pendingOnlinePlural']()
@@ -461,15 +461,13 @@
 
 								<!-- Manual Payment Instructions -->
 								{#if ticket.tier?.payment_method !== 'online' && ticket.tier?.manual_payment_instructions}
-									<div
-										class="mt-3 rounded-md border border-orange-300 bg-orange-100 p-3 dark:border-orange-700 dark:bg-orange-900"
-									>
-										<p class="text-sm font-medium text-orange-900 dark:text-orange-100">
+									<div class="mt-3 rounded-md border border-highlight/40 bg-card p-3">
+										<p class="text-sm font-bold text-foreground">
 											{m['myTicketModal.paymentInstructions']()}
 										</p>
 										<MarkdownContent
 											content={ticket.tier.manual_payment_instructions}
-											class="mt-1 text-sm text-orange-800 dark:text-orange-200"
+											class="mt-1 text-sm text-muted-foreground"
 										/>
 									</div>
 								{/if}
@@ -482,11 +480,11 @@
 											<button
 												onclick={() => onResumePayment(paymentId)}
 												disabled={isResumingPayment || isCancellingReservation}
-												class="inline-flex items-center gap-2 rounded-md bg-orange-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-orange-500 dark:hover:bg-orange-600"
+												class="inline-flex items-center gap-2 rounded-md bg-highlight px-4 py-2 text-sm font-medium text-highlight-foreground shadow-sm hover:bg-highlight/90 focus:outline-none focus:ring-2 focus:ring-highlight focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 											>
 												{#if isResumingPayment}
 													<div
-														class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+														class="h-4 w-4 animate-spin rounded-full border-2 border-highlight-foreground border-t-transparent"
 														aria-hidden="true"
 													></div>
 													{m['myTicketModal.processing']()}
@@ -499,11 +497,11 @@
 											<button
 												onclick={() => onCancelReservation(paymentId)}
 												disabled={isResumingPayment || isCancellingReservation}
-												class="inline-flex items-center gap-2 rounded-md border border-orange-300 bg-transparent px-4 py-2 text-sm font-medium text-orange-700 shadow-sm hover:bg-orange-100 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-orange-700 dark:text-orange-300 dark:hover:bg-orange-900/50"
+												class="inline-flex items-center gap-2 rounded-md border border-highlight/60 bg-transparent px-4 py-2 text-sm font-medium text-foreground shadow-sm hover:bg-highlight/10 focus:outline-none focus:ring-2 focus:ring-highlight focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 											>
 												{#if isCancellingReservation}
 													<div
-														class="h-4 w-4 animate-spin rounded-full border-2 border-orange-600 border-t-transparent dark:border-orange-400"
+														class="h-4 w-4 animate-spin rounded-full border-2 border-foreground border-t-transparent"
 														aria-hidden="true"
 													></div>
 													{m['myTicketModal.cancelling']()}
@@ -574,10 +572,12 @@
 					</div>
 				{/if}
 
-				<!-- Checked In Info -->
+				<!-- Checked In Info. bg-info/10 + text-info mirrors ToneTile's audited
+				     info tokens (hand-verified 8.3:1 light / 8.0:1 dark — see
+				     ToneTile.svelte). -->
 				{#if ticket.status === 'checked_in' && checkedInDate}
-					<div class="rounded-lg bg-blue-50 p-4 text-sm dark:bg-blue-950/50">
-						<p class="font-medium text-blue-900 dark:text-blue-100">
+					<div class="rounded-lg bg-info/10 p-4 text-sm">
+						<p class="font-bold text-info">
 							{m['myTicketModal.checkedInAt']({ date: checkedInDate })}
 						</p>
 					</div>

--- a/src/lib/components/tickets/MyTicketModal.svelte
+++ b/src/lib/components/tickets/MyTicketModal.svelte
@@ -351,15 +351,21 @@
 				<!-- Header band — the brand moment (what people screenshot at the door).
 				     On the logo gradient (--logo-from -> --logo-to, the same pair
 				     RevelMark uses); inset (not bled to the dialog edge) so it never
-				     collides with the dialog's close button. Only large/bold text and
-				     icons sit on the gradient: white on the purple end measures
-				     ~5.5:1, white on the crimson end ~4.3:1 — that clears the WCAG AA
-				     *large-text* floor (3:1) at both ends but not the 4.5:1
-				     normal-text floor, so smaller metadata (tier name, status) stays
+				     collides with the dialog's close button. NOTE: --logo-from/
+				     --logo-to are already COMPLETE hsl(...) values (see app.css) — do
+				     not wrap them in another hsl() (see RevelMark.svelte:36 for the
+				     correct var()-only usage); doing so produces hsl(hsl(...)), an
+				     invalid value that drops the whole declaration and leaves the
+				     band transparent. Only large/bold text and icons sit on the
+				     gradient: white on the purple end measures ~5.5:1, white on the
+				     crimson end ~4.3:1 — that clears the WCAG AA *large-text* floor
+				     (3:1) at both ends but NOT the 4.5:1 normal-text floor. Do not
+				     shrink this text below the large-text threshold (effectively
+				     `font-black` here). Smaller metadata (tier name, status) stays
 				     off the gradient, on the dialog surface below. -->
 				<div
 					class="flex items-center gap-3 rounded-lg px-5 py-4"
-					style="background: linear-gradient(135deg, hsl(var(--logo-from)), hsl(var(--logo-to)));"
+					style="background: linear-gradient(135deg, var(--logo-from), var(--logo-to));"
 				>
 					<Ticket class="h-6 w-6 shrink-0 text-poster-white" aria-hidden="true" />
 					<h2 class="text-xl font-black leading-tight text-poster-white">{eventName}</h2>
@@ -424,8 +430,9 @@
 
 				<!-- Pending Payment Banner. Tint/text pair mirrors ToneTile's audited
 				     warning tokens (bg-highlight/20, text-highlight-foreground light /
-				     text-highlight dark — see ToneTile.svelte for the hand-verified
-				     ratios: 12.6:1 light, 6.7:1 dark). -->
+				     text-highlight dark). Hand-verified on THIS surface (bg-highlight/20
+				     composited over --background — DialogContent uses bg-background,
+				     not bg-card, unlike MyTicket's Card): 12.56:1 light, 6.65:1 dark. -->
 				{#if ticket.status === 'pending'}
 					{@const paymentGroup = currentTicketPaymentGroup}
 					{@const ticketsInGroup = paymentGroup?.tickets.length ?? 1}
@@ -573,8 +580,9 @@
 				{/if}
 
 				<!-- Checked In Info. bg-info/10 + text-info mirrors ToneTile's audited
-				     info tokens (hand-verified 8.3:1 light / 8.0:1 dark — see
-				     ToneTile.svelte). -->
+				     info tokens. Hand-verified on THIS surface (bg-info/10 composited
+				     over --background — DialogContent uses bg-background, not
+				     bg-card): 8.27:1 light, 7.98:1 dark. -->
 				{#if ticket.status === 'checked_in' && checkedInDate}
 					<div class="rounded-lg bg-info/10 p-4 text-sm">
 						<p class="font-bold text-info">

--- a/src/lib/components/tickets/TicketListCard.svelte
+++ b/src/lib/components/tickets/TicketListCard.svelte
@@ -98,7 +98,7 @@
 			<div class="min-w-0 flex-1">
 				<div class="mb-2 flex items-start justify-between gap-2">
 					<div class="min-w-0 flex-1">
-						<h3 class="text-lg font-semibold">
+						<h3 class="text-lg font-bold">
 							<a
 								href={resolve('/(public)/events/[id]', { id: ticket.event.id })}
 								class="hover:underline focus:underline focus:outline-none"

--- a/src/lib/components/tickets/TicketStatusBadge.svelte
+++ b/src/lib/components/tickets/TicketStatusBadge.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { CheckCircle, Clock, XCircle, Ticket as TicketIcon } from '@lucide/svelte';
-	import { cn } from '$lib/utils';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		status: string;
@@ -10,56 +11,23 @@
 
 	const { status, class: className }: Props = $props();
 
-	const config = $derived.by(() => {
+	// Thin mapper over the shared StatusBadge (rebrand primitive): same filename,
+	// same props, same visible labels as before — only the rendering delegates
+	// to the audited solid-fill tone system instead of hand-picked hues.
+	const config = $derived.by((): { label: string; icon: typeof CheckCircle; tone: Tone } => {
 		switch (status) {
 			case 'active':
-				return {
-					label: m['ticketStatusBadge.active'](),
-					icon: CheckCircle,
-					className:
-						'bg-green-100 text-green-800 border-green-200 dark:bg-green-950 dark:text-green-100 dark:border-green-800'
-				};
+				return { label: m['ticketStatusBadge.active'](), icon: CheckCircle, tone: 'success' };
 			case 'pending':
-				return {
-					label: m['ticketStatusBadge.pending'](),
-					icon: Clock,
-					className:
-						'bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-950 dark:text-orange-100 dark:border-orange-800'
-				};
+				return { label: m['ticketStatusBadge.pending'](), icon: Clock, tone: 'warning' };
 			case 'checked_in':
-				return {
-					label: m['ticketStatusBadge.checkedIn'](),
-					icon: TicketIcon,
-					className:
-						'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-950 dark:text-blue-100 dark:border-blue-800'
-				};
+				return { label: m['ticketStatusBadge.checkedIn'](), icon: TicketIcon, tone: 'info' };
 			case 'cancelled':
-				return {
-					label: m['ticketStatusBadge.cancelled'](),
-					icon: XCircle,
-					className:
-						'bg-red-100 text-red-800 border-red-200 dark:bg-red-950 dark:text-red-100 dark:border-red-800'
-				};
+				return { label: m['ticketStatusBadge.cancelled'](), icon: XCircle, tone: 'danger' };
 			default:
-				return {
-					label: status.replace(/_/g, ' '),
-					icon: TicketIcon,
-					className:
-						'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700'
-				};
+				return { label: status.replace(/_/g, ' '), icon: TicketIcon, tone: 'neutral' };
 		}
 	});
-
-	const Icon = $derived(config.icon);
 </script>
 
-<span
-	class={cn(
-		'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold',
-		config.className,
-		className
-	)}
->
-	<Icon class="h-3.5 w-3.5" aria-hidden="true" />
-	{config.label}
-</span>
+<StatusBadge tone={config.tone} label={config.label} icon={config.icon} class={className} />

--- a/src/routes/(auth)/dashboard/+page.svelte
+++ b/src/routes/(auth)/dashboard/+page.svelte
@@ -17,6 +17,8 @@
 		DashboardUpcomingEvents,
 		DashboardOrganizationsSection
 	} from '$lib/components/dashboard';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import {
 		filterPresets,
 		isFilterActive as isFilterActiveFor,
@@ -304,13 +306,7 @@
 
 <div class="container mx-auto px-4 py-6 md:py-8">
 	<!-- Welcome Header -->
-	<div class="mb-8">
-		<h1 class="mb-2 text-2xl font-bold md:text-3xl">{m['dashboard.pageTitle']({ firstName })}</h1>
-		<p class="text-muted-foreground">{m['dashboard.pageSubtitle']()}</p>
-	</div>
-
-	<!-- Quick Action Bar -->
-	<div class="mb-8 flex flex-wrap gap-3">
+	{#snippet quickActions()}
 		<a
 			href={resolve('/(public)/events', {})}
 			class="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
@@ -394,7 +390,15 @@
 				<span>{m['dashboard.createOrganizationButton']()}</span>
 			</a>
 		{/if}
-	</div>
+	{/snippet}
+	<PageHeader
+		title={m['dashboard.pageTitle']({ firstName })}
+		subtitle={m['dashboard.pageSubtitle']()}
+		kicker={m['userMenu.dashboard']()}
+		volume="celebration"
+		actions={quickActions}
+		class="mb-8"
+	/>
 
 	<!-- Activity Summary Cards -->
 	<DashboardActivityCards {activeTicketsCount} {pendingInvitationsCount} {upcomingRsvpsCount} />
@@ -406,7 +410,7 @@
 			<section aria-labelledby="your-events-heading">
 				<div class="mb-4">
 					<div class="mb-3 flex items-center justify-between">
-						<h2 id="your-events-heading" class="flex items-center gap-2 text-xl font-semibold">
+						<h2 id="your-events-heading" class="flex items-center gap-2 text-xl font-extrabold">
 							<Calendar class="h-5 w-5 text-primary" aria-hidden="true" />
 							<span>{m['dashboard.sections.yourEvents']()}</span>
 							{#if viewMode === 'list' && yourEvents.length > 0}
@@ -494,13 +498,12 @@
 						</div>
 					{:else}
 						<!-- Empty state when filter returns no results -->
-						<div class="rounded-lg border bg-card p-8 text-center">
-							<Calendar class="mx-auto mb-4 h-12 w-12 text-muted-foreground" aria-hidden="true" />
-							<h3 class="mb-2 text-lg font-semibold">{m['dashboard.emptyStates.noEvents']()}</h3>
-							<p class="mb-4 text-sm text-muted-foreground">
-								{m['dashboard.emptyStates.noEventsFiltered']()}
-							</p>
-						</div>
+						<EmptyState
+							icon={Calendar}
+							title={m['dashboard.emptyStates.noEvents']()}
+							body={m['dashboard.emptyStates.noEventsFiltered']()}
+							tone="neutral"
+						/>
 					{/if}
 				{:else}
 					<!-- Calendar View -->

--- a/src/routes/(auth)/dashboard/following/+page.svelte
+++ b/src/routes/(auth)/dashboard/following/+page.svelte
@@ -10,9 +10,11 @@
 		eventseriesUnfollowEventSeries,
 		eventseriesUpdateEventSeriesFollow
 	} from '$lib/api/generated/sdk.gen';
-	import { Heart, Building2, Calendar, Loader2, ChevronLeft, ChevronRight } from '@lucide/svelte';
+	import { Building2, Calendar, Loader2, ChevronLeft, ChevronRight } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { toast } from 'svelte-sonner';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
@@ -199,16 +201,12 @@
 
 <div class="container mx-auto px-4 py-6 md:py-8">
 	<!-- Page Header -->
-	<div class="mb-8">
-		<div class="mb-2 flex items-center gap-3">
-			<div class="rounded-lg bg-primary/10 p-2">
-				<Heart class="h-6 w-6 text-primary" aria-hidden="true" />
-			</div>
-			<div>
-				<h1 class="text-2xl font-bold md:text-3xl">{m['dashboard.following.title']()}</h1>
-			</div>
-		</div>
-	</div>
+	<PageHeader
+		title={m['dashboard.following.title']()}
+		kicker={m['dashboard.followingButton']()}
+		volume="celebration"
+		class="mb-8"
+	/>
 
 	<!-- Tabs -->
 	<div class="mb-6">
@@ -266,17 +264,17 @@
 					<Loader2 class="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
 				</div>
 			{:else if organizations.length === 0}
-				<div class="rounded-lg border bg-card p-12 text-center">
-					<div
-						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10"
-					>
-						<Building2 class="h-8 w-8 text-primary" aria-hidden="true" />
-					</div>
-					<h3 class="mb-2 text-lg font-semibold">{m['dashboard.following.noOrganizations']()}</h3>
-					<Button href="/organizations" variant="default" class="mt-4">
+				{#snippet discoverOrganizationsAction()}
+					<Button href="/organizations" variant="default">
 						{m['dashboard.following.discoverOrganizations']()}
 					</Button>
-				</div>
+				{/snippet}
+				<EmptyState
+					icon={Building2}
+					title={m['dashboard.following.noOrganizations']()}
+					action={discoverOrganizationsAction}
+					level={3}
+				/>
 			{:else}
 				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{#each organizations as follow (follow.id)}
@@ -299,7 +297,7 @@
 								<div class="min-w-0 flex-1">
 									<a
 										href={resolve('/(public)/org/[slug]', { slug: org.slug })}
-										class="block truncate font-semibold hover:text-primary hover:underline"
+										class="block truncate font-bold hover:text-primary hover:underline"
 									>
 										{org.name}
 									</a>
@@ -399,17 +397,17 @@
 					<Loader2 class="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
 				</div>
 			{:else if eventSeries.length === 0}
-				<div class="rounded-lg border bg-card p-12 text-center">
-					<div
-						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10"
-					>
-						<Calendar class="h-8 w-8 text-primary" aria-hidden="true" />
-					</div>
-					<h3 class="mb-2 text-lg font-semibold">{m['dashboard.following.noEventSeries']()}</h3>
-					<Button href="/events" variant="default" class="mt-4">
+				{#snippet discoverEventSeriesAction()}
+					<Button href="/events" variant="default">
 						{m['dashboard.following.discoverEventSeries']()}
 					</Button>
-				</div>
+				{/snippet}
+				<EmptyState
+					icon={Calendar}
+					title={m['dashboard.following.noEventSeries']()}
+					action={discoverEventSeriesAction}
+					level={3}
+				/>
 			{:else}
 				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{#each eventSeries as follow (follow.id)}
@@ -435,7 +433,7 @@
 											org_slug: series.organization.slug,
 											series_slug: series.slug
 										})}
-										class="block truncate font-semibold hover:text-primary hover:underline"
+										class="block truncate font-bold hover:text-primary hover:underline"
 									>
 										{series.name}
 									</a>

--- a/src/routes/(auth)/dashboard/following/+page.svelte
+++ b/src/routes/(auth)/dashboard/following/+page.svelte
@@ -203,7 +203,7 @@
 	<!-- Page Header -->
 	<PageHeader
 		title={m['dashboard.following.title']()}
-		kicker={m['dashboard.followingButton']()}
+		kicker={m['userMenu.dashboard']()}
 		volume="celebration"
 		class="mb-8"
 	/>
@@ -215,10 +215,10 @@
 				<button
 					type="button"
 					onclick={() => switchTab('organizations')}
-					class="inline-flex items-center gap-2 border-b-2 px-1 py-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {activeTab ===
+					class="inline-flex items-center gap-2 border-b-2 px-1 py-4 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {activeTab ===
 					'organizations'
-						? 'border-primary text-primary'
-						: 'border-transparent text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground'}"
+						? 'border-primary font-bold text-primary'
+						: 'border-transparent font-semibold text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground'}"
 					aria-current={activeTab === 'organizations' ? 'page' : undefined}
 				>
 					<Building2 class="h-4 w-4" aria-hidden="true" />
@@ -235,10 +235,10 @@
 				<button
 					type="button"
 					onclick={() => switchTab('event-series')}
-					class="inline-flex items-center gap-2 border-b-2 px-1 py-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {activeTab ===
+					class="inline-flex items-center gap-2 border-b-2 px-1 py-4 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {activeTab ===
 					'event-series'
-						? 'border-primary text-primary'
-						: 'border-transparent text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground'}"
+						? 'border-primary font-bold text-primary'
+						: 'border-transparent font-semibold text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground'}"
 					aria-current={activeTab === 'event-series' ? 'page' : undefined}
 				>
 					<Calendar class="h-4 w-4" aria-hidden="true" />

--- a/src/routes/(auth)/dashboard/invitations/+page.svelte
+++ b/src/routes/(auth)/dashboard/invitations/+page.svelte
@@ -8,6 +8,8 @@
 	} from '$lib/api/generated/sdk.gen';
 	import InvitationCard from '$lib/components/invitations/InvitationCard.svelte';
 	import InvitationRequestCard from '$lib/components/invitations/InvitationRequestCard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { Mail, Send, Loader2, Filter } from '@lucide/svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
@@ -141,17 +143,13 @@
 
 <div class="container mx-auto px-4 py-6 md:py-8">
 	<!-- Page Header -->
-	<div class="mb-8">
-		<div class="mb-2 flex items-center gap-3">
-			<div class="rounded-lg bg-primary/10 p-2">
-				<Mail class="h-6 w-6 text-primary" aria-hidden="true" />
-			</div>
-			<div>
-				<h1 class="text-2xl font-bold md:text-3xl">{m['dashboard.invitations.title']()}</h1>
-				<p class="text-muted-foreground">{m['dashboard.invitations.description']()}</p>
-			</div>
-		</div>
-	</div>
+	<PageHeader
+		title={m['dashboard.invitations.title']()}
+		subtitle={m['dashboard.invitations.description']()}
+		kicker={m['nav.invitations']()}
+		volume="celebration"
+		class="mb-8"
+	/>
 
 	<!-- Tabs -->
 	<div class="mb-6">
@@ -251,33 +249,27 @@
 					<span class="sr-only">{m['dashboard.invitations.loadingInvitations']()}</span>
 				</div>
 			{:else if invitations.length === 0}
-				<div class="rounded-lg border bg-card p-12 text-center">
-					<div
-						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10"
+				{#snippet clearInvitationsSearchAction()}
+					<button
+						type="button"
+						onclick={() => {
+							invitationsSearch = '';
+							navigateToPage(1);
+						}}
+						class="rounded-lg border bg-background px-6 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 					>
-						<Mail class="h-8 w-8 text-primary" aria-hidden="true" />
-					</div>
-					<h2 class="mb-2 text-xl font-semibold">{m['dashboard.invitations.noInvitations']()}</h2>
-					{#if invitationsDebounced}
-						<p class="mb-4 text-muted-foreground">
-							{m['dashboard.invitations.tryAdjustingSearch']()}
-						</p>
-						<button
-							type="button"
-							onclick={() => {
-								invitationsSearch = '';
-								navigateToPage(1);
-							}}
-							class="rounded-lg border bg-background px-6 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-						>
-							{m['dashboard.invitations.clearSearch']()}
-						</button>
-					{:else}
-						<p class="text-muted-foreground">
-							{m['dashboard.invitations.noReceivedInvitations']()}
-						</p>
-					{/if}
-				</div>
+						{m['dashboard.invitations.clearSearch']()}
+					</button>
+				{/snippet}
+				<EmptyState
+					icon={Mail}
+					title={m['dashboard.invitations.noInvitations']()}
+					body={invitationsDebounced
+						? m['dashboard.invitations.tryAdjustingSearch']()
+						: m['dashboard.invitations.noReceivedInvitations']()}
+					action={invitationsDebounced ? clearInvitationsSearchAction : undefined}
+					level={2}
+				/>
 			{:else}
 				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{#each invitations as invitation (invitation.id)}
@@ -372,34 +364,28 @@
 					<span class="sr-only">{m['dashboard.invitations.loadingRequests']()}</span>
 				</div>
 			{:else if requests.length === 0}
-				<div class="rounded-lg border bg-card p-12 text-center">
-					<div
-						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10"
+				{#snippet clearRequestsFiltersAction()}
+					<button
+						type="button"
+						onclick={() => {
+							requestsSearch = '';
+							requestsStatus = 'pending';
+							navigateToPage(1);
+						}}
+						class="rounded-lg border bg-background px-6 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 					>
-						<Send class="h-8 w-8 text-primary" aria-hidden="true" />
-					</div>
-					<h2 class="mb-2 text-xl font-semibold">{m['dashboard.invitations.noRequests']()}</h2>
-					{#if requestsDebounced || requestsStatus}
-						<p class="mb-4 text-muted-foreground">
-							{m['dashboard.invitations.tryAdjustingFilters']()}
-						</p>
-						<button
-							type="button"
-							onclick={() => {
-								requestsSearch = '';
-								requestsStatus = 'pending';
-								navigateToPage(1);
-							}}
-							class="rounded-lg border bg-background px-6 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-						>
-							{m['dashboard.invitations.clearFilters']()}
-						</button>
-					{:else}
-						<p class="text-muted-foreground">
-							{m['dashboard.invitations.noSentInvitations']()}
-						</p>
-					{/if}
-				</div>
+						{m['dashboard.invitations.clearFilters']()}
+					</button>
+				{/snippet}
+				<EmptyState
+					icon={Send}
+					title={m['dashboard.invitations.noRequests']()}
+					body={requestsDebounced || requestsStatus
+						? m['dashboard.invitations.tryAdjustingFilters']()
+						: m['dashboard.invitations.noSentInvitations']()}
+					action={requestsDebounced || requestsStatus ? clearRequestsFiltersAction : undefined}
+					level={2}
+				/>
 			{:else}
 				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{#each requests as request (request.id)}

--- a/src/routes/(auth)/dashboard/invitations/+page.svelte
+++ b/src/routes/(auth)/dashboard/invitations/+page.svelte
@@ -146,7 +146,7 @@
 	<PageHeader
 		title={m['dashboard.invitations.title']()}
 		subtitle={m['dashboard.invitations.description']()}
-		kicker={m['nav.invitations']()}
+		kicker={m['userMenu.dashboard']()}
 		volume="celebration"
 		class="mb-8"
 	/>
@@ -158,10 +158,10 @@
 				<button
 					type="button"
 					onclick={() => switchTab('invitations')}
-					class="inline-flex items-center gap-2 border-b-2 px-1 py-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {activeTab ===
+					class="inline-flex items-center gap-2 border-b-2 px-1 py-4 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {activeTab ===
 					'invitations'
-						? 'border-primary text-primary'
-						: 'border-transparent text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground'}"
+						? 'border-primary font-bold text-primary'
+						: 'border-transparent font-semibold text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground'}"
 					aria-current={activeTab === 'invitations' ? 'page' : undefined}
 				>
 					<Mail class="h-4 w-4" aria-hidden="true" />
@@ -178,10 +178,10 @@
 				<button
 					type="button"
 					onclick={() => switchTab('requests')}
-					class="inline-flex items-center gap-2 border-b-2 px-1 py-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {activeTab ===
+					class="inline-flex items-center gap-2 border-b-2 px-1 py-4 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {activeTab ===
 					'requests'
-						? 'border-primary text-primary'
-						: 'border-transparent text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground'}"
+						? 'border-primary font-bold text-primary'
+						: 'border-transparent font-semibold text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground'}"
 					aria-current={activeTab === 'requests' ? 'page' : undefined}
 				>
 					<Send class="h-4 w-4" aria-hidden="true" />

--- a/src/routes/(auth)/dashboard/passes/+page.svelte
+++ b/src/routes/(auth)/dashboard/passes/+page.svelte
@@ -5,6 +5,8 @@
 	import { seriespassListMySeriesPasses } from '$lib/api';
 	import { seriesPassQueryKeys } from '$lib/queries/series-passes';
 	import HeldPassCard from '$lib/components/series-passes/HeldPassCard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { Ticket, ChevronLeft, ChevronRight, Loader2 } from '@lucide/svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
@@ -56,15 +58,13 @@
 
 <div class="container mx-auto px-4 py-6 md:py-8">
 	<!-- Page Header -->
-	<div class="mb-8">
-		<div class="mb-2 flex items-center gap-3">
-			<div class="rounded-lg bg-primary/10 p-2">
-				<Ticket class="h-6 w-6 text-primary" aria-hidden="true" />
-			</div>
-			<h1 class="text-2xl font-bold md:text-3xl">{m['seriesPass.myPassesTitle']()}</h1>
-		</div>
-		<p class="text-muted-foreground">{m['seriesPass.myPassesDescription']()}</p>
-	</div>
+	<PageHeader
+		title={m['seriesPass.myPassesTitle']()}
+		subtitle={m['seriesPass.myPassesDescription']()}
+		kicker={m['nav.myPasses']()}
+		volume="celebration"
+		class="mb-8"
+	/>
 
 	{#if passesQuery.isPending}
 		<div class="flex items-center justify-center py-16" role="status">
@@ -83,17 +83,21 @@
 			</button>
 		</div>
 	{:else if passes.length === 0}
-		<div class="rounded-lg border bg-card p-8 text-center">
-			<Ticket class="mx-auto mb-4 h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h2 class="mb-2 text-lg font-semibold">{m['seriesPass.noPassesTitle']()}</h2>
-			<p class="mb-4 text-sm text-muted-foreground">{m['seriesPass.noPassesDescription']()}</p>
+		{#snippet browseEventsAction()}
 			<a
 				href={resolve('/(public)/events', {})}
 				class="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
 			>
 				{m['seriesPass.browseEvents']()}
 			</a>
-		</div>
+		{/snippet}
+		<EmptyState
+			icon={Ticket}
+			title={m['seriesPass.noPassesTitle']()}
+			body={m['seriesPass.noPassesDescription']()}
+			action={browseEventsAction}
+			level={2}
+		/>
 	{:else}
 		<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 			{#each passes as heldPass (heldPass.id)}

--- a/src/routes/(auth)/dashboard/passes/+page.svelte
+++ b/src/routes/(auth)/dashboard/passes/+page.svelte
@@ -61,7 +61,7 @@
 	<PageHeader
 		title={m['seriesPass.myPassesTitle']()}
 		subtitle={m['seriesPass.myPassesDescription']()}
-		kicker={m['nav.myPasses']()}
+		kicker={m['userMenu.dashboard']()}
 		volume="celebration"
 		class="mb-8"
 	/>

--- a/src/routes/(auth)/dashboard/rsvps/+page.svelte
+++ b/src/routes/(auth)/dashboard/rsvps/+page.svelte
@@ -5,6 +5,8 @@
 	import { dashboardDashboardRsvps } from '$lib/api/generated/sdk.gen';
 	import type { RsvpStatus } from '$lib/api/generated/types.gen';
 	import RSVPCard from '$lib/components/rsvps/RSVPCard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { CheckCircle2, Filter, ChevronLeft, ChevronRight, Loader2 } from '@lucide/svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
@@ -122,28 +124,24 @@
 
 <div class="container mx-auto px-4 py-6 md:py-8">
 	<!-- Page Header -->
-	<div class="mb-8">
-		<div class="mb-2 flex items-center gap-3">
-			<div class="rounded-lg bg-primary/10 p-2">
-				<CheckCircle2 class="h-6 w-6 text-primary" aria-hidden="true" />
-			</div>
-			<div>
-				<h1 class="text-2xl font-bold md:text-3xl">{m['dashboard.rsvps.title']()}</h1>
-				<p class="text-muted-foreground">{m['dashboard.rsvps.description']()}</p>
-			</div>
-		</div>
+	<PageHeader
+		title={m['dashboard.rsvps.title']()}
+		subtitle={m['dashboard.rsvps.description']()}
+		kicker={m['nav.rsvps']()}
+		volume="celebration"
+		class="mb-4"
+	/>
 
-		<!-- RSVP Count -->
-		{#if !rsvpsQuery.isPending && totalCount > 0}
-			<p class="mt-4 text-sm text-muted-foreground">
-				{m['dashboard.rsvps.showing']({
-					count: rsvps.length.toString(),
-					total: totalCount.toString()
-				})}
-				{totalCount === 1 ? m['dashboard.rsvps.rsvp']() : m['dashboard.rsvps.rsvps']()}
-			</p>
-		{/if}
-	</div>
+	<!-- RSVP Count -->
+	{#if !rsvpsQuery.isPending && totalCount > 0}
+		<p class="mb-6 text-sm text-muted-foreground">
+			{m['dashboard.rsvps.showing']({
+				count: rsvps.length.toString(),
+				total: totalCount.toString()
+			})}
+			{totalCount === 1 ? m['dashboard.rsvps.rsvp']() : m['dashboard.rsvps.rsvps']()}
+		</p>
+	{/if}
 
 	<!-- Search Bar -->
 	<div class="mb-6">
@@ -219,17 +217,8 @@
 		</div>
 	{:else if rsvps.length === 0}
 		<!-- Empty State -->
-		<div class="rounded-lg border bg-card p-12 text-center">
-			<div
-				class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10"
-			>
-				<CheckCircle2 class="h-8 w-8 text-primary" aria-hidden="true" />
-			</div>
-			<h2 class="mb-2 text-xl font-semibold">{m['dashboardRsvpsPage.noResults']()}</h2>
+		{#snippet rsvpsEmptyAction()}
 			{#if selectedStatuses.length || debouncedSearch}
-				<p class="mb-4 text-muted-foreground">
-					{m['dashboardRsvpsPage.noResultsFiltered']()}
-				</p>
 				<button
 					type="button"
 					onclick={() => {
@@ -241,9 +230,6 @@
 					{m['dashboardRsvpsPage.clearFilters']()}
 				</button>
 			{:else}
-				<p class="mb-4 text-muted-foreground">
-					{m['dashboardRsvpsPage.emptyHint']()}
-				</p>
 				<a
 					href={resolve('/(public)/events', {})}
 					class="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
@@ -251,7 +237,16 @@
 					{m['dashboardRsvpsPage.browseEvents']()}
 				</a>
 			{/if}
-		</div>
+		{/snippet}
+		<EmptyState
+			icon={CheckCircle2}
+			title={m['dashboardRsvpsPage.noResults']()}
+			body={selectedStatuses.length || debouncedSearch
+				? m['dashboardRsvpsPage.noResultsFiltered']()
+				: m['dashboardRsvpsPage.emptyHint']()}
+			action={rsvpsEmptyAction}
+			level={2}
+		/>
 	{:else}
 		<!-- RSVPs Grid -->
 		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/routes/(auth)/dashboard/rsvps/+page.svelte
+++ b/src/routes/(auth)/dashboard/rsvps/+page.svelte
@@ -127,7 +127,7 @@
 	<PageHeader
 		title={m['dashboard.rsvps.title']()}
 		subtitle={m['dashboard.rsvps.description']()}
-		kicker={m['nav.rsvps']()}
+		kicker={m['userMenu.dashboard']()}
 		volume="celebration"
 		class="mb-4"
 	/>

--- a/src/routes/(auth)/dashboard/tickets/+page.svelte
+++ b/src/routes/(auth)/dashboard/tickets/+page.svelte
@@ -9,6 +9,8 @@
 	import type { PaymentMethod, TicketStatus } from '$lib/api/generated/types.gen';
 	import TicketListCard from '$lib/components/tickets/TicketListCard.svelte';
 	import HeldPassCard from '$lib/components/series-passes/HeldPassCard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { seriesPassQueryKeys } from '$lib/queries/series-passes';
 	import { groupTicketsWithPasses } from '$lib/utils/ticket-pass-grouping';
 	import type { HeldSeriesPassSchema } from '$lib/api/generated/types.gen';
@@ -151,28 +153,24 @@
 
 <div class="container mx-auto px-4 py-6 md:py-8">
 	<!-- Page Header -->
-	<div class="mb-8">
-		<div class="mb-2 flex items-center gap-3">
-			<div class="rounded-lg bg-primary/10 p-2">
-				<Ticket class="h-6 w-6 text-primary" aria-hidden="true" />
-			</div>
-			<div>
-				<h1 class="text-2xl font-bold md:text-3xl">{m['dashboard.tickets.title']()}</h1>
-				<p class="text-muted-foreground">{m['dashboard.tickets.description']()}</p>
-			</div>
-		</div>
+	<PageHeader
+		title={m['dashboard.tickets.title']()}
+		subtitle={m['dashboard.tickets.description']()}
+		kicker={m['nav.myTickets']()}
+		volume="celebration"
+		class="mb-4"
+	/>
 
-		<!-- Ticket Count -->
-		{#if !ticketsQuery.isPending && totalCount > 0}
-			<p class="mt-4 text-sm text-muted-foreground">
-				{m['dashboard.tickets.showing']({
-					count: tickets.length.toString(),
-					total: totalCount.toString()
-				})}
-				{totalCount === 1 ? m['dashboard.tickets.ticket']() : m['dashboard.tickets.tickets']()}
-			</p>
-		{/if}
-	</div>
+	<!-- Ticket Count -->
+	{#if !ticketsQuery.isPending && totalCount > 0}
+		<p class="mb-6 text-sm text-muted-foreground">
+			{m['dashboard.tickets.showing']({
+				count: tickets.length.toString(),
+				total: totalCount.toString()
+			})}
+			{totalCount === 1 ? m['dashboard.tickets.ticket']() : m['dashboard.tickets.tickets']()}
+		</p>
+	{/if}
 
 	<!-- Search Bar -->
 	<div class="mb-6">
@@ -259,17 +257,8 @@
 		</div>
 	{:else if tickets.length === 0}
 		<!-- Empty State -->
-		<div class="rounded-lg border bg-card p-12 text-center">
-			<div
-				class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10"
-			>
-				<Ticket class="h-8 w-8 text-primary" aria-hidden="true" />
-			</div>
-			<h2 class="mb-2 text-xl font-semibold">{m['dashboardTicketsPage.noResults']()}</h2>
+		{#snippet ticketsEmptyAction()}
 			{#if statusFilter || paymentMethodFilter || debouncedSearch}
-				<p class="mb-4 text-muted-foreground">
-					{m['dashboardTicketsPage.noResultsFiltered']()}
-				</p>
 				<button
 					type="button"
 					onclick={() => {
@@ -283,9 +272,6 @@
 					{m['dashboardTicketsPage.clearFilters']()}
 				</button>
 			{:else}
-				<p class="mb-4 text-muted-foreground">
-					{m['dashboardTicketsPage.emptyHint']()}
-				</p>
 				<a
 					href={resolve('/(public)/events', {})}
 					class="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
@@ -293,7 +279,16 @@
 					{m['dashboardTicketsPage.browseEvents']()}
 				</a>
 			{/if}
-		</div>
+		{/snippet}
+		<EmptyState
+			icon={Ticket}
+			title={m['dashboardTicketsPage.noResults']()}
+			body={statusFilter || paymentMethodFilter || debouncedSearch
+				? m['dashboardTicketsPage.noResultsFiltered']()
+				: m['dashboardTicketsPage.emptyHint']()}
+			action={ticketsEmptyAction}
+			level={2}
+		/>
 	{:else}
 		<!-- Tickets Grid -->
 		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/routes/(auth)/dashboard/tickets/+page.svelte
+++ b/src/routes/(auth)/dashboard/tickets/+page.svelte
@@ -156,7 +156,7 @@
 	<PageHeader
 		title={m['dashboard.tickets.title']()}
 		subtitle={m['dashboard.tickets.description']()}
-		kicker={m['nav.myTickets']()}
+		kicker={m['userMenu.dashboard']()}
 		volume="celebration"
 		class="mb-4"
 	/>


### PR DESCRIPTION
## Platform rebrand, PR 5 of 10 — User dashboard

Vol. 2 (Celebration, medium loudness) pass over all six dashboard routes plus their component trees (dashboard/, calendar/, notifications/, invitations/, rsvps/, tickets/MyTicket*). Base: `feature/rebranding` after PR 1 foundations (#765).

### What's in it
- `PageHeader` (celebration) on all six pages, "Dashboard" kicker on sub-pages; bolder tab strips
- **Ticket brand moment**: `MyTicket`/`MyTicketModal` header band on the brand gradient (`var(--logo-from) → var(--logo-to)`), event name at display weight; QR area untouched
- Domain status badges (`TicketStatusBadge` family, RSVP/invitation/membership pills) reimplemented as thin mappers over `common/StatusBadge` — same filenames, props, and visible labels
- `EmptyState`/`SectionHeader`/`ToneTile` adoption; full raw-hue sweep in all 26 touched files
- **Zero i18n changes** — every kicker reuses existing keys

### Review process
Whole-branch opus review + one fix round + scoped re-review, all clean. The review caught a Critical no gate could: the gradient was written `hsl(var(--logo-from))` — `--logo-*` are complete hsl() values, so the double-wrap silently dropped the background (white-on-white event names in light mode). Fixed and verified via real browser computed-style check. Also fixed: kicker==h1 duplication on five pages, missed tab typography, per-surface ratio-comment corrections.

### Notes for sibling PRs
- This PR restyles shared pixels rendered on other clusters' surfaces: `MyTicket` appears on the public event page (PR 3) and `TicketStatusBadge` in series-passes admin dialogs (PR 8/10).
- `events/waitlist/*` (raw hues) deliberately untouched — public banner belongs to PR 3, admin tables to PR 8.

### Verification
`make check` 0 errors · full suite 202 files / 2426 tests green · brand audit 0 failures · orchestrator screenshots (dashboard home + tickets, light/dark) against the live backend. Note: ticket-band screenshots with real ticket data come from the implementer's verification run (local backend had no seeded tickets for the QA persona); the e2e checkpoint after PRs 2–6 exercises these pages fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)