### PR TITLE
feat(rebrand): account settings — studio pass, create-org celebration, badge mappers (PR 6/10)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -4411,6 +4411,7 @@
 		"error_updateFailed": "Token konnte nicht aktualisiert werden",
 		"error_deleteFailed": "Link konnte nicht gelöscht werden"
 	},
+	"orgCreate.kicker": "Neue Organisation",
 	"orgCreate.alreadyOwner": "Du besitzt bereits eine Organisation",
 	"orgCreate.alreadyOwnerDescription": "Jede*r Benutzer*in kann nur eine Organisation besitzen. Du kannst deine bestehende Organisation über das Dashboard verwalten.",
 	"orgCreate.backToDashboard": "Zurück zum Dashboard",

--- a/messages/de.json
+++ b/messages/de.json
@@ -9120,6 +9120,7 @@
 		"inProgress": "In Bearbeitung",
 		"closed": "Beendet",
 		"empty": "Noch keine Bewerbungen. Wenn du dich bei einer Organisation bewirbst, kannst du sie hier verfolgen.",
+		"emptyTitle": "Noch keine Bewerbungen",
 		"loadError": "Deine Bewerbungen konnten nicht geladen werden. Lade die Seite neu.",
 		"appliedOn": "Beworben am {date}",
 		"tierLine": "Stufe: {tier}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4411,6 +4411,7 @@
 		"error_updateFailed": "Failed to update token",
 		"error_deleteFailed": "Failed to delete link"
 	},
+	"orgCreate.kicker": "New Organization",
 	"orgCreate.alreadyOwner": "You already own an organization",
 	"orgCreate.alreadyOwnerDescription": "Each user can only own one organization. You can manage your existing organization from the dashboard.",
 	"orgCreate.backToDashboard": "Back to Dashboard",

--- a/messages/en.json
+++ b/messages/en.json
@@ -9120,6 +9120,7 @@
 		"inProgress": "In progress",
 		"closed": "Closed",
 		"empty": "No applications yet. When you apply to join an organization, you can track it here.",
+		"emptyTitle": "No applications yet",
 		"loadError": "Could not load your applications. Try reloading the page.",
 		"appliedOn": "Applied on {date}",
 		"tierLine": "Tier: {tier}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -9120,6 +9120,7 @@
 		"inProgress": "En curso",
 		"closed": "Cerradas",
 		"empty": "Todavía no hay candidaturas. Cuando te postules para unirte a una organización, podrás seguirla aquí.",
+		"emptyTitle": "Todavía no hay candidaturas",
 		"loadError": "No se han podido cargar tus candidaturas. Intenta recargar la página.",
 		"appliedOn": "Enviada el {date}",
 		"tierLine": "Nivel: {tier}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -4411,6 +4411,7 @@
 		"error_updateFailed": "No se ha podido actualizar el token",
 		"error_deleteFailed": "No se ha podido eliminar el enlace"
 	},
+	"orgCreate.kicker": "Nueva organización",
 	"orgCreate.alreadyOwner": "Ya tienes una organización",
 	"orgCreate.alreadyOwnerDescription": "Cada cuenta solo puede tener una organización. Puedes gestionar tu organización actual desde el panel.",
 	"orgCreate.backToDashboard": "Volver al panel",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -9120,6 +9120,7 @@
 		"inProgress": "En cours",
 		"closed": "Clôturées",
 		"empty": "Aucune candidature pour l'instant. Quand tu postules auprès d'une organisation, tu peux la suivre ici.",
+		"emptyTitle": "Aucune candidature pour l'instant",
 		"loadError": "Impossible de charger tes candidatures. Essaie de recharger la page.",
 		"appliedOn": "Candidature envoyée le {date}",
 		"tierLine": "Niveau : {tier}",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -4382,6 +4382,7 @@
 		"error_updateFailed": "Échec de la mise à jour du jeton",
 		"error_deleteFailed": "Échec de la suppression du lien"
 	},
+	"orgCreate.kicker": "Nouvelle organisation",
 	"orgCreate.alreadyOwner": "Tu possèdes déjà une organisation",
 	"orgCreate.alreadyOwnerDescription": "Chaque utilisateur·rice ne peut posséder qu'une seule organisation. Tu peux gérer ton organisation existante depuis le tableau de bord.",
 	"orgCreate.backToDashboard": "Retour au tableau de bord",

--- a/messages/it.json
+++ b/messages/it.json
@@ -4411,6 +4411,7 @@
 		"error_updateFailed": "Impossibile aggiornare il token",
 		"error_deleteFailed": "Impossibile eliminare il link"
 	},
+	"orgCreate.kicker": "Nuova Organizzazione",
 	"orgCreate.alreadyOwner": "Possiedi già un'organizzazione",
 	"orgCreate.alreadyOwnerDescription": "Ogni utente può possedere solo un'organizzazione. Puoi gestire la tua organizzazione esistente dalla dashboard.",
 	"orgCreate.backToDashboard": "Torna alla Dashboard",

--- a/messages/it.json
+++ b/messages/it.json
@@ -9120,6 +9120,7 @@
 		"inProgress": "In corso",
 		"closed": "Chiuse",
 		"empty": "Nessuna candidatura per ora. Quando ti candidi a un'organizzazione, puoi seguirla qui.",
+		"emptyTitle": "Nessuna candidatura per ora",
 		"loadError": "Non è stato possibile caricare le tue candidature. Prova a ricaricare la pagina.",
 		"appliedOn": "Candidatura inviata il {date}",
 		"tierLine": "Livello: {tier}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -4411,6 +4411,7 @@
 		"error_updateFailed": "Não foi possível atualizar o token",
 		"error_deleteFailed": "Não foi possível eliminar o link"
 	},
+	"orgCreate.kicker": "Nova organização",
 	"orgCreate.alreadyOwner": "Já és titular de uma organização",
 	"orgCreate.alreadyOwnerDescription": "Cada conta só pode ser titular de uma organização. Podes gerir a tua organização existente a partir do painel.",
 	"orgCreate.backToDashboard": "Voltar ao painel",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -9120,6 +9120,7 @@
 		"inProgress": "Em curso",
 		"closed": "Encerradas",
 		"empty": "Ainda não há candidaturas. Quando te candidatares a uma organização, podes acompanhá-la aqui.",
+		"emptyTitle": "Ainda não há candidaturas",
 		"loadError": "Não foi possível carregar as tuas candidaturas. Tenta recarregar a página.",
 		"appliedOn": "Candidatura enviada em {date}",
 		"tierLine": "Nível: {tier}",

--- a/src/lib/components/account/MembershipCard.svelte
+++ b/src/lib/components/account/MembershipCard.svelte
@@ -254,7 +254,7 @@
 		<article aria-label={membership.organization_name}>
 			<div class="flex items-start justify-between gap-3">
 				<div class="min-w-0">
-					<h3 class="font-semibold">{membership.organization_name}</h3>
+					<h3 class="font-bold">{membership.organization_name}</h3>
 					{#if sub}
 						<p class="text-sm text-muted-foreground">
 							{sub.plan.name} · {formatPlanPrice(sub.plan)}
@@ -272,9 +272,10 @@
 
 			{#if sub && line}
 				{#if pastDueOnline}
+					<!-- Warning tint mirrors ToneTile's amber recipe (see security page). -->
 					<p
 						role="alert"
-						class="mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-100"
+						class="mt-3 rounded-lg border border-highlight/40 bg-highlight/20 p-3 text-sm text-highlight-foreground dark:text-highlight"
 					>
 						{#if sub.grace_deadline}
 							{m['subscriptions.pastDue.bannerDated']({ date: formatDate(sub.grace_deadline) })}

--- a/src/lib/components/account/MembershipPaymentHistory.svelte
+++ b/src/lib/components/account/MembershipPaymentHistory.svelte
@@ -9,6 +9,8 @@
 	import { MY_MEMBERSHIPS_KEY } from '$lib/utils/subscription-cache';
 	import { formatDate } from '$lib/utils/date';
 	import { formatMoney } from '$lib/utils/format';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import { ChevronDown, Loader2 } from '@lucide/svelte';
 
 	interface Props {
@@ -111,6 +113,23 @@
 		}
 	}
 
+	/** Thin mapper: raw payment status -> StatusBadge tone. Each of the four
+	 * backend statuses gets its own tone. */
+	function statusTone(status: PaymentStatus): Tone {
+		switch (status) {
+			case 'succeeded':
+				return 'success';
+			case 'pending':
+				return 'warning';
+			case 'failed':
+				return 'danger';
+			case 'refunded':
+				return 'neutral';
+			default:
+				return 'neutral';
+		}
+	}
+
 	function goTo(next: number) {
 		page = Math.min(Math.max(1, next), pageCount);
 	}
@@ -157,15 +176,17 @@
 				<div class="overflow-x-auto">
 					<table class="mt-1 w-full text-sm">
 						<caption class="sr-only">{m['subscriptions.payments.title']()}</caption>
-						<thead class="border-b text-left text-xs text-muted-foreground">
+						<thead
+							class="border-b text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+						>
 							<tr>
-								<th scope="col" class="py-2 pr-3 font-medium">
+								<th scope="col" class="py-2 pr-3">
 									{m['subscriptions.payments.colDate']()}
 								</th>
-								<th scope="col" class="py-2 pr-3 font-medium">
+								<th scope="col" class="py-2 pr-3">
 									{m['subscriptions.payments.colAmount']()}
 								</th>
-								<th scope="col" class="py-2 font-medium">
+								<th scope="col" class="py-2">
 									{m['subscriptions.payments.colStatus']()}
 								</th>
 							</tr>
@@ -189,7 +210,9 @@
 											<span class="block text-xs text-muted-foreground">{refunded}</span>
 										{/if}
 									</td>
-									<td class="py-2">{statusLabel(p.status)}</td>
+									<td class="py-2">
+										<StatusBadge tone={statusTone(p.status)} label={statusLabel(p.status)} size="sm" />
+									</td>
 								</tr>
 							{/each}
 						</tbody>

--- a/src/lib/components/account/MembershipPaymentHistory.svelte
+++ b/src/lib/components/account/MembershipPaymentHistory.svelte
@@ -211,7 +211,11 @@
 										{/if}
 									</td>
 									<td class="py-2">
-										<StatusBadge tone={statusTone(p.status)} label={statusLabel(p.status)} size="sm" />
+										<StatusBadge
+											tone={statusTone(p.status)}
+											label={statusLabel(p.status)}
+											size="sm"
+										/>
 									</td>
 								</tr>
 							{/each}

--- a/src/lib/components/account/OrgMembershipInline.svelte
+++ b/src/lib/components/account/OrgMembershipInline.svelte
@@ -52,7 +52,7 @@
 	{@const line = getDateLine(sub)}
 	<Card>
 		<CardContent class="p-4">
-			<h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+			<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
 				{m['orgPublic.yourMembership.title']()}
 			</h3>
 			<div class="mt-1 font-medium">{sub.plan.name}</div>

--- a/src/lib/components/account/RejoinCard.svelte
+++ b/src/lib/components/account/RejoinCard.svelte
@@ -75,10 +75,11 @@
 	});
 </script>
 
-<Card class="border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40">
+<!-- Warning tint mirrors ToneTile's amber recipe (see security page). -->
+<Card class="border-highlight/40 bg-highlight/20">
 	<CardContent class="p-4">
 		<article aria-label={sub.organization_name}>
-			<h3 class="font-semibold">
+			<h3 class="font-bold">
 				{m['subscriptions.rejoin.title']({ org: sub.organization_name })}
 			</h3>
 

--- a/src/lib/components/account/applications/ApplicationRow.svelte
+++ b/src/lib/components/account/applications/ApplicationRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" module>
 	import type { MembershipRequestStatus } from '$lib/api/generated/types.gen';
+	import type { Tone } from '$lib/components/common/tones';
 
 	/**
 	 * Statuses the backend will never move off. A row in one of these must not be
@@ -9,16 +10,15 @@
 	const TERMINAL = new Set<MembershipRequestStatus>(['rejected', 'cancelled', 'completed']);
 
 	/**
-	 * Chip tones mirror `STATUS_CONFIG` in `$lib/utils/subscriptions`. Separated by
-	 * lightness as much as hue, and always paired with the status word — the
-	 * colour is decoration, never the message.
+	 * Chip tones: each of the five statuses keeps its own tone, always paired
+	 * with the status word — the colour is decoration, never the message.
 	 */
-	const REQUEST_STATUS_CLASSES: Record<MembershipRequestStatus, string> = {
-		pending: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-100',
-		approved: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-100',
-		completed: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-100',
-		rejected: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-100',
-		cancelled: 'bg-muted text-muted-foreground'
+	const REQUEST_STATUS_TONES: Record<MembershipRequestStatus, Tone> = {
+		pending: 'info',
+		approved: 'warning',
+		completed: 'success',
+		rejected: 'danger',
+		cancelled: 'neutral'
 	};
 </script>
 
@@ -39,6 +39,7 @@
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import ApplyDialog from '$lib/components/organization/membership/ApplyDialog.svelte';
 	import { formatDate } from '$lib/utils/date';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import { getImageUrl } from '$lib/utils/url';
 	import { backendMessage } from '$lib/utils/api-error-detail';
 	import { MY_MEMBERSHIPS_KEY, MY_SUBSCRIPTIONS_KEY } from '$lib/utils/subscription-cache';
@@ -257,7 +258,7 @@
 				/>
 			{/if}
 			<div class="min-w-0">
-				<h4 class="font-semibold">
+				<h4 class="font-bold">
 					<a
 						class="hover:underline"
 						href={resolve('/(public)/org/[slug]', { slug: app.organization_slug })}
@@ -275,14 +276,13 @@
 				</p>
 			</div>
 		</div>
-		<span
-			class="inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-medium {REQUEST_STATUS_CLASSES[
-				app.status
-			]}"
+		<StatusBadge
+			tone={REQUEST_STATUS_TONES[app.status]}
+			label={statusLabel}
+			size="sm"
+			class="shrink-0"
 			aria-label={m['applications.statusAriaLabel']({ status: statusLabel })}
