### PR TITLE
feat(rebrand): global shell — header, footer, banners, error page, SEO landing template (PR 2/10)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -2679,6 +2679,16 @@
 		"rejectedHint": "Wende dich an die Organisator*innen, um eine neue Einladung zu erhalten.",
 		"rejectedCta": "Events durchstöbern"
 	},
+	"landingTemplate": {
+		"benefitsKicker": "Warum Revel",
+		"ctaKicker": "Jetzt loslegen",
+		"ctaSticker": "Open Source",
+		"faqHeading": "Häufig gestellte Fragen",
+		"faqKicker": "Fragen",
+		"featuresKicker": "Das ist inklusive",
+		"relatedHeading": "Verwandte Themen",
+		"relatedKicker": "Mehr entdecken"
+	},
 	"languageSwitcher": {
 		"selectLanguage": "Select language: {name}"
 	},

--- a/messages/de.json
+++ b/messages/de.json
@@ -2685,7 +2685,7 @@
 		"ctaSticker": "Open Source",
 		"faqHeading": "Häufig gestellte Fragen",
 		"faqKicker": "Fragen",
-		"featuresKicker": "Das ist inklusive",
+		"featuresHeading": "Das ist inklusive",
 		"relatedHeading": "Verwandte Themen",
 		"relatedKicker": "Mehr entdecken"
 	},

--- a/messages/en.json
+++ b/messages/en.json
@@ -2685,7 +2685,7 @@
 		"ctaSticker": "Open source",
 		"faqHeading": "Frequently Asked Questions",
 		"faqKicker": "Questions",
-		"featuresKicker": "What's included",
+		"featuresHeading": "What's included",
 		"relatedHeading": "Related Topics",
 		"relatedKicker": "Explore more"
 	},

--- a/messages/en.json
+++ b/messages/en.json
@@ -2679,6 +2679,16 @@
 		"rejectedHint": "Contact the organizer to get a new invitation.",
 		"rejectedCta": "Browse events"
 	},
+	"landingTemplate": {
+		"benefitsKicker": "Why Revel",
+		"ctaKicker": "Get started",
+		"ctaSticker": "Open source",
+		"faqHeading": "Frequently Asked Questions",
+		"faqKicker": "Questions",
+		"featuresKicker": "What's included",
+		"relatedHeading": "Related Topics",
+		"relatedKicker": "Explore more"
+	},
 	"languageSwitcher": {
 		"selectLanguage": "Select language: {name}"
 	},

--- a/messages/es.json
+++ b/messages/es.json
@@ -2679,6 +2679,16 @@
 		"rejectedHint": "Contacta con quien organiza el evento para conseguir una nueva invitación.",
 		"rejectedCta": "Explorar eventos"
 	},
+	"landingTemplate": {
+		"benefitsKicker": "Por qué Revel",
+		"ctaKicker": "Empezar",
+		"ctaSticker": "Código abierto",
+		"faqHeading": "Preguntas Frecuentes",
+		"faqKicker": "Preguntas",
+		"featuresKicker": "Qué incluye",
+		"relatedHeading": "Temas Relacionados",
+		"relatedKicker": "Descubre más"
+	},
 	"languageSwitcher": {
 		"selectLanguage": "Seleccionar idioma: {name}"
 	},

--- a/messages/es.json
+++ b/messages/es.json
@@ -2685,7 +2685,7 @@
 		"ctaSticker": "Código abierto",
 		"faqHeading": "Preguntas Frecuentes",
 		"faqKicker": "Preguntas",
-		"featuresKicker": "Qué incluye",
+		"featuresHeading": "Qué incluye",
 		"relatedHeading": "Temas Relacionados",
 		"relatedKicker": "Descubre más"
 	},

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2566,6 +2566,16 @@
 		"rejectedHint": "Contactez l'équipe organisatrice pour obtenir une nouvelle invitation.",
 		"rejectedCta": "Parcourir les événements"
 	},
+	"landingTemplate": {
+		"benefitsKicker": "Pourquoi Revel",
+		"ctaKicker": "Commencer",
+		"ctaSticker": "Open source",
+		"faqHeading": "Questions Fréquentes",
+		"faqKicker": "Questions",
+		"featuresKicker": "Ce qui est inclus",
+		"relatedHeading": "Sujets Connexes",
+		"relatedKicker": "En savoir plus"
+	},
 	"languageSwitcher": {
 		"selectLanguage": "Select language: {name}"
 	},

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2572,7 +2572,7 @@
 		"ctaSticker": "Open source",
 		"faqHeading": "Questions Fréquentes",
 		"faqKicker": "Questions",
-		"featuresKicker": "Ce qui est inclus",
+		"featuresHeading": "Ce qui est inclus",
 		"relatedHeading": "Sujets Connexes",
 		"relatedKicker": "En savoir plus"
 	},

--- a/messages/it.json
+++ b/messages/it.json
@@ -2679,6 +2679,16 @@
 		"rejectedHint": "Contatta chi organizza per ricevere un nuovo invito.",
 		"rejectedCta": "Sfoglia gli eventi"
 	},
+	"landingTemplate": {
+		"benefitsKicker": "Perché Revel",
+		"ctaKicker": "Inizia ora",
+		"ctaSticker": "Open source",
+		"faqHeading": "Domande Frequenti",
+		"faqKicker": "Domande",
+		"featuresKicker": "Cosa include",
+		"relatedHeading": "Argomenti Correlati",
+		"relatedKicker": "Scopri di più"
+	},
 	"languageSwitcher": {
 		"selectLanguage": "Select language: {name}"
 	},

--- a/messages/it.json
+++ b/messages/it.json
@@ -2685,7 +2685,7 @@
 		"ctaSticker": "Open source",
 		"faqHeading": "Domande Frequenti",
 		"faqKicker": "Domande",
-		"featuresKicker": "Cosa include",
+		"featuresHeading": "Cosa include",
 		"relatedHeading": "Argomenti Correlati",
 		"relatedKicker": "Scopri di più"
 	},

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2680,12 +2680,12 @@
 		"rejectedCta": "Explorar eventos"
 	},
 	"landingTemplate": {
-		"benefitsKicker": "Por que Revel",
+		"benefitsKicker": "Porquê Revel",
 		"ctaKicker": "Começar",
 		"ctaSticker": "Código aberto",
 		"faqHeading": "Perguntas Frequentes",
 		"faqKicker": "Perguntas",
-		"featuresKicker": "O que está incluído",
+		"featuresHeading": "O que está incluído",
 		"relatedHeading": "Tópicos Relacionados",
 		"relatedKicker": "Saiba mais"
 	},

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2679,6 +2679,16 @@
 		"rejectedHint": "Contacta quem organiza para receberes um novo convite.",
 		"rejectedCta": "Explorar eventos"
 	},
+	"landingTemplate": {
+		"benefitsKicker": "Por que Revel",
+		"ctaKicker": "Começar",
+		"ctaSticker": "Código aberto",
+		"faqHeading": "Perguntas Frequentes",
+		"faqKicker": "Perguntas",
+		"featuresKicker": "O que está incluído",
+		"relatedHeading": "Tópicos Relacionados",
+		"relatedKicker": "Saiba mais"
+	},
 	"languageSwitcher": {
 		"selectLanguage": "Selecionar idioma: {name}"
 	},