-		>
-			{statusLabel}
-		</span>
+		/>
 	</div>
 
 	{#if becameMember}

--- a/src/lib/components/account/applications/ApplicationsSection.svelte
+++ b/src/lib/components/account/applications/ApplicationsSection.svelte
@@ -66,7 +66,12 @@
 		<p role="alert" class="text-sm text-destructive">{m['applications.loadError']()}</p>
 	{:else if applications.length === 0}
 		<!-- level=3: sits inside this section, whose own heading is the level-2. -->
-		<EmptyState icon={ClipboardList} level={3} title={m['applications.empty']()} />
+		<EmptyState
+			icon={ClipboardList}
+			level={3}
+			title={m['applications.emptyTitle']()}
+			body={m['applications.empty']()}
+		/>
 	{:else}
 		{#if inProgress.length > 0}
 			<h3 id="applications-in-progress-heading" class="text-sm font-medium text-muted-foreground">

--- a/src/lib/components/account/applications/ApplicationsSection.svelte
+++ b/src/lib/components/account/applications/ApplicationsSection.svelte
@@ -5,7 +5,9 @@
 	import type { MembershipApplicationSchema } from '$lib/api/generated/types.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import ApplicationRow from './ApplicationRow.svelte';
-	import { Loader2 } from '@lucide/svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import { ClipboardList, Loader2 } from '@lucide/svelte';
 
 	const accessToken = $derived(authStore.accessToken);
 
@@ -51,7 +53,7 @@
 </script>
 
 <section aria-labelledby="applications-heading" class="space-y-3">
-	<h2 id="applications-heading" class="text-lg font-semibold">{m['applications.title']()}</h2>
+	<SectionHeader id="applications-heading" title={m['applications.title']()} />
 
 	{#if isSectionPending}
 		<div role="status">
@@ -63,7 +65,8 @@
 		     live region the failure is silent to anyone who has moved focus on. -->
 		<p role="alert" class="text-sm text-destructive">{m['applications.loadError']()}</p>
 	{:else if applications.length === 0}
-		<p class="text-sm text-muted-foreground">{m['applications.empty']()}</p>
+		<!-- level=3: sits inside this section, whose own heading is the level-2. -->
+		<EmptyState icon={ClipboardList} level={3} title={m['applications.empty']()} />
 	{:else}
 		{#if inProgress.length > 0}
 			<h3 id="applications-in-progress-heading" class="text-sm font-medium text-muted-foreground">

--- a/src/lib/components/account/applications/ApplicationsSection.test.ts
+++ b/src/lib/components/account/applications/ApplicationsSection.test.ts
@@ -107,7 +107,13 @@ describe('ApplicationsSection', () => {
 		mockList([]);
 		renderSection();
 
-		expect(await screen.findByText(/no applications yet/i)).toBeInTheDocument();
+		// The EmptyState splits into a title (h3) + body paragraph, both of which
+		// contain "no applications yet" — target the heading so the query doesn't
+		// ambiguously match both.
+		expect(
+			await screen.findByRole('heading', { level: 3, name: /no applications yet/i })
+		).toBeInTheDocument();
+		expect(screen.getByText(/when you apply to join an organization/i)).toBeInTheDocument();
 		expect(screen.queryByRole('list', { name: 'In progress' })).toBeNull();
 	});
 
@@ -156,7 +162,7 @@ describe('ApplicationsSection', () => {
 		mockList([]);
 		renderSection();
 
-		await screen.findByText(/no applications yet/i);
+		await screen.findByRole('heading', { level: 3, name: /no applications yet/i });
 		expect(listMock).toHaveBeenCalledWith(expect.objectContaining({ query: { page_size: 50 } }));
 	});
 });

--- a/src/lib/components/billing/BillingProfileForm.svelte
+++ b/src/lib/components/billing/BillingProfileForm.svelte
@@ -348,9 +348,21 @@
 				</span>
 
 				{#if vatIdStatus === 'validated'}
-					<StatusBadge tone="success" icon={Check} label={m['billing.form.vatIdValidated']()} size="sm" role="status" />
+					<StatusBadge
+						tone="success"
+						icon={Check}
+						label={m['billing.form.vatIdValidated']()}
+						size="sm"
+						role="status"
+					/>
 				{:else if vatIdStatus === 'pending'}
-					<StatusBadge tone="warning" icon={AlertCircle} label={m['billing.form.vatIdPending']()} size="sm" role="status" />
+					<StatusBadge
+						tone="warning"
+						icon={AlertCircle}
+						label={m['billing.form.vatIdPending']()}
+						size="sm"
+						role="status"
+					/>
 				{/if}
 
 				<Button

--- a/src/lib/components/billing/BillingProfileForm.svelte
+++ b/src/lib/components/billing/BillingProfileForm.svelte
@@ -8,6 +8,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Check, AlertCircle, AlertTriangle, Loader2, Shield } from '@lucide/svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import {
 		userbillingGetBillingProfile,
 		userbillingCreateBillingProfile,
@@ -162,22 +163,23 @@
 	});
 </script>
 
-<!-- Incomplete warning (only shown when profile exists but is incomplete) -->
+<!-- Incomplete warning (only shown when profile exists but is incomplete).
+     Warning tint mirrors ToneTile's amber recipe (see security page). -->
 {#if hasBillingProfile && !isBillingComplete}
 	<div
-		class="mt-4 flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-950/30"
+		class="mt-4 flex items-start gap-3 rounded-lg border border-highlight/40 bg-highlight/20 p-4"
 		role="alert"
 		aria-live="polite"
 	>
 		<AlertTriangle
-			class="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400"
+			class="mt-0.5 h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
 			aria-hidden="true"
 		/>
 		<div>
-			<p class="font-medium text-amber-900 dark:text-amber-100">
+			<p class="font-medium text-highlight-foreground dark:text-highlight">
 				{m['billing.form.incomplete']()}
 			</p>
-			<p class="mt-1 text-sm text-amber-800 dark:text-amber-200">
+			<p class="mt-1 text-sm text-foreground">
 				{m['billing.form.incompleteDescription']()}
 			</p>
 		</div>
@@ -346,21 +348,9 @@
 				</span>
 
 				{#if vatIdStatus === 'validated'}
-					<span
-						class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-300"
-						role="status"
-					>
-						<Check class="h-3 w-3" aria-hidden="true" />
-						{m['billing.form.vatIdValidated']()}
-					</span>
+					<StatusBadge tone="success" icon={Check} label={m['billing.form.vatIdValidated']()} size="sm" role="status" />
 				{:else if vatIdStatus === 'pending'}
-					<span
-						class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-300"
-						role="status"
-					>
-						<AlertCircle class="h-3 w-3" aria-hidden="true" />
-						{m['billing.form.vatIdPending']()}
-					</span>
+					<StatusBadge tone="warning" icon={AlertCircle} label={m['billing.form.vatIdPending']()} size="sm" role="status" />
 				{/if}
 
 				<Button

--- a/src/lib/components/members/StatusBadge.svelte
+++ b/src/lib/components/members/StatusBadge.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import {
-		getStatusLabel,
-		type SubscriptionStatus
-	} from '$lib/utils/subscriptions';
+	import { getStatusLabel, type SubscriptionStatus } from '$lib/utils/subscriptions';
 	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { Tone } from '$lib/components/common/tones';
 

--- a/src/lib/components/members/StatusBadge.svelte
+++ b/src/lib/components/members/StatusBadge.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import {
-		getStatusConfig,
 		getStatusLabel,
 		type SubscriptionStatus
 	} from '$lib/utils/subscriptions';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		status: SubscriptionStatus;
@@ -12,13 +13,24 @@
 
 	const { status, class: extraClass = '' }: Props = $props();
 
-	const config = $derived(getStatusConfig(status));
+	/**
+	 * Thin mapper over the shared `StatusBadge` primitive: each of the six
+	 * `SubscriptionStatus` values keeps its OWN tone (no collapsing) — in
+	 * particular `paused` (admin-imposed, brand) stays visually distinct from
+	 * `cancelled` (over, neutral), a real distinction the old raw gray/muted
+	 * pairing barely carried.
+	 */
+	const TONE_MAP: Record<SubscriptionStatus, Tone> = {
+		active: 'success',
+		pending: 'info',
+		past_due: 'warning',
+		paused: 'brand',
+		cancelled: 'neutral',
+		expired: 'danger'
+	};
+
+	const tone = $derived(TONE_MAP[status]);
 	const label = $derived(getStatusLabel(status));
 </script>
 
-<span
-	class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {config.className} {extraClass}"
-	aria-label={label}
->
-	{label}
-</span>
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} />

--- a/src/lib/components/members/StatusBadge.svelte
+++ b/src/lib/components/members/StatusBadge.svelte
@@ -11,19 +11,22 @@
 	const { status, class: extraClass = '' }: Props = $props();
 
 	/**
-	 * Thin mapper over the shared `StatusBadge` primitive: each of the six
-	 * `SubscriptionStatus` values keeps its OWN tone (no collapsing) — in
-	 * particular `paused` (admin-imposed, brand) stays visually distinct from
-	 * `cancelled` (over, neutral), a real distinction the old raw gray/muted
-	 * pairing barely carried.
+	 * Thin mapper over the shared `StatusBadge` primitive. `brand` is reserved
+	 * for emphasis, not for a suspended state, so `paused` takes `warning`
+	 * (needs attention) instead — it does not share `active`'s `success`, and
+	 * it stays visually louder than the two terminal states. `past_due` is a
+	 * harder problem than "pending payment" (it risks losing access), so it
+	 * escalates to `danger`. `cancelled` and `expired` collapse onto the same
+	 * `neutral` tone deliberately: both are terminal/over, and the label text
+	 * ("Cancelled" vs "Expired") — not the tone — carries the distinction.
 	 */
 	const TONE_MAP: Record<SubscriptionStatus, Tone> = {
 		active: 'success',
 		pending: 'info',
-		past_due: 'warning',
-		paused: 'brand',
+		past_due: 'danger',
+		paused: 'warning',
 		cancelled: 'neutral',
-		expired: 'danger'
+		expired: 'neutral'
 	};
 
 	const tone = $derived(TONE_MAP[status]);

--- a/src/lib/components/profile/DietaryPreferencesManager.svelte
+++ b/src/lib/components/profile/DietaryPreferencesManager.svelte
@@ -176,7 +176,7 @@
 <div class="space-y-4">
 	<div class="flex items-start justify-between">
 		<div>
-			<h3 class="text-lg font-semibold">{m['dietary.preferences_sectionHeading']()}</h3>
+			<h3 class="text-lg font-bold">{m['dietary.preferences_sectionHeading']()}</h3>
 			<p class="text-sm text-muted-foreground">
 				{m['dietary.preferences_sectionDescription']()}
 			</p>
@@ -216,12 +216,14 @@
 					<div class="flex-1 space-y-2">
 						<div class="flex items-center justify-between">
 							<h4 class="font-medium">{pref.preference.name}</h4>
+							<!-- text-success unchanged by the light tint (>=5:1 vs card per
+							     audit-brand-themes.py; a 15% overlay barely shifts lightness). -->
 							<button
 								type="button"
 								onclick={() => handleToggleVisibility(pref)}
 								class="rounded px-2 py-1 text-xs font-medium transition-colors {pref.is_public
-									? 'bg-green-100 text-green-800 hover:bg-green-200 dark:bg-green-950 dark:text-green-400'
-									: 'bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400'}"
+									? 'bg-success/15 text-success hover:bg-success/25'
+									: 'bg-muted text-muted-foreground hover:bg-muted/70'}"
 								aria-label={pref.is_public
 									? m['dietary.preferences_publicLabel']()
 									: m['dietary.preferences_privateLabel']()}

--- a/src/lib/components/profile/DietaryPreferencesManager.svelte
+++ b/src/lib/components/profile/DietaryPreferencesManager.svelte
@@ -216,13 +216,16 @@
 					<div class="flex-1 space-y-2">
 						<div class="flex items-center justify-between">
 							<h4 class="font-medium">{pref.preference.name}</h4>
-							<!-- text-success unchanged by the light tint (>=5:1 vs card per
-							     audit-brand-themes.py; a 15% overlay barely shifts lightness). -->
+							<!-- Solid audited pair (same fill StatusBadge uses for tone="success"):
+							     the /15 tint measured 4.10:1 on the actual surface (this manager
+							     renders in a plain bordered <li> on --background, not on --card),
+							     under the 4.5 floor for text-xs. success-foreground on success is
+							     9.92:1 in dark / audited >=4.5 in both modes. -->
 							<button
 								type="button"
 								onclick={() => handleToggleVisibility(pref)}
 								class="rounded px-2 py-1 text-xs font-medium transition-colors {pref.is_public