--- a/src/lib/components/common/DemoBanner.svelte
+++ b/src/lib/components/common/DemoBanner.svelte
@@ -37,8 +37,12 @@
 </script>
 
 {#if isDemoMode}
+	<!-- Demo → info tone. text-info on bg-info/10 (composited over --background)
+	     measures 8.27:1 light / 7.98:1 dark — both comfortably clear of the
+	     4.5:1 AA floor even applied to the whole paragraph, not just the icon
+	     (see scripts/audit-brand-themes.py for the base info-on-* pairs). -->
 	<div
-		class="border-b border-orange-200 bg-orange-50 px-4 py-3 text-orange-900 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-100"
+		class="border-b border-info/30 bg-info/10 px-4 py-3 text-info"
 		role="alert"
 		aria-live="polite"
 	>

--- a/src/lib/components/common/DemoCardInfo.svelte
+++ b/src/lib/components/common/DemoCardInfo.svelte
@@ -26,42 +26,43 @@
 </script>
 
 {#if isDemoMode}
-	<div
-		class="mt-4 rounded-md border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950"
-	>
+	<!-- Demo → info tone (matches DemoBanner). text-info on bg-info/10 measures
+	     8.27:1 light / 7.98:1 dark (see DemoBanner for the base computation);
+	     the heading here is the same pair, just bolder. -->
+	<div class="mt-4 rounded-md border border-info/30 bg-info/10 p-4">
 		<div class="flex items-start gap-3">
-			<CreditCard class="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
+			<CreditCard class="mt-0.5 h-5 w-5 flex-shrink-0 text-info" />
 			<div class="flex-1 space-y-2">
-				<h3 class="text-sm font-semibold text-blue-900 dark:text-blue-100">
+				<h3 class="text-sm font-bold text-info">
 					{m['demoCardInfo.demoPaymentTestCard']()}
 				</h3>
-				<p class="text-xs text-blue-800 dark:text-blue-200">
+				<p class="text-xs text-info">
 					{m['demoCardInfo.useTestCredentials']()}
 				</p>
 
 				<!-- Test Card Number -->
 				<div class="mt-2 flex items-center gap-2">
 					<div
-						class="flex-1 rounded border border-blue-300 bg-white px-3 py-2 font-mono text-sm dark:border-blue-700 dark:bg-blue-900"
+						class="flex-1 rounded border border-info/30 bg-card px-3 py-2 font-mono text-sm text-card-foreground"
 					>
 						{TEST_CARD_NUMBER}
 					</div>
 					<button
 						type="button"
 						onclick={copyCardNumber}
-						class="rounded-md border border-blue-300 bg-white p-2 transition-colors hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-blue-700 dark:bg-blue-900 dark:hover:bg-blue-800"
+						class="rounded-md border border-info/30 bg-card p-2 transition-colors hover:bg-info/10 focus:outline-none focus:ring-2 focus:ring-info"
 						aria-label={m['demoCardInfo.copyCardNumber']()}
 					>
 						{#if copied}
-							<Check class="h-4 w-4 text-green-600" aria-hidden="true" />
+							<Check class="h-4 w-4 text-success" aria-hidden="true" />
 						{:else}
-							<Copy class="h-4 w-4 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+							<Copy class="h-4 w-4 text-info" aria-hidden="true" />
 						{/if}
 					</button>
 				</div>
 
 				<!-- Other Fields -->
-				<ul class="mt-2 space-y-1 text-xs text-blue-800 dark:text-blue-200">
+				<ul class="mt-2 space-y-1 text-xs text-info">
 					<li>
 						<strong>{m['demoCardInfo.expiry']()}</strong>
 						{m['demoCardInfo.expiryValue']()}

--- a/src/lib/components/common/Footer.svelte
+++ b/src/lib/components/common/Footer.svelte
@@ -244,7 +244,7 @@
 					</Tooltip.Content>
 				</Tooltip.Root>
 
-				<span class="text-background/30 dark:text-muted-foreground/50">|</span>
+				<span class="text-background/45 dark:text-muted-foreground/50">|</span>
 
 				<Tooltip.Root>
 					<Tooltip.Trigger
@@ -284,7 +284,7 @@
 					</Tooltip.Content>
 				</Tooltip.Root>
 
-				<span class="text-background/30 dark:text-muted-foreground/50">|</span>
+				<span class="text-background/45 dark:text-muted-foreground/50">|</span>
 
 				<a
 					href="https://forms.gle/c6ovKV92nMQEbR877"
@@ -299,10 +299,13 @@
 			</div>
 		</Tooltip.Provider>
 
-		<!-- Cookie Notice. Light: bg-background/10 (surface) + text-background/90
-		     composited over the opaque ink band measures 11.85:1; dark keeps the
-		     original muted/50-on-card treatment (7.04:1, hand-verified) since
-		     that's already a themed, non-inverted surface. -->
+		<!-- Cookie Notice. Light: bg-background/10 (surface) composited over the
+		     opaque ink band, then text-background/90 composited over THAT
+		     surface (not directly over the ink) — 9.91:1 (re-verified; an
+		     earlier draft of this comment mistakenly quoted the full-opacity
+		     text number, 11.85:1). Dark keeps the original muted/50-on-card
+		     treatment (7.04:1, hand-verified) since that's already a themed,
+		     non-inverted surface. -->
 		<div class="mt-8 border-t border-background/20 pt-8 dark:border-border">
 			<div
 				class="rounded-lg bg-background/10 p-4 text-center text-sm text-background/90 dark:bg-muted/50 dark:text-muted-foreground"

--- a/src/lib/components/common/Footer.svelte
+++ b/src/lib/components/common/Footer.svelte
@@ -7,6 +7,20 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { getLocale } from '$lib/paraglide/runtime.js';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import RevelMark from '$lib/components/brand/RevelMark.svelte';
+
+	// Shared link treatment for the inverted band: this surface is a dark one
+	// in BOTH themes (ink in light, deepened card in dark — see the <footer>
+	// class below), so "muted" text needs its own recipe per side rather than
+	// the usual muted-foreground token (which assumes a light-mode-light /
+	// dark-mode-dark surface). Light: text-background/70 on the opaque ink bg
+	// measures 8.05:1 (full text-background is 15.43:1) — see the <footer>
+	// comment for the base numbers this scales from. Dark: bg-card is a normal
+	// themed surface, so muted-foreground/foreground on it are the SAME
+	// audited pairs used everywhere else (card-foreground/muted-foreground on
+	// card, both >= 4.5:1 in audit-brand-themes.py).
+	const footerLinkClass =
+		'text-background/70 transition-colors hover:text-background dark:text-muted-foreground dark:hover:text-foreground';
 
 	// Frontend version from environment variable (set in Dockerfile).
 	// Read via $env/dynamic/public so it has no compile-time requirement —
@@ -60,58 +74,64 @@
 	}
 </script>
 
-<footer class="border-t bg-muted/30">
-	<div class="container mx-auto max-w-5xl px-4 py-8 md:py-12">
+<!-- Inverted "band" echoing the poster ClosePanel: dark surface in BOTH
+     themes (ink in light, deepened card in dark — never a near-white band,
+     per the imagery rule the dark side must still read as a dark surface). -->
+<footer
+	class="bg-foreground text-background dark:border-t dark:border-border dark:bg-card dark:text-card-foreground"
+>
+	<div class="container mx-auto max-w-5xl px-4 py-10 md:py-14">
+		<!-- Brand lockup: hand-set per the Digital Styleguide's on-dark variant
+		     ("let's" Light, "revel." Semibold, all white/near-white, weights
+		     unchanged) — not RevelWordmark, whose accent-crimson period assumes
+		     a themed (non-inverted) background. Visible text is the link's
+		     accessible name (WCAG 2.5.3). text-background on bg-foreground
+		     mirrors the audited foreground-on-background pair (contrast is
+		     symmetric): 15.43:1 in light; dark reuses the audited
+		     card-foreground-on-card pair (foreground === card-foreground in
+		     this theme). -->
+		<a
+			href={resolve('/(public)', {})}
+			class="mb-8 inline-flex items-center gap-2 transition-opacity hover:opacity-80"
+		>
+			<RevelMark decorative class="h-7 w-auto" />
+			<span class="text-2xl leading-none tracking-[0.06em]">
+				<span class="font-light">let&rsquo;s</span><span class="font-semibold"> revel.</span>
+			</span>
+		</a>
+
 		<div class="grid grid-cols-2 gap-8 md:grid-cols-4">
 			<!-- Solutions - spans 2 columns on md+ -->
 			<div class="col-span-2">
-				<h3 class="mb-4 text-lg font-semibold">{m['footer.solutionsTitle']()}</h3>
+				<h3 class="mb-4 text-lg font-extrabold">{m['footer.solutionsTitle']()}</h3>
 				<div class="grid grid-cols-2 gap-x-8 gap-y-2 text-sm">
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing path; the prefix comes from getLocale() and cannot map to a single static route id -->
-					<a
-						href="{landingPagePrefix}/eventbrite-alternative"
-						class="text-muted-foreground transition-colors hover:text-foreground"
-					>
+					<a href="{landingPagePrefix}/eventbrite-alternative" class={footerLinkClass}>
 						{m['footer.solutionEventbrite']()}
 					</a>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing path; the prefix comes from getLocale() and cannot map to a single static route id -->
-					<a
-						href="{landingPagePrefix}/privacy-focused-events"
-						class="text-muted-foreground transition-colors hover:text-foreground"
-					>
+					<a href="{landingPagePrefix}/privacy-focused-events" class={footerLinkClass}>
 						{m['footer.solutionPrivacy']()}
 					</a>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing path; the prefix comes from getLocale() and cannot map to a single static route id -->
-					<a
-						href="{landingPagePrefix}/self-hosted-event-platform"
-						class="text-muted-foreground transition-colors hover:text-foreground"
-					>
+					<a href="{landingPagePrefix}/self-hosted-event-platform" class={footerLinkClass}>
 						{m['footer.solutionSelfHosted']()}
 					</a>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing path; the prefix comes from getLocale() and cannot map to a single static route id -->
-					<a
-						href="{landingPagePrefix}/community-first-event-platform"
-						class="text-muted-foreground transition-colors hover:text-foreground"
-					>
+					<a href="{landingPagePrefix}/community-first-event-platform" class={footerLinkClass}>
 						{m['footer.solutionCommunity']()}
 					</a>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing path; the prefix comes from getLocale() and cannot map to a single static route id -->
-					<a
-						href="{landingPagePrefix}/queer-event-management"
-						class="text-muted-foreground transition-colors hover:text-foreground"
-					>
+					<a href="{landingPagePrefix}/queer-event-management" class={footerLinkClass}>
 						{m['footer.solutionQueer']()}
 					</a>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing path; the prefix comes from getLocale() and cannot map to a single static route id -->
-					<a
-						href="{landingPagePrefix}/kink-event-ticketing"
-						class="text-muted-foreground transition-colors hover:text-foreground"
-					>
+					<a href="{landingPagePrefix}/kink-event-ticketing" class={footerLinkClass}>
 						{m['footer.solutionKink']()}
 					</a>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
@@ -120,29 +140,20 @@
 
 			<!-- Legal Links -->
 			<div>
-				<h3 class="mb-4 text-lg font-semibold">{m['footer.legalTitle']()}</h3>
+				<h3 class="mb-4 text-lg font-extrabold">{m['footer.legalTitle']()}</h3>
 				<ul class="space-y-2 text-sm">
 					<li>
-						<a
-							href={resolve('/(public)/legal/privacy', {})}
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
+						<a href={resolve('/(public)/legal/privacy', {})} class={footerLinkClass}>
 							{m['footer.privacyPolicy']()}
 						</a>
 					</li>
 					<li>
-						<a
-							href={resolve('/(public)/legal/terms', {})}
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
+						<a href={resolve('/(public)/legal/terms', {})} class={footerLinkClass}>
 							{m['footer.termsOfService']()}
 						</a>
 					</li>
 					<li>
-						<a
-							href="mailto:contact@letsrevel.io"
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
+						<a href="mailto:contact@letsrevel.io" class={footerLinkClass}>
 							{m['footer.contact']()}
 						</a>
 					</li>
@@ -151,21 +162,15 @@
 
 			<!-- Resources -->
 			<div>
-				<h3 class="mb-4 text-lg font-semibold">{m['footer.resourcesTitle']()}</h3>
+				<h3 class="mb-4 text-lg font-extrabold">{m['footer.resourcesTitle']()}</h3>
 				<ul class="space-y-2 text-sm">
 					<li>
-						<a
-							href={resolve('/(public)/events', {})}
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
+						<a href={resolve('/(public)/events', {})} class={footerLinkClass}>
 							{m['nav.browseEvents']()}
 						</a>
 					</li>
 					<li>
-						<a
-							href={resolve('/(public)/organizations', {})}
-							class="text-muted-foreground transition-colors hover:text-foreground"
-						>
+						<a href={resolve('/(public)/organizations', {})} class={footerLinkClass}>
 							{m['nav.organizations']()}
 						</a>
 					</li>
@@ -174,7 +179,7 @@
 							href="https://github.com/letsrevel"
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-muted-foreground transition-colors hover:text-foreground"
+							class={footerLinkClass}
 						>
 							{m['footer.github']()}
 						</a>
@@ -184,7 +189,7 @@
 							href="https://forms.gle/7wAqQXqrWk3X6Ddu7"
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-muted-foreground transition-colors hover:text-foreground"
+							class={footerLinkClass}
 						>
 							{m['footer.sendFeedback']()}
 						</a>
@@ -196,7 +201,7 @@
 		<!-- Version Info - Compact inline -->
 		<Tooltip.Provider>
 			<div
-				class="mt-8 flex flex-wrap items-center justify-center gap-4 border-t pt-6 text-xs text-muted-foreground"
+				class="mt-8 flex flex-wrap items-center justify-center gap-4 border-t border-background/20 pt-6 text-xs text-background/70 dark:border-border dark:text-muted-foreground"
 			>
 				<Tooltip.Root>
 					<!-- The link itself is the tooltip trigger (child snippet): a default
@@ -212,12 +217,15 @@
 								href={FRONTEND_REPO}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="flex items-center gap-1.5 transition-colors hover:text-foreground"
+								class="flex items-center gap-1.5 transition-colors hover:text-background dark:hover:text-foreground"
 								aria-label="{m['footer.frontend']()} repository on GitHub"
 							>
 								<Github class="h-3.5 w-3.5" aria-hidden="true" />
 								<span>FE v{FRONTEND_VERSION}</span>
-								<Info class="h-3 w-3 text-muted-foreground/70" aria-hidden="true" />
+								<Info
+									class="h-3 w-3 text-background/50 dark:text-muted-foreground/70"
+									aria-hidden="true"
+								/>
 							</a>
 						{/snippet}
 					</Tooltip.Trigger>
@@ -236,7 +244,7 @@
 					</Tooltip.Content>
 				</Tooltip.Root>
 
-				<span class="text-muted-foreground/50">|</span>
+				<span class="text-background/30 dark:text-muted-foreground/50">|</span>
 
 				<Tooltip.Root>
 					<Tooltip.Trigger
@@ -249,12 +257,15 @@
 								href={BACKEND_REPO}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="flex items-center gap-1.5 transition-colors hover:text-foreground"
+								class="flex items-center gap-1.5 transition-colors hover:text-background dark:hover:text-foreground"
 								aria-label="{m['footer.backend']()} repository on GitHub"
 							>
 								<Github class="h-3.5 w-3.5" aria-hidden="true" />
 								<span>BE v{backendVersion}{isDemoMode ? ' (demo)' : ''}</span>
-								<Info class="h-3 w-3 text-muted-foreground/70" aria-hidden="true" />
+								<Info
+									class="h-3 w-3 text-background/50 dark:text-muted-foreground/70"
+									aria-hidden="true"
+								/>
 							</a>
 						{/snippet}
 					</Tooltip.Trigger>
@@ -273,13 +284,13 @@
 					</Tooltip.Content>
 				</Tooltip.Root>
 
-				<span class="text-muted-foreground/50">|</span>
+				<span class="text-background/30 dark:text-muted-foreground/50">|</span>
 
 				<a
 					href="https://forms.gle/c6ovKV92nMQEbR877"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="flex items-center gap-1.5 transition-colors hover:text-foreground"
+					class="flex items-center gap-1.5 transition-colors hover:text-background dark:hover:text-foreground"
 					aria-label={m['footer.reportBug']()}
 				>
 					<Bug class="h-3.5 w-3.5" aria-hidden="true" />
@@ -288,9 +299,14 @@
 			</div>
 		</Tooltip.Provider>
 
-		<!-- Cookie Notice -->
-		<div class="mt-8 border-t pt-8">
-			<div class="rounded-lg bg-muted/50 p-4 text-center text-sm text-muted-foreground">
+		<!-- Cookie Notice. Light: bg-background/10 (surface) + text-background/90
+		     composited over the opaque ink band measures 11.85:1; dark keeps the
+		     original muted/50-on-card treatment (7.04:1, hand-verified) since
+		     that's already a themed, non-inverted surface. -->
+		<div class="mt-8 border-t border-background/20 pt-8 dark:border-border">
+			<div
+				class="rounded-lg bg-background/10 p-4 text-center text-sm text-background/90 dark:bg-muted/50 dark:text-muted-foreground"
+			>
 				<p>
 					{m['footer.cookieNotice']()}
 				</p>
@@ -298,7 +314,7 @@
 		</div>
 
 		<!-- Copyright -->
-		<div class="mt-6 text-center text-sm text-muted-foreground">
+		<div class="mt-6 text-center text-sm text-background/70 dark:text-muted-foreground">
 			<p>&copy; {new Date().getFullYear()} Revel. {m['footer.copyright']()}</p>
 		</div>
 	</div>

--- a/src/lib/components/common/Header.svelte
+++ b/src/lib/components/common/Header.svelte
@@ -82,9 +82,9 @@
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- href is a ResolvedPathname produced by resolve() in the nav item list above -->
 					<a
 						href={item.href}
-						class="text-sm font-medium transition-colors hover:text-primary {isActive(item.href)
-							? 'text-foreground'
-							: 'text-muted-foreground'}"
+						class="text-sm transition-colors hover:text-primary {isActive(item.href)
+							? 'font-bold text-primary'
+							: 'font-semibold text-muted-foreground'}"
 						aria-current={isActive(item.href) ? 'page' : undefined}
 					>
 						{item.label}