-									? 'bg-success/15 text-success hover:bg-success/25'
+									? 'bg-success text-success-foreground hover:bg-success/90'
 									: 'bg-muted text-muted-foreground hover:bg-muted/70'}"
 								aria-label={pref.is_public
 									? m['dietary.preferences_publicLabel']()

--- a/src/lib/components/profile/DietaryRestrictionsManager.svelte
+++ b/src/lib/components/profile/DietaryRestrictionsManager.svelte
@@ -333,13 +333,16 @@
 								label={getSeverityLabel(restriction.restriction_type)}
 								size="sm"
 							/>
-							<!-- text-success unchanged by the light tint (>=5:1 vs card per
-							     audit-brand-themes.py; a 15% overlay barely shifts lightness). -->
+							<!-- Solid audited pair (same fill StatusBadge uses for tone="success"):
+							     the /15 tint measured 4.10:1 on the actual surface (this manager
+							     renders in a plain bordered <li> on --background, not on --card),
+							     under the 4.5 floor for text-xs. success-foreground on success is
+							     9.92:1 in dark / audited >=4.5 in both modes. -->
 							<button
 								type="button"
 								onclick={() => handleToggleVisibility(restriction)}
 								class="ml-auto rounded px-2 py-1 text-xs font-medium transition-colors {restriction.is_public
-									? 'bg-success/15 text-success hover:bg-success/25'
+									? 'bg-success text-success-foreground hover:bg-success/90'
 									: 'bg-muted text-muted-foreground hover:bg-muted/70'}"
 								aria-label={restriction.is_public
 									? m['dietary.restrictions_publicLabel']()
@@ -356,8 +359,11 @@
 						{/if}
 
 						{#if restriction.restriction_type === 'severe_allergy'}
-							<div class="flex items-center gap-2 text-sm text-destructive">
-								<AlertTriangle class="h-4 w-4" aria-hidden="true" />
+							<!-- Bare on card: text-destructive measures 2.85:1 in dark (below
+							     4.5). Only the icon carries the tone; the line reads on
+							     --foreground, same pattern as the tinted-banner headings. -->
+							<div class="flex items-center gap-2 text-sm text-foreground">
+								<AlertTriangle class="h-4 w-4 text-destructive" aria-hidden="true" />
 								<span>{m['dietaryRestrictionsManager.severeAllergyWarning']()}</span>
 							</div>
 						{/if}

--- a/src/lib/components/profile/DietaryRestrictionsManager.svelte
+++ b/src/lib/components/profile/DietaryRestrictionsManager.svelte
@@ -11,6 +11,8 @@
 	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import { Plus, Trash2, Loader2, AlertTriangle } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import type {
 		DietaryRestrictionSchema,
 		DietaryRestrictionCreateSchema,
@@ -208,19 +210,20 @@
 		}
 	}
 
-	// Get severity badge color
-	function getSeverityColor(type: RestrictionType): string {
+	// Severity tone: each of the four levels gets its own tone so the
+	// escalation (dislike -> severe allergy) stays visible, not collapsed.
+	function getSeverityTone(type: RestrictionType): Tone {
 		switch (type) {
 			case 'dislike':
-				return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-400';
+				return 'neutral';
 			case 'intolerant':
-				return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-400';
+				return 'info';
 			case 'allergy':
-				return 'bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-400';
+				return 'warning';
 			case 'severe_allergy':
-				return 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-400';
+				return 'danger';
 			default:
-				return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-400';
+				return 'neutral';
 		}
 	}
 
@@ -286,7 +289,7 @@
 <div class="space-y-4">
 	<div class="flex items-start justify-between">
 		<div>
-			<h3 class="text-lg font-semibold">{m['dietary.restrictions_sectionHeading']()}</h3>
+			<h3 class="text-lg font-bold">{m['dietary.restrictions_sectionHeading']()}</h3>
 			<p class="text-sm text-muted-foreground">
 				{m['dietary.restrictions_sectionDescription']()}
 			</p>
@@ -325,19 +328,19 @@
 					<div class="flex-1 space-y-2">
 						<div class="flex flex-wrap items-center gap-2">
 							<h4 class="font-medium">{restriction.food_item.name}</h4>
-							<span
-								class="rounded px-2 py-1 text-xs font-medium {getSeverityColor(
-									restriction.restriction_type
-								)}"
-							>
-								{getSeverityLabel(restriction.restriction_type)}
-							</span>
+							<StatusBadge
+								tone={getSeverityTone(restriction.restriction_type)}
+								label={getSeverityLabel(restriction.restriction_type)}
+								size="sm"
+							/>
+							<!-- text-success unchanged by the light tint (>=5:1 vs card per
+							     audit-brand-themes.py; a 15% overlay barely shifts lightness). -->
 							<button
 								type="button"
 								onclick={() => handleToggleVisibility(restriction)}
 								class="ml-auto rounded px-2 py-1 text-xs font-medium transition-colors {restriction.is_public
-									? 'bg-green-100 text-green-800 hover:bg-green-200 dark:bg-green-950 dark:text-green-400'
-									: 'bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400'}"
+									? 'bg-success/15 text-success hover:bg-success/25'
+									: 'bg-muted text-muted-foreground hover:bg-muted/70'}"
 								aria-label={restriction.is_public
 									? m['dietary.restrictions_publicLabel']()
 									: m['dietary.restrictions_privateLabel']()}
@@ -353,7 +356,7 @@
 						{/if}
 
 						{#if restriction.restriction_type === 'severe_allergy'}
-							<div class="flex items-center gap-2 text-sm text-orange-600 dark:text-orange-400">
+							<div class="flex items-center gap-2 text-sm text-destructive">
 								<AlertTriangle class="h-4 w-4" aria-hidden="true" />
 								<span>{m['dietaryRestrictionsManager.severeAllergyWarning']()}</span>
 							</div>

--- a/src/lib/components/profile/ProfilePictureUploader.svelte
+++ b/src/lib/components/profile/ProfilePictureUploader.svelte
@@ -196,10 +196,7 @@
 </script>
 
 <div class={cn('space-y-4', className)}>
-	<span
-		class="block text-sm font-medium text-gray-900 dark:text-gray-100"
-		id="profile-picture-label"
-	>
+	<span class="block text-sm font-medium text-foreground" id="profile-picture-label">
 		{m['profilePage.profilePicture_label']()}
 	</span>
 

--- a/src/lib/components/referral/ReferralCodeInput.svelte
+++ b/src/lib/components/referral/ReferralCodeInput.svelte
@@ -101,12 +101,13 @@
 	{#if isOpen}
 		<div class="space-y-3 border-t px-4 py-3">
 			{#if validatedCode}
-				<!-- Applied code display -->
-				<div class="rounded-md bg-emerald-50 p-3 dark:bg-emerald-950/30">
+				<!-- Applied code display. Composited tint mirrors ToneTile's audited
+				     success pair; body copy stays on --foreground/--success. -->
+				<div class="rounded-md border border-success/30 bg-success/10 p-3">
 					<div class="flex items-center justify-between">
 						<div class="flex items-center gap-2">
-							<Check class="h-4 w-4 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
-							<span class="font-mono font-semibold text-emerald-800 dark:text-emerald-300">
+							<Check class="h-4 w-4 text-success" aria-hidden="true" />
+							<span class="font-mono font-semibold text-success">
 								{validatedCode}
 							</span>
 						</div>
@@ -114,13 +115,13 @@
 							type="button"
 							onclick={handleRemove}
 							disabled={isProcessing}
-							class="rounded-md p-1 text-emerald-600 hover:bg-emerald-100 dark:text-emerald-400 dark:hover:bg-emerald-900/50"
+							class="rounded-md p-1 text-success hover:bg-success/15"
 							aria-label={m['referral.removeCode']()}
 						>
 							<X class="h-4 w-4" />
 						</button>
 					</div>
-					<p class="mt-1 text-sm text-emerald-700 dark:text-emerald-300">
+					<p class="mt-1 text-sm text-foreground">
 						{m['referral.validCode']()}
 					</p>
 				</div>

--- a/src/routes/(auth)/account/invoices/+page.svelte
+++ b/src/routes/(auth)/account/invoices/+page.svelte
@@ -25,6 +25,10 @@
 	} from '$lib/api/generated/sdk.gen';
 	import type { AttendeeInvoiceSchema } from '$lib/api/generated/types.gen';
 	import { formatDate } from '$lib/utils/date';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	const accessToken = $derived(authStore.accessToken);
 
@@ -114,14 +118,17 @@
 		return formatMoney(amount, currency);
 	}
 
-	function statusColor(status: string): string {
+	/** Thin mapper: raw invoice status -> StatusBadge tone. `issued`/`cancelled`
+	 * are the only statuses the backend emits today; anything else falls back to
+	 * neutral rather than guessing a tone for a future value. */
+	function statusTone(status: string): Tone {
 		switch (status) {
 			case 'issued':
-				return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
+				return 'info';
 			case 'cancelled':
-				return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+				return 'danger';
 			default:
-				return 'bg-muted text-muted-foreground';
+				return 'neutral';
 		}
 	}
 
@@ -153,10 +160,12 @@
 		</a>
 	</div>
 
-	<div class="mb-6">
-		<h1 class="text-2xl font-bold tracking-tight">{m['myInvoices.pageTitle']()}</h1>
-		<p class="mt-1 text-sm text-muted-foreground">{m['myInvoices.pageDescription']()}</p>
-	</div>
+	<PageHeader
+		kicker={m['myInvoices.account']()}
+		title={m['myInvoices.pageTitle']()}
+		subtitle={m['myInvoices.pageDescription']()}
+		class="mb-6"
+	/>
 
 	<!-- Search -->
 	<div class="relative mb-6">
@@ -189,30 +198,28 @@
 			{m['referral.error']()}
 		</div>
 	{:else if invoices.length === 0}
-		<!-- Empty State -->
-		<div
-			class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center"
-		>
-			<FileText class="mb-3 h-10 w-10 text-muted-foreground/50" aria-hidden="true" />
-			<h2 class="font-medium">{m['myInvoices.empty']()}</h2>
-			<p class="mt-1 text-sm text-muted-foreground">{m['myInvoices.emptyDescription']()}</p>
-		</div>
+		<EmptyState
+			icon={FileText}
+			level={2}
+			title={m['myInvoices.empty']()}
+			body={m['myInvoices.emptyDescription']()}
+		/>
 	{:else}
 		<!-- Invoice Table -->
 		<div class="overflow-x-auto rounded-lg border">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/50">
-					<tr>
-						<th class="px-4 py-3 text-left font-medium">{m['myInvoices.invoiceNumber']()}</th>
-						<th class="hidden px-4 py-3 text-left font-medium sm:table-cell">
+					<tr class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+						<th class="px-4 py-3 text-left">{m['myInvoices.invoiceNumber']()}</th>
+						<th class="hidden px-4 py-3 text-left sm:table-cell">
 							{m['myInvoices.seller']()}
 						</th>
-						<th class="hidden px-4 py-3 text-left font-medium md:table-cell">
+						<th class="hidden px-4 py-3 text-left md:table-cell">
 							{m['myInvoices.date']()}
 						</th>
-						<th class="px-4 py-3 text-left font-medium">{m['myInvoices.status']()}</th>
-						<th class="px-4 py-3 text-right font-medium">{m['myInvoices.amount']()}</th>
-						<th class="px-4 py-3 text-center font-medium">
+						<th class="px-4 py-3 text-left">{m['myInvoices.status']()}</th>
+						<th class="px-4 py-3 text-right">{m['myInvoices.amount']()}</th>
+						<th class="px-4 py-3 text-center">
 							<span class="sr-only">{m['myInvoices.actions']()}</span>
 						</th>
 					</tr>
@@ -237,13 +244,7 @@
 								{invoice.issued_at ? formatDate(invoice.issued_at) : formatDate(invoice.created_at)}
 							</td>
 							<td class="px-4 py-3">
-								<span
-									class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium {statusColor(
-										invoice.status
-									)}"
-								>
-									{statusLabel(invoice.status)}
-								</span>
+								<StatusBadge tone={statusTone(invoice.status)} label={statusLabel(invoice.status)} size="sm" />
 							</td>
 							<td class="px-4 py-3 text-right font-mono">
 								{formatCurrency(invoice.total_gross, invoice.currency)}
@@ -325,13 +326,12 @@
 						<p class="text-xs text-muted-foreground">{m['myInvoices.invoiceNumber']()}</p>
 						<p class="text-lg font-semibold">{inv.invoice_number}</p>
 					</div>
-					<span
-						class="mt-1 inline-flex shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium {statusColor(
-							inv.status
-						)}"
-					>
-						{statusLabel(inv.status)}
-					</span>
+					<StatusBadge
+						tone={statusTone(inv.status)}
+						label={statusLabel(inv.status)}
+						size="sm"
+						class="mt-1 shrink-0"
+					/>
 				</div>
 
 				<!-- Seller -->

--- a/src/routes/(auth)/account/invoices/+page.svelte
+++ b/src/routes/(auth)/account/invoices/+page.svelte
@@ -160,8 +160,8 @@
 		</a>
 	</div>
 
+	<!-- No kicker: the "Account" back-link two lines above already says it. -->
 	<PageHeader
-		kicker={m['myInvoices.account']()}
 		title={m['myInvoices.pageTitle']()}
 		subtitle={m['myInvoices.pageDescription']()}
 		class="mb-6"

--- a/src/routes/(auth)/account/invoices/+page.svelte
+++ b/src/routes/(auth)/account/invoices/+page.svelte
@@ -244,7 +244,11 @@
 								{invoice.issued_at ? formatDate(invoice.issued_at) : formatDate(invoice.created_at)}
 							</td>
 							<td class="px-4 py-3">
-								<StatusBadge tone={statusTone(invoice.status)} label={statusLabel(invoice.status)} size="sm" />
+								<StatusBadge
+									tone={statusTone(invoice.status)}
+									label={statusLabel(invoice.status)}
+									size="sm"
+								/>
 							</td>
 							<td class="px-4 py-3 text-right font-mono">
 								{formatCurrency(invoice.total_gross, invoice.currency)}

--- a/src/routes/(auth)/account/memberships/+page.svelte
+++ b/src/routes/(auth)/account/memberships/+page.svelte
@@ -13,7 +13,10 @@
 	import { isWithinRevivalWindow } from '$lib/utils/subscriptions';
 	import { MY_MEMBERSHIPS_KEY, MY_SUBSCRIPTIONS_KEY } from '$lib/utils/subscription-cache';
 	import { Button } from '$lib/components/ui/button';
-	import { Loader2 } from '@lucide/svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import { Loader2, Users } from '@lucide/svelte';
 
 	const accessToken = $derived(authStore.accessToken);
 
@@ -171,12 +174,10 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-3xl space-y-6 px-4 py-6">
-	<h1 class="text-2xl font-bold">{m['account.memberships.title']()}</h1>
+	<PageHeader kicker={m['myInvoices.account']()} title={m['account.memberships.title']()} />
 
 	<section aria-labelledby="memberships-heading" class="space-y-3">