--- a/src/lib/components/common/ImpersonationBanner.svelte
+++ b/src/lib/components/common/ImpersonationBanner.svelte
@@ -57,30 +57,39 @@
 </script>
 
 {#if impersonationInfo.isImpersonated}
+	<!-- Impersonation → danger tone (this is a privileged, high-stakes state).
+	     Soft fill reuses ToneTile's audited danger pair: text-destructive on
+	     bg-destructive/10 measures 7.19:1 on the page background (light); dark
+	     switches to bg-destructive/25 + text-destructive-foreground (plain /10
+	     text-destructive measures only 2.95:1 in dark — see ToneTile's inline
+	     note) which measures 15.26:1. The "less prominent" (opacity-80) spans
+	     dim that same pair to 5.02:1 (light) / 10.14:1 (dark) — still clear of
+	     the 4.5:1 floor. The inline time-remaining chip layers a second tint
+	     over the already-tinted banner: /20 on /10 (light) = 5.04:1, /30 on
+	     /25 (dark, text-destructive-foreground) = 11.82:1; the pulsing
+	     "expiring soon" chip is a fully opaque bg-destructive/text-destructive-
+	     foreground pair (9.74:1 light / 5.87:1 dark), same as StatusBadge. -->
 	<div
-		class="sticky top-0 z-[100] border-b border-amber-300 bg-amber-100 px-4 py-2 text-amber-900 dark:border-amber-700 dark:bg-amber-900/90 dark:text-amber-100"
+		class="sticky top-0 z-[100] border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground"
 		role="alert"
 		aria-live="assertive"
 	>
 		<div class="container mx-auto flex flex-wrap items-center justify-between gap-2">
 			<div class="flex items-center gap-3">
-				<AlertTriangle
-					class="h-5 w-5 flex-shrink-0 text-amber-600 dark:text-amber-400"
-					aria-hidden="true"
-				/>
+				<AlertTriangle class="h-5 w-5 flex-shrink-0" aria-hidden="true" />
 				<div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
-					<span role="heading" aria-level="2" class="font-semibold"
+					<span role="heading" aria-level="2" class="font-bold"
 						>{m['impersonationBanner.title']()}</span
 					>
 					<span class="flex items-center gap-1">
 						<User class="h-4 w-4" aria-hidden="true" />
 						<span class="font-medium">{authStore.user?.display_name ?? authStore.user?.email}</span>
 						{#if authStore.user?.email}
-							<span class="text-amber-700 dark:text-amber-300">({authStore.user.email})</span>
+							<span class="opacity-80">({authStore.user.email})</span>
 						{/if}
 					</span>
 					{#if impersonationInfo.impersonatedByName || impersonationInfo.impersonatedByEmail}
-						<span class="text-amber-700 dark:text-amber-300">
+						<span class="opacity-80">
 							| {m['impersonationBanner.by']()}
 							<span class="font-medium">
 								{impersonationInfo.impersonatedByName ?? impersonationInfo.impersonatedByEmail}
@@ -92,9 +101,9 @@
 
 			{#if timeRemaining}
 				<div
-					class="flex items-center gap-2 rounded-md px-2 py-1 text-sm font-medium {isExpiringSoon
-						? 'animate-pulse bg-red-200 text-red-800 dark:bg-red-800 dark:text-red-100'
-						: 'bg-amber-200 text-amber-800 dark:bg-amber-800 dark:text-amber-100'}"
+					class="flex items-center gap-2 rounded-md px-2 py-1 text-sm font-bold {isExpiringSoon
+						? 'animate-pulse bg-destructive text-destructive-foreground'
+						: 'bg-destructive/20 text-destructive dark:bg-destructive/30 dark:text-destructive-foreground'}"
 					title={m['impersonationBanner.timeRemainingTitle']()}
 				>
 					<Clock class="h-4 w-4" aria-hidden="true" />
@@ -105,7 +114,7 @@
 			{/if}
 		</div>
 
-		<p class="container mx-auto mt-1 text-xs text-amber-700 dark:text-amber-300">
+		<p class="container mx-auto mt-1 text-xs opacity-80">
 			{m['impersonationBanner.notice']()}
 		</p>
 	</div>

--- a/src/lib/components/common/ImpersonationBanner.svelte
+++ b/src/lib/components/common/ImpersonationBanner.svelte
@@ -58,6 +58,12 @@
 
 {#if impersonationInfo.isImpersonated}
 	<!-- Impersonation → danger tone (this is a privileged, high-stakes state).
+	     The outer sticky element is opaque (bg-background): this banner is
+	     `sticky top-0`, so a translucent tint directly on it would composite
+	     over whatever page content has scrolled underneath, not over
+	     --background as every ratio below assumes. The tint lives on the inner
+	     wrapper, which now genuinely sits on --background.
+
 	     Soft fill reuses ToneTile's audited danger pair: text-destructive on
 	     bg-destructive/10 measures 7.19:1 on the page background (light); dark
 	     switches to bg-destructive/25 + text-destructive-foreground (plain /10
@@ -69,53 +75,55 @@
 	     /25 (dark, text-destructive-foreground) = 11.82:1; the pulsing
 	     "expiring soon" chip is a fully opaque bg-destructive/text-destructive-
 	     foreground pair (9.74:1 light / 5.87:1 dark), same as StatusBadge. -->
-	<div
-		class="sticky top-0 z-[100] border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground"
-		role="alert"
-		aria-live="assertive"
-	>
-		<div class="container mx-auto flex flex-wrap items-center justify-between gap-2">
-			<div class="flex items-center gap-3">
-				<AlertTriangle class="h-5 w-5 flex-shrink-0" aria-hidden="true" />
-				<div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
-					<span role="heading" aria-level="2" class="font-bold"
-						>{m['impersonationBanner.title']()}</span
-					>
-					<span class="flex items-center gap-1">
-						<User class="h-4 w-4" aria-hidden="true" />
-						<span class="font-medium">{authStore.user?.display_name ?? authStore.user?.email}</span>
-						{#if authStore.user?.email}
-							<span class="opacity-80">({authStore.user.email})</span>
-						{/if}
-					</span>
-					{#if impersonationInfo.impersonatedByName || impersonationInfo.impersonatedByEmail}
-						<span class="opacity-80">
-							| {m['impersonationBanner.by']()}
-							<span class="font-medium">
-								{impersonationInfo.impersonatedByName ?? impersonationInfo.impersonatedByEmail}
-							</span>
+	<div class="sticky top-0 z-[100] bg-background" role="alert" aria-live="assertive">
+		<div
+			class="border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground"
+		>
+			<div class="container mx-auto flex flex-wrap items-center justify-between gap-2">
+				<div class="flex items-center gap-3">
+					<AlertTriangle class="h-5 w-5 flex-shrink-0" aria-hidden="true" />
+					<div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+						<span role="heading" aria-level="2" class="font-bold"
+							>{m['impersonationBanner.title']()}</span
+						>
+						<span class="flex items-center gap-1">
+							<User class="h-4 w-4" aria-hidden="true" />
+							<span class="font-medium"
+								>{authStore.user?.display_name ?? authStore.user?.email}</span
+							>
+							{#if authStore.user?.email}
+								<span class="opacity-80">({authStore.user.email})</span>
+							{/if}
 						</span>
-					{/if}
+						{#if impersonationInfo.impersonatedByName || impersonationInfo.impersonatedByEmail}
+							<span class="opacity-80">
+								| {m['impersonationBanner.by']()}
+								<span class="font-medium">
+									{impersonationInfo.impersonatedByName ?? impersonationInfo.impersonatedByEmail}
+								</span>
+							</span>
+						{/if}
+					</div>
 				</div>
+
+				{#if timeRemaining}
+					<div
+						class="flex items-center gap-2 rounded-md px-2 py-1 text-sm font-bold {isExpiringSoon
+							? 'animate-pulse bg-destructive text-destructive-foreground'
+							: 'bg-destructive/20 text-destructive dark:bg-destructive/30 dark:text-destructive-foreground'}"
+						title={m['impersonationBanner.timeRemainingTitle']()}
+					>
+						<Clock class="h-4 w-4" aria-hidden="true" />
+						<span aria-label={m['impersonationBanner.timeRemainingLabel']({ time: timeRemaining })}>
+							{timeRemaining}
+						</span>
+					</div>
+				{/if}
 			</div>
 
-			{#if timeRemaining}
-				<div
-					class="flex items-center gap-2 rounded-md px-2 py-1 text-sm font-bold {isExpiringSoon
-						? 'animate-pulse bg-destructive text-destructive-foreground'
-						: 'bg-destructive/20 text-destructive dark:bg-destructive/30 dark:text-destructive-foreground'}"
-					title={m['impersonationBanner.timeRemainingTitle']()}
-				>
-					<Clock class="h-4 w-4" aria-hidden="true" />
-					<span aria-label={m['impersonationBanner.timeRemainingLabel']({ time: timeRemaining })}>
-						{timeRemaining}
-					</span>
-				</div>
-			{/if}
+			<p class="container mx-auto mt-1 text-xs opacity-80">
+				{m['impersonationBanner.notice']()}
+			</p>
 		</div>
-
-		<p class="container mx-auto mt-1 text-xs opacity-80">
-			{m['impersonationBanner.notice']()}
-		</p>
 	</div>
 {/if}

--- a/src/lib/components/common/MaintenanceBanner.svelte
+++ b/src/lib/components/common/MaintenanceBanner.svelte
@@ -45,36 +45,38 @@
 		return format(new Date(iso), 'MMM d, yyyy HH:mm');
 	}
 
+	// Severity → tone: debug/neutral, info/info, warning/highlight, error/danger
+	// (soft), critical/danger (solid) — critical stays visually distinct from
+	// error via weight of fill, not hue alone (guardrail: never encode meaning
+	// by color alone). Soft pairs reuse ToneTile's audited token combos
+	// (src/lib/components/common/ToneTile.svelte); the solid critical pair is
+	// the StatusBadge-style audited destructive-foreground/destructive pair.
 	const severityConfig = {
 		debug: {
 			icon: Bug,
-			classes:
-				'border-gray-200 bg-gray-50 text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100',
-			iconClasses: 'text-gray-500 dark:text-gray-400'
+			classes: 'border-border bg-muted text-muted-foreground',
+			iconClasses: 'text-muted-foreground'
 		},
 		info: {
 			icon: Info,
-			classes:
-				'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100',
-			iconClasses: 'text-blue-500 dark:text-blue-400'
+			classes: 'border-info/30 bg-info/10 text-info',
+			iconClasses: 'text-info'
 		},
 		warning: {
 			icon: AlertTriangle,
-			classes:
-				'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100',
-			iconClasses: 'text-amber-500 dark:text-amber-400'
+			classes: 'border-highlight/40 bg-highlight/20 text-highlight-foreground dark:text-highlight',
+			iconClasses: 'text-highlight-foreground dark:text-highlight'
 		},
 		error: {
 			icon: AlertCircle,
 			classes:
-				'border-red-200 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100',
-			iconClasses: 'text-red-500 dark:text-red-400'
+				'border-destructive/30 bg-destructive/10 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground',
+			iconClasses: 'text-destructive dark:text-destructive-foreground'
 		},
 		critical: {
 			icon: AlertOctagon,
-			classes:
-				'border-red-300 bg-red-100 text-red-900 dark:border-red-700 dark:bg-red-900 dark:text-red-100',
-			iconClasses: 'animate-pulse text-red-600 dark:text-red-400'
+			classes: 'border-destructive bg-destructive text-destructive-foreground',
+			iconClasses: 'animate-pulse text-destructive-foreground'
 		}
 	} as const;
 

--- a/src/lib/components/common/MaintenanceBanner.svelte
+++ b/src/lib/components/common/MaintenanceBanner.svelte
@@ -51,6 +51,11 @@
 	// by color alone). Soft pairs reuse ToneTile's audited token combos
 	// (src/lib/components/common/ToneTile.svelte); the solid critical pair is
 	// the StatusBadge-style audited destructive-foreground/destructive pair.
+	// These classes render on the INNER wrapper below, which sits on the
+	// outer sticky element's opaque bg-background — so every ratio computed
+	// against --background in this file's history is now literally true, not
+	// an assumption (the banner is `sticky top-0` and would otherwise
+	// composite over whatever page content has scrolled underneath it).
 	const severityConfig = {
 		debug: {
 			icon: Bug,
@@ -85,39 +90,43 @@
 
 {#if visible && banner}
 	{@const Icon = config.icon}
-	<div
-		class="sticky top-0 z-[90] border-b px-4 py-3 {config.classes}"
-		role="alert"
-		aria-live="assertive"
-	>
-		<div class="container mx-auto flex items-start gap-3 md:items-center">
-			<Icon class="mt-0.5 h-5 w-5 flex-shrink-0 {config.iconClasses} md:mt-0" aria-hidden="true" />
-			<div class="flex-1 text-sm">
-				<p class="font-semibold">{banner.message}</p>
-				{#if banner.scheduled_at || banner.ends_at}
-					<p class="mt-1 text-xs opacity-80">
-						{#if banner.scheduled_at}
-							<span
-								>{m['maintenanceBanner.scheduled']({ time: formatTime(banner.scheduled_at) })}</span
-							>
-						{/if}
-						{#if banner.scheduled_at && banner.ends_at}
-							<span class="mx-1">&middot;</span>
-						{/if}
-						{#if banner.ends_at}
-							<span>{m['maintenanceBanner.until']({ time: formatTime(banner.ends_at) })}</span>
-						{/if}
-					</p>
-				{/if}
+	<!-- Opaque outer + tinted inner — see the severityConfig comment above. -->
+	<div class="sticky top-0 z-[90] bg-background" role="alert" aria-live="assertive">
+		<div class="border-b px-4 py-3 {config.classes}">
+			<div class="container mx-auto flex items-start gap-3 md:items-center">
+				<Icon
+					class="mt-0.5 h-5 w-5 flex-shrink-0 {config.iconClasses} md:mt-0"
+					aria-hidden="true"
+				/>
+				<div class="flex-1 text-sm">
+					<p class="font-semibold">{banner.message}</p>
+					{#if banner.scheduled_at || banner.ends_at}
+						<p class="mt-1 text-xs opacity-80">
+							{#if banner.scheduled_at}
+								<span
+									>{m['maintenanceBanner.scheduled']({
+										time: formatTime(banner.scheduled_at)
+									})}</span
+								>
+							{/if}
+							{#if banner.scheduled_at && banner.ends_at}
+								<span class="mx-1">&middot;</span>
+							{/if}
+							{#if banner.ends_at}
+								<span>{m['maintenanceBanner.until']({ time: formatTime(banner.ends_at) })}</span>
+							{/if}
+						</p>
+					{/if}
+				</div>
+				<button
+					type="button"
+					onclick={dismiss}
+					class="flex-shrink-0 rounded-md p-1 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-current focus:ring-offset-2"
+					aria-label={m['maintenanceBanner.dismiss']()}
+				>
+					<X class="h-4 w-4" aria-hidden="true" />
+				</button>
 			</div>
-			<button
-				type="button"
-				onclick={dismiss}
-				class="flex-shrink-0 rounded-md p-1 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-current focus:ring-offset-2"
-				aria-label={m['maintenanceBanner.dismiss']()}
-			>
-				<X class="h-4 w-4" aria-hidden="true" />
-			</button>
 		</div>
 	</div>
 {/if}

--- a/src/lib/components/common/MobileNav.svelte
+++ b/src/lib/components/common/MobileNav.svelte
@@ -97,11 +97,9 @@
 						<!-- eslint-disable svelte/no-navigation-without-resolve -- href is a ResolvedPathname produced by resolve() in the nav item list above -->
 						<a
 							href={item.href}
-							class="block rounded-md px-4 py-3 text-base font-medium transition-colors {isActive(
-								item.href
-							)
-								? 'bg-accent text-accent-foreground'
-								: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+							class="block rounded-md px-4 py-3 text-base transition-colors {isActive(item.href)
+								? 'bg-accent font-bold text-accent-foreground'
+								: 'font-semibold text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
 							onclick={handleLinkClick}
 							aria-current={isActive(item.href) ? 'page' : undefined}
 						>

--- a/src/lib/components/common/UserMenu.svelte
+++ b/src/lib/components/common/UserMenu.svelte
@@ -185,7 +185,7 @@
 			<!-- eslint-disable svelte/no-navigation-without-resolve -- href is a ResolvedPathname produced by resolve() in the nav item list above -->
 			<a
 				href={item.href}
-				class="flex items-center gap-3 rounded-md px-4 py-3 text-base transition-colors hover:bg-accent hover:text-accent-foreground"
+				class="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 				onclick={handleItemClick}
 			>
 				<Icon class="h-5 w-5" aria-hidden="true" />
@@ -197,12 +197,16 @@
 		<!-- Referral Section (Mobile) -->
 		{#if isReferrer}
 			<div class="space-y-2 border-t pt-4">
-				<div role="heading" aria-level="3" class="px-4 text-sm font-semibold text-muted-foreground">
+				<div
+					role="heading"
+					aria-level="3"
+					class="px-4 text-xs font-extrabold uppercase tracking-[0.12em] text-primary"
+				>
 					{m['referral.referralProgram']()}
 				</div>
 				<a
 					href={resolve('/(auth)/account/referral', {})}
-					class="flex items-center gap-3 rounded-md px-4 py-2 text-base transition-colors hover:bg-accent hover:text-accent-foreground"
+					class="flex items-center gap-3 rounded-md px-4 py-2 text-base font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 					onclick={handleItemClick}
 				>
 					<Gift class="h-5 w-5" aria-hidden="true" />
@@ -210,7 +214,7 @@
 				</a>
 				<a
 					href={resolve('/(auth)/account/referral/payouts', {})}
-					class="flex items-center gap-3 rounded-md px-4 py-2 text-base transition-colors hover:bg-accent hover:text-accent-foreground"
+					class="flex items-center gap-3 rounded-md px-4 py-2 text-base font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 					onclick={handleItemClick}
 				>
 					<FileText class="h-5 w-5" aria-hidden="true" />
@@ -226,7 +230,7 @@
 					<div
 						role="heading"
 						aria-level="3"
-						class="px-4 text-sm font-semibold text-muted-foreground"
+						class="px-4 text-xs font-extrabold uppercase tracking-[0.12em] text-primary"
 					>
 						{m['userMenu.myOrganizations']()}
 					</div>
@@ -234,7 +238,7 @@
 						<div class="space-y-1">
 							<a
 								href={resolve('/(public)/org/[slug]', { slug: org.slug })}
-								class="flex items-center gap-3 rounded-md px-4 py-2 text-base transition-colors hover:bg-accent hover:text-accent-foreground"
+								class="flex items-center gap-3 rounded-md px-4 py-2 text-base font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 								onclick={handleItemClick}
 							>
 								<Building2 class="h-5 w-5" aria-hidden="true" />
@@ -258,7 +262,7 @@
 				{#if !ownsOrganization() && features.organization_creation}
 					<a
 						href={resolve('/(auth)/create-org', {})}
-						class="flex items-center gap-3 rounded-md px-4 py-3 text-base transition-colors hover:bg-accent hover:text-accent-foreground"
+						class="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 						onclick={handleItemClick}
 					>
 						<PlusCircle class="h-5 w-5" aria-hidden="true" />
@@ -270,7 +274,7 @@
 
 		<button
 			type="button"
-			class="mt-4 flex w-full items-center gap-3 rounded-md border-t px-4 py-3 pt-6 text-base text-destructive transition-colors hover:bg-destructive/10"
+			class="mt-4 flex w-full items-center gap-3 rounded-md border-t px-4 py-3 pt-6 text-base font-medium text-destructive transition-colors hover:bg-destructive/10"
 			onclick={handleLogout}
 		>
 			<LogOut class="h-5 w-5" aria-hidden="true" />
@@ -318,7 +322,7 @@
 						<!-- eslint-disable svelte/no-navigation-without-resolve -- href is a ResolvedPathname produced by resolve() in the nav item list above -->
 						<a
 							href={item.href}
-							class="flex items-center gap-3 rounded-sm px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+							class="flex items-center gap-3 rounded-sm px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 							onclick={handleItemClick}
 							role="menuitem"
 						>
@@ -333,12 +337,12 @@
 				{#if isReferrer}
 					<div class="border-t">
 						<div class="p-1">
-							<div class="px-3 py-2 text-xs font-semibold text-muted-foreground">
+							<div class="px-3 py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
 								{m['referral.referralProgram']()}
 							</div>
 							<a
 								href={resolve('/(auth)/account/referral', {})}
-								class="flex items-center gap-2 rounded-sm px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+								class="flex items-center gap-2 rounded-sm px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 								onclick={handleItemClick}
 								role="menuitem"
 							>
@@ -347,7 +351,7 @@
 							</a>
 							<a
 								href={resolve('/(auth)/account/referral/payouts', {})}
-								class="flex items-center gap-2 rounded-sm px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+								class="flex items-center gap-2 rounded-sm px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 								onclick={handleItemClick}
 								role="menuitem"
 							>
@@ -363,14 +367,14 @@
 					<div class="border-t">
 						<div class="p-1">
 							{#if userOrganizations.length > 0}
-								<div class="px-3 py-2 text-xs font-semibold text-muted-foreground">
+								<div class="px-3 py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
 									{m['userMenu.myOrganizations']()}
 								</div>
 								{#each userOrganizations as org (org.id)}
 									<div class="space-y-1">
 										<a
 											href={resolve('/(public)/org/[slug]', { slug: org.slug })}
-											class="flex items-center gap-2 rounded-sm px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+											class="flex items-center gap-2 rounded-sm px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 											onclick={handleItemClick}
 											role="menuitem"
 										>
@@ -396,7 +400,7 @@
 							{#if !ownsOrganization() && features.organization_creation}
 								<a
 									href={resolve('/(auth)/create-org', {})}
-									class="flex items-center gap-2 rounded-sm px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+									class="flex items-center gap-2 rounded-sm px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 									onclick={handleItemClick}
 									role="menuitem"
 								>
@@ -412,7 +416,7 @@
 				<div class="border-t p-1">
 					<button
 						type="button"
-						class="flex w-full items-center gap-3 rounded-sm px-3 py-2 text-sm text-destructive transition-colors hover:bg-destructive/10"
+						class="flex w-full items-center gap-3 rounded-sm px-3 py-2 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10"
 						onclick={handleLogout}
 						role="menuitem"
 					>

--- a/src/lib/components/common/UserMenu.svelte
+++ b/src/lib/components/common/UserMenu.svelte
@@ -337,7 +337,9 @@
 				{#if isReferrer}
 					<div class="border-t">
 						<div class="p-1">
-							<div class="px-3 py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
+							<div
+								class="px-3 py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-primary"
+							>
 								{m['referral.referralProgram']()}
 							</div>
 							<a
@@ -367,7 +369,9 @@
 					<div class="border-t">
 						<div class="p-1">
 							{#if userOrganizations.length > 0}
-								<div class="px-3 py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
+								<div
+									class="px-3 py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-primary"
+								>
 									{m['userMenu.myOrganizations']()}
 								</div>
 								{#each userOrganizations as org (org.id)}

--- a/src/lib/components/landing/LandingPageTemplate.svelte
+++ b/src/lib/components/landing/LandingPageTemplate.svelte
@@ -6,7 +6,6 @@
 	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import Sticker from '$lib/components/brand/Sticker.svelte';
-	import type { Tone } from '$lib/components/common/tones';
 	import {
 		Ticket,
 		Shield,
@@ -50,14 +49,6 @@
 		return iconMap[iconName] || Check;
 	}
 
-	// Feature tiles cycle through non-alarming semantic tones (never
-	// warning/danger — these are marketing bullets, not status signals) purely
-	// for rhythm; the tone carries no per-feature meaning.
-	const featureTones: Tone[] = ['brand', 'info', 'success'];
-	function getFeatureTone(index: number): Tone {
-		return featureTones[index % featureTones.length];
-	}
-
 	// FAQ accordion state
 	let openFaqIndex = $state<number | null>(null);
 
@@ -85,7 +76,18 @@
      text-poster-white on bg-poster-purple measures 5.52:1 (same pair
      ClosePanel documents for this exact color). Button variants below avoid
      any translucent-over-gradient wash so every pair stays a plain
-     opaque-or-bordered combination on this single audited number. -->
+     opaque-or-bordered combination on this single audited number.
+
+     TRAP (guardrail 6, hit here in its INVERSE form): a Button with a custom
+     bg-* class keeps the variant's default text unless you also set text-*
+     — but a custom text-* class ALSO keeps the variant's default bg-* unless
+     you explicitly set bg-* too. The "outline" branch below previously set
+     only text-poster-white, so shadcn's `outline` variant's own
+     `bg-background` (rest) and `hover:text-accent-foreground` (hover)
+     survived cn()'s merge untouched → white text on a light bg-background at
+     rest (1.13:1). Fixed by adding bg-transparent + hover:text-poster-white
+     so every state has an explicit bg AND text pair. Border also bumped to
+     /65 (was /60 = 2.96:1, under the 3:1 non-text floor) → 3.22:1. -->
 <section class="relative overflow-hidden bg-poster-purple py-16 md:py-24">
 	<div class="absolute inset-0 bg-[url('/grid.svg')] opacity-10"></div>
 	<div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
@@ -114,7 +116,7 @@
 							? 'bg-poster-white text-poster-purple hover:bg-poster-paper'
 							: button.variant === 'secondary'
 								? 'border-2 border-poster-white bg-transparent text-poster-white hover:bg-poster-white/10'
-								: 'border-poster-white/60 text-poster-white hover:bg-poster-white/10'}
+								: 'border-poster-white/65 bg-transparent text-poster-white hover:bg-poster-white/10 hover:text-poster-white'}
 					>
 						{button.text}
 					</Button>
@@ -141,15 +143,19 @@
 <section class="bg-muted/50 py-12 md:py-16">
 	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 		<SectionHeader
-			title={m['landingTemplate.featuresKicker']()}
+			title={m['landingTemplate.featuresHeading']({}, { locale: content.locale })}
 			volume="celebration"
 			class="mb-8 justify-center text-center"
 		/>
 		<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-			{#each content.features as feature, i (feature.title)}
+			{#each content.features as feature (feature.title)}
 				{@const IconComponent = getIcon(feature.icon)}
 				<div class="rounded-lg border bg-card p-6 shadow-sm transition-shadow hover:shadow-md">
-					<ToneTile tone={getFeatureTone(i)} icon={IconComponent} size="lg" class="mb-4" />
+					<!-- Uniform brand tone: ToneTile's tone axis is semantic, and these
+					     marketing bullets carry no per-feature meaning to encode — the
+					     identity/tint axis for "same tone, different accent color per
+					     destination" lands with PR 7's poster-tint prop. -->
+					<ToneTile tone="brand" icon={IconComponent} size="lg" class="mb-4" />
 					<h3 class="mb-2 text-lg font-bold text-foreground">{feature.title}</h3>
 					<p class="text-sm text-muted-foreground">{feature.description}</p>
 				</div>
@@ -163,7 +169,7 @@
 	<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
 		<SectionHeader
 			title={content.benefits.title}
-			kicker={m['landingTemplate.benefitsKicker']()}
+			kicker={m['landingTemplate.benefitsKicker']({}, { locale: content.locale })}
 			volume="celebration"
 			class="mb-8 justify-center text-center"
 		/>
@@ -182,8 +188,8 @@
 <section class="bg-muted/50 py-12 md:py-16">
 	<div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
 		<SectionHeader
-			title={m['landingTemplate.faqHeading']()}
-			kicker={m['landingTemplate.faqKicker']()}
+			title={m['landingTemplate.faqHeading']({}, { locale: content.locale })}
+			kicker={m['landingTemplate.faqKicker']({}, { locale: content.locale })}
 			volume="celebration"
 			class="mb-8 justify-center text-center"
 		/>
@@ -221,8 +227,13 @@
      normally — not aria-hidden — same as the poster's own sticker usage. -->
 <section class="bg-poster-purple py-12 md:py-16">
 	<div class="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
-		<p class="mb-3">
-			<Sticker tint="crimson" rotate={-2}>{m['landingTemplate.ctaSticker']()}</Sticker>
+		<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-poster-white">
+			{m['landingTemplate.ctaKicker']({}, { locale: content.locale })}
+		</p>
+		<p class="mb-3 mt-2">
+			<Sticker tint="crimson" rotate={-2}
+				>{m['landingTemplate.ctaSticker']({}, { locale: content.locale })}</Sticker
+			>
 		</p>
 		<h2 class="text-2xl font-extrabold text-poster-white md:text-3xl">
 			{content.cta.title}
@@ -244,7 +255,7 @@
 						? 'bg-poster-white text-poster-purple hover:bg-poster-paper'
 						: button.variant === 'secondary'
 							? 'border-2 border-poster-white bg-transparent text-poster-white hover:bg-poster-white/10'
-							: 'border-poster-white/60 text-poster-white hover:bg-poster-white/10'}
+							: 'border-poster-white/65 bg-transparent text-poster-white hover:bg-poster-white/10 hover:text-poster-white'}
 				>
 					{button.text}
 				</Button>
@@ -258,8 +269,8 @@
 	<section class="bg-background py-12 md:py-16">
 		<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
 			<SectionHeader
-				title={m['landingTemplate.relatedHeading']()}
-				kicker={m['landingTemplate.relatedKicker']()}
+				title={m['landingTemplate.relatedHeading']({}, { locale: content.locale })}
+				kicker={m['landingTemplate.relatedKicker']({}, { locale: content.locale })}
 				volume="celebration"
 				class="mb-6 justify-center text-center"
 			/>

--- a/src/lib/components/landing/LandingPageTemplate.svelte
+++ b/src/lib/components/landing/LandingPageTemplate.svelte
@@ -2,6 +2,11 @@
 	import type { LandingPageContent, LandingPageFeature } from '$lib/data/landing-pages';
 	import { landingPages } from '$lib/data/landing-pages';
 	import { Button } from '$lib/components/ui/button';
+	import * as m from '$lib/paraglide/messages.js';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import Sticker from '$lib/components/brand/Sticker.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import {
 		Ticket,
 		Shield,
@@ -45,6 +50,14 @@
 		return iconMap[iconName] || Check;
 	}
 
+	// Feature tiles cycle through non-alarming semantic tones (never
+	// warning/danger — these are marketing bullets, not status signals) purely
+	// for rhythm; the tone carries no per-feature meaning.
+	const featureTones: Tone[] = ['brand', 'info', 'success'];
+	function getFeatureTone(index: number): Tone {
+		return featureTones[index % featureTones.length];
+	}
+
 	// FAQ accordion state
 	let openFaqIndex = $state<number | null>(null);
 
@@ -67,17 +80,22 @@
 	}
 </script>
 
-<!-- Hero Section -->
-<section
-	class="relative overflow-hidden bg-gradient-to-br from-violet-600 via-purple-600 to-violet-700 py-16 md:py-24"
->
+<!-- Hero Section. Fixed poster-purple background (imagery rule: decorative
+     brand panel, identical in both themes, like the landing's own panels).
+     text-poster-white on bg-poster-purple measures 5.52:1 (same pair
+     ClosePanel documents for this exact color). Button variants below avoid
+     any translucent-over-gradient wash so every pair stays a plain
+     opaque-or-bordered combination on this single audited number. -->
+<section class="relative overflow-hidden bg-poster-purple py-16 md:py-24">
 	<div class="absolute inset-0 bg-[url('/grid.svg')] opacity-10"></div>
 	<div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 		<div class="text-center">
-			<h1 class="text-3xl font-bold tracking-tight text-white sm:text-4xl md:text-5xl lg:text-6xl">
+			<h1
+				class="text-3xl font-black leading-[1.12] text-poster-white sm:text-4xl md:text-5xl lg:text-6xl"
+			>
 				{content.hero.headline}
 			</h1>
-			<p class="mx-auto mt-4 max-w-3xl text-lg text-violet-100 sm:text-xl md:mt-6">
+			<p class="mx-auto mt-4 max-w-3xl text-lg text-poster-white sm:text-xl md:mt-6">
 				{content.hero.subheadline}
 			</p>
 			<div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row md:mt-10">
@@ -93,10 +111,10 @@
 						{variant}
 						size="lg"
 						class={button.variant === 'primary'
-							? 'bg-white text-violet-700 hover:bg-violet-50'
+							? 'bg-poster-white text-poster-purple hover:bg-poster-paper'
 							: button.variant === 'secondary'
-								? 'border-white/30 bg-white/10 text-white hover:bg-white/20'
-								: 'border-white/30 text-white hover:bg-white/10'}
+								? 'border-2 border-poster-white bg-transparent text-poster-white hover:bg-poster-white/10'
+								: 'border-poster-white/60 text-poster-white hover:bg-poster-white/10'}
 					>
 						{button.text}
 					</Button>
@@ -122,14 +140,17 @@
 <!-- Features Section -->
 <section class="bg-muted/50 py-12 md:py-16">
 	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+		<SectionHeader
+			title={m['landingTemplate.featuresKicker']()}
+			volume="celebration"
+			class="mb-8 justify-center text-center"
+		/>
 		<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-			{#each content.features as feature (feature.title)}
+			{#each content.features as feature, i (feature.title)}
 				{@const IconComponent = getIcon(feature.icon)}
 				<div class="rounded-lg border bg-card p-6 shadow-sm transition-shadow hover:shadow-md">
-					<div class="mb-4 inline-flex rounded-lg bg-primary/10 p-3">
-						<IconComponent class="h-6 w-6 text-primary" />
-					</div>
-					<h3 class="mb-2 text-lg font-semibold text-foreground">{feature.title}</h3>
+					<ToneTile tone={getFeatureTone(i)} icon={IconComponent} size="lg" class="mb-4" />
+					<h3 class="mb-2 text-lg font-bold text-foreground">{feature.title}</h3>
 					<p class="text-sm text-muted-foreground">{feature.description}</p>
 				</div>
 			{/each}
@@ -140,9 +161,12 @@
 <!-- Benefits Section -->
 <section class="bg-background py-12 md:py-16">
 	<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
-		<h2 class="mb-8 text-center text-2xl font-bold text-foreground md:text-3xl">
-			{content.benefits.title}
-		</h2>
+		<SectionHeader
+			title={content.benefits.title}
+			kicker={m['landingTemplate.benefitsKicker']()}
+			volume="celebration"
+			class="mb-8 justify-center text-center"
+		/>
 		<ul class="space-y-4">
 			{#each content.benefits.items as item, i (i)}
 				<li class="flex items-start gap-3">
@@ -157,13 +181,12 @@
 <!-- FAQ Section -->
 <section class="bg-muted/50 py-12 md:py-16">
 	<div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
-		<h2 class="mb-8 text-center text-2xl font-bold text-foreground md:text-3xl">
-			{content.locale === 'de'
-				? 'Häufig gestellte Fragen'
-				: content.locale === 'it'
-					? 'Domande Frequenti'
-					: 'Frequently Asked Questions'}
-		</h2>
+		<SectionHeader
+			title={m['landingTemplate.faqHeading']()}
+			kicker={m['landingTemplate.faqKicker']()}
+			volume="celebration"
+			class="mb-8 justify-center text-center"
+		/>
 		<div class="space-y-4">
 			{#each content.faq as faq, index (faq.question)}
 				<div class="overflow-hidden rounded-lg border bg-card">
@@ -192,13 +215,19 @@
 	</div>
 </section>
 
-<!-- CTA Section -->
-<section class="bg-gradient-to-br from-violet-600 via-purple-600 to-violet-700 py-12 md:py-16">
+<!-- CTA Section: same fixed poster-purple treatment as the hero, plus a
+     Sticker accent (the "optionally one Sticker" flagship touch). The
+     Sticker is real, meaningful content (not decoration), so it's rendered
+     normally — not aria-hidden — same as the poster's own sticker usage. -->
+<section class="bg-poster-purple py-12 md:py-16">
 	<div class="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
-		<h2 class="text-2xl font-bold text-white md:text-3xl">
+		<p class="mb-3">
+			<Sticker tint="crimson" rotate={-2}>{m['landingTemplate.ctaSticker']()}</Sticker>
+		</p>
+		<h2 class="text-2xl font-extrabold text-poster-white md:text-3xl">
 			{content.cta.title}
 		</h2>
-		<p class="mx-auto mt-4 max-w-2xl text-violet-100">
+		<p class="mx-auto mt-4 max-w-2xl text-poster-white">
 			{content.cta.description}
 		</p>
 		<div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
@@ -212,10 +241,10 @@
 							: 'outline'}
 					size="lg"
 					class={button.variant === 'primary'
-						? 'bg-white text-violet-700 hover:bg-violet-50'
+						? 'bg-poster-white text-poster-purple hover:bg-poster-paper'
 						: button.variant === 'secondary'
-							? 'border-white/30 bg-white/10 text-white hover:bg-white/20'
-							: 'border-white/30 text-white hover:bg-white/10'}
+							? 'border-2 border-poster-white bg-transparent text-poster-white hover:bg-poster-white/10'
+							: 'border-poster-white/60 text-poster-white hover:bg-poster-white/10'}
 				>
 					{button.text}
 				</Button>
@@ -228,13 +257,12 @@
 {#if content.relatedPages.length > 0}
 	<section class="bg-background py-12 md:py-16">
 		<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
-			<h2 class="mb-6 text-center text-xl font-semibold text-foreground">
-				{content.locale === 'de'
-					? 'Verwandte Themen'
-					: content.locale === 'it'
-						? 'Argomenti Correlati'
-						: 'Related Topics'}
-			</h2>
+			<SectionHeader
+				title={m['landingTemplate.relatedHeading']()}
+				kicker={m['landingTemplate.relatedKicker']()}
+				volume="celebration"
+				class="mb-6 justify-center text-center"
+			/>
 			<div class="flex flex-wrap justify-center gap-4">
 				{#each content.relatedPages as relatedSlug (relatedSlug)}
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing-page path built from a runtime slug; not a static route id -->

--- a/src/routes/(public)/legal/privacy/+page.svelte
+++ b/src/routes/(public)/legal/privacy/+page.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { PageData } from './$types';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { SeoHead } from '$lib/seo';
 
 	const { data }: { data: PageData } = $props();
@@ -9,8 +10,12 @@
 
 <SeoHead config={data.seo} />
 
-<div class="container mx-auto px-4 py-8">
-	<h1 class="mb-8 text-3xl font-bold">{m['privacyPolicyPage.privacyPolicy']()}</h1>
+<div class="container mx-auto px-4 py-8 md:py-12">
+	<PageHeader
+		title={m['privacyPolicyPage.privacyPolicy']()}
+		volume="celebration"
+		class="mb-8 md:mb-10"
+	/>
 
 	<MarkdownContent content={data.privacyPolicy} class="prose-slate" />
 </div>

--- a/src/routes/(public)/legal/terms/+page.svelte
+++ b/src/routes/(public)/legal/terms/+page.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { PageData } from './$types';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { SeoHead } from '$lib/seo';
 
 	const { data }: { data: PageData } = $props();
@@ -9,8 +10,12 @@
 
 <SeoHead config={data.seo} />
 
-<div class="container mx-auto px-4 py-8">
-	<h1 class="mb-8 text-3xl font-bold">{m['termsOfServicePage.termsOfService']()}</h1>
+<div class="container mx-auto px-4 py-8 md:py-12">
+	<PageHeader
+		title={m['termsOfServicePage.termsOfService']()}
+		volume="celebration"
+		class="mb-8 md:mb-10"
+	/>
 
 	<MarkdownContent content={data.termsAndConditions} class="prose-slate" />
 </div>

--- a/src/routes/(public)/unsubscribe/+page.svelte
+++ b/src/routes/(public)/unsubscribe/+page.svelte
@@ -58,13 +58,16 @@
 	{:else if success}
 		<!-- Success message: EmptyState's playful tilted chip is the personality
 		     vehicle here too, replacing the raw green-*/50/900/950 hues with the
-		     audited success token pair. -->
+		     audited success token pair. EmptyState's own heading stays at its
+		     default level (3) — the page's real h1 is the sr-only one below, so
+		     the visible title isn't duplicated and the document still has
+		     exactly one h1. -->
+		<h1 class="sr-only">{m['unsubscribePage.successTitle']()}</h1>
 		<EmptyState
 			icon={Bell}
 			title={m['unsubscribePage.successTitle']()}
 			body={m['unsubscribePage.successDescription']()}
 			tone="success"
-			level={2}
 		/>
 		<p class="mt-4 text-center text-sm text-muted-foreground">
 			{m['unsubscribePage.redirecting']()}

--- a/src/routes/(public)/unsubscribe/+page.svelte
+++ b/src/routes/(public)/unsubscribe/+page.svelte
@@ -7,6 +7,8 @@
 	import { resolve } from '$app/paths';
 	import { Bell } from '@lucide/svelte';
 	import { SeoHead } from '$lib/seo';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -40,7 +42,7 @@
 	{#if !data.token}
 		<!-- Invalid or missing token -->
 		<div class="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-			<h1 class="text-2xl font-bold text-destructive">
+			<h1 class="text-2xl font-extrabold text-destructive">
 				{m['unsubscribePage.invalidTokenTitle']()}
 			</h1>
 			<p class="mt-2 text-muted-foreground">
@@ -54,31 +56,27 @@
 			</a>
 		</div>
 	{:else if success}
-		<!-- Success message -->
-		<div
-			class="rounded-lg border border-green-500/50 bg-green-50 p-6 text-center dark:bg-green-950/50"
-		>
-			<div class="mb-4 flex justify-center">
-				<Bell class="h-16 w-16 text-green-600 dark:text-green-400" aria-hidden="true" />
-			</div>
-			<h1 class="text-2xl font-bold text-green-900 dark:text-green-100">
-				{m['unsubscribePage.successTitle']()}
-			</h1>
-			<p class="mt-2 text-green-800 dark:text-green-200">
-				{m['unsubscribePage.successDescription']()}
-			</p>
-			<p class="mt-4 text-sm text-muted-foreground">
-				{m['unsubscribePage.redirecting']()}
-			</p>
-		</div>
+		<!-- Success message: EmptyState's playful tilted chip is the personality
+		     vehicle here too, replacing the raw green-*/50/900/950 hues with the
+		     audited success token pair. -->
+		<EmptyState
+			icon={Bell}
+			title={m['unsubscribePage.successTitle']()}
+			body={m['unsubscribePage.successDescription']()}
+			tone="success"
+			level={2}
+		/>
+		<p class="mt-4 text-center text-sm text-muted-foreground">
+			{m['unsubscribePage.redirecting']()}
+		</p>
 	{:else}
 		<!-- Unsubscribe form -->
-		<div class="mb-8">
-			<h1 class="text-3xl font-bold tracking-tight">{m['unsubscribePage.title']()}</h1>
-			<p class="mt-2 text-muted-foreground">
-				{m['unsubscribePage.subtitle']()}
-			</p>
-		</div>
+		<PageHeader
+			title={m['unsubscribePage.title']()}
+			subtitle={m['unsubscribePage.subtitle']()}
+			volume="celebration"
+			class="mb-8"
+		/>
 
 		<div class="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
 			<NotificationPreferencesForm

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -137,10 +137,14 @@
 <div class="flex min-h-screen items-center justify-center bg-background px-4 py-16">
 	<div class="w-full max-w-2xl">
 		<!-- Error Icon + status-code Sticker: the flagship personality moment.
-		     The Sticker is decorative (aria-hidden) — the status code is already
-		     part of the accessible text below via errorPage.errorLabel. -->
+		     Both are decorative art, not a second announcement of the title —
+		     the h1 below is the actual accessible heading, and the status code
+		     is separately in the accessible errorPage.errorLabel text. ToneTile
+		     omits `label` (→ aria-hidden by default) rather than repeating
+		     config.title() as its accessible name; the Sticker is likewise
+		     wrapped aria-hidden. -->
 		<div class="mb-8 flex flex-col items-center gap-4">
-			<ToneTile tone={config.tone} icon={ErrorIcon} size="lg" label={config.title()} />
+			<ToneTile tone={config.tone} icon={ErrorIcon} size="lg" />
 			<span aria-hidden="true">
 				<Sticker tint="purple" rotate={-3} class="text-2xl">{status}</Sticker>
 			</span>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -11,19 +11,38 @@
 		AlertCircle,
 		LinkIcon
 	} from '@lucide/svelte';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
+	import Sticker from '$lib/components/brand/Sticker.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	// Get error details from page store
 	const status = $derived($page.status);
 	const message = $derived($page.error?.message || m['errorPage.defaultMessage']());
 
-	// Define error configurations for different status codes
-	const errorConfigs = {
+	// Define error configurations for different status codes. `tone` drives
+	// the ToneTile icon chip below — semantic, not decorative: info (404,
+	// benign miss), warning (401, needs auth), neutral (410, gone), danger
+	// (403/500, access/server failure). 403 and 500 share a tone (as the old
+	// red/red pairing did) but stay visually distinct via icon + copy, never
+	// color alone.
+	const errorConfigs: Record<
+		number,
+		{
+			title: () => string;
+			description: () => string;
+			icon: typeof Search;
+			tone: Tone;
+			suggestions: () => string[];
+			showBackButton: boolean;
+			showHomeButton: boolean;
+			showLoginButton?: boolean;
+		}
+	> = {
 		404: {
 			title: () => m['errorPage.error404_title'](),
 			description: () => m['errorPage.error404_description'](),
 			icon: Search,
-			iconColor: 'text-blue-600 dark:text-blue-400',
-			iconBg: 'bg-blue-50 dark:bg-blue-950',
+			tone: 'info',
 			suggestions: () => [
 				m['errorPage.error404_suggestion1'](),
 				m['errorPage.error404_suggestion2'](),
@@ -36,8 +55,7 @@
 			title: () => m['errorPage.error401_title'](),
 			description: () => m['errorPage.error401_description'](),
 			icon: Lock,
-			iconColor: 'text-amber-600 dark:text-amber-400',
-			iconBg: 'bg-amber-50 dark:bg-amber-950',
+			tone: 'warning',
 			suggestions: () => [
 				m['errorPage.error401_suggestion1'](),
 				m['errorPage.error401_suggestion2'](),
@@ -51,8 +69,7 @@
 			title: () => m['errorPage.error410_title'](),
 			description: () => m['errorPage.error410_description'](),
 			icon: LinkIcon,
-			iconColor: 'text-orange-600 dark:text-orange-400',
-			iconBg: 'bg-orange-50 dark:bg-orange-950',
+			tone: 'neutral',
 			suggestions: () => [
 				m['errorPage.error410_suggestion1'](),
 				m['errorPage.error410_suggestion2'](),
@@ -65,8 +82,7 @@
 			title: () => m['errorPage.error403_title'](),
 			description: () => m['errorPage.error403_description'](),
 			icon: Lock,
-			iconColor: 'text-red-600 dark:text-red-400',
-			iconBg: 'bg-red-50 dark:bg-red-950',
+			tone: 'danger',
 			suggestions: () => [
 				m['errorPage.error403_suggestion1'](),
 				m['errorPage.error403_suggestion2'](),
@@ -79,8 +95,7 @@
 			title: () => m['errorPage.error500_title'](),
 			description: () => m['errorPage.error500_description'](),
 			icon: ServerCrash,
-			iconColor: 'text-red-600 dark:text-red-400',
-			iconBg: 'bg-red-50 dark:bg-red-950',
+			tone: 'danger',
 			suggestions: () => [
 				m['errorPage.error500_suggestion1'](),
 				m['errorPage.error500_suggestion2'](),
@@ -93,12 +108,11 @@
 
 	// Get config for current status or default
 	const config = $derived(
-		errorConfigs[status as keyof typeof errorConfigs] || {
+		errorConfigs[status] || {
 			title: () => m['errorPage.errorDefault_title']({ status: status.toString() }),
 			description: () => message,
 			icon: AlertCircle,
-			iconColor: 'text-gray-600 dark:text-gray-400',
-			iconBg: 'bg-gray-50 dark:bg-gray-950',
+			tone: 'neutral' as Tone,
 			suggestions: () => [
 				m['errorPage.errorDefault_suggestion1'](),
 				m['errorPage.errorDefault_suggestion2']()
@@ -122,22 +136,25 @@
 
 <div class="flex min-h-screen items-center justify-center bg-background px-4 py-16">
 	<div class="w-full max-w-2xl">
-		<!-- Error Icon -->
-		<div class="mb-8 flex justify-center">
-			<div class="inline-flex rounded-full {config.iconBg} p-6">
-				<ErrorIcon class="h-16 w-16 {config.iconColor}" aria-hidden="true" />
-			</div>
+		<!-- Error Icon + status-code Sticker: the flagship personality moment.
+		     The Sticker is decorative (aria-hidden) — the status code is already
+		     part of the accessible text below via errorPage.errorLabel. -->
+		<div class="mb-8 flex flex-col items-center gap-4">
+			<ToneTile tone={config.tone} icon={ErrorIcon} size="lg" label={config.title()} />
+			<span aria-hidden="true">
+				<Sticker tint="purple" rotate={-3} class="text-2xl">{status}</Sticker>
+			</span>
 		</div>
 
 		<!-- Error Content -->
 		<div class="text-center">
 			<!-- Status Code -->
-			<p class="mb-2 text-sm font-semibold uppercase tracking-wider text-primary">
+			<p class="mb-2 text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
 				{m['errorPage.errorLabel']({ status: status.toString() })}
 			</p>
 
 			<!-- Title -->
-			<h1 class="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+			<h1 class="mb-4 text-3xl font-black leading-[1.12] sm:text-4xl">
 				{config.title()}
 			</h1>
 
@@ -176,7 +193,7 @@
 					</button>
 				{/if}
 
-				{#if 'showLoginButton' in config && config.showLoginButton}
+				{#if config.showLoginButton}
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
 					<a
 						href={`${resolve('/(public)/login', {})}?redirect=${encodeURIComponent($page.url.pathname)}`}


### PR DESCRIPTION
## Platform rebrand, PR 2 of 10 — Global shell

The chrome around every page: Header/MobileNav/UserMenu typography, the Footer as an ink band (theme-aware: deliberate dark-band variant in dark mode), site banners on tone tokens with opaque sticky bases, the root error page in full Celebration (tilted sticker status code + display headline), and `LandingPageTemplate` — which restyles all 42 SEO landing routes in one file (color-block hero, ToneTile feature grid, kicker rhythm, sticker CTA). Legal + unsubscribe get the light PageHeader touch.

### Review process
Whole-branch opus review + one fix round + scoped re-review, clean. The review caught two Criticals: the restyled sticky banners had gone translucent over scrolling content (opaque-base fix), and the outline CTA on all 42 landing routes rendered white-on-lavender at 1.13:1 (the shadcn outline variant's `bg-background` survives class-merging — fixed with explicit `bg-transparent`). It also caught a locale correctness bug: template headings now pin to `content.locale` (`m[...]({}, { locale })`), so `/de/` pages get German headings regardless of the visitor's UI cookie — strictly better than both prior behaviors.

### Notes
- New `landingTemplate.*` keys in all 6 locales (additive only); feature tiles use a uniform brand tone pending PR 7's identity-tint axis.
- i18n merge caveat: sibling wave PRs also add catalog keys — trivial conflicts possible depending on merge order.
- No test coverage exists for the shell components (pre-existing); the e2e checkpoint after PRs 2–6 is the regression net.

### Verification
`make check` 0 errors · full suite 202 files / 2426 green · brand audit 0 failures · i18n-check 100% ×6 · orchestrator screenshots: landing template (light), 404, footer light+dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)