-		<h2 id="memberships-heading" class="text-lg font-semibold">
-			{m['account.memberships.sectionMemberships']()}
-		</h2>
+		<SectionHeader id="memberships-heading" title={m['account.memberships.sectionMemberships']()} />
 
 		{#if isSectionPending}
 			<div role="status">
@@ -203,15 +204,20 @@
 			{/if}
 
 			{#if showEmptyState}
-				<div class="rounded-lg border p-6 text-center">
-					<!-- h3, not h2: this sits *inside* the memberships section, so an h2
-					     here would read as a third top-level section. -->
-					<h3 class="font-medium">{m['account.memberships.empty.title']()}</h3>
-					<p class="mt-1 text-sm text-muted-foreground">{m['account.memberships.empty.body']()}</p>
-					<Button href="/organizations" variant="outline" class="mt-4">
-						{m['account.memberships.empty.cta']()}
-					</Button>
-				</div>
+				<!-- level=3: this sits *inside* the memberships section, so a level-2
+				     heading here would read as a third top-level section. -->
+				<EmptyState
+					icon={Users}
+					level={3}
+					title={m['account.memberships.empty.title']()}
+					body={m['account.memberships.empty.body']()}
+				>
+					{#snippet action()}
+						<Button href="/organizations" variant="outline">
+							{m['account.memberships.empty.cta']()}
+						</Button>
+					{/snippet}
+				</EmptyState>
 			{:else if !hasNoRows}
 				<div class="space-y-3">
 					{#each displayedMemberships as mb (mb.organization_id)}

--- a/src/routes/(auth)/account/memberships/page.test.ts
+++ b/src/routes/(auth)/account/memberships/page.test.ts
@@ -157,7 +157,9 @@ describe('Account memberships page', () => {
 			renderPage();
 
 			expect(await screen.findByText(/don't have any active memberships/i)).toBeInTheDocument();
-			expect(await screen.findByText(/no applications yet/i)).toBeInTheDocument();
+			expect(
+				await screen.findByRole('heading', { level: 3, name: /no applications yet/i })
+			).toBeInTheDocument();
 		});
 
 		it('keeps the applications section mounted while the memberships lists are in flight', async () => {
@@ -177,7 +179,9 @@ describe('Account memberships page', () => {
 			);
 			renderPage();
 
-			expect(await screen.findByText(/no applications yet/i)).toBeInTheDocument();
+			expect(
+				await screen.findByRole('heading', { level: 3, name: /no applications yet/i })
+			).toBeInTheDocument();
 			expect(screen.getByRole('heading', { level: 2, name: 'Applications' })).toBeVisible();
 			// The memberships half is still loading, so it must not have decided it is empty.
 			expect(screen.queryByText(/don't have any active memberships/i)).toBeNull();

--- a/src/routes/(auth)/account/notifications/+page.svelte
+++ b/src/routes/(auth)/account/notifications/+page.svelte
@@ -3,6 +3,7 @@
 	import { NotificationList } from '$lib/components/notifications';
 	import * as m from '$lib/paraglide/messages.js';
 	import { Button } from '$lib/components/ui/button';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { Settings } from '@lucide/svelte';
 </script>
 
@@ -12,23 +13,19 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-8">
-	<!-- Page Header -->
-	<div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-		<div>
-			<h1 class="text-3xl font-bold tracking-tight">
-				{m['notificationsPage.title']()}
-			</h1>
-			<p class="mt-2 text-muted-foreground">
-				{m['notificationsPage.description']()}
-			</p>
-		</div>
-
-		<!-- Settings Button -->
-		<Button href="/account/settings" variant="outline" size="sm" class="shrink-0">
-			<Settings class="mr-2 h-4 w-4" aria-hidden="true" />
-			{m['notificationsPage.settingsButton']()}
-		</Button>
-	</div>
+	<PageHeader
+		kicker={m['myInvoices.account']()}
+		title={m['notificationsPage.title']()}
+		subtitle={m['notificationsPage.description']()}
+		class="mb-8"
+	>
+		{#snippet actions()}
+			<Button href="/account/settings" variant="outline" size="sm" class="shrink-0">
+				<Settings class="mr-2 h-4 w-4" aria-hidden="true" />
+				{m['notificationsPage.settingsButton']()}
+			</Button>
+		{/snippet}
+	</PageHeader>
 
 	<!-- Notification List Component. Gated on the in-memory token (populated by
 		the refresh-on-hydration flow); the route already redirects unauthenticated

--- a/src/routes/(auth)/account/privacy/+page.svelte
+++ b/src/routes/(auth)/account/privacy/+page.svelte
@@ -19,6 +19,8 @@
 	import { Button } from '$lib/components/ui/button';
 	import AudioPlayer from '$lib/components/questionnaires/AudioPlayer.svelte';
 	import { isAudio } from '$lib/utils/audio';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		form: ActionData;
@@ -120,30 +122,28 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-8">
-	<!-- Page Header -->
-	<div class="mb-8">
-		<h1 class="text-3xl font-bold tracking-tight">{m['accountPrivacyPage.title']()}</h1>
-		<p class="mt-2 text-muted-foreground">
-			{m['accountPrivacyPage.subtitle']()}
-		</p>
-	</div>
+	<PageHeader
+		kicker={m['myInvoices.account']()}
+		title={m['accountPrivacyPage.title']()}
+		subtitle={m['accountPrivacyPage.subtitle']()}
+		class="mb-8"
+	/>
 
 	<!-- Success Message -->
 	{#if success}
-		<div
-			role="status"
-			class="mb-8 rounded-md border border-green-500 bg-green-50 p-6 dark:bg-green-950"
-		>
+		<!-- Composited tint mirrors ToneTile's audited success pair (>=3:1 vs
+		     background/card); body copy stays on --foreground/--muted-foreground. -->
+		<div role="status" class="mb-8 rounded-md border border-success/30 bg-success/10 p-6">
 			<div class="flex items-start gap-3">
-				<Mail class="h-6 w-6 flex-shrink-0 text-green-600 dark:text-green-400" aria-hidden="true" />
+				<Mail class="h-6 w-6 flex-shrink-0 text-success" aria-hidden="true" />
 				<div class="flex-1 space-y-2">
-					<p class="text-sm font-medium text-green-800 dark:text-green-200">
+					<p class="text-sm font-medium text-foreground">
 						{m['accountPrivacyPage.deletionEmailSent']()}
 					</p>
-					<p class="text-sm text-green-700 dark:text-green-300">
+					<p class="text-sm text-muted-foreground">
 						{m['accountPrivacyPage.deletionEmailBody']()}
 					</p>
-					<p class="text-xs text-green-600 dark:text-green-400">
+					<p class="text-xs text-muted-foreground">
 						{m['accountPrivacyPage.deletionEmailIgnore']()}
 					</p>
 				</div>
@@ -167,27 +167,22 @@
 				<Download class="h-6 w-6 text-primary" aria-hidden="true" />
 			</div>
 			<div class="flex-1">
-				<h2 class="text-xl font-semibold">{m['accountPrivacyPage.exportDataTitle']()}</h2>
+				<h2 class="text-xl font-bold">{m['accountPrivacyPage.exportDataTitle']()}</h2>
 				<p class="mt-2 text-sm text-muted-foreground">
 					{m['accountPrivacyPage.exportDataDescription']()}
 				</p>
 
 				<!-- Export Success Message -->
 				{#if exportSuccess}
-					<div
-						role="status"
-						class="mt-4 rounded-md border border-green-500 bg-green-50 p-4 dark:bg-green-950"
-					>
+					<!-- Composited tint mirrors ToneTile's audited success pair. -->
+					<div role="status" class="mt-4 rounded-md border border-success/30 bg-success/10 p-4">
 						<div class="flex items-start gap-2">
-							<Check
-								class="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400"
-								aria-hidden="true"
-							/>
+							<Check class="h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />
 							<div class="flex-1">
-								<p class="text-sm font-medium text-green-800 dark:text-green-200">
+								<p class="text-sm font-medium text-foreground">
 									{m['accountPrivacyPage.exportRequestReceived']()}
 								</p>
-								<p class="mt-1 text-sm text-green-700 dark:text-green-300">
+								<p class="mt-1 text-sm text-muted-foreground">
 									{m['accountPrivacyPage.exportEmailNote']()}
 								</p>
 							</div>
@@ -271,7 +266,7 @@
 				<FolderOpen class="h-6 w-6 text-primary" aria-hidden="true" />
 			</div>
 			<div class="flex-1">
-				<h2 class="text-xl font-semibold">{m['accountPrivacyPage.yourFilesTitle']()}</h2>
+				<h2 class="text-xl font-bold">{m['accountPrivacyPage.yourFilesTitle']()}</h2>
 				<p class="mt-2 text-sm text-muted-foreground">
 					{m['accountPrivacyPage.yourFilesDescription']()}
 				</p>
@@ -347,13 +342,12 @@
 							})}
 						</p>
 					{:else}
-						<div class="flex flex-col items-center justify-center py-8 text-center">
-							<FolderOpen class="h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
-							<h3 class="mt-4 text-sm font-medium">{m['accountPrivacyPage.noFilesTitle']()}</h3>
-							<p class="mt-1 text-xs text-muted-foreground">
-								{m['accountPrivacyPage.noFilesDescription']()}
-							</p>
-						</div>
+						<EmptyState
+							icon={FolderOpen}
+							level={3}
+							title={m['accountPrivacyPage.noFilesTitle']()}
+							body={m['accountPrivacyPage.noFilesDescription']()}
+						/>
 					{/if}
 				</div>
 			</div>
@@ -369,7 +363,7 @@
 				<AlertTriangle class="h-6 w-6 text-destructive" aria-hidden="true" />
 			</div>
 			<div class="flex-1">
-				<h2 class="text-xl font-semibold text-destructive">
+				<h2 class="text-xl font-bold text-destructive">
 					{m['accountPrivacyPage.dangerZone']()}
 				</h2>
 				<p class="mt-2 text-sm text-muted-foreground">
@@ -580,8 +574,10 @@
 				</div>
 			</div>
 
-			<div class="mb-6 rounded-md border border-amber-500/30 bg-amber-50 p-4 dark:bg-amber-950/30">
-				<p class="text-sm text-amber-800 dark:text-amber-200">
+			<!-- Warning tint mirrors ToneTile's amber recipe (see security page); raw
+			     text-highlight alone fails AA on the light background. -->
+			<div class="mb-6 rounded-md border border-highlight/40 bg-highlight/20 p-4">
+				<p class="text-sm text-highlight-foreground dark:text-highlight">
 					{m['accountPrivacyPage.fileDeleteModal_warning']()}
 				</p>
 			</div>

--- a/src/routes/(auth)/account/privacy/+page.svelte
+++ b/src/routes/(auth)/account/privacy/+page.svelte
@@ -20,6 +20,7 @@
 	import AudioPlayer from '$lib/components/questionnaires/AudioPlayer.svelte';
 	import { isAudio } from '$lib/utils/audio';
 	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
@@ -167,7 +168,7 @@
 				<Download class="h-6 w-6 text-primary" aria-hidden="true" />
 			</div>
 			<div class="flex-1">
-				<h2 class="text-xl font-bold">{m['accountPrivacyPage.exportDataTitle']()}</h2>
+				<SectionHeader title={m['accountPrivacyPage.exportDataTitle']()} class="flex-1" />
 				<p class="mt-2 text-sm text-muted-foreground">
 					{m['accountPrivacyPage.exportDataDescription']()}
 				</p>
@@ -266,7 +267,7 @@
 				<FolderOpen class="h-6 w-6 text-primary" aria-hidden="true" />
 			</div>
 			<div class="flex-1">
-				<h2 class="text-xl font-bold">{m['accountPrivacyPage.yourFilesTitle']()}</h2>
+				<SectionHeader title={m['accountPrivacyPage.yourFilesTitle']()} class="flex-1" />
 				<p class="mt-2 text-sm text-muted-foreground">
 					{m['accountPrivacyPage.yourFilesDescription']()}
 				</p>
@@ -363,9 +364,10 @@
 				<AlertTriangle class="h-6 w-6 text-destructive" aria-hidden="true" />
 			</div>
 			<div class="flex-1">
-				<h2 class="text-xl font-bold text-destructive">
-					{m['accountPrivacyPage.dangerZone']()}
-				</h2>
+				<!-- text-destructive as a heading would measure 2.85:1 in dark on this
+				     tint (below 4.5) — the same trap as the create-org/referral
+				     headings; the icon + border/tint already carry "danger zone". -->
+				<SectionHeader title={m['accountPrivacyPage.dangerZone']()} class="flex-1" />
 				<p class="mt-2 text-sm text-muted-foreground">
 					{m['accountPrivacyPage.dangerZoneDescription']()}
 				</p>

--- a/src/routes/(auth)/account/profile/+page.svelte
+++ b/src/routes/(auth)/account/profile/+page.svelte
@@ -376,7 +376,10 @@
 
 				{#if verificationEmailSent}
 					<!-- Composited tint mirrors ToneTile's audited success pair. -->
-					<div role="status" class="space-y-2 rounded-md border border-success/30 bg-success/10 p-3">
+					<div
+						role="status"
+						class="space-y-2 rounded-md border border-success/30 bg-success/10 p-3"
+					>
 						<div class="flex items-center gap-2">
 							<Check class="h-5 w-5 text-success" aria-hidden="true" />
 							<p class="text-sm font-medium text-foreground">

--- a/src/routes/(auth)/account/profile/+page.svelte
+++ b/src/routes/(auth)/account/profile/+page.svelte
@@ -22,6 +22,9 @@
 	} from '$lib/api/generated';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { toast } from 'svelte-sonner';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 
 	interface Props {
 		data: PageData;
@@ -175,30 +178,29 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-2xl px-4 py-8">
-	<div class="mb-8">
-		<h1 class="text-3xl font-bold tracking-tight">{m['profilePage.heading']()}</h1>
-		<p class="mt-2 text-muted-foreground">{m['profilePage.subheading']()}</p>
-	</div>
+	<PageHeader
+		kicker={m['myInvoices.account']()}
+		title={m['profilePage.heading']()}
+		subtitle={m['profilePage.subheading']()}
+		class="mb-8"
+	/>
 
 	{#if redirectUrl}
-		<div
-			class="mb-6 rounded-md border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950"
-		>
-			<p class="text-sm text-blue-800 dark:text-blue-200">
-				<Info class="mr-2 inline-block h-4 w-4" aria-hidden="true" />
+		<!-- Composited tint mirrors ToneTile's audited info pair; body copy stays on --foreground. -->
+		<div class="mb-6 rounded-md border border-info/30 bg-info/10 p-4">
+			<p class="text-sm text-foreground">
+				<Info class="mr-2 inline-block h-4 w-4 text-info" aria-hidden="true" />
 				{m['profile.completeToReturn']()}
 			</p>
 		</div>
 	{/if}
 
 	{#if success}
-		<div
-			role="status"
-			class="mb-6 rounded-md border border-green-500 bg-green-50 p-4 dark:bg-green-950"
-		>
+		<!-- Composited tint mirrors ToneTile's audited success pair. -->
+		<div role="status" class="mb-6 rounded-md border border-success/30 bg-success/10 p-4">
 			<div class="flex items-center gap-2">
-				<Check class="h-5 w-5 text-green-600 dark:text-green-400" aria-hidden="true" />
-				<p class="text-sm font-medium text-green-800 dark:text-green-200">
+				<Check class="h-5 w-5 text-success" aria-hidden="true" />
+				<p class="text-sm font-medium text-foreground">
 					{#if redirectUrl}
 						{m['profile.savedRedirecting']()}
 					{:else}
@@ -328,48 +330,35 @@
 						class="flex h-10 w-full cursor-not-allowed rounded-md border border-input bg-muted px-3 py-2 text-sm text-muted-foreground"
 					/>
 					{#if emailVerified}
-						<div
-							class="flex items-center gap-1.5 rounded-md bg-green-100 px-3 py-1.5 dark:bg-green-950"
+						<StatusBadge
+							tone="success"
+							icon={ShieldCheck}
+							label={m['profile.email_verified']()}
 							role="status"
 							aria-label={m['profile.email_verified_label']()}
-						>
-							<ShieldCheck
-								class="h-4 w-4 flex-shrink-0 text-green-700 dark:text-green-400"
-								aria-hidden="true"
-							/>
-							<span class="text-xs font-medium text-green-800 dark:text-green-300">
-								{m['profile.email_verified']()}
-							</span>
-						</div>
+						/>
 					{:else}
-						<div
-							class="flex items-center gap-1.5 rounded-md bg-amber-100 px-3 py-1.5 dark:bg-amber-950"
+						<StatusBadge
+							tone="warning"
+							icon={ShieldAlert}
+							label={m['profile.email_unverified']()}
 							role="status"
 							aria-label={m['profile.email_unverified_label']()}
-						>
-							<ShieldAlert
-								class="h-4 w-4 flex-shrink-0 text-amber-700 dark:text-amber-400"
-								aria-hidden="true"
-							/>
-							<span class="text-xs font-medium text-amber-800 dark:text-amber-300">
-								{m['profile.email_unverified']()}
-							</span>
-						</div>
+						/>
 					{/if}
 				</div>
 
 				{#if !emailVerified}
-					<div
-						class="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950"
-					>
-						<p class="mb-2 text-sm text-amber-900 dark:text-amber-200">
+					<!-- Warning tint mirrors ToneTile's amber recipe (see security page). -->
+					<div class="rounded-md border border-highlight/40 bg-highlight/20 p-3">
+						<p class="mb-2 text-sm text-highlight-foreground dark:text-highlight">
 							{m['profile.email_verificationNeeded']()}
 						</p>
 						<button
 							type="button"
 							onclick={handleResendVerification}
 							disabled={!canResendEmail}
-							class="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-amber-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-amber-700 dark:hover:bg-amber-600"
+							class="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-highlight px-3 py-2 text-sm font-medium text-highlight-foreground transition-colors hover:bg-highlight/90 focus:outline-none focus:ring-2 focus:ring-highlight focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 						>
 							{#if isResendingVerification}
 								<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
@@ -386,25 +375,23 @@
 				{/if}
 
 				{#if verificationEmailSent}
-					<div
-						role="status"
-						class="space-y-2 rounded-md border border-green-500 bg-green-50 p-3 dark:bg-green-950"
-					>
+					<!-- Composited tint mirrors ToneTile's audited success pair. -->
+					<div role="status" class="space-y-2 rounded-md border border-success/30 bg-success/10 p-3">
 						<div class="flex items-center gap-2">
-							<Check class="h-5 w-5 text-green-600 dark:text-green-400" aria-hidden="true" />
-							<p class="text-sm font-medium text-green-800 dark:text-green-200">
+							<Check class="h-5 w-5 text-success" aria-hidden="true" />
+							<p class="text-sm font-medium text-foreground">
 								{m['profile.email_resendSuccess']()}
 							</p>
 						</div>
-						<p class="text-sm text-green-700 dark:text-green-300">
+						<p class="text-sm text-muted-foreground">
 							{m['profile.email_checkSpam']()}
 						</p>
 					</div>
 				{/if}
 
 				{#if verificationError}
-					<div role="alert" class="rounded-md border border-red-500 bg-red-50 p-3 dark:bg-red-950">
-						<p class="text-sm font-medium text-red-800 dark:text-red-200">
+					<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-3">
+						<p class="text-sm font-medium text-destructive">
 							{verificationError}
 						</p>
 					</div>
@@ -623,20 +610,15 @@
 		<div class="mt-12 space-y-6" id="dietary-section">
 			<div class="border-t pt-8">
 				<div class="mb-6">
-					<h2 class="text-2xl font-bold tracking-tight">{m['dietary.profile_heading']()}</h2>
+					<SectionHeader title={m['dietary.profile_heading']()} />
 					<p class="mt-2 text-sm text-muted-foreground">
 						{m['dietary.profile_description']()}
 					</p>
 
-					<!-- Visibility Info -->
-					<div
-						class="mt-4 flex gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 dark:border-blue-900 dark:bg-blue-950"
-					>
-						<Info
-							class="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400"
-							aria-hidden="true"
-						/>
-						<p class="text-sm text-blue-800 dark:text-blue-200">
+					<!-- Visibility Info: composited tint mirrors ToneTile's audited info pair. -->
+					<div class="mt-4 flex gap-2 rounded-md border border-info/30 bg-info/10 p-3">
+						<Info class="h-5 w-5 flex-shrink-0 text-info" aria-hidden="true" />
+						<p class="text-sm text-foreground">
 							{m['dietary.profile_visibilityInfo']()}
 						</p>
 					</div>

--- a/src/routes/(auth)/account/profile/+page.svelte
+++ b/src/routes/(auth)/account/profile/+page.svelte
@@ -393,8 +393,11 @@
 				{/if}
 
 				{#if verificationError}
+					<!-- text-destructive as lead text measures 2.68:1 in dark on this tint
+					     (below 4.5); the border/tint carry the tone, text reads on
+					     --foreground. -->
 					<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-3">
-						<p class="text-sm font-medium text-destructive">
+						<p class="text-sm font-medium text-foreground">
 							{verificationError}
 						</p>
 					</div>

--- a/src/routes/(auth)/account/referral/+page.svelte
+++ b/src/routes/(auth)/account/referral/+page.svelte
@@ -29,7 +29,6 @@
 	import { BillingProfileForm } from '$lib/components/billing';
 	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
-	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { Tone } from '$lib/components/common/tones';
 
 	const user = $derived(authStore.user);
@@ -322,8 +321,13 @@
 											<Check class="h-3 w-3 text-success" aria-hidden="true" />
 											<span class="text-success">{m['referral.yes']()}</span>
 										{:else}
-											<AlertCircle class="h-3 w-3 text-highlight-foreground dark:text-highlight" aria-hidden="true" />
-											<span class="text-highlight-foreground dark:text-highlight">{m['referral.no']()}</span>
+											<AlertCircle
+												class="h-3 w-3 text-highlight-foreground dark:text-highlight"
+												aria-hidden="true"
+											/>
+											<span class="text-highlight-foreground dark:text-highlight"
+												>{m['referral.no']()}</span
+											>
 										{/if}
 									</dd>
 								</div>

--- a/src/routes/(auth)/account/referral/+page.svelte
+++ b/src/routes/(auth)/account/referral/+page.svelte
@@ -182,7 +182,13 @@
 					<p class="text-sm text-muted-foreground">{m['referral.yourCode']()}</p>
 					<p class="font-mono text-lg font-black">{referralCode.code}</p>
 					{#if !referralCode.is_active}
-						<p class="text-sm text-highlight-foreground dark:text-highlight">
+						<!-- text-highlight-foreground is contrast-safe but reads as plain
+						     dark text on an untinted surface — pair with a visible icon so
+						     the warning survives without relying on color alone. -->
+						<p
+							class="flex items-center gap-1 text-sm text-highlight-foreground dark:text-highlight"
+						>
+							<AlertCircle class="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
 							{m['referral.codeInactive']()}
 						</p>
 					{/if}
@@ -335,13 +341,16 @@
 									<dt class="font-medium text-muted-foreground">
 										{m['referral.chargesEnabled']()}
 									</dt>
+									<!-- Bare on card: text-destructive measures 2.85:1 in dark
+									     (below 4.5). Only the icon carries the tone; the label
+									     reads on --foreground. -->
 									<dd class="mt-0.5 flex items-center gap-1">
 										{#if stripeChargesEnabled}
 											<Check class="h-3 w-3 text-success" aria-hidden="true" />
 											<span class="text-success">{m['referral.yes']()}</span>
 										{:else}
 											<AlertCircle class="h-3 w-3 text-destructive" aria-hidden="true" />
-											<span class="text-destructive">{m['referral.no']()}</span>
+											<span class="text-foreground">{m['referral.no']()}</span>
 										{/if}
 									</dd>
 								</div>
@@ -352,11 +361,14 @@
 			</div>
 
 			{#if stripeConnectMutation.error}
+				<!-- text-destructive as lead text measures 2.85:1 in dark on this card
+				     tint (below 4.5); the border/tint + icon carry the tone, text reads
+				     on --foreground. -->
 				<div
-					class="mt-3 flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-destructive"
+					class="mt-3 flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-foreground"
 					role="alert"
 				>
-					<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
+					<AlertCircle class="h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
 					<p class="text-sm">{stripeConnectMutation.error.message}</p>
 				</div>
 			{/if}

--- a/src/routes/(auth)/account/referral/+page.svelte
+++ b/src/routes/(auth)/account/referral/+page.svelte
@@ -27,6 +27,10 @@
 		StripeAccountStatusSchema
 	} from '$lib/api/generated/types.gen';
 	import { BillingProfileForm } from '$lib/components/billing';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	const user = $derived(authStore.user);
 	const accessToken = $derived(authStore.accessToken);
@@ -139,24 +143,26 @@
 		setTimeout(() => (linkCopied = false), 2000);
 	}
 
-	// Stripe status display
-	const stripeStatusInfo = $derived.by(() => {
+	// Stripe status display. `tone` drives the StatusBadge/card tint below —
+	// each of the five states gets its own tone so no real distinction (e.g.
+	// "incomplete" vs "restricted") collapses onto the same color.
+	const stripeStatusInfo = $derived.by((): { type: string; tone: Tone } => {
 		if (!stripeStatus || !isStripeConnected) {
-			return { type: 'not-connected', color: 'gray' };
+			return { type: 'not-connected', tone: 'neutral' };
 		}
 		if (stripeStatusQuery.isFetching) {
-			return { type: 'loading', color: 'blue' };
+			return { type: 'loading', tone: 'info' };
 		}
 		if (stripeChargesEnabled && stripeDetailsSubmitted) {
-			return { type: 'fully-connected', color: 'green' };
+			return { type: 'fully-connected', tone: 'success' };
 		}
 		if (!stripeDetailsSubmitted) {
-			return { type: 'incomplete', color: 'yellow' };
+			return { type: 'incomplete', tone: 'warning' };
 		}
 		if (!stripeChargesEnabled) {
-			return { type: 'restricted', color: 'red' };
+			return { type: 'restricted', tone: 'danger' };
 		}
-		return { type: 'unknown', color: 'gray' };
+		return { type: 'unknown', tone: 'neutral' };
 	});
 </script>
 
@@ -165,7 +171,7 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-2xl px-4 py-8">
-	<h1 class="text-2xl font-bold">{m['referral.referralProgram']()}</h1>
+	<PageHeader kicker={m['myInvoices.account']()} title={m['referral.referralProgram']()} />
 
 	{#if !referralCode}
 		<p class="mt-4 text-muted-foreground">{m['referralPage.loading']()}</p>
@@ -175,9 +181,9 @@
 			<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 				<div>
 					<p class="text-sm text-muted-foreground">{m['referral.yourCode']()}</p>
-					<p class="font-mono text-lg font-bold">{referralCode.code}</p>
+					<p class="font-mono text-lg font-black">{referralCode.code}</p>
 					{#if !referralCode.is_active}
-						<p class="text-sm text-amber-600 dark:text-amber-400">
+						<p class="text-sm text-highlight-foreground dark:text-highlight">
 							{m['referral.codeInactive']()}
 						</p>
 					{/if}
@@ -196,21 +202,18 @@
 
 		<!-- Payout Setup Checklist -->
 		<section class="mt-8 rounded-lg border bg-card p-6">
-			<h2 class="text-lg font-semibold">{m['referral.setupChecklist']()}</h2>
+			<SectionHeader title={m['referral.setupChecklist']()} />
 			<p class="mt-1 text-sm text-muted-foreground">{m['referral.setupDescription']()}</p>
 
 			<div class="mt-4 space-y-3">
 				{#each [{ done: isStripeFullySetup, label: m['referral.stepStripe']() }, { done: isBillingComplete, label: m['referral.stepBilling']() }, { done: isSelfBillingAgreed, label: m['referral.stepSelfBilling']() }] as step, i (i)}
 					<div class="flex items-center gap-3">
 						{#if step.done}
-							<CircleCheck
-								class="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400"
-								aria-hidden="true"
-							/>
+							<CircleCheck class="h-5 w-5 shrink-0 text-success" aria-hidden="true" />
 						{:else}
 							<Circle class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
 						{/if}
-						<span class={step.done ? 'text-emerald-700 dark:text-emerald-300' : ''}>
+						<span class={step.done ? 'text-success' : ''}>
 							{step.label}
 						</span>
 					</div>
@@ -218,11 +221,12 @@
 			</div>
 
 			{#if isPayoutEligible}
+				<!-- Composited tint mirrors ToneTile's audited success pair. -->
 				<div
-					class="mt-4 flex items-center gap-2 rounded-md bg-emerald-50 p-3 text-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-200"
+					class="mt-4 flex items-center gap-2 rounded-md border border-success/30 bg-success/10 p-3 text-foreground"
 					role="status"
 				>
-					<Check class="h-5 w-5 shrink-0" aria-hidden="true" />
+					<Check class="h-5 w-5 shrink-0 text-success" aria-hidden="true" />
 					<span class="text-sm font-medium">{m['referral.allStepsComplete']()}</span>
 				</div>
 			{/if}
@@ -232,16 +236,17 @@
 		<section class="mt-6 rounded-lg border bg-card p-6">
 			<div class="mb-4 flex items-center gap-2">
 				<CreditCard class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-				<h2 class="text-lg font-semibold">{m['referral.stripeConnect']()}</h2>
+				<SectionHeader title={m['referral.stripeConnect']()} class="flex-1" />
 			</div>
 			<p class="text-sm text-muted-foreground">{m['referral.stripeConnectDescription']()}</p>
 
 			{#if justReturnedFromStripe}
+				<!-- Composited tint mirrors ToneTile's audited success pair. -->
 				<div
-					class="mt-4 flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
+					class="mt-4 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 p-4 text-foreground"
 					role="alert"
 				>
-					<Check class="h-5 w-5 shrink-0" aria-hidden="true" />
+					<Check class="h-5 w-5 shrink-0 text-success" aria-hidden="true" />
 					<div>
 						<p class="font-medium">{m['referral.stripeWelcomeBack']()}</p>
 						<p class="text-sm">{m['referral.stripeVerifyingAccount']()}</p>
@@ -249,39 +254,41 @@
 				</div>
 			{/if}
 
-			<!-- Status Card -->
+			<!-- Status Card. Tone-tinted border/bg mirror the audited icon/accent
+			     pairs (>=3:1 vs background/card); body copy stays on
+			     --foreground/--muted-foreground so contrast never depends on the tint. -->
 			<div
 				class="mt-4 rounded-lg border-2 p-4
-					{stripeStatusInfo.color === 'green'
-					? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30'
-					: stripeStatusInfo.color === 'yellow'
-						? 'border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950/30'
-						: stripeStatusInfo.color === 'red'
-							? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/30'
+					{stripeStatusInfo.tone === 'success'
+					? 'border-success/30 bg-success/10'
+					: stripeStatusInfo.tone === 'warning'
+						? 'border-highlight/40 bg-highlight/20'
+						: stripeStatusInfo.tone === 'danger'
+							? 'border-destructive/30 bg-destructive/10'
 							: 'border-border bg-muted'}"
 			>
 				<div class="flex items-start gap-3">
 					<div class="shrink-0">
 						{#if stripeStatusInfo.type === 'fully-connected'}
-							<div class="rounded-full bg-green-600 p-2">
-								<Check class="h-5 w-5 text-white" aria-hidden="true" />
+							<div class="rounded-full bg-success p-2 text-success-foreground">
+								<Check class="h-5 w-5" aria-hidden="true" />
 							</div>
 						{:else if stripeStatusInfo.type === 'incomplete'}
-							<div class="rounded-full bg-yellow-600 p-2">
-								<AlertTriangle class="h-5 w-5 text-white" aria-hidden="true" />
+							<div class="rounded-full bg-highlight p-2 text-highlight-foreground">
+								<AlertTriangle class="h-5 w-5" aria-hidden="true" />
 							</div>
 						{:else if stripeStatusInfo.type === 'restricted'}
-							<div class="rounded-full bg-red-600 p-2">
-								<AlertCircle class="h-5 w-5 text-white" aria-hidden="true" />
+							<div class="rounded-full bg-destructive p-2 text-destructive-foreground">
+								<AlertCircle class="h-5 w-5" aria-hidden="true" />
 							</div>
 						{:else}
-							<div class="rounded-full bg-gray-400 p-2">
-								<CreditCard class="h-5 w-5 text-white" aria-hidden="true" />
+							<div class="rounded-full bg-muted-foreground p-2 text-background">
+								<CreditCard class="h-5 w-5" aria-hidden="true" />
 							</div>
 						{/if}
 					</div>
 					<div class="flex-1">
-						<h3 class="font-semibold">
+						<h3 class="font-bold">
 							{#if stripeStatusInfo.type === 'fully-connected'}
 								{m['referral.stripeConnected']()}
 							{:else if stripeStatusInfo.type === 'incomplete'}
@@ -312,11 +319,11 @@
 									</dt>
 									<dd class="mt-0.5 flex items-center gap-1">
 										{#if stripeDetailsSubmitted}
-											<Check class="h-3 w-3 text-green-600" aria-hidden="true" />
-											<span class="text-green-700 dark:text-green-300">{m['referral.yes']()}</span>
+											<Check class="h-3 w-3 text-success" aria-hidden="true" />
+											<span class="text-success">{m['referral.yes']()}</span>
 										{:else}
-											<AlertCircle class="h-3 w-3 text-yellow-600" aria-hidden="true" />
-											<span class="text-yellow-700 dark:text-yellow-300">{m['referral.no']()}</span>
+											<AlertCircle class="h-3 w-3 text-highlight-foreground dark:text-highlight" aria-hidden="true" />
+											<span class="text-highlight-foreground dark:text-highlight">{m['referral.no']()}</span>
 										{/if}
 									</dd>
 								</div>
@@ -326,11 +333,11 @@
 									</dt>
 									<dd class="mt-0.5 flex items-center gap-1">
 										{#if stripeChargesEnabled}
-											<Check class="h-3 w-3 text-green-600" aria-hidden="true" />
-											<span class="text-green-700 dark:text-green-300">{m['referral.yes']()}</span>
+											<Check class="h-3 w-3 text-success" aria-hidden="true" />
+											<span class="text-success">{m['referral.yes']()}</span>
 										{:else}
-											<AlertCircle class="h-3 w-3 text-red-600" aria-hidden="true" />
-											<span class="text-red-700 dark:text-red-300">{m['referral.no']()}</span>
+											<AlertCircle class="h-3 w-3 text-destructive" aria-hidden="true" />
+											<span class="text-destructive">{m['referral.no']()}</span>
 										{/if}
 									</dd>
 								</div>
@@ -342,7 +349,7 @@
 
 			{#if stripeConnectMutation.error}
 				<div
-					class="mt-3 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+					class="mt-3 flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-destructive"
 					role="alert"
 				>
 					<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
@@ -387,13 +394,11 @@
 
 		<!-- Billing Information -->
 		<section class="mt-6 rounded-lg border bg-card p-6">
-			<div class="mb-4 flex items-center gap-2">
+			<div class="flex items-center gap-2">
 				<CreditCard class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-				<div>
-					<h2 class="text-lg font-semibold">{m['billing.form.title']()}</h2>
-					<p class="mt-1 text-sm text-muted-foreground">{m['billing.form.description']()}</p>
-				</div>
+				<SectionHeader title={m['billing.form.title']()} class="flex-1" />
 			</div>
+			<p class="mt-1 text-sm text-muted-foreground">{m['billing.form.description']()}</p>
 			<BillingProfileForm authToken={accessToken} showSelfBilling={true} />
 		</section>
 

--- a/src/routes/(auth)/account/referral/payouts/+page.svelte
+++ b/src/routes/(auth)/account/referral/payouts/+page.svelte
@@ -18,6 +18,10 @@
 		ReferralPayoutStatementSchema
 	} from '$lib/api/generated/types.gen';
 	import { formatDate } from '$lib/utils/date';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	const user = $derived(authStore.user);
 	const accessToken = $derived(authStore.accessToken);
@@ -109,20 +113,23 @@
 		return `${currency.toUpperCase()} ${num.toFixed(2)}`;
 	}
 
-	function statusColor(status: string): string {
+	/** Thin mapper: raw payout status -> StatusBadge tone. Each of the five
+	 * backend statuses gets its own tone so none of the real distinctions
+	 * (e.g. "pending" vs "failed") collapse onto the same color. */
+	function statusTone(status: string): Tone {
 		switch (status) {
 			case 'paid':
-				return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-300';
+				return 'success';
 			case 'pending':
-				return 'bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-300';
+				return 'warning';
 			case 'calculated':
-				return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
+				return 'neutral';
 			case 'failed':
-				return 'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300';
+				return 'danger';
 			case 'rolled_over':
-				return 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300';
+				return 'info';
 			default:
-				return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
+				return 'neutral';
 		}
 	}
 
@@ -159,8 +166,11 @@
 		</a>
 	</div>
 
-	<h1 class="text-2xl font-bold">{m['referral.payoutsTitle']()}</h1>
-	<p class="mt-1 text-sm text-muted-foreground">{m['referral.payoutsDescription']()}</p>
+	<PageHeader
+		kicker={m['myInvoices.account']()}
+		title={m['referral.payoutsTitle']()}
+		subtitle={m['referral.payoutsDescription']()}
+	/>
 
 	{#if payoutsQuery.isLoading}
 		<div class="mt-8 flex justify-center">
@@ -174,21 +184,23 @@
 			{m['referral.error']()}
 		</div>
 	{:else if payouts.length === 0}
-		<div class="mt-8 rounded-lg border bg-card p-8 text-center">
-			<FileText class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h2 class="mt-4 text-lg font-semibold">{m['referral.noPayouts']()}</h2>
-			<p class="mt-1 text-sm text-muted-foreground">{m['referral.noPayoutsDescription']()}</p>
-		</div>
+		<EmptyState
+			icon={FileText}
+			level={2}
+			title={m['referral.noPayouts']()}
+			body={m['referral.noPayoutsDescription']()}
+			class="mt-8"
+		/>
 	{:else}
 		<!-- Payouts Table -->
 		<div class="mt-6 overflow-x-auto rounded-lg border">
 			<table class="w-full text-sm">
 				<thead class="border-b bg-muted/50">
-					<tr>
-						<th class="px-4 py-3 text-left font-medium">{m['referral.period']()}</th>
-						<th class="px-4 py-3 text-right font-medium">{m['referral.amount']()}</th>
-						<th class="px-4 py-3 text-center font-medium">{m['referral.status']()}</th>
-						<th class="px-4 py-3 text-right font-medium">{m['referral.actions']()}</th>
+					<tr class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+						<th class="px-4 py-3 text-left">{m['referral.period']()}</th>
+						<th class="px-4 py-3 text-right">{m['referral.amount']()}</th>
+						<th class="px-4 py-3 text-center">{m['referral.status']()}</th>
+						<th class="px-4 py-3 text-right">{m['referral.actions']()}</th>
 					</tr>
 				</thead>
 				<tbody class="divide-y">
@@ -200,10 +212,7 @@
 							<td class="px-4 py-3 text-right font-mono text-sm">
 								{formatAmount(payout.payout_amount, payout.currency)}
 								{#if parseFloat(payout.rolled_over_amount) > 0}
-									<p
-										class="mt-0.5 text-xs text-blue-600 dark:text-blue-400"
-										title={m['referral.rolledOverTooltip']()}
-									>
+									<p class="mt-0.5 text-xs text-info" title={m['referral.rolledOverTooltip']()}>
 										{m['referral.rolledOverAmount']()}: {formatAmount(
 											payout.rolled_over_amount,
 											payout.currency
@@ -212,13 +221,7 @@
 								{/if}
 							</td>
 							<td class="px-4 py-3 text-center">
-								<span
-									class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {statusColor(
-										payout.status
-									)}"
-								>
-									{statusLabel(payout.status)}
-								</span>
+								<StatusBadge tone={statusTone(payout.status)} label={statusLabel(payout.status)} size="sm" />
 							</td>
 							<td class="px-4 py-3 text-right">
 								<div class="flex items-center justify-end gap-1">

--- a/src/routes/(auth)/account/referral/payouts/+page.svelte
+++ b/src/routes/(auth)/account/referral/payouts/+page.svelte
@@ -221,7 +221,11 @@
 								{/if}
 							</td>
 							<td class="px-4 py-3 text-center">
-								<StatusBadge tone={statusTone(payout.status)} label={statusLabel(payout.status)} size="sm" />
+								<StatusBadge
+									tone={statusTone(payout.status)}
+									label={statusLabel(payout.status)}
+									size="sm"
+								/>
 							</td>
 							<td class="px-4 py-3 text-right">
 								<div class="flex items-center justify-end gap-1">

--- a/src/routes/(auth)/account/referral/payouts/+page.svelte
+++ b/src/routes/(auth)/account/referral/payouts/+page.svelte
@@ -167,7 +167,7 @@
 	</div>
 
 	<PageHeader
-		kicker={m['myInvoices.account']()}
+		kicker={m['referral.referralProgram']()}
 		title={m['referral.payoutsTitle']()}
 		subtitle={m['referral.payoutsDescription']()}
 	/>

--- a/src/routes/(auth)/account/security/+page.svelte
+++ b/src/routes/(auth)/account/security/+page.svelte
@@ -18,6 +18,8 @@
 	import type { PageData, ActionData } from './$types';
 	import QRCode from 'qrcode';
 	import { accountResetPasswordRequest } from '$lib/api/generated';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 
 	interface Props {
 		data: PageData;
@@ -164,13 +166,12 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-8">
-	<!-- Page Header -->
-	<div class="mb-8">
-		<h1 class="text-3xl font-bold">{m['accountSecurityPage.title']()}</h1>
-		<p class="mt-2 text-muted-foreground">
-			{m['accountSecurityPage.subtitle']()}
-		</p>
-	</div>
+	<PageHeader
+		kicker={m['myInvoices.account']()}
+		title={m['accountSecurityPage.title']()}
+		subtitle={m['accountSecurityPage.subtitle']()}
+		class="mb-8"
+	/>
 
 	<!-- 2FA Section -->
 	<div class="rounded-lg border bg-card p-6">
@@ -184,26 +185,17 @@
 			<div class="flex-1">
 				<div class="flex items-center justify-between">
 					<div>
-						<h2 class="text-xl font-semibold">{m['accountSecurityPage.twoFactorAuth']()}</h2>
+						<h2 class="text-xl font-bold">{m['accountSecurityPage.twoFactorAuth']()}</h2>
 						<p class="mt-1 text-sm text-muted-foreground">
 							{m['accountSecurityPage.twoFactorDescription']()}
 						</p>
 					</div>
 
-					<!-- Status Badge -->
-					<div
-						class="flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium {totpActive
-							? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-							: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400'}"
-					>
-						{#if totpActive}
-							<CheckCircle class="h-4 w-4" aria-hidden="true" />
-							<span>{m['accountSecurityPage.statusEnabled']()}</span>
-						{:else}
-							<XCircle class="h-4 w-4" aria-hidden="true" />
-							<span>{m['accountSecurityPage.statusDisabled']()}</span>
-						{/if}
-					</div>
+					{#if totpActive}
+						<StatusBadge tone="success" icon={CheckCircle} label={m['accountSecurityPage.statusEnabled']()} />
+					{:else}
+						<StatusBadge tone="neutral" icon={XCircle} label={m['accountSecurityPage.statusDisabled']()} />
+					{/if}
 				</div>
 
 				<!-- Enable/Disable Button (when not in a flow) -->
@@ -256,7 +248,7 @@
 				<!-- Setup Flow -->
 				{#if showSetupFlow}
 					<div class="mt-6 rounded-lg border bg-muted/50 p-6">
-						<h3 class="font-semibold">{m['accountSecurityPage.setupTitle']()}</h3>
+						<h3 class="font-bold">{m['accountSecurityPage.setupTitle']()}</h3>
 
 						{#if provisioningUri}
 							<!-- Step 1: Scan QR Code -->
@@ -305,7 +297,7 @@
 													aria-label={m['accountSecurityPage.copyCodeLabel']()}
 												>
 													{#if manualEntryCopied}
-														<Check class="h-4 w-4 text-green-600" aria-hidden="true" />
+														<Check class="h-4 w-4 text-success" aria-hidden="true" />
 													{:else}
 														<Copy class="h-4 w-4" aria-hidden="true" />
 													{/if}
@@ -390,7 +382,7 @@
 						<div class="flex gap-3">
 							<AlertCircle class="h-5 w-5 text-destructive" aria-hidden="true" />
 							<div class="flex-1">
-								<h3 class="font-semibold text-destructive">
+								<h3 class="font-bold text-destructive">
 									{m['accountSecurityPage.disableTitle']()}
 								</h3>
 								<p class="mt-2 text-sm text-muted-foreground">
@@ -466,7 +458,7 @@
 			<div class="flex-1">
 				<div class="flex items-center justify-between">
 					<div>
-						<h2 class="text-xl font-semibold">{m['accountSecurityPage.passwordChange']()}</h2>
+						<h2 class="text-xl font-bold">{m['accountSecurityPage.passwordChange']()}</h2>
 						<p class="mt-1 text-sm text-muted-foreground">
 							{m['accountSecurityPage.passwordChangeDescription']()}
 						</p>
@@ -491,18 +483,17 @@
 				<!-- Password Change Flow -->
 				{#if showPasswordChangeFlow}
 					<div class="mt-6 rounded-lg border bg-muted/50 p-6">
-						<h3 class="font-semibold">{m['accountSecurityPage.requestPasswordResetTitle']()}</h3>
+						<h3 class="font-bold">{m['accountSecurityPage.requestPasswordResetTitle']()}</h3>
 						<p class="mt-2 text-sm text-muted-foreground">
 							{m['accountSecurityPage.requestPasswordResetDescription']()}
 						</p>
 
 						{#if !passwordResetRequested}
-							<div class="mt-4 flex items-center gap-2 rounded-md bg-blue-50 p-3 dark:bg-blue-950">
-								<Mail
-									class="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400"
-									aria-hidden="true"
-								/>
-								<p class="text-sm text-blue-800 dark:text-blue-200">
+							<!-- Composited tint mirrors ToneTile's audited info pair (>=3:1 vs
+							     background/card); body copy stays on --foreground. -->
+							<div class="mt-4 flex items-center gap-2 rounded-md border border-info/30 bg-info/10 p-3">
+								<Mail class="h-5 w-5 flex-shrink-0 text-info" aria-hidden="true" />
+								<p class="text-sm text-foreground">
 									{m['accountSecurityPage.emailWillBeSent']({ email: data.user?.email || '' })}
 								</p>
 							</div>
@@ -527,19 +518,16 @@
 								</button>
 							</div>
 						{:else}
-							<div
-								class="mt-4 rounded-md border border-green-500 bg-green-50 p-4 dark:bg-green-950"
-							>
+							<!-- Composited tint mirrors ToneTile's audited success pair (>=3:1
+							     vs background/card); body copy stays on --foreground. -->
+							<div class="mt-4 rounded-md border border-success/30 bg-success/10 p-4">
 								<div class="flex items-center gap-2">
-									<CheckCircle
-										class="h-5 w-5 text-green-600 dark:text-green-400"
-										aria-hidden="true"
-									/>
+									<CheckCircle class="h-5 w-5 text-success" aria-hidden="true" />
 									<div class="flex-1">
-										<p class="text-sm font-medium text-green-800 dark:text-green-200">
+										<p class="text-sm font-medium text-foreground">
 											{m['accountSecurityPage.resetLinkSent']()}
 										</p>
-										<p class="mt-1 text-xs text-green-700 dark:text-green-300">
+										<p class="mt-1 text-xs text-muted-foreground">
 											{m['accountSecurityPage.checkEmailInbox']()}
 										</p>
 									</div>
@@ -564,22 +552,22 @@
 
 	<!-- Additional Security Tips -->
 	<div class="mt-6 rounded-lg border bg-muted/50 p-6">
-		<h3 class="font-semibold">{m['accountSecurityPage.securityTips']()}</h3>
+		<h3 class="font-bold">{m['accountSecurityPage.securityTips']()}</h3>
 		<ul class="mt-3 space-y-2 text-sm text-muted-foreground">
 			<li class="flex gap-2">
-				<CheckCircle class="h-5 w-5 flex-shrink-0 text-green-600" aria-hidden="true" />
+				<CheckCircle class="h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />
 				<span>{m['accountSecurityPage.tip1']()}</span>
 			</li>
 			<li class="flex gap-2">
-				<CheckCircle class="h-5 w-5 flex-shrink-0 text-green-600" aria-hidden="true" />
+				<CheckCircle class="h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />
 				<span>{m['accountSecurityPage.tip2']()}</span>
 			</li>
 			<li class="flex gap-2">
-				<CheckCircle class="h-5 w-5 flex-shrink-0 text-green-600" aria-hidden="true" />
+				<CheckCircle class="h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />
 				<span>{m['accountSecurityPage.tip3']()}</span>
 			</li>
 			<li class="flex gap-2">
-				<CheckCircle class="h-5 w-5 flex-shrink-0 text-green-600" aria-hidden="true" />
+				<CheckCircle class="h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />
 				<span>{m['accountSecurityPage.tip4']()}</span>
 			</li>
 		</ul>

--- a/src/routes/(auth)/account/security/+page.svelte
+++ b/src/routes/(auth)/account/security/+page.svelte
@@ -19,6 +19,7 @@
 	import QRCode from 'qrcode';
 	import { accountResetPasswordRequest } from '$lib/api/generated';
 	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 
 	interface Props {
@@ -183,28 +184,26 @@
 			</div>
 
 			<div class="flex-1">
-				<div class="flex items-center justify-between">
-					<div>
-						<h2 class="text-xl font-bold">{m['accountSecurityPage.twoFactorAuth']()}</h2>
-						<p class="mt-1 text-sm text-muted-foreground">
-							{m['accountSecurityPage.twoFactorDescription']()}
-						</p>
-					</div>
-
-					{#if totpActive}
-						<StatusBadge
-							tone="success"
-							icon={CheckCircle}
-							label={m['accountSecurityPage.statusEnabled']()}
-						/>
-					{:else}
-						<StatusBadge
-							tone="neutral"
-							icon={XCircle}
-							label={m['accountSecurityPage.statusDisabled']()}
-						/>
-					{/if}
-				</div>
+				<SectionHeader title={m['accountSecurityPage.twoFactorAuth']()} class="flex-1">
+					{#snippet actions()}
+						{#if totpActive}
+							<StatusBadge
+								tone="success"
+								icon={CheckCircle}
+								label={m['accountSecurityPage.statusEnabled']()}
+							/>
+						{:else}
+							<StatusBadge
+								tone="neutral"
+								icon={XCircle}
+								label={m['accountSecurityPage.statusDisabled']()}
+							/>
+						{/if}
+					{/snippet}
+				</SectionHeader>
+				<p class="mt-1 text-sm text-muted-foreground">
+					{m['accountSecurityPage.twoFactorDescription']()}
+				</p>
 
 				<!-- Enable/Disable Button (when not in a flow) -->
 				{#if !showSetupFlow && !showDisableFlow}
@@ -464,14 +463,10 @@
 			</div>
 
 			<div class="flex-1">
-				<div class="flex items-center justify-between">
-					<div>
-						<h2 class="text-xl font-bold">{m['accountSecurityPage.passwordChange']()}</h2>
-						<p class="mt-1 text-sm text-muted-foreground">
-							{m['accountSecurityPage.passwordChangeDescription']()}
-						</p>
-					</div>
-				</div>
+				<SectionHeader title={m['accountSecurityPage.passwordChange']()} class="flex-1" />
+				<p class="mt-1 text-sm text-muted-foreground">
+					{m['accountSecurityPage.passwordChangeDescription']()}
+				</p>
 
 				<!-- Change Password Button (when not in flow) -->
 				{#if !showPasswordChangeFlow}
@@ -562,7 +557,7 @@
 
 	<!-- Additional Security Tips -->
 	<div class="mt-6 rounded-lg border bg-muted/50 p-6">
-		<h3 class="font-bold">{m['accountSecurityPage.securityTips']()}</h3>
+		<SectionHeader title={m['accountSecurityPage.securityTips']()} level={3} />
 		<ul class="mt-3 space-y-2 text-sm text-muted-foreground">
 			<li class="flex gap-2">
 				<CheckCircle class="h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />

--- a/src/routes/(auth)/account/security/+page.svelte
+++ b/src/routes/(auth)/account/security/+page.svelte
@@ -192,9 +192,17 @@
 					</div>
 
 					{#if totpActive}
-						<StatusBadge tone="success" icon={CheckCircle} label={m['accountSecurityPage.statusEnabled']()} />
+						<StatusBadge
+							tone="success"
+							icon={CheckCircle}
+							label={m['accountSecurityPage.statusEnabled']()}
+						/>
 					{:else}
-						<StatusBadge tone="neutral" icon={XCircle} label={m['accountSecurityPage.statusDisabled']()} />
+						<StatusBadge
+							tone="neutral"
+							icon={XCircle}
+							label={m['accountSecurityPage.statusDisabled']()}
+						/>
 					{/if}
 				</div>
 
@@ -491,7 +499,9 @@
 						{#if !passwordResetRequested}
 							<!-- Composited tint mirrors ToneTile's audited info pair (>=3:1 vs
 							     background/card); body copy stays on --foreground. -->
-							<div class="mt-4 flex items-center gap-2 rounded-md border border-info/30 bg-info/10 p-3">
+							<div
+								class="mt-4 flex items-center gap-2 rounded-md border border-info/30 bg-info/10 p-3"
+							>
 								<Mail class="h-5 w-5 flex-shrink-0 text-info" aria-hidden="true" />
 								<p class="text-sm text-foreground">
 									{m['accountSecurityPage.emailWillBeSent']({ email: data.user?.email || '' })}

--- a/src/routes/(auth)/account/security/email-change-card.svelte
+++ b/src/routes/(auth)/account/security/email-change-card.svelte
@@ -4,6 +4,7 @@
 	import { Mail, Eye, EyeOff, AlertTriangle, CheckCircle, ShieldCheck } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { RevelUserSchema } from '$lib/api/generated/types.gen';
 
 	interface EmailChangeFormState {
@@ -125,7 +126,7 @@
 
 		<div class="flex-1">
 			<div>
-				<h2 class="text-xl font-semibold">{m['accountSecurityPage.emailChange_title']()}</h2>
+				<h2 class="text-xl font-bold">{m['accountSecurityPage.emailChange_title']()}</h2>
 				<p class="mt-1 text-sm text-muted-foreground">
 					{m['accountSecurityPage.emailChange_description']()}
 				</p>
@@ -139,12 +140,13 @@
 						>
 						<span class="ml-1 font-medium">{currentEmail}</span>
 						{#if emailVerified}
-							<span
-								class="ml-2 inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-950 dark:text-green-300"
-							>
-								<ShieldCheck class="h-3 w-3" aria-hidden="true" />
-								{m['profile.email_verified']()}
-							</span>
+							<StatusBadge
+								tone="success"
+								icon={ShieldCheck}
+								label={m['profile.email_verified']()}
+								size="sm"
+								class="ml-2"
+							/>
 						{/if}
 					</p>
 				</div>
@@ -163,19 +165,22 @@
 
 			{#if showForm && !submissionSucceeded}
 				<div class="mt-6 rounded-lg border bg-muted/50 p-6">
-					<h3 class="font-semibold">{m['accountSecurityPage.emailChange_formTitle']()}</h3>
+					<h3 class="font-bold">{m['accountSecurityPage.emailChange_formTitle']()}</h3>
 					<p class="mt-2 text-sm text-muted-foreground">
 						{m['accountSecurityPage.emailChange_formDescription']()}
 					</p>
 
+					<!-- Warning tint mirrors ToneTile's amber recipe (light: highlight-foreground
+					     on bg-highlight/20 = 12.6:1; dark: text-highlight on the same tint =
+					     6.0:1) — raw text-highlight alone is only 1.8:1 on light background. -->
 					<div
-						class="mt-4 flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950"
+						class="mt-4 flex items-start gap-3 rounded-md border border-highlight/40 bg-highlight/20 p-3"
 					>
 						<AlertTriangle
-							class="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-700 dark:text-amber-400"
+							class="mt-0.5 h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
 							aria-hidden="true"
 						/>
-						<p class="text-sm text-amber-900 dark:text-amber-200">
+						<p class="text-sm text-foreground">
 							{m['accountSecurityPage.emailChange_signoutWarning']()}
 						</p>
 					</div>
@@ -298,25 +303,24 @@
 			{/if}
 
 			{#if submissionSucceeded}
-				<div class="mt-6 rounded-md border border-green-500 bg-green-50 p-6 dark:bg-green-950">
+				<!-- Composited tint mirrors ToneTile's audited success pair (>=3:1 vs
+				     background/card); body copy stays on --foreground/--muted-foreground. -->
+				<div class="mt-6 rounded-md border border-success/30 bg-success/10 p-6">
 					<div class="flex items-start gap-3">
-						<CheckCircle
-							class="mt-0.5 h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400"
-							aria-hidden="true"
-						/>
+						<CheckCircle class="mt-0.5 h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />
 						<div class="flex-1 space-y-2 text-sm">
-							<h3 class="font-medium text-green-800 dark:text-green-200">
+							<h3 class="font-bold text-foreground">
 								{m['accountSecurityPage.emailChange_successTitle']()}
 							</h3>
-							<p class="text-green-700 dark:text-green-300">
+							<p class="text-muted-foreground">
 								{m['accountSecurityPage.emailChange_successBody']({ new_email: submittedEmail })}
 							</p>
-							<p class="text-green-700 dark:text-green-300">
+							<p class="text-muted-foreground">
 								{m['accountSecurityPage.emailChange_successNotice']({
 									current_email: currentEmail
 								})}
 							</p>
-							<p class="text-xs text-green-700 dark:text-green-300">
+							<p class="text-xs text-muted-foreground">
 								{m['accountSecurityPage.emailChange_successExpiry']()}
 							</p>
 						</div>

--- a/src/routes/(auth)/account/security/email-change-card.svelte
+++ b/src/routes/(auth)/account/security/email-change-card.svelte
@@ -4,6 +4,7 @@
 	import { Mail, Eye, EyeOff, AlertTriangle, CheckCircle, ShieldCheck } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { RevelUserSchema } from '$lib/api/generated/types.gen';
 
@@ -125,12 +126,10 @@
 		</div>
 
 		<div class="flex-1">
-			<div>
-				<h2 class="text-xl font-bold">{m['accountSecurityPage.emailChange_title']()}</h2>
-				<p class="mt-1 text-sm text-muted-foreground">
-					{m['accountSecurityPage.emailChange_description']()}
-				</p>
-			</div>
+			<SectionHeader title={m['accountSecurityPage.emailChange_title']()} class="flex-1" />
+			<p class="mt-1 text-sm text-muted-foreground">
+				{m['accountSecurityPage.emailChange_description']()}
+			</p>
 
 			{#if !showForm && !submissionSucceeded}
 				<div class="mt-4">

--- a/src/routes/(auth)/account/settings/+page.svelte
+++ b/src/routes/(auth)/account/settings/+page.svelte
@@ -9,6 +9,8 @@
 	import CityAutocomplete from '$lib/components/forms/CityAutocomplete.svelte';
 	import AttendeeVisibilitySelect from '$lib/components/profile/AttendeeVisibilitySelect.svelte';
 	import { Button } from '$lib/components/ui/button';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import { userpreferencesUpdateGeneralPreferences } from '$lib/api/generated';
 	import type { CitySchema } from '$lib/api/generated';
 	import type { VisibilityValue } from '$lib/schemas/preferences';
@@ -77,17 +79,20 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-2xl px-4 py-8">
-	<div class="mb-8">
-		<h1 class="text-3xl font-bold tracking-tight">{m['accountSettingsPage.title']()}</h1>
-		<p class="mt-2 text-muted-foreground">{m['accountSettingsPage.subtitle']()}</p>
-	</div>
+	<PageHeader
+		kicker={m['myInvoices.account']()}
+		title={m['accountSettingsPage.title']()}
+		subtitle={m['accountSettingsPage.subtitle']()}
+		class="mb-8"
+	/>
 
 	{#if redirectUrl}
-		<div
-			class="mb-6 rounded-md border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950"
-		>
-			<p class="text-sm text-blue-800 dark:text-blue-200">
-				<Info class="mr-2 inline-block h-4 w-4" aria-hidden="true" />
+		<!-- Composited tint mirrors ToneTile's audited "info as icon/accent" pair
+		     (>=3:1 vs background/card per audit-brand-themes.py); body copy stays on
+		     --foreground so contrast never depends on the alpha overlay. -->
+		<div class="mb-6 rounded-md border border-info/30 bg-info/10 p-4">
+			<p class="text-sm text-foreground">
+				<Info class="mr-2 inline-block h-4 w-4 text-info" aria-hidden="true" />
 				{m['settings.updateToReturn']()}
 			</p>
 		</div>
@@ -96,7 +101,10 @@
 	{#if authStore.accessToken}
 		<!-- General Preferences -->
 		<div class="mb-8 rounded-lg border bg-card p-6">
-			<h2 class="mb-4 text-xl font-semibold">{m['accountSettingsPage.general.title']()}</h2>
+			<SectionHeader
+				title={m['accountSettingsPage.general.title']()}
+				class="mb-4"
+			/>
 			<p class="mb-6 text-sm text-muted-foreground">
 				{m['accountSettingsPage.general.description']()}
 			</p>
@@ -136,15 +144,16 @@
 
 		<!-- Billing Information -->
 		<div class="mb-8 rounded-lg border bg-card p-6">
-			<div class="mb-4 flex items-center gap-2">
+			<div class="flex items-center gap-2">
 				<FileText class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-				<div>
-					<h2 class="text-xl font-semibold">{m['accountSettingsPage.billing.title']()}</h2>
-					<p class="mt-1 text-sm text-muted-foreground">
-						{m['accountSettingsPage.billing.description']()}
-					</p>
-				</div>
+				<SectionHeader
+					title={m['accountSettingsPage.billing.title']()}
+					class="flex-1"
+				/>
 			</div>
+			<p class="mt-1 text-sm text-muted-foreground">
+				{m['accountSettingsPage.billing.description']()}
+			</p>
 			<BillingProfileForm authToken={authStore.accessToken} />
 		</div>
 

--- a/src/routes/(auth)/account/settings/+page.svelte
+++ b/src/routes/(auth)/account/settings/+page.svelte
@@ -101,10 +101,7 @@
 	{#if authStore.accessToken}
 		<!-- General Preferences -->
 		<div class="mb-8 rounded-lg border bg-card p-6">
-			<SectionHeader
-				title={m['accountSettingsPage.general.title']()}
-				class="mb-4"
-			/>
+			<SectionHeader title={m['accountSettingsPage.general.title']()} class="mb-4" />
 			<p class="mb-6 text-sm text-muted-foreground">
 				{m['accountSettingsPage.general.description']()}
 			</p>
@@ -146,10 +143,7 @@
 		<div class="mb-8 rounded-lg border bg-card p-6">
 			<div class="flex items-center gap-2">
 				<FileText class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-				<SectionHeader
-					title={m['accountSettingsPage.billing.title']()}
-					class="flex-1"
-				/>
+				<SectionHeader title={m['accountSettingsPage.billing.title']()} class="flex-1" />
 			</div>
 			<p class="mt-1 text-sm text-muted-foreground">
 				{m['accountSettingsPage.billing.description']()}

--- a/src/routes/(auth)/create-org/+page.svelte
+++ b/src/routes/(auth)/create-org/+page.svelte
@@ -135,11 +135,14 @@
 		</div>
 	{:else if !user?.email_verified}
 		<!-- Email not verified warning -->
+		<!-- text-destructive as a heading measures 2.68:1 in dark on this tint
+		     (below 4.5); the border/tint + icon carry the tone, text reads on
+		     --foreground. -->
 		<div class="rounded-lg border border-destructive/40 bg-destructive/10 p-6">
 			<div class="flex gap-3">
 				<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />
 				<div>
-					<h3 class="font-bold text-destructive">
+					<h3 class="font-bold text-foreground">
 						{m['orgCreate.emailNotVerified']()}
 					</h3>
 					<p class="mt-1 text-sm text-foreground">

--- a/src/routes/(auth)/create-org/+page.svelte
+++ b/src/routes/(auth)/create-org/+page.svelte
@@ -8,6 +8,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import CityAutocomplete from '$lib/components/forms/CityAutocomplete.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { AlertCircle, Building2, CheckCircle, Loader2, Mail } from '@lucide/svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import type { PageData, ActionData } from './$types';
@@ -84,17 +85,22 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-2xl px-4 py-8">
-	<!-- Header -->
+	<!-- The one Celebration moment in this cluster: creating an organization is
+	     an acquisition milestone, so it gets the display-scale PageHeader while
+	     the wizard body below stays studio-calm. -->
 	<div class="mb-8 text-center">
 		<div class="mb-4 flex justify-center">
 			<div class="rounded-full bg-primary/10 p-4">
 				<Building2 class="h-8 w-8 text-primary" aria-hidden="true" />
 			</div>
 		</div>
-		<h1 class="mb-2 text-3xl font-bold">{m['orgCreate.title']()}</h1>
-		<p class="text-muted-foreground">
-			{m['orgCreate.subtitle']()}
-		</p>
+		<PageHeader
+			volume="celebration"
+			kicker={m['orgCreate.kicker']()}
+			title={m['orgCreate.title']()}
+			subtitle={m['orgCreate.subtitle']()}
+			class="text-center sm:flex-col sm:items-center"
+		/>
 		<p class="mt-2 text-sm text-muted-foreground">
 			{m['createOrgPage.customizeHint']()}
 		</p>
@@ -102,25 +108,24 @@
 
 	<!-- Check if user already owns an organization -->
 	{#if ownsOrganization}
-		<div
-			class="rounded-lg border border-yellow-200 bg-yellow-50 p-6 dark:border-yellow-900 dark:bg-yellow-950"
-		>
+		<!-- Warning tint mirrors ToneTile's amber recipe (see security page). -->
+		<div class="rounded-lg border border-highlight/40 bg-highlight/20 p-6">
 			<div class="flex gap-3">
 				<AlertCircle
-					class="h-5 w-5 flex-shrink-0 text-yellow-600 dark:text-yellow-400"
+					class="h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
 					aria-hidden="true"
 				/>
 				<div>
-					<h3 class="font-semibold text-yellow-900 dark:text-yellow-100">
+					<h3 class="font-bold text-highlight-foreground dark:text-highlight">
 						{m['orgCreate.alreadyOwner']()}
 					</h3>
-					<p class="mt-1 text-sm text-yellow-800 dark:text-yellow-200">
+					<p class="mt-1 text-sm text-foreground">
 						{m['orgCreate.alreadyOwnerDescription']()}
 					</p>
 					<div class="mt-4">
 						<a
 							href={resolve('/(auth)/dashboard', {})}
-							class="inline-flex items-center gap-2 rounded-md bg-yellow-600 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-700 dark:bg-yellow-700 dark:hover:bg-yellow-600"
+							class="inline-flex items-center gap-2 rounded-md bg-highlight px-4 py-2 text-sm font-medium text-highlight-foreground hover:bg-highlight/90"
 						>
 							{m['orgCreate.backToDashboard']()}
 						</a>
@@ -130,23 +135,20 @@
 		</div>
 	{:else if !user?.email_verified}
 		<!-- Email not verified warning -->
-		<div class="rounded-lg border border-red-200 bg-red-50 p-6 dark:border-red-900 dark:bg-red-950">
+		<div class="rounded-lg border border-destructive/40 bg-destructive/10 p-6">
 			<div class="flex gap-3">
-				<AlertCircle
-					class="h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400"
-					aria-hidden="true"
-				/>
+				<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />
 				<div>
-					<h3 class="font-semibold text-red-900 dark:text-red-100">
+					<h3 class="font-bold text-destructive">
 						{m['orgCreate.emailNotVerified']()}
 					</h3>
-					<p class="mt-1 text-sm text-red-800 dark:text-red-200">
+					<p class="mt-1 text-sm text-foreground">
 						{m['orgCreate.emailNotVerifiedDescription']()}
 					</p>
 					<div class="mt-4">
 						<a
 							href={resolve('/(auth)/account/profile', {})}
-							class="inline-flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600"
+							class="inline-flex items-center gap-2 rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
 						>
 							{m['orgCreate.verifyEmail']()}
 						</a>
@@ -220,22 +222,16 @@
 
 					<!-- Info about email verification -->
 					{#if contactEmailChanged}
-						<div class="flex gap-2 rounded-md bg-blue-50 p-3 dark:bg-blue-950">
-							<Mail
-								class="h-4 w-4 flex-shrink-0 text-blue-600 dark:text-blue-400"
-								aria-hidden="true"
-							/>
-							<p id="contact-email-hint" class="text-xs text-blue-800 dark:text-blue-200">
+						<div class="flex gap-2 rounded-md border border-info/30 bg-info/10 p-3">
+							<Mail class="h-4 w-4 flex-shrink-0 text-info" aria-hidden="true" />
+							<p id="contact-email-hint" class="text-xs text-foreground">
 								{m['orgCreate.form.contactEmailVerificationNeeded']()}
 							</p>
 						</div>
 					{:else}
-						<div class="flex gap-2 rounded-md bg-green-50 p-3 dark:bg-green-950">
-							<CheckCircle
-								class="h-4 w-4 flex-shrink-0 text-green-600 dark:text-green-400"
-								aria-hidden="true"
-							/>
-							<p id="contact-email-hint" class="text-xs text-green-800 dark:text-green-200">
+						<div class="flex gap-2 rounded-md border border-success/30 bg-success/10 p-3">
+							<CheckCircle class="h-4 w-4 flex-shrink-0 text-success" aria-hidden="true" />
+							<p id="contact-email-hint" class="text-xs text-foreground">
 								{m['orgCreate.form.contactEmailAutoVerified']()}
 							</p>
 						</div>
@@ -346,11 +342,11 @@
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
 		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-xl">
 			<div class="mb-4 flex justify-center">
-				<div class="rounded-full bg-yellow-100 p-3 dark:bg-yellow-900">
-					<AlertCircle class="h-6 w-6 text-yellow-600 dark:text-yellow-400" aria-hidden="true" />
+				<div class="rounded-full bg-highlight p-3 text-highlight-foreground">
+					<AlertCircle class="h-6 w-6" aria-hidden="true" />
 				</div>
 			</div>
-			<h3 class="mb-2 text-center text-lg font-semibold">
+			<h3 class="mb-2 text-center text-lg font-bold">
 				{m['orgCreate.confirm.title']()}
 			</h3>
 			<p class="mb-1 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Platform rebrand, PR 6 of 10 — Account settings + create-org

Vol. 1 (Studio) pass over all nine account pages plus the create-org wizard (the one Celebration moment). `PageHeader`/`SectionHeader` rhythm everywhere including privacy/security's icon-row sections, table status pills as thin mappers over `common/StatusBadge` (identical filenames/props/labels), `EmptyState` adoption, full raw-hue sweep. Security/GDPR/2FA logic provably untouched (visual-only verified script-block by script-block in review).

### Review process
Whole-branch opus review + one fix round + scoped re-review, clean. Fixed on review: a dietary-toggle AA failure (4.10:1 with a wrong inline ratio — now the solid audited success pill), five dark-mode `text-destructive` text regressions (headings now `text-foreground`, icons carry the tone), a two-sentence paragraph that had become a heading (new `applications.emptyTitle` key ×6 locales, tests tightened not weakened), the `paused → brand` tone overruled to `warning` (full remap: past_due→danger, expired/cancelled→neutral), and SectionHeader adoption on the two hold-out pages.

### Notes
- New keys: `orgCreate.kicker`, `applications.emptyTitle` (×6 locales, additive). i18n merge caveat with sibling wave PRs.
- Cross-PR: `OrgMembershipInline`'s kicker renders on the public org page (PR 3 surface, disclosed); PR 9 should align `members/SubscriptionMetrics` (last `StatusConfig.className` consumer) then delete `className`.
- Follow-up bundle (with the dark-destructive token issue): security page's disable-2FA heading has the same pre-existing dark-contrast pattern (~3.05:1), untouched here as it sits inside the visual-only 2FA flow.

### Verification
`make check` 0 errors · full suite 202 files / 2426 green (3 assertions tightened for the title/body split) · brand audit 0 failures · orchestrator screenshots: profile (light), invoices (dark), create-org (light).

🤖 Generated with [Claude Code](https://claude.com/claude-code)