### PR TITLE
feat(rebrand): public discovery — event & org heroes, discovery cards, PricingCard consolidation (PR 3/10)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -827,6 +827,7 @@
 	},
 	"browse": {
 		"events_title": "Veranstaltungen entdecken",
+		"events_kicker": "Was läuft",
 		"events_skipTo": "Zu Veranstaltungen springen",
 		"events_noEventsFound": "Keine Veranstaltungen gefunden",
 		"events_tryAdjustingFilters": "Versuche, deine Filter anzupassen, um mehr Veranstaltungen zu finden.",
@@ -835,6 +836,7 @@
 		"events_listingsLabel": "Veranstaltungsliste",
 		"events_count": "{count} {eventPlural} gefunden",
 		"organizations_title": "Organisationen entdecken",
+		"organizations_kicker": "Communitys",
 		"organizations_skipTo": "Zu Organisationen springen",
 		"organizations_noOrganizationsFound": "Keine Organisationen gefunden",
 		"organizations_tryAdjustingFilters": "Versuche, deine Filter anzupassen, um mehr Organisationen zu finden.",
@@ -4521,6 +4523,7 @@
 	},
 	"organizationProfile": {
 		"editProfile": "Profil bearbeiten",
+		"kicker": "Community",
 		"resources_heading": "Ressourcen",
 		"resources_description": "Hilfreiche Dokumente, Links und Informationen von {organizationName}",
 		"resources_viewAll": "Alle anzeigen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -827,6 +827,7 @@
 	},
 	"browse": {
 		"events_title": "Discover Events",
+		"events_kicker": "What's on",
 		"events_skipTo": "Skip to events",
 		"events_noEventsFound": "No events found",
 		"events_tryAdjustingFilters": "Try adjusting your filters to find more events.",
@@ -835,6 +836,7 @@
 		"events_listingsLabel": "Event listings",
 		"events_count": "{count} {eventPlural} found",
 		"organizations_title": "Discover Organizations",
+		"organizations_kicker": "Communities",
 		"organizations_skipTo": "Skip to organizations",
 		"organizations_noOrganizationsFound": "No organizations found",
 		"organizations_tryAdjustingFilters": "Try adjusting your filters to find more organizations.",
@@ -4521,6 +4523,7 @@
 	},
 	"organizationProfile": {
 		"editProfile": "Edit Profile",
+		"kicker": "Community",
 		"resources_heading": "Resources",
 		"resources_description": "Helpful documents, links, and information from {organizationName}",
 		"resources_viewAll": "View all",

--- a/messages/es.json
+++ b/messages/es.json
@@ -827,6 +827,7 @@
 	},
 	"browse": {
 		"events_title": "Descubre eventos",
+		"events_kicker": "Qué hay",
 		"events_skipTo": "Saltar a los eventos",
 		"events_noEventsFound": "No se encontraron eventos",
 		"events_tryAdjustingFilters": "Prueba a ajustar tus filtros para encontrar más eventos.",
@@ -835,6 +836,7 @@
 		"events_listingsLabel": "Listado de eventos",
 		"events_count": "{count} {eventPlural} encontrados",
 		"organizations_title": "Descubre organizaciones",
+		"organizations_kicker": "Comunidades",
 		"organizations_skipTo": "Saltar a las organizaciones",
 		"organizations_noOrganizationsFound": "No se encontraron organizaciones",
 		"organizations_tryAdjustingFilters": "Prueba a ajustar tus filtros para encontrar más organizaciones.",
@@ -4521,6 +4523,7 @@
 	},
 	"organizationProfile": {
 		"editProfile": "Editar perfil",
+		"kicker": "Comunidad",
 		"resources_heading": "Recursos",
 		"resources_description": "Documentos, enlaces e información útiles de {organizationName}",
 		"resources_viewAll": "Ver todo",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -714,6 +714,7 @@
 	},
 	"browse": {
 		"events_title": "Découvrir des événements",
+		"events_kicker": "À l'affiche",
 		"events_skipTo": "Aller aux événements",
 		"events_noEventsFound": "Aucun événement trouvé",
 		"events_tryAdjustingFilters": "Essaie d'ajuster tes filtres pour trouver plus d'événements.",
@@ -722,6 +723,7 @@
 		"events_listingsLabel": "Liste des événements",
 		"events_count": "{count} {eventPlural} trouvés",
 		"organizations_title": "Découvrir des organisations",
+		"organizations_kicker": "Communautés",
 		"organizations_skipTo": "Aller aux organisations",
 		"organizations_noOrganizationsFound": "Aucune organisation trouvée",
 		"organizations_tryAdjustingFilters": "Essaie d'ajuster tes filtres pour trouver plus d'organisations.",
@@ -4492,6 +4494,7 @@
 	},
 	"organizationProfile": {
 		"editProfile": "Modifier le profil",
+		"kicker": "Communauté",
 		"resources_heading": "Ressources",
 		"resources_description": "Documents utiles, liens et informations de {organizationName}",
 		"resources_viewAll": "Voir tout",

--- a/messages/it.json
+++ b/messages/it.json
@@ -827,6 +827,7 @@
 	},
 	"browse": {
 		"events_title": "Scopri Eventi",
+		"events_kicker": "Cosa succede",
 		"events_skipTo": "Passa agli eventi",
 		"events_noEventsFound": "Nessun evento trovato",
 		"events_tryAdjustingFilters": "Prova a modificare i tuoi filtri per trovare più eventi.",
@@ -835,6 +836,7 @@
 		"events_listingsLabel": "Elenco eventi",
 		"events_count": "{count} {eventPlural} trovati",
 		"organizations_title": "Scopri Organizzazioni",
+		"organizations_kicker": "Community",
 		"organizations_skipTo": "Passa alle organizzazioni",
 		"organizations_noOrganizationsFound": "Nessuna organizzazione trovata",
 		"organizations_tryAdjustingFilters": "Prova a modificare i tuoi filtri per trovare più organizzazioni.",
@@ -4521,6 +4523,7 @@
 	},
 	"organizationProfile": {
 		"editProfile": "Modifica Profilo",
+		"kicker": "Community",
 		"resources_heading": "Risorse",
 		"resources_description": "Documenti utili, link e informazioni da {organizationName}",
 		"resources_viewAll": "Vedi tutto",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -827,6 +827,7 @@
 	},
 	"browse": {
 		"events_title": "Descobre eventos",
+		"events_kicker": "O que há",
 		"events_skipTo": "Saltar para os eventos",
 		"events_noEventsFound": "Nenhum evento encontrado",
 		"events_tryAdjustingFilters": "Tenta ajustar os teus filtros para encontrar mais eventos.",
@@ -835,6 +836,7 @@
 		"events_listingsLabel": "Lista de eventos",
 		"events_count": "{count} {eventPlural} encontrados",
 		"organizations_title": "Descobre organizações",
+		"organizations_kicker": "Comunidades",
 		"organizations_skipTo": "Saltar para as organizações",
 		"organizations_noOrganizationsFound": "Nenhuma organização encontrada",
 		"organizations_tryAdjustingFilters": "Tenta ajustar os teus filtros para encontrar mais organizações.",
@@ -4521,6 +4523,7 @@
 	},
 	"organizationProfile": {
 		"editProfile": "Editar perfil",
+		"kicker": "Comunidade",
 		"resources_heading": "Recursos",
 		"resources_description": "Documentos úteis, links e informações de {organizationName}",
 		"resources_viewAll": "Ver tudo",

--- a/src/lib/components/announcements/AnnouncementPublicCard.svelte
+++ b/src/lib/components/announcements/AnnouncementPublicCard.svelte
@@ -3,6 +3,7 @@
 	import type { AnnouncementPublicSchema } from '$lib/api/generated/types.gen';
 	import { formatRelativeTime } from '$lib/utils/time';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import { Megaphone, Users, Layers, UserCog, Calendar } from '@lucide/svelte';
 
 	interface Props {
@@ -32,13 +33,9 @@
 <article class="rounded-lg border bg-card p-4">
 	<!-- Header -->
 	<div class="mb-3 flex items-start gap-3">
-		<div
-			class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
-		>
-			<Megaphone class="h-5 w-5" aria-hidden="true" />
-		</div>
+		<ToneTile tone="brand" icon={Megaphone} class="rounded-full" />
 		<div class="min-w-0 flex-1">
-			<h3 class="font-semibold">{announcement.title}</h3>
+			<h3 class="font-bold">{announcement.title}</h3>
 			<div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm text-muted-foreground">
 				{#if announcement.sent_at}
 					<span

--- a/src/lib/components/announcements/EventAnnouncements.svelte
+++ b/src/lib/components/announcements/EventAnnouncements.svelte
@@ -56,9 +56,9 @@
 		>
 			<div class="flex items-center gap-2">
 				<Megaphone class="h-5 w-5 text-primary" aria-hidden="true" />
-				<h2 class="text-lg font-semibold">{m['announcements.public.title']()}</h2>
+				<h2 class="text-xl font-extrabold">{m['announcements.public.title']()}</h2>
 				{#if hasAnnouncements}
-					<span class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+					<span class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary">
 						{announcements.length}
 					</span>
 				{/if}

--- a/src/lib/components/announcements/OrgAnnouncements.svelte
+++ b/src/lib/components/announcements/OrgAnnouncements.svelte
@@ -4,6 +4,7 @@
 	import { createQuery } from '@tanstack/svelte-query';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { Megaphone, Loader2 } from '@lucide/svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import AnnouncementPublicCard from './AnnouncementPublicCard.svelte';
 
 	interface Props {
@@ -38,10 +39,10 @@
 	<section class="space-y-4">
 		<!-- Header -->
 		<div class="flex items-center gap-2">
-			<Megaphone class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-			<h2 class="text-xl font-semibold">{m['announcements.public.title']()}</h2>
+			<Megaphone class="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+			<SectionHeader volume="celebration" title={m['announcements.public.title']()} />
 			{#if hasAnnouncements}
-				<span class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+				<span class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary">
 					{announcements.length}
 				</span>
 			{/if}

--- a/src/lib/components/common/PricingCard.svelte
+++ b/src/lib/components/common/PricingCard.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import type { Component, Snippet } from 'svelte';
+	import { cn } from '$lib/utils';
+
+	/**
+	 * The one tier/pricing card of the app.
+	 *
+	 * Three independent "TierCard"s used to exist — the buyer's ticket tier
+	 * (`tickets/TierCard`), the organizer's tier summary (`events/admin/TierCard`)
+	 * and the membership tier container (`organization/membership/TierCard`) — and
+	 * they disagreed about heading weight, price size, badge shape and where the
+	 * actions live. They are NOT the same component (one sells, one configures,
+	 * one contains plan cards), so this is deliberately a SHELL rather than a
+	 * merged component: it owns the chrome and the typography, each of the three
+	 * keeps its own props, data and logic and fills the slots.
+	 *
+	 * Look borrowed from the landing's pricing panel: a kicker-weight tier name, a
+	 * price that is genuinely big and black, and a caption doing the qualifying —
+	 * hierarchy by weight and size, never by transparency.
+	 *
+	 * i18n stays at the call site: every string here arrives already translated.
+	 */
+	interface Props {
+		/** Tier / plan name. */
+		name: string;
+		/** Heading level — match the surrounding page outline (axe heading-order). */
+		level?: 2 | 3 | 4;
+		/** Set on the heading so callers keep their `aria-labelledby` wiring. */
+		headingId?: string;
+		/** Display price: "€25.00", "Free", "€10.00 – €50.00". */
+		price?: string;
+		/** Qualifier under the price ("per month", "Pay what you can"). */
+		priceNote?: string;
+		/** Lucide icon shown before the name. Decorative. */
+		icon?: Component;
+		/** Chips beside the name: availability, "Free", "Default". */
+		badges?: Snippet;
+		/** Description / rich body. */
+		children?: Snippet;
+		/** Detail rows — a `<dl>`, a requirements list, nested plan cards. */
+		meta?: Snippet;
+		/** Buy / edit / apply controls. */
+		actions?: Snippet;
+		/**
+		 * `split` puts the actions in a right rail from `sm` up (buyer + organizer
+		 * rows); `stack` keeps them at the bottom of a full-height card (the
+		 * membership grid, where cards are columns that must bottom-align).
+		 */
+		layout?: 'split' | 'stack';
+		/** Dim the card when its tier cannot currently be acted on. */
+		muted?: boolean;
+		class?: string;
+	}
+	const {
+		name,
+		level = 3,
+		headingId,
+		price,
+		priceNote,
+		icon: Icon,
+		badges,
+		children,
+		meta,
+		actions,
+		layout = 'split',
+		muted = false,
+		class: className = ''
+	}: Props = $props();
+
+	const headingClass = 'text-lg font-extrabold leading-tight';
+</script>
+
+<div
+	class={cn(
+		'rounded-lg border bg-card p-4 text-card-foreground shadow-sm transition-shadow sm:p-5',
+		layout === 'stack' && 'flex h-full flex-col',
+		muted && 'opacity-60',
+		className
+	)}
+>
+	<div
+		class={cn(
+			'flex flex-col gap-4',
+			layout === 'stack' && 'flex-1',
+			layout === 'split' && 'sm:flex-row sm:items-start sm:justify-between'
+		)}
+	>
+		<!-- min-w-0 so a long tier name wraps instead of pushing the action rail
+		     off a 390px viewport. -->
+		<div class={cn('min-w-0 flex-1', layout === 'stack' && 'flex flex-1 flex-col')}>
+			<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+				{#if Icon}
+					<Icon class="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+				{/if}
+				{#if level === 2}
+					<h2 class={headingClass} id={headingId}>{name}</h2>
+				{:else if level === 3}
+					<h3 class={headingClass} id={headingId}>{name}</h3>
+				{:else}
+					<h4 class={headingClass} id={headingId}>{name}</h4>
+				{/if}
+				{#if badges}
+					{@render badges()}
+				{/if}
+			</div>
+
+			{#if price}
+				<p class="mt-1.5 text-3xl font-black leading-none tracking-tight">{price}</p>
+			{/if}
+			{#if priceNote}
+				<p class="mt-1 text-sm font-bold text-muted-foreground">{priceNote}</p>
+			{/if}
+
+			{#if children}
+				<div class="mt-2 min-w-0">{@render children()}</div>
+			{/if}
+
+			{#if meta}
+				<div class={cn('mt-3 min-w-0', layout === 'stack' && 'flex-1')}>{@render meta()}</div>
+			{/if}
+		</div>
+
+		{#if actions}
+			<div
+				class={cn(
+					'flex flex-col gap-2',
+					layout === 'split' && 'shrink-0 sm:items-end',
+					layout === 'stack' && 'mt-auto pt-1'
+				)}
+			>
+				{@render actions()}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/events/ActionButton.svelte
+++ b/src/lib/components/events/ActionButton.svelte
@@ -133,7 +133,9 @@
 		variant === 'secondary' &&
 			'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
 		variant === 'success' &&
-			'bg-green-600 text-white hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600',
+			// TRAP: a custom bg-* on a Button keeps the variant's
+			// text-primary-foreground, so the text colour is stated explicitly.
+			'bg-success text-success-foreground hover:bg-success/90',
 		variant === 'destructive' &&
 			'bg-destructive text-destructive-foreground hover:bg-destructive/90',
 		isDisabled && 'cursor-not-allowed opacity-50',

--- a/src/lib/components/events/AttendeeList.svelte
+++ b/src/lib/components/events/AttendeeList.svelte
@@ -153,7 +153,7 @@
 	<section class="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
 		<div class="mb-4 flex items-center gap-2">
 			<Users class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-			<h2 class="text-lg font-semibold">{m['attendeeList.whosComing']()}</h2>
+			<h2 class="text-xl font-extrabold">{m['attendeeList.whosComing']()}</h2>
 			{#if totalAttendees != null}
 				<span class="text-sm text-muted-foreground">({totalAttendees})</span>
 			{/if}
@@ -197,7 +197,7 @@
 
 							<!-- Attendee info -->
 							<div class="min-w-0 flex-1">
-								<p class="truncate font-medium">{attendee.display_name}</p>
+								<p class="truncate font-bold">{attendee.display_name}</p>
 								{#if attendee.pronouns}
 									<p class="truncate text-sm text-muted-foreground">({attendee.pronouns})</p>
 								{/if}
@@ -220,7 +220,7 @@
 
 							<!-- Attendee info -->
 							<div class="min-w-0 flex-1">
-								<p class="truncate font-medium">{attendee.display_name}</p>
+								<p class="truncate font-bold">{attendee.display_name}</p>
 								{#if attendee.pronouns}
 									<p class="truncate text-sm text-muted-foreground">({attendee.pronouns})</p>
 								{/if}

--- a/src/lib/components/events/ConfirmationResult.svelte
+++ b/src/lib/components/events/ConfirmationResult.svelte
@@ -121,7 +121,7 @@
 				<Loader2 class="h-16 w-16 animate-spin text-primary" aria-hidden="true" />
 			</div>
 			<div class="space-y-2">
-				<h1 class="text-2xl font-bold">{m['guest_attendance.confirmation_processing']()}</h1>
+				<h1 class="text-2xl font-extrabold">{m['guest_attendance.confirmation_processing']()}</h1>
 				<p class="text-muted-foreground">
 					{m['guest_attendance.confirmation_wait']()}
 				</p>
@@ -135,7 +135,7 @@
 			</div>
 
 			<div class="space-y-3">
-				<h1 class="text-3xl font-bold">
+				<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
 					{result.type === 'rsvp'
 						? m['guest_attendance.rsvp_confirmed_title']()
 						: m['guest_attendance.ticket_confirmed_title']()}
@@ -172,7 +172,9 @@
 			</div>
 
 			<div class="space-y-3">
-				<h1 class="text-3xl font-bold">{m['confirmationResult.confirmationFailed']()}</h1>
+				<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
+					{m['confirmationResult.confirmationFailed']()}
+				</h1>
 				<Alert variant="destructive" class="text-left">
 					<AlertDescription>
 						{result.error || m['guest_attendance.network_error']()}

--- a/src/lib/components/events/DietarySummary.svelte
+++ b/src/lib/components/events/DietarySummary.svelte
@@ -79,36 +79,31 @@
 			case 'severe_allergy':
 				return {
 					label: m['dietarySummary.severitySevereAllergy'](),
-					color:
-						'bg-red-100 text-red-800 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-900',
+					color: 'border-destructive/40 bg-destructive/10 text-foreground',
 					icon: AlertTriangle
 				};
 			case 'allergy':
 				return {
 					label: m['dietarySummary.severityAllergy'](),
-					color:
-						'bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-950 dark:text-orange-400 dark:border-orange-900',
+					color: 'border-highlight/60 bg-highlight/20 text-foreground',
 					icon: AlertCircle
 				};
 			case 'intolerant':
 				return {
 					label: m['dietarySummary.severityIntolerant'](),
-					color:
-						'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-950 dark:text-yellow-400 dark:border-yellow-900',
+					color: 'border-highlight/40 bg-highlight/10 text-foreground',
 					icon: Circle
 				};
 			case 'dislike':
 				return {
 					label: m['dietarySummary.severityDislike'](),
-					color:
-						'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700',
+					color: 'border-border bg-muted text-muted-foreground',
 					icon: Frown
 				};
 			default:
 				return {
 					label: type,
-					color:
-						'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700',
+					color: 'border-border bg-muted text-muted-foreground',
 					icon: Circle
 				};
 		}
@@ -169,7 +164,7 @@
 			<div class="flex items-center gap-3">
 				<Info class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
 				<div>
-					<h3 class="font-semibold">{m['dietary.eventSummary_heading']()}</h3>
+					<h3 class="text-lg font-extrabold">{m['dietary.eventSummary_heading']()}</h3>
 					<p class="text-sm text-muted-foreground">{m['dietary.eventSummary_description']()}</p>
 				</div>
 			</div>
@@ -178,7 +173,7 @@
 				<a
 					href={profileDietaryUrl}
 					onclick={(e) => e.stopPropagation()}
-					class="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+					class="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90"
 					aria-label={m['dietarySummary.addDietaryPreferencesAriaLabel']()}
 				>
 					<span>{m['dietary.profile_quickActionButton']()}</span>

--- a/src/lib/components/events/DietarySummary.svelte
+++ b/src/lib/components/events/DietarySummary.svelte
@@ -69,7 +69,28 @@
 		return m['dietary.eventSummary_attendeeCount']({ count });
 	}
 
-	// Get severity display info
+	/**
+	 * Severity ladder. This is a SAFETY surface, so the four steps must stay
+	 * distinguishable: an allergy at two opacities of the same amber as an
+	 * intolerance is not a ladder.
+	 *
+	 *   severe allergy  destructive/20 + AlertTriangle   (hardest stop)
+	 *   allergy         destructive/10 + AlertCircle     (same family, lighter)
+	 *   intolerant      highlight/10   + Circle          (amber: caution, not danger)
+	 *   dislike         muted          + Frown           (preference)
+	 *
+	 * Every step also carries its own icon AND its own translated label, so the
+	 * fill is redundant reinforcement and never the message (WCAG 1.4.1) — which
+	 * is what makes separating the two destructive steps by opacity alone safe.
+	 *
+	 * Ratios hand-computed (composited alpha is invisible to
+	 * scripts/audit-brand-themes.py) — `text-foreground` over the tint on a card,
+	 * light | dark:
+	 *   destructive/20 11.90 | 13.70 · destructive/10 14.50 | 14.79
+	 *   highlight/10   16.34 | 12.90
+	 * The borders are decoration at these alphas (border-destructive is 9.74:1 on
+	 * the light card but 2.86:1 on the dark one); the icon and the words carry it.
+	 */
 	function getSeverityInfo(type: RestrictionType): {
 		label: string;
 		color: string;
@@ -79,13 +100,13 @@
 			case 'severe_allergy':
 				return {
 					label: m['dietarySummary.severitySevereAllergy'](),
-					color: 'border-destructive/40 bg-destructive/10 text-foreground',
+					color: 'border-destructive/60 bg-destructive/20 text-foreground',
 					icon: AlertTriangle
 				};
 			case 'allergy':
 				return {
 					label: m['dietarySummary.severityAllergy'](),
-					color: 'border-highlight/60 bg-highlight/20 text-foreground',
+					color: 'border-destructive/40 bg-destructive/10 text-foreground',
 					icon: AlertCircle
 				};
 			case 'intolerant':

--- a/src/lib/components/events/EligibilityStatusDisplay.svelte
+++ b/src/lib/components/events/EligibilityStatusDisplay.svelte
@@ -148,8 +148,8 @@
 <div
 	class={cn(
 		'rounded-lg border-2 p-4',
-		variant === 'success' && 'border-green-500/30 bg-green-500/5',
-		variant === 'warning' && 'border-yellow-500/30 bg-yellow-500/5',
+		variant === 'success' && 'border-success/40 bg-success/10',
+		variant === 'warning' && 'border-highlight/50 bg-highlight/10',
 		className
 	)}
 	role="status"
@@ -160,8 +160,8 @@
 		<div
 			class={cn(
 				'shrink-0',
-				variant === 'success' && 'text-green-600 dark:text-green-400',
-				variant === 'warning' && 'text-yellow-600 dark:text-yellow-400'
+				variant === 'success' && 'text-success',
+				variant === 'warning' && 'text-highlight-foreground dark:text-highlight'
 			)}
 		>
 			<IconComponent class="h-6 w-6" aria-hidden="true" />
@@ -250,7 +250,7 @@
 			<!-- Application Deadline Display -->
 			{#if shouldShowDeadline && applyBefore}
 				<div
-					class="mt-2 flex items-center gap-2 rounded-md bg-orange-50 px-3 py-2 text-sm text-orange-800 dark:bg-orange-950/30 dark:text-orange-200"
+					class="mt-2 flex items-center gap-2 rounded-md bg-highlight/10 px-3 py-2 text-sm text-foreground"
 				>
 					<Calendar class="h-4 w-4 shrink-0" aria-hidden="true" />
 					<span>

--- a/src/lib/components/events/EventActionSidebar.svelte
+++ b/src/lib/components/events/EventActionSidebar.svelte
@@ -27,6 +27,7 @@
 	import EventRSVP from './EventRSVP.svelte';
 	import EligibilityStatusDisplay from './EligibilityStatusDisplay.svelte';
 	import { Check, Ticket, CalendarDays, MessageSquare, Ban } from '@lucide/svelte';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import { downloadRevelEventICalFile } from '$lib/utils/ical';
 	import EventManageSection from './EventManageSection.svelte';
 
@@ -324,13 +325,15 @@
 			>
 				<div class="flex items-start gap-2">
 					<Ban class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
-					<div role="heading" aria-level="3" class="flex-1 font-semibold text-destructive">
+					<div role="heading" aria-level="3" class="flex-1 font-extrabold text-destructive">
 						{m['eventActionSidebar.cancelledBannerTitle']()}
 					</div>
 				</div>
 				{#if event.cancellation_reason}
 					<div class="mt-1 text-sm">
-						<div class="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+						<div
+							class="mb-1 text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+						>
 							{m['eventActionSidebar.cancelledBannerReasonLabel']()}
 						</div>
 						<p class="whitespace-pre-line break-words text-foreground">
@@ -343,14 +346,23 @@
 
 		<!-- Pending Payment Warning (for online tickets pending payment) -->
 		{#if shouldShowResumePayment}
+			<!-- Unfinished payment. Amber `highlight` tokens instead of a hand-picked
+			     orange ramp: the 10% tint composites to ~the card colour, so the copy
+			     stays `text-foreground` and keeps the token contract's AA guarantee,
+			     and the RESUME button uses the solid highlight pair (audited).
+			     TRAP guarded: a custom `bg-*` on a Button keeps the variant's
+			     `text-primary-foreground`, so the explicit text colour is required. -->
 			<div
-				class="flex flex-col gap-3 rounded-md border-2 border-orange-200 bg-orange-50 p-4 text-orange-900 dark:border-orange-800 dark:bg-orange-950/50 dark:text-orange-100"
+				class="flex flex-col gap-3 rounded-md border-2 border-highlight/60 bg-highlight/10 p-4 text-foreground"
 				role="alert"
 			>
 				<div class="flex items-start gap-2">
-					<Ticket class="h-5 w-5 shrink-0" aria-hidden="true" />
+					<Ticket
+						class="h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
+						aria-hidden="true"
+					/>
 					<div class="flex-1">
-						<div class="font-semibold">{m['eventActionSidebar.ticketPendingPayment']()}</div>
+						<div class="font-extrabold">{m['eventActionSidebar.ticketPendingPayment']()}</div>
 						{#if ticketTierName}
 							<div class="text-sm opacity-90">{ticketTierName}</div>
 						{/if}
@@ -363,7 +375,7 @@
 					type="button"
 					onclick={onResumePayment}
 					disabled={isResumingPayment}
-					class="w-full rounded-md border-2 border-orange-600 bg-orange-600 px-4 py-2 font-semibold text-white transition-colors hover:bg-orange-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-orange-500 dark:bg-orange-500"
+					class="w-full rounded-md border-2 border-highlight bg-highlight px-4 py-2 font-bold text-highlight-foreground transition-colors hover:bg-highlight/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 				>
 					{isResumingPayment
 						? m['eventActionSidebar.processing']()
@@ -373,7 +385,7 @@
 					<button
 						type="button"
 						onclick={onShowTicketClick}
-						class="w-full rounded-md border border-orange-300 bg-transparent px-4 py-2 text-sm font-medium text-orange-700 transition-colors hover:bg-orange-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:border-orange-700 dark:text-orange-300 dark:hover:bg-orange-900/30"
+						class="w-full rounded-md border border-highlight/60 bg-transparent px-4 py-2 text-sm font-bold text-foreground transition-colors hover:bg-highlight/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						{#if userTickets.length > 1}
 							{m['eventActionSidebar.viewAllTickets']({ count: userTickets.length })}
@@ -387,23 +399,24 @@
 			<!-- Attendance Status Display (if user is attending) -->
 			{@const hasPendingTicket =
 				userTickets.length > 0 && userTickets.some((t) => t.status === 'pending')}
+			<!-- Same tint-plus-token-icon recipe as above; the words carry the state,
+			     the tint only reinforces it. -->
 			<div
 				class={cn(
-					'flex items-center gap-2 rounded-md p-3',
-					hasPendingTicket
-						? 'bg-orange-50 text-orange-900 dark:bg-orange-950/50 dark:text-orange-100'
-						: 'bg-green-50 text-green-900 dark:bg-green-950/50 dark:text-green-100'
+					'flex items-center gap-2 rounded-md p-3 text-foreground',
+					hasPendingTicket ? 'bg-highlight/10' : 'bg-success/10'
 				)}
 				role="status"
 				aria-live="polite"
 			>
-				{#if userStatus && isTicket(userStatus)}
-					<Ticket class="h-5 w-5 shrink-0" aria-hidden="true" />
-				{:else}
-					<Check class="h-5 w-5 shrink-0" aria-hidden="true" />
-				{/if}
+				<ToneTile
+					tone={hasPendingTicket ? 'warning' : 'success'}
+					icon={userStatus && isTicket(userStatus) ? Ticket : Check}
+					size="sm"
+					class="bg-transparent"
+				/>
 				<div class="flex-1">
-					<div class="font-semibold">{attendanceStatusText}</div>
+					<div class="font-extrabold">{attendanceStatusText}</div>
 					{#if ticketTierName}
 						<div class="text-sm opacity-90">{ticketTierName}</div>
 					{/if}
@@ -437,7 +450,7 @@
 				{#if shouldShowEligibility && userStatus && isEligibility(userStatus)}
 					<!-- Show eligibility status for ticketed events -->
 					<div>
-						<h3 class="mb-2 text-sm font-semibold">
+						<h3 class="mb-2 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
 							{m['eventActionSidebar.eligibilityStatus']()}
 						</h3>
 						<EligibilityStatusDisplay
@@ -477,7 +490,7 @@
 					<button
 						type="button"
 						onclick={handleSecondaryAction}
-						class="w-full cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						class="w-full cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<span class="flex items-center justify-center gap-2">
 							<Ticket class="h-4 w-4" aria-hidden="true" />
@@ -491,7 +504,7 @@
 					<button
 						type="button"
 						onclick={handleSecondaryAction}
-						class="w-full cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						class="w-full cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						{showManageRSVP
 							? m['eventActionSidebar.hideRsvp']()
@@ -504,7 +517,7 @@
 					<button
 						type="button"
 						onclick={onGetTicketsClick}
-						class="w-full cursor-pointer rounded-md border border-primary bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						class="w-full cursor-pointer rounded-md border border-primary bg-primary/10 px-4 py-2 text-sm font-bold text-primary transition-colors hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<span class="flex items-center justify-center gap-2">
 							<Ticket class="h-4 w-4" aria-hidden="true" />
@@ -517,7 +530,7 @@
 				<button
 					type="button"
 					onclick={handleDownloadCalendar}
-					class="w-full cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					class="w-full cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					aria-label={m['eventActionSidebar.downloadCalendarAriaLabel']()}
 				>
 					<span class="flex items-center justify-center gap-2">
@@ -528,14 +541,12 @@
 
 				<!-- Feedback Questionnaires (after event ends) -->
 				{#if hasFeedbackQuestionnaires}
-					<div
-						class="mt-4 rounded-md border-2 border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/50"
-					>
-						<div class="mb-2 flex items-center gap-2 text-blue-900 dark:text-blue-100">
-							<MessageSquare class="h-5 w-5" aria-hidden="true" />
-							<span class="font-semibold">{m['eventActionSidebar.feedbackAvailable']()}</span>
+					<div class="mt-4 rounded-md border-2 border-info/40 bg-info/10 p-3">
+						<div class="mb-2 flex items-center gap-2 text-foreground">
+							<MessageSquare class="h-5 w-5 text-info" aria-hidden="true" />
+							<span class="font-extrabold">{m['eventActionSidebar.feedbackAvailable']()}</span>
 						</div>
-						<p class="mb-3 text-sm text-blue-800 dark:text-blue-200">
+						<p class="mb-3 text-sm text-muted-foreground">
 							{m['eventActionSidebar.feedbackDescription']()}
 						</p>
 						{#each feedbackQuestionnaires as questionnaireId (questionnaireId)}
@@ -545,7 +556,7 @@
 									event_slug: event.slug,
 									id: questionnaireId
 								})}
-								class="flex w-full items-center justify-center gap-2 rounded-md border-2 border-blue-600 bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:border-blue-500 dark:bg-blue-500"
+								class="flex w-full items-center justify-center gap-2 rounded-md border-2 border-info bg-info px-4 py-2 text-sm font-bold text-info-foreground transition-colors hover:bg-info/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 							>
 								<MessageSquare class="h-4 w-4" aria-hidden="true" />
 								{m['eventActionSidebar.giveFeedback']()}
@@ -590,7 +601,7 @@
 			<button
 				type="button"
 				onclick={handleDownloadCalendar}
-				class="w-full cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				class="w-full cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 				aria-label={m['eventActionSidebar.downloadCalendarAriaLabel']()}
 			>
 				<span class="flex items-center justify-center gap-2">

--- a/src/lib/components/events/EventBadges.svelte
+++ b/src/lib/components/events/EventBadges.svelte
@@ -4,12 +4,21 @@
 	import { isEventPast, isRSVPClosed } from '$lib/utils/date';
 	import { isEventFull } from '$lib/utils/event';
 	import { cn } from '$lib/utils/cn';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import { EyeOff } from '@lucide/svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
 	interface Badge {
 		label: string;
-		variant: 'default' | 'success' | 'secondary' | 'destructive' | 'outline' | 'cancelled';
+		/**
+		 * Semantic tone, resolved here rather than a private colour table — the
+		 * domain→tone mapper the rebrand asks for, so every fill is an audited
+		 * `StatusBadge` pair. The old `outline` and `secondary` variants both land
+		 * on `neutral`: they always said "context, not status", and nothing here
+		 * was ever distinguished by fill alone (every badge is a word).
+		 */
+		tone: Tone;
 		hasIcon?: boolean;
 	}
 
@@ -31,16 +40,16 @@
 		// Priority 0: Administrative Status (highest priority - show event status)
 		// These badges indicate the event's administrative state
 		if (event.status === 'draft') {
-			result.push({ label: m['orgAdmin.events.status.draft'](), variant: 'outline' });
+			result.push({ label: m['orgAdmin.events.status.draft'](), tone: 'neutral' });
 		} else if (event.status === 'cancelled') {
-			result.push({ label: m['orgAdmin.events.status.cancelled'](), variant: 'cancelled' });
+			result.push({ label: m['orgAdmin.events.status.cancelled'](), tone: 'warning' });
 		} else if (event.status === 'closed') {
-			result.push({ label: m['orgAdmin.events.status.closed'](), variant: 'destructive' });
+			result.push({ label: m['orgAdmin.events.status.closed'](), tone: 'danger' });
 		}
 
 		// Priority 0.5: Unlisted visibility (important context for staff/owners who can see it)
 		if (event.visibility === 'unlisted') {
-			result.push({ label: m['eventBadges.unlisted'](), variant: 'outline', hasIcon: true });
+			result.push({ label: m['eventBadges.unlisted'](), tone: 'neutral', hasIcon: true });
 		}
 
 		// If we already have 2 badges, stop here
@@ -49,11 +58,11 @@
 		// Priority 1: User Relationship
 		if (userStatus) {
 			if (userStatus.organizing) {
-				result.push({ label: m['eventBadges.youreOrganizing'](), variant: 'default' });
+				result.push({ label: m['eventBadges.youreOrganizing'](), tone: 'brand' });
 			} else if (userStatus.attending) {
-				result.push({ label: m['eventBadges.youreAttending'](), variant: 'success' });
+				result.push({ label: m['eventBadges.youreAttending'](), tone: 'success' });
 			} else if (userStatus.invitationPending) {
-				result.push({ label: m['eventBadges.invitationPending'](), variant: 'secondary' });
+				result.push({ label: m['eventBadges.invitationPending'](), tone: 'neutral' });
 			}
 		}
 
@@ -66,13 +75,13 @@
 		const rsvpClosed = isRSVPClosed(event.rsvp_before);
 
 		if (isPast) {
-			result.push({ label: m['eventBadges.pastEvent'](), variant: 'outline' });
+			result.push({ label: m['eventBadges.pastEvent'](), tone: 'neutral' });
 		} else if (isFull && !event.waitlist_open) {
-			result.push({ label: m['eventBadges.soldOut'](), variant: 'destructive' });
+			result.push({ label: m['eventBadges.soldOut'](), tone: 'danger' });
 		} else if (isFull && event.waitlist_open) {
-			result.push({ label: m['eventBadges.waitlistOpen'](), variant: 'secondary' });
+			result.push({ label: m['eventBadges.waitlistOpen'](), tone: 'info' });
 		} else if (rsvpClosed) {
-			result.push({ label: m['eventBadges.rsvpClosed'](), variant: 'outline' });
+			result.push({ label: m['eventBadges.rsvpClosed'](), tone: 'neutral' });
 		}
 
 		// If we already have 2 badges, stop here
@@ -80,50 +89,26 @@
 
 		// Priority 3: Event Type (only if we have room)
 		if (event.event_type === 'members-only') {
-			result.push({ label: m['eventBadges.membersOnly'](), variant: 'secondary' });
+			result.push({ label: m['eventBadges.membersOnly'](), tone: 'neutral' });
 		} else if (event.event_type === 'private') {
-			result.push({ label: m['eventBadges.private'](), variant: 'secondary' });
+			result.push({ label: m['eventBadges.private'](), tone: 'neutral' });
 		} else if (event.event_type === 'public') {
-			result.push({ label: m['eventBadges.public'](), variant: 'outline' });
+			result.push({ label: m['eventBadges.public'](), tone: 'neutral' });
 		}
 
 		// Return max 2 badges
 		return result.slice(0, 2);
 	});
-
-	/**
-	 * Get Tailwind classes for badge variant
-	 */
-	function getBadgeClasses(variant: Badge['variant']): string {
-		const baseClasses =
-			'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors';
-
-		// 700-level backgrounds: white text on green/orange-600 is < 4.5:1
-		// (WCAG AA fail); green-700 = 5.02:1, orange-700 = 5.18:1.
-		const variantClasses = {
-			default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-			success:
-				'bg-green-700 text-white hover:bg-green-800 dark:bg-green-700 dark:hover:bg-green-800',
-			secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-			destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-			outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-			cancelled:
-				'bg-orange-700 text-white hover:bg-orange-800 dark:bg-orange-700 dark:hover:bg-orange-800'
-		};
-
-		return cn(baseClasses, variantClasses[variant]);
-	}
 </script>
 
 {#if badges.length > 0}
 	<div class={cn('flex flex-wrap gap-2', className)}>
 		{#each badges as badge (badge.label)}
-			<span class={getBadgeClasses(badge.variant)}>
-				{#if badge.hasIcon}
-					<EyeOff class="h-3 w-3" aria-hidden="true" />
-				{/if}
-				{badge.label}
-			</span>
+			<StatusBadge
+				tone={badge.tone}
+				label={badge.label}
+				icon={badge.hasIcon ? EyeOff : undefined}
+			/>
 		{/each}
 	</div>
 {/if}

--- a/src/lib/components/events/EventCard.svelte
+++ b/src/lib/components/events/EventCard.svelte
@@ -111,7 +111,8 @@
 	const containerClasses = $derived(
 		cn(
 			'group relative overflow-hidden rounded-lg border bg-card transition-all',
-			'hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+			// Same lift on all three discovery cards (event / series / organization).
+			'hover:-translate-y-0.5 hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',
 			isPast && 'opacity-75',
@@ -192,7 +193,7 @@
 		<div class="space-y-1">
 			<h3
 				class={cn(
-					'line-clamp-2 font-semibold leading-tight',
+					'line-clamp-2 font-bold leading-tight',
 					variant === 'compact' ? 'text-base md:text-lg' : 'text-lg'
 				)}
 			>
@@ -249,9 +250,13 @@
 					<div class="flex items-start gap-2 text-sm">
 						<Tag class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
 						<div class="flex flex-wrap gap-1">
+							<!-- Tag chips: primary on a 10% primary tint. The tint composites
+							     to ~the card colour, so primary-vs-card governs — 5.9:1 light /
+							     5.3:1 dark (recomputed by hand; a composited alpha is invisible
+							     to scripts/audit-brand-themes.py). -->
 							{#each event.tags.slice(0, 3) as tag (tag)}
 								<span
-									class="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+									class="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary"
 								>
 									{tag}
 								</span>

--- a/src/lib/components/events/EventConfirmationBanners.svelte
+++ b/src/lib/components/events/EventConfirmationBanners.svelte
@@ -15,7 +15,7 @@
 {#if paymentSuccess}
 	<div class="container mx-auto px-6 pt-4 md:px-8">
 		<div
-			class="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
+			class="flex items-center gap-2 rounded-lg border border-success/40 bg-success/10 p-4 text-foreground"
 			role="alert"
 		>
 			<svg class="h-5 w-5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
@@ -37,7 +37,7 @@
 {#if paymentCancelled}
 	<div class="container mx-auto px-6 pt-4 md:px-8">
 		<div
-			class="flex items-center gap-2 rounded-lg border border-yellow-200 bg-yellow-50 p-4 text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-100"
+			class="flex items-center gap-2 rounded-lg border border-highlight/50 bg-highlight/10 p-4 text-foreground"
 			role="alert"
 		>
 			<svg class="h-5 w-5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
@@ -59,7 +59,7 @@
 {#if rsvpConfirmed}
 	<div class="container mx-auto px-6 pt-4 md:px-8">
 		<div
-			class="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
+			class="flex items-center gap-2 rounded-lg border border-success/40 bg-success/10 p-4 text-foreground"
 			role="alert"
 		>
 			<svg class="h-5 w-5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
@@ -81,7 +81,7 @@
 {#if ticketConfirmed}
 	<div class="container mx-auto px-6 pt-4 md:px-8">
 		<div
-			class="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
+			class="flex items-center gap-2 rounded-lg border border-success/40 bg-success/10 p-4 text-foreground"
 			role="alert"
 		>
 			<svg class="h-5 w-5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">

--- a/src/lib/components/events/EventCoverImage.svelte
+++ b/src/lib/components/events/EventCoverImage.svelte
@@ -56,7 +56,7 @@
 			{#if logoUrl}
 				<div class="flex h-full w-full items-center justify-center p-4">
 					<div
-						class="aspect-square w-full max-w-[60%] overflow-hidden rounded-lg bg-white/10 p-4 backdrop-blur-sm"
+						class="aspect-square w-full max-w-[60%] overflow-hidden rounded-lg bg-poster-white/10 p-4 backdrop-blur-sm"
 					>
 						<img
 							src={logoUrl}
@@ -69,7 +69,7 @@
 			{:else}
 				<!-- Ultimate fallback: Calendar icon -->
 				<div class="flex h-full w-full items-center justify-center">
-					<Calendar class="h-16 w-16 text-white opacity-50" aria-hidden="true" />
+					<Calendar class="h-16 w-16 text-poster-white/60" aria-hidden="true" />
 				</div>
 			{/if}
 		</div>

--- a/src/lib/components/events/EventDetails.svelte
+++ b/src/lib/components/events/EventDetails.svelte
@@ -146,10 +146,27 @@
 
 			<!-- Capacity -->
 			{#if capacityText}
+				<!-- Urgency emphasis. There is no `--warning` token — the tone vocabulary
+			     maps warning -> highlight — so the previous `border-warning
+			     bg-warning/5` / `text-warning` compiled to NOTHING and this cell
+			     rendered identically to its calm siblings.
+			     What differentiates it, per mode, and why the text colour flips:
+			       * the CONTAINER is the differentiator in light mode — a warm
+			         `bg-highlight/10` wash beside plain white `bg-card` cells.
+			         `border-highlight` is 1.94:1 on the light card, so it is
+			         decoration, not the signal (WCAG 1.4.11 does not bind: this is
+			         an informational cell, not a control, and the words —
+			         "Only N spots left" / the relative deadline — carry the meaning).
+			       * `--highlight-foreground` is near-ink, so in light mode it is
+			         simply legible (14.88:1 on the tint) rather than emphatic; in
+			         dark mode `text-highlight` is the amber emphasis (7.54:1 on the
+			         tint). The flip is mandatory: amber itself is 1.94:1 on a light
+			         card. Ratios hand-computed — composited alpha is invisible to
+			         scripts/audit-brand-themes.py. -->
 				<div
 					class={cn(
 						'flex gap-3 rounded-lg border p-4',
-						isNearCapacity ? 'border-warning bg-warning/5' : 'bg-card'
+						isNearCapacity ? 'border-highlight bg-highlight/10' : 'bg-card'
 					)}
 				>
 					<Users class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
@@ -157,7 +174,13 @@
 						<div class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
 							{m['eventDetails.attendance_label']()}
 						</div>
-						<div class={cn('mt-1 font-bold', isNearCapacity && 'text-warning')} aria-live="polite">
+						<div
+							class={cn(
+								'mt-1 font-bold',
+								isNearCapacity && 'text-highlight-foreground dark:text-highlight'
+							)}
+							aria-live="polite"
+						>
 							{capacityText}
 							{#if seatsHeldText}
 								<span class="ml-1 text-xs font-normal text-muted-foreground">
@@ -171,10 +194,11 @@
 
 			<!-- RSVP Deadline -->
 			{#if rsvpDeadlineText}
+				<!-- Same recipe and same reasoning as the capacity cell above. -->
 				<div
 					class={cn(
 						'flex gap-3 rounded-lg border p-4',
-						isDeadlineSoon ? 'border-warning bg-warning/5' : 'bg-card'
+						isDeadlineSoon ? 'border-highlight bg-highlight/10' : 'bg-card'
 					)}
 				>
 					<Clock class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
@@ -184,7 +208,10 @@
 						</div>
 						<time
 							datetime={event.rsvp_before}
-							class={cn('mt-1 block font-bold', isDeadlineSoon && 'text-warning')}
+							class={cn(
+								'mt-1 block font-bold',
+								isDeadlineSoon && 'text-highlight-foreground dark:text-highlight'
+							)}
 							aria-live="polite"
 						>
 							{rsvpDeadlineText}

--- a/src/lib/components/events/EventDetails.svelte
+++ b/src/lib/components/events/EventDetails.svelte
@@ -5,6 +5,7 @@
 	import { cn } from '$lib/utils/cn';
 	import * as m from '$lib/paraglide/messages.js';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import EventTimezoneNote from './EventTimezoneNote.svelte';
 
 	interface Props {
@@ -91,9 +92,12 @@
 	{#if event.description}
 		{#key event.description}
 			<section aria-labelledby="description-heading">
-				<h2 id="description-heading" class="mb-3 text-xl font-semibold">
-					{m['eventDetails.about_heading']()}
-				</h2>
+				<SectionHeader
+					volume="celebration"
+					id="description-heading"
+					title={m['eventDetails.about_heading']()}
+					class="mb-3"
+				/>
 				<MarkdownContent content={event.description} class="max-w-prose" />
 			</section>
 		{/key}
@@ -101,20 +105,23 @@
 
 	<!-- Event Metadata Grid -->
 	<section aria-labelledby="details-heading">
-		<h2 id="details-heading" class="mb-3 text-xl font-semibold">
-			{m['eventDetails.details_heading']()}
-		</h2>
+		<SectionHeader
+			volume="celebration"
+			id="details-heading"
+			title={m['eventDetails.details_heading']()}
+			class="mb-3"
+		/>
 
 		<div class="grid gap-4 md:grid-cols-2">
 			<!-- Date & Time -->
 			<div class="flex gap-3 rounded-lg border bg-card p-4">
 				<Calendar class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
 				<div class="flex-1">
-					<div class="text-sm font-medium text-muted-foreground">
+					<div class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
 						{m['eventDetails.dateTime_label']()}
 					</div>
 					<div class="mt-1">
-						<time datetime={event.start} class="block font-medium">
+						<time datetime={event.start} class="block font-bold">
 							{formatEventDate(event.start, event.timezone, false)}
 						</time>
 						{#if event.is_open_ended}
@@ -147,13 +154,10 @@
 				>
 					<Users class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
 					<div class="flex-1">
-						<div class="text-sm font-medium text-muted-foreground">
+						<div class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
 							{m['eventDetails.attendance_label']()}
 						</div>
-						<div
-							class={cn('mt-1 font-medium', isNearCapacity && 'text-warning')}
-							aria-live="polite"
-						>
+						<div class={cn('mt-1 font-bold', isNearCapacity && 'text-warning')} aria-live="polite">
 							{capacityText}
 							{#if seatsHeldText}
 								<span class="ml-1 text-xs font-normal text-muted-foreground">
@@ -175,12 +179,12 @@
 				>
 					<Clock class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
 					<div class="flex-1">
-						<div class="text-sm font-medium text-muted-foreground">
+						<div class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
 							{m['eventDetails.rsvpDeadline_label']()}
 						</div>
 						<time
 							datetime={event.rsvp_before}
-							class={cn('mt-1 block font-medium', isDeadlineSoon && 'text-warning')}
+							class={cn('mt-1 block font-bold', isDeadlineSoon && 'text-warning')}
 							aria-live="polite"
 						>
 							{rsvpDeadlineText}
@@ -193,10 +197,10 @@
 			<div class="flex gap-3 rounded-lg border bg-card p-4">
 				<Info class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
 				<div class="flex-1">
-					<div class="text-sm font-medium text-muted-foreground">
+					<div class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
 						{m['eventDetails.eventType_label']()}
 					</div>
-					<div class="mt-1 font-medium capitalize">
+					<div class="mt-1 font-bold capitalize">
 						{event.event_type.replace('-', ' ')}
 					</div>
 					{#if visibilityMismatch}
@@ -226,9 +230,12 @@
 				aria-labelledby="invitation-heading"
 				class="rounded-lg border-2 border-primary/20 bg-primary/5 p-4"
 			>
-				<h2 id="invitation-heading" class="mb-2 text-lg font-semibold">
-					{m['eventDetails.invitation_heading']()}
-				</h2>
+				<SectionHeader
+					volume="celebration"
+					id="invitation-heading"
+					title={m['eventDetails.invitation_heading']()}
+					class="mb-2"
+				/>
 				<MarkdownContent content={event.invitation_message} class="max-w-prose" />
 			</section>
 		{/key}

--- a/src/lib/components/events/EventGuestSignInPrompt.svelte
+++ b/src/lib/components/events/EventGuestSignInPrompt.svelte
@@ -73,7 +73,7 @@
 		<div class="flex items-start gap-3">
 			<LogIn class="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
 			<div>
-				<h2 id="guest-signin-heading" class="font-semibold">
+				<h2 id="guest-signin-heading" class="text-xl font-extrabold">
 					{m['eventGuestPrompt.title']()}
 				</h2>
 				<p class="mt-1 text-sm text-muted-foreground">{m['eventGuestPrompt.subtitle']()}</p>
@@ -82,7 +82,7 @@
 		<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended returnUrl query cannot be expressed through resolve() -->
 		<a
 			href={loginHref}
-			class="inline-flex shrink-0 items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+			class="inline-flex shrink-0 items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 		>
 			{m['eventGuestPrompt.cta']()}
 		</a>
@@ -95,7 +95,7 @@
 		onclick={() => (isExpanded = !isExpanded)}
 		aria-expanded={isExpanded}
 		aria-controls="guest-signin-perks"
-		class="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+		class="mt-3 inline-flex items-center gap-1.5 text-sm font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 	>
 		{#if isExpanded}
 			<ChevronUp class="h-4 w-4" aria-hidden="true" />
@@ -112,7 +112,7 @@
 				<li class="flex items-start gap-3">
 					<Icon class="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
 					<div class="text-sm">
-						<p class="font-medium">{perk.label}</p>
+						<p class="font-bold">{perk.label}</p>
 						<p class="text-muted-foreground">{perk.description}</p>
 					</div>
 				</li>

--- a/src/lib/components/events/EventHeader.svelte
+++ b/src/lib/components/events/EventHeader.svelte
@@ -86,29 +86,49 @@
 			/>
 			<!-- Gradient overlay for text contrast -->
 			<div
-				class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent"
+				class="absolute inset-0 bg-gradient-to-t from-poster-ink/85 via-poster-ink/45 to-transparent"
 			></div>
 		{:else}
-			<!-- Fallback gradient -->
-			<div class="h-full w-full {fallbackGradient}"></div>
-			<div class="absolute inset-0 bg-gradient-to-br from-black/20 to-black/40"></div>
+			<!-- Fallback cover. The direction utility was missing here, so the colour
+			     stops painted nothing and the hero rendered on bare background;
+			     restored alongside the poster ramp. The scrim now matches the
+			     cover-image branch, and the type block sits in the bottom third
+			     where `from-poster-ink/85` applies. Hand-computed against the
+			     LIGHTEST stop in the ramp (lavender, 68% L), because a composited
+			     alpha is invisible to scripts/audit-brand-themes.py:
+			       ink@85% over lavender → 14.1:1 vs white, 11.7:1 vs white/90
+			       ink@45% over lavender (mid-gradient) → 6.7:1 / 5.8:1
+			     so every text layer here clears AA on every cover. -->
+			<div class="h-full w-full bg-gradient-to-br {fallbackGradient}"></div>
+			<div
+				class="absolute inset-0 bg-gradient-to-t from-poster-ink/85 via-poster-ink/45 to-poster-ink/20"
+			></div>
 		{/if}
 
 		<!-- Header Content Overlay -->
 		<div class="absolute inset-0 flex flex-col justify-end p-6 pb-12 md:p-8">
 			<div class="max-w-4xl">
+				<!-- Kicker: who is putting this on. The organization badge below the
+				     cover repeats it as a link; up here it is the eyebrow that gives
+				     the display title something to sit on. -->
+				<p class="mb-1 text-sm font-extrabold uppercase tracking-[0.12em] text-poster-white/90">
+					{event.organization.name}
+				</p>
+
 				<!-- Event Name -->
-				<h1 class="mb-3 text-3xl font-bold text-white md:text-4xl lg:text-5xl">
+				<h1
+					class="mb-3 text-3xl font-black leading-[1.12] text-poster-white sm:text-4xl lg:text-5xl"
+				>
 					{event.name}
 				</h1>
 
 				<!-- Metadata Row -->
-				<div class="flex flex-col gap-2 text-sm text-white/90 md:text-base">
+				<div class="flex flex-col gap-2 text-sm text-poster-white/90 md:text-base">
 					<!-- Date (clickable to download iCal) -->
 					<button
 						type="button"
 						onclick={handleDownloadCalendar}
-						class="group flex items-center gap-2 transition-all hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/50"
+						class="group flex items-center gap-2 transition-all hover:text-poster-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50"
 						title={m['eventHeader.downloadCalendarEventTitle']()}
 						aria-label={m['eventHeader.downloadCalendarEventFor']({ name: event.name })}
 					>
@@ -126,7 +146,7 @@
 							href={mapsUrl}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="group flex items-center gap-2 transition-all hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/50"
+							class="group flex items-center gap-2 transition-all hover:text-poster-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50"
 							aria-label="{locationDisplay} - {m['eventQuickInfo.openInMaps']()}"
 						>
 							<MapPin class="h-5 w-5 shrink-0" aria-hidden="true" />
@@ -147,10 +167,10 @@
 			<button
 				type="button"
 				onclick={handleShare}
-				class="absolute right-6 top-6 hidden rounded-full bg-white/20 p-3 backdrop-blur-sm transition-all hover:bg-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/50 md:block"
+				class="absolute right-6 top-6 hidden rounded-full bg-poster-white/20 p-3 backdrop-blur-sm transition-all hover:bg-poster-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50 md:block"
 				aria-label={m['eventHeader.shareEvent']()}
 			>
-				<Share2 class="h-5 w-5 text-white" aria-hidden="true" />
+				<Share2 class="h-5 w-5 text-poster-white" aria-hidden="true" />
 			</button>
 		</div>
 	</div>
@@ -178,8 +198,10 @@
 			{/if}
 
 			<div class="flex flex-col">
-				<span class="text-xs text-muted-foreground">{m['eventHeader.organizedBy']()}</span>
-				<span class="font-semibold text-foreground group-hover:text-primary">
+				<span class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+					{m['eventHeader.organizedBy']()}
+				</span>
+				<span class="font-bold text-foreground group-hover:text-primary">
 					{event.organization.name}
 				</span>
 			</div>

--- a/src/lib/components/events/EventQuickInfo.svelte
+++ b/src/lib/components/events/EventQuickInfo.svelte
@@ -298,8 +298,16 @@
 
 	<!-- Capacity Status (if max_capacity exists) -->
 	{#if capacityDisplay}
+		<!-- `text-warning` compiled to nothing (no `--warning` token; the tone
+		     vocabulary maps warning -> highlight), so this row rendered plain.
+		     These are compact sidebar rows with no container to tint, so the
+		     emphasis has to be the text: `highlight-foreground` in light (15.90:1
+		     on the card — legible, near-ink) flipping to `highlight` in dark
+		     (9.17:1). The flip is mandatory: amber is 1.94:1 on a light card. The
+		     "Limited spots" / "Closes soon" line beneath says it in words, so
+		     nothing here is carried by colour alone. -->
 		<div
-			class={cn(itemClasses, isNearCapacity && 'text-warning')}
+			class={cn(itemClasses, isNearCapacity && 'text-highlight-foreground dark:text-highlight')}
 			role="listitem"
 			aria-live="polite"
 		>
@@ -316,7 +324,7 @@
 	<!-- RSVP Deadline (if rsvp_closes_at exists and event is not ticketed) -->
 	{#if rsvpDeadlineDisplay && !event.requires_ticket}
 		<div
-			class={cn(itemClasses, isDeadlineSoon && 'text-warning')}
+			class={cn(itemClasses, isDeadlineSoon && 'text-highlight-foreground dark:text-highlight')}
 			role="listitem"
 			aria-live="polite"
 		>

--- a/src/lib/components/events/EventQuickInfo.svelte
+++ b/src/lib/components/events/EventQuickInfo.svelte
@@ -208,7 +208,7 @@
 	<div class={itemClasses} role="listitem">
 		<Calendar class={iconClasses} aria-hidden="true" />
 		<div class={textClasses}>
-			<time datetime={event.start} class="block font-medium">
+			<time datetime={event.start} class="block font-bold">
 				{formattedStartDate}
 			</time>
 		</div>
@@ -305,7 +305,7 @@
 		>
 			<Users class={iconClasses} aria-hidden="true" />
 			<div class={textClasses}>
-				<span class="block font-medium">{capacityDisplay}</span>
+				<span class="block font-bold">{capacityDisplay}</span>
 				{#if isNearCapacity}
 					<span class="text-xs text-muted-foreground">{m['eventQuickInfo.limitedSpots']()}</span>
 				{/if}
@@ -322,7 +322,7 @@
 		>
 			<Clock class={iconClasses} aria-hidden="true" />
 			<div class={textClasses}>
-				<time datetime={event.rsvp_before} class="block font-medium">
+				<time datetime={event.rsvp_before} class="block font-bold">
 					{rsvpDeadlineDisplay}
 				</time>
 				{#if isDeadlineSoon}

--- a/src/lib/components/events/EventRSVP.svelte
+++ b/src/lib/components/events/EventRSVP.svelte
@@ -457,19 +457,19 @@
 		{#if showSuccess && successMessage}
 			<div
 				class={cn(
-					'flex items-start gap-3 rounded-md p-4',
-					successType === 'yes' &&
-						'bg-green-50 text-green-900 dark:bg-green-950/50 dark:text-green-100',
-					successType === 'maybe' &&
-						'bg-yellow-50 text-yellow-900 dark:bg-yellow-950/50 dark:text-yellow-100',
-					successType === 'no' && 'bg-red-50 text-red-900 dark:bg-red-950/50 dark:text-red-100'
+					// Tints at 10% composite to ~the page colour, so the copy keeps
+					// `text-foreground` and the token contract's AA guarantee.
+					'flex items-start gap-3 rounded-md p-4 text-foreground',
+					successType === 'yes' && 'bg-success/10',
+					successType === 'maybe' && 'bg-highlight/10',
+					successType === 'no' && 'bg-destructive/10'
 				)}
 				role="status"
 				aria-live="polite"
 			>
 				<Check class="mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" />
 				<div class="flex-1">
-					<p class="font-semibold">{successMessage}</p>
+					<p class="font-extrabold">{successMessage}</p>
 					{#if noteNotSaved}
 						<p class="mt-1 text-sm">{m['eventRSVP.noteNotSaved']()}</p>
 					{/if}
@@ -478,9 +478,9 @@
 						onclick={handleChangeResponse}
 						class={cn(
 							'mt-2 text-sm underline hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
-							successType === 'yes' && 'focus-visible:ring-green-600',
-							successType === 'maybe' && 'focus-visible:ring-yellow-600',
-							successType === 'no' && 'focus-visible:ring-red-600'
+							successType === 'yes' && 'focus-visible:ring-success',
+							successType === 'maybe' && 'focus-visible:ring-highlight',
+							successType === 'no' && 'focus-visible:ring-destructive'
 						)}
 					>
 						{m['eventRSVP.changeResponse']()}

--- a/src/lib/components/events/EventResources.svelte
+++ b/src/lib/components/events/EventResources.svelte
@@ -4,6 +4,8 @@
 	import { FileText, Link as LinkIcon, AlignLeft, ExternalLink, Download } from '@lucide/svelte';
 	import { getBackendUrl } from '$lib/config/api';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 
 	interface Props {
 		resources: AdditionalResourceSchema[];
@@ -38,8 +40,13 @@
 </script>
 
 {#if hasResources}
-	<section class="rounded-lg border bg-card p-6">
-		<h2 class="mb-4 text-xl font-bold">{m['eventResources.title']()}</h2>
+	<section class="rounded-lg border bg-card p-6" aria-labelledby="event-resources-heading">
+		<SectionHeader
+			volume="celebration"
+			id="event-resources-heading"
+			title={m['eventResources.title']()}
+			class="mb-4"
+		/>
 		<p class="mb-6 text-sm text-muted-foreground">{m['eventResources.description']()}</p>
 
 		<div class="space-y-3">
@@ -49,15 +56,11 @@
 					class="flex items-start gap-4 rounded-md border p-4 transition-all hover:bg-accent/50"
 				>
 					<!-- Icon -->
-					<div
-						class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary"
-					>
-						<IconComponent class="h-5 w-5" aria-hidden="true" />
-					</div>
+					<ToneTile tone="brand" icon={IconComponent} />
 
 					<!-- Content -->
 					<div class="min-w-0 flex-1">
-						<h3 class="font-semibold leading-tight">
+						<h3 class="font-bold leading-tight">
 							{resource.name || 'Untitled Resource'}
 						</h3>
 						{#if resource.description}
@@ -82,7 +85,7 @@
 						<button
 							type="button"
 							onclick={() => openResource(resource)}
-							class="shrink-0 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							class="shrink-0 rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 							aria-label={resource.resource_type === 'file' ? 'Download file' : 'Open link'}
 						>
 							<span class="flex items-center gap-2">

--- a/src/lib/components/events/EventSchedule.svelte
+++ b/src/lib/components/events/EventSchedule.svelte
@@ -4,6 +4,7 @@
 	import { formatTimeOfDay, formatDate } from '$lib/utils/date';
 	import { AlertCircle, MapPin } from '@lucide/svelte';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import EventTimezoneNote from './EventTimezoneNote.svelte';
 
 	interface Props {
@@ -53,7 +54,12 @@
 
 {#if hasSchedule}
 	<section class="rounded-lg border bg-card p-6" aria-labelledby="schedule-heading">
-		<h2 id="schedule-heading" class="mb-4 text-xl font-bold">{m['eventSchedule.title']()}</h2>
+		<SectionHeader
+			volume="celebration"
+			id="schedule-heading"
+			title={m['eventSchedule.title']()}
+			class="mb-4"
+		/>
 		<p class="mb-2 text-sm text-muted-foreground">{m['eventSchedule.description']()}</p>
 
 		<!-- Times below are in the event timezone, not the viewer's — shown once here. -->
@@ -65,7 +71,7 @@
 				<li class="flex items-start gap-4 rounded-md border p-4">
 					<!-- Time column -->
 					<div class="w-24 shrink-0 sm:w-28">
-						<p class="text-sm font-semibold tabular-nums leading-tight">{timeLabel(session)}</p>
+						<p class="text-sm font-bold tabular-nums leading-tight">{timeLabel(session)}</p>
 						{#if day}
 							<p class="mt-0.5 text-xs text-muted-foreground">{day}</p>
 						{/if}
@@ -74,10 +80,10 @@
 					<!-- Details -->
 					<div class="min-w-0 flex-1">
 						<div class="flex flex-wrap items-center gap-2">
-							<h3 class="font-semibold leading-tight">{session.title}</h3>
+							<h3 class="font-bold leading-tight">{session.title}</h3>
 							{#if session.is_required}
 								<span
-									class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+									class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary"
 								>
 									<AlertCircle class="h-3 w-3" aria-hidden="true" />
 									{m['eventSchedule.requiredBadge']()}

--- a/src/lib/components/events/EventSeriesCard.svelte
+++ b/src/lib/components/events/EventSeriesCard.svelte
@@ -5,6 +5,7 @@
 	import { cn } from '$lib/utils/cn';
 	import { getImageUrl } from '$lib/utils/url';
 	import { Calendar, Tag, Users } from '@lucide/svelte';
+	import { getPosterFallbackGradient } from '$lib/utils/fallback-gradient';
 
 	interface Props {
 		series: EventSeriesRetrieveSchema;
@@ -58,15 +59,9 @@
 		seriesLogoThumbnailUrl || seriesLogoUrl || orgLogoThumbnailUrl || orgLogoUrl
 	);
 
-	// Fallback gradient based on series ID
-	const gradients = [
-		'from-blue-500 to-purple-600',
-		'from-green-500 to-teal-600',
-		'from-orange-500 to-pink-600',
-		'from-purple-500 to-indigo-600',
-		'from-red-500 to-orange-600'
-	];
-	const fallbackGradient = $derived(gradients[series.id.charCodeAt(0) % gradients.length]);
+	// Fallback gradient based on series ID — shared poster ramp, so a series, its
+	// organization and its events fall back to the same visual family.
+	const fallbackGradient = $derived(getPosterFallbackGradient(series.id));
 
 	// Accessible card label for screen readers
 	const accessibleLabel = $derived.by(() => {
@@ -88,7 +83,8 @@
 	const containerClasses = $derived(
 		cn(
 			'group relative overflow-hidden rounded-lg border bg-card transition-all',
-			'hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+			// Same lift on all three discovery cards (event / series / organization).
+			'hover:-translate-y-0.5 hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',
 			className
@@ -150,7 +146,7 @@
 				{:else}
 					<!-- Ultimate fallback: Users icon -->
 					<div class="flex h-full w-full items-center justify-center">
-						<Users class="h-16 w-16 text-white opacity-50" aria-hidden="true" />
+						<Users class="h-16 w-16 text-poster-white/60" aria-hidden="true" />
 					</div>
 				{/if}
 			</div>
@@ -159,7 +155,7 @@
 		<!-- Series indicator badge (top-right) -->
 		<div class="absolute right-2 top-2 z-20">
 			<div
-				class="rounded-full bg-background/90 px-2 py-1 text-xs font-medium backdrop-blur-sm"
+				class="rounded-full bg-background/90 px-2 py-1 text-xs font-bold backdrop-blur-sm"
 				aria-label={m['eventSeriesCard.eventSeries']()}
 			>
 				<div class="flex items-center gap-1">
@@ -181,7 +177,7 @@
 		<div class="space-y-1">
 			<h3
 				class={cn(
-					'line-clamp-2 font-semibold leading-tight',
+					'line-clamp-2 font-bold leading-tight',
 					variant === 'compact' ? 'text-base md:text-lg' : 'text-lg'
 				)}
 			>
@@ -212,9 +208,13 @@
 					<div class="flex items-start gap-2 text-sm">
 						<Tag class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
 						<div class="flex flex-wrap gap-1">
+							<!-- Tag chips: primary on a 10% primary tint. The tint composites
+							     to ~the card colour, so primary-vs-card governs — 5.9:1 light /
+							     5.3:1 dark (hand-recomputed; a composited alpha is invisible to
+							     scripts/audit-brand-themes.py). -->
 							{#each series.tags.slice(0, 3) as tag (tag)}
 								<span
-									class="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+									class="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary"
 								>
 									{tag}
 								</span>

--- a/src/lib/components/events/EventStatusBadge.svelte
+++ b/src/lib/components/events/EventStatusBadge.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { EventDetailSchema, EventStatus } from '$lib/api/generated/types.gen';
-	import { cn } from '$lib/utils/cn';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import {
 		Calendar,
 		Clock,
@@ -30,11 +31,23 @@
 	const { event, class: className }: Props = $props();
 
 	/**
-	 * Badge configuration with label, variant, and icon
+	 * Badge configuration with label, tone, and icon
 	 */
 	interface BadgeConfig {
 		label: string;
-		variant: 'success' | 'default' | 'secondary' | 'destructive' | 'cancelled';
+		/**
+		 * Semantic tone, resolved here rather than a private colour table: this is
+		 * the domain→tone mapper the rebrand asks for, so every fill is an audited
+		 * `StatusBadge` token pair.
+		 *
+		 * The one collapse worth naming: CANCELLED and CLOSED used to be two
+		 * hand-picked hues (orange-700 / destructive). They stay distinguishable —
+		 * cancelled is `warning` (amber, the organizer called it off), closed is
+		 * `danger` (red, no longer joinable) — and, per the house rule, the label
+		 * carries the distinction on its own for anyone who cannot separate the
+		 * two hues.
+		 */
+		tone: Tone;
 		icon: LucideIcon;
 	}
 
@@ -55,7 +68,7 @@
 		if (event.status === 'draft') {
 			return {
 				label: m['orgAdmin.events.status.draft'](),
-				variant: 'secondary',
+				tone: 'neutral',
 				icon: FileText
 			};
 		}
@@ -63,7 +76,7 @@
 		if (event.status === 'cancelled') {
 			return {
 				label: m['orgAdmin.events.status.cancelled'](),
-				variant: 'cancelled',
+				tone: 'warning',
 				icon: Ban
 			};
 		}
@@ -71,7 +84,7 @@
 		if (event.status === 'closed') {
 			return {
 				label: m['orgAdmin.events.status.closed'](),
-				variant: 'destructive',
+				tone: 'danger',
 				icon: XCircle
 			};
 		}
@@ -85,7 +98,7 @@
 		if (endDate < now) {
 			return {
 				label: m['eventStatus.past'](),
-				variant: 'secondary',
+				tone: 'neutral',
 				icon: CheckCircle
 			};
 		}
@@ -96,7 +109,7 @@
 		if (event.is_full === true) {
 			return {
 				label: m['eventStatus.full'](),
-				variant: 'destructive',
+				tone: 'danger',
 				icon: AlertCircle
 			};
 		}
@@ -105,7 +118,7 @@
 		if (startDate <= now && now <= endDate) {
 			return {
 				label: m['eventStatus.ongoing'](),
-				variant: 'success',
+				tone: 'success',
 				icon: Clock
 			};
 		}
@@ -118,7 +131,7 @@
 		if (isToday) {
 			return {
 				label: m['eventStatus.happeningToday'](),
-				variant: 'success',
+				tone: 'success',
 				icon: Calendar
 			};
 		}
@@ -126,33 +139,10 @@
 		// 5. Default: Upcoming
 		return {
 			label: m['eventStatus.upcoming'](),
-			variant: 'default',
+			tone: 'brand',
 			icon: Calendar
 		};
 	});
-
-	/**
-	 * Get Tailwind classes for badge variant
-	 */
-	function getBadgeClasses(variant: BadgeConfig['variant']): string {
-		const baseClasses =
-			'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors';
-
-		// 700-level backgrounds: white text on green/orange-600 is < 4.5:1
-		// (WCAG AA fail — caught by the E2E a11y smoke once cancelled events
-		// appeared); green-700 = 5.02:1, orange-700 = 5.18:1.
-		const variantClasses = {
-			success:
-				'bg-green-700 text-white hover:bg-green-800 dark:bg-green-700 dark:hover:bg-green-800',
-			default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-			secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-			destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-			cancelled:
-				'bg-orange-700 text-white hover:bg-orange-800 dark:bg-orange-700 dark:hover:bg-orange-800'
-		};
-
-		return cn(baseClasses, variantClasses[variant]);
-	}
 </script>
 
 <!--
@@ -167,9 +157,12 @@
   <EventStatusBadge event={data.event} class="mb-4" />
 -->
 {#if badge}
-	{@const IconComponent = badge.icon}
-	<span class={cn(getBadgeClasses(badge.variant), className)} role="status" aria-live="polite">
-		<IconComponent class="h-3 w-3" aria-hidden="true" />
-		<span>{badge.label}</span>
-	</span>
+	<StatusBadge
+		tone={badge.tone}
+		label={badge.label}
+		icon={badge.icon}
+		class={className}
+		role="status"
+		aria-live="polite"
+	/>
 {/if}

--- a/src/lib/components/events/EventStatusBadge.test.ts
+++ b/src/lib/components/events/EventStatusBadge.test.ts
@@ -64,7 +64,7 @@ describe('EventStatusBadge', () => {
 			render(EventStatusBadge, { props: { event } });
 
 			expect(screen.getByRole('status')).toHaveTextContent('Cancelled');
-			expect(screen.getByRole('status')).toHaveClass('bg-orange-700');
+			expect(screen.getByRole('status')).toHaveClass('bg-highlight');
 		});
 	});
 
@@ -146,7 +146,7 @@ describe('EventStatusBadge', () => {
 			render(EventStatusBadge, { props: { event } });
 
 			expect(screen.getByRole('status')).toHaveTextContent('Past');
-			expect(screen.getByRole('status')).toHaveClass('bg-secondary');
+			expect(screen.getByRole('status')).toHaveClass('bg-muted');
 		});
 	});
 
@@ -162,7 +162,7 @@ describe('EventStatusBadge', () => {
 			render(EventStatusBadge, { props: { event } });
 
 			expect(screen.getByRole('status')).toHaveTextContent('Ongoing');
-			expect(screen.getByRole('status')).toHaveClass('bg-green-700');
+			expect(screen.getByRole('status')).toHaveClass('bg-success');
 		});
 
 		it('shows "Ongoing" at the exact start time', () => {
@@ -204,7 +204,7 @@ describe('EventStatusBadge', () => {
 			render(EventStatusBadge, { props: { event } });
 
 			expect(screen.getByRole('status')).toHaveTextContent('Happening Today');
-			expect(screen.getByRole('status')).toHaveClass('bg-green-700');
+			expect(screen.getByRole('status')).toHaveClass('bg-success');
 		});
 
 		it('does not show "Happening Today" for events starting tomorrow', () => {

--- a/src/lib/components/events/IneligibilityActionButton.svelte
+++ b/src/lib/components/events/IneligibilityActionButton.svelte
@@ -429,7 +429,7 @@
 		<!-- Success Message -->
 		{#if showSuccess}
 			<div
-				class="rounded-md bg-green-50 p-3 text-sm text-green-900 dark:bg-green-950/50 dark:text-green-100"
+				class="rounded-md bg-success/10 p-3 text-sm text-foreground"
 				role="status"
 				aria-live="polite"
 			>

--- a/src/lib/components/events/IneligibilityMessage.svelte
+++ b/src/lib/components/events/IneligibilityMessage.svelte
@@ -342,11 +342,9 @@
 	 */
 	function getVariantClasses(variant: 'warning' | 'info' | 'destructive' | 'muted'): string {
 		const classes = {
-			warning:
-				'border-yellow-200 bg-yellow-50 text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950/50 dark:text-yellow-100',
-			info: 'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950/50 dark:text-blue-100',
-			destructive:
-				'border-red-200 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950/50 dark:text-red-100',
+			warning: 'border-highlight/50 bg-highlight/10 text-foreground',
+			info: 'border-info/40 bg-info/10 text-foreground',
+			destructive: 'border-destructive/40 bg-destructive/10 text-foreground',
 			muted:
 				'border-muted-foreground/20 bg-muted/50 text-muted-foreground dark:border-muted-foreground/10'
 		};
@@ -455,7 +453,7 @@
 			<!-- Application Deadline Display -->
 			{#if shouldShowDeadline && applyBefore}
 				<div
-					class="flex items-center gap-2 rounded-md bg-orange-50 px-3 py-2 text-sm text-orange-800 dark:bg-orange-950/30 dark:text-orange-200"
+					class="flex items-center gap-2 rounded-md bg-highlight/10 px-3 py-2 text-sm text-foreground"
 				>
 					<Calendar class="h-4 w-4 shrink-0" aria-hidden="true" />
 					<span>

--- a/src/lib/components/events/OrganizationInfo.svelte
+++ b/src/lib/components/events/OrganizationInfo.svelte
@@ -13,6 +13,7 @@
 	import OrgContactButton from '$lib/components/organization/OrgContactButton.svelte';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import FollowButton from '$lib/components/common/FollowButton.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 
 	interface Props {
 		organization: OrganizationRetrieveSchema;
@@ -53,9 +54,11 @@
 </script>
 
 <section aria-labelledby="organizer-heading" class={cn('space-y-4', className)}>
-	<h2 id="organizer-heading" class="text-xl font-semibold">
-		{m['organizationInfo.aboutOrganizer']()}
-	</h2>
+	<SectionHeader
+		volume="celebration"
+		id="organizer-heading"
+		title={m['organizationInfo.aboutOrganizer']()}
+	/>
 
 	<div class="rounded-lg border bg-card p-6">
 		<!-- Organization Header -->
@@ -75,7 +78,7 @@
 			{/if}
 
 			<div class="flex-1">
-				<h3 class="text-lg font-semibold">{organization.name}</h3>
+				<h3 class="text-lg font-bold">{organization.name}</h3>
 				{#if organization.description}
 					<MarkdownContent
 						content={organization.description}
@@ -89,7 +92,7 @@
 		<div class="mt-6 flex flex-wrap gap-2">
 			<a
 				href={resolve('/(public)/org/[slug]', { slug: organization.slug })}
-				class="inline-flex rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				class="inline-flex rounded-md border border-input bg-background px-4 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 			>
 				{m['organizationInfo.viewProfile']()}
 			</a>

--- a/src/lib/components/events/PotluckItem.svelte
+++ b/src/lib/components/events/PotluckItem.svelte
@@ -139,12 +139,9 @@
 		<span
 			class={cn(
 				'shrink-0 rounded-full border px-2 py-1 text-xs font-medium',
-				statusBadgeVariant === 'success' &&
-					'border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-300',
-				statusBadgeVariant === 'info' &&
-					'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300',
-				statusBadgeVariant === 'default' &&
-					'border-gray-200 bg-gray-50 text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300'
+				statusBadgeVariant === 'success' && 'border-success/40 bg-success/10 text-foreground',
+				statusBadgeVariant === 'info' && 'border-info/40 bg-info/10 text-foreground',
+				statusBadgeVariant === 'default' && 'border-border bg-muted text-muted-foreground'
 			)}
 			aria-label={`Status: ${statusBadgeText}`}
 		>

--- a/src/lib/components/events/PotluckSection.svelte
+++ b/src/lib/components/events/PotluckSection.svelte
@@ -459,7 +459,7 @@
 			class="flex w-full items-center justify-between text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 		>
 			<div class="flex-1">
-				<h2 id="potluck-heading" class="text-xl font-semibold">{m['potluck.heading']()}</h2>
+				<h2 id="potluck-heading" class="text-xl font-extrabold">{m['potluck.heading']()}</h2>
 				<p class="mt-1 text-sm text-muted-foreground">
 					{stats.total}
 					{m['common.plurals_items']()} • {stats.claimed}
@@ -525,7 +525,7 @@
 					<button
 						type="button"
 						onclick={handleAddClick}
-						class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<Plus class="h-4 w-4" aria-hidden="true" />
 						{permissions.hasManagePermission
@@ -577,7 +577,7 @@
 				{#each Object.entries(groupedItems) as [category, items] (category)}
 					{#if items.length > 0}
 						<div class="space-y-3">
-							<h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+							<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
 								{category} ({items.length})
 							</h3>
 							<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/lib/components/events/RSVPButtons.svelte
+++ b/src/lib/components/events/RSVPButtons.svelte
@@ -55,30 +55,36 @@
 
 		return cn(
 			// Base styles
-			'flex h-12 w-full min-w-0 items-center justify-center gap-2 rounded-md px-4 py-3 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+			'flex h-12 w-full min-w-0 items-center justify-center gap-2 rounded-md px-4 py-3 text-sm font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 			// Mobile, Tablet, Desktop: Full width, 48px height for touch
 			'xl:h-auto xl:min-w-[120px]',
-			// Yes button - Green theme
+			// The yes/maybe/no triad IS the semantic triad, so it now rides the
+			// success / highlight / destructive tokens instead of a hand-picked
+			// green/yellow/red ramp — same meaning, audited pairs, one dark mode.
+			//
+			// Unselected: a 10% tint that composites to ~the page colour, so the
+			// label stays `text-foreground` and inherits the token contract's AA
+			// guarantee. Selected: the solid token pair, which the audit script
+			// enforces at >= 4.5:1 in both modes. Selection is also carried by
+			// `aria-pressed` and the ring, never by fill alone.
 			answer === 'yes' &&
 				!selected &&
-				'border-2 border-green-200 bg-green-50 text-green-700 hover:border-green-300 hover:bg-green-100 dark:border-green-900 dark:bg-green-950 dark:text-green-400 dark:hover:border-green-800 dark:hover:bg-green-900',
+				'border-2 border-success/40 bg-success/10 text-foreground hover:border-success hover:bg-success/20',
 			answer === 'yes' &&
 				selected &&
-				'border-2 border-green-600 bg-green-600 text-white ring-2 ring-green-300 dark:border-green-500 dark:bg-green-500 dark:ring-green-400',
-			// Maybe button - Yellow theme
+				'border-2 border-success bg-success text-success-foreground ring-2 ring-success/50',
 			answer === 'maybe' &&
 				!selected &&
-				'border-2 border-yellow-200 bg-yellow-50 text-yellow-700 hover:border-yellow-300 hover:bg-yellow-100 dark:border-yellow-900 dark:bg-yellow-950 dark:text-yellow-400 dark:hover:border-yellow-800 dark:hover:bg-yellow-900',
+				'border-2 border-highlight/50 bg-highlight/10 text-foreground hover:border-highlight hover:bg-highlight/20',
 			answer === 'maybe' &&
 				selected &&
-				'border-2 border-yellow-500 bg-yellow-500 text-white ring-2 ring-yellow-300 dark:border-yellow-600 dark:bg-yellow-600 dark:ring-yellow-400',
-			// No button - Red theme
+				'border-2 border-highlight bg-highlight text-highlight-foreground ring-2 ring-highlight/50',
 			answer === 'no' &&
 				!selected &&
-				'border-2 border-red-200 bg-red-50 text-red-700 hover:border-red-300 hover:bg-red-100 dark:border-red-900 dark:bg-red-950 dark:text-red-400 dark:hover:border-red-800 dark:hover:bg-red-900',
+				'border-2 border-destructive/40 bg-destructive/10 text-foreground hover:border-destructive hover:bg-destructive/20',
 			answer === 'no' &&
 				selected &&
-				'border-2 border-red-600 bg-red-600 text-white ring-2 ring-red-300 dark:border-red-500 dark:bg-red-500 dark:ring-red-400',
+				'border-2 border-destructive bg-destructive text-destructive-foreground ring-2 ring-destructive/50',
 			// Loading state
 			loading && 'cursor-wait',
 			// Disabled state

--- a/src/lib/components/events/RequestInvitationButton.svelte
+++ b/src/lib/components/events/RequestInvitationButton.svelte
@@ -101,7 +101,7 @@
 {#if hasAlreadyRequested}
 	<!-- Already Requested Badge -->
 	<div
-		class="inline-flex items-center gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-2 text-sm font-medium text-yellow-700 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-300 {className}"
+		class="inline-flex items-center gap-2 rounded-md border border-highlight/50 bg-highlight/10 px-4 py-2 text-sm font-bold text-foreground {className}"
 		role="status"
 		aria-label={m['requestInvitationButton.alreadyRequestedAriaLabel']()}
 	>
@@ -122,10 +122,10 @@
 				<!-- Success State -->
 				<div class="py-8 text-center">
 					<div
-						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900"
+						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-success/10"
 					>
 						<svg
-							class="h-8 w-8 text-green-600 dark:text-green-300"
+							class="h-8 w-8 text-success"
 							fill="none"
 							stroke="currentColor"
 							viewBox="0 0 24 24"
@@ -175,7 +175,7 @@
 							placeholder={m['requestInvitationButton.messagePlaceholder']()}
 							rows="4"
 							maxlength="500"
-							class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+							class="mt-1 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						></textarea>
 						<p class="mt-1 text-xs text-muted-foreground">
 							{m['requestInvitationButton.characterCount']({ count: message.length })}
@@ -184,7 +184,7 @@
 
 					{#if requestMutation.isError}
 						<div
-							class="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+							class="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-foreground"
 							role="alert"
 						>
 							{requestMutation.error?.message ||

--- a/src/lib/components/events/RequestWhitelistButton.svelte
+++ b/src/lib/components/events/RequestWhitelistButton.svelte
@@ -106,7 +106,7 @@
 {#if hasAlreadyRequested}
 	<!-- Already Requested Badge -->
 	<div
-		class="inline-flex items-center gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-2 text-sm font-medium text-yellow-700 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-300 {className}"
+		class="inline-flex items-center gap-2 rounded-md border border-highlight/50 bg-highlight/10 px-4 py-2 text-sm font-bold text-foreground {className}"
 		role="status"
 		aria-label={m['requestWhitelistButton.alreadyRequested']()}
 	>
@@ -127,10 +127,10 @@
 				<!-- Success State -->
 				<div class="py-8 text-center">
 					<div
-						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900"
+						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-success/10"
 					>
 						<svg
-							class="h-8 w-8 text-green-600 dark:text-green-300"
+							class="h-8 w-8 text-success"
 							fill="none"
 							stroke="currentColor"
 							viewBox="0 0 24 24"
@@ -186,7 +186,7 @@
 							placeholder={m['requestWhitelistButton.messagePlaceholder']()}
 							rows="4"
 							maxlength="500"
-							class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+							class="mt-1 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						></textarea>
 						<p class="mt-1 text-xs text-muted-foreground">
 							{m['requestWhitelistButton.characterCount']({ count: message.length })}
@@ -195,7 +195,7 @@
 
 					{#if requestMutation.isError}
 						<div
-							class="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+							class="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-foreground"
 							role="alert"
 						>
 							{requestMutation.error?.message ||

--- a/src/lib/components/events/RsvpNoteDialog.svelte
+++ b/src/lib/components/events/RsvpNoteDialog.svelte
@@ -45,12 +45,9 @@
 
 	const confirmClasses = $derived(
 		cn(
-			answer === 'yes' &&
-				'bg-green-600 text-white hover:bg-green-700 dark:bg-green-500 dark:text-white dark:hover:bg-green-600',
-			answer === 'maybe' &&
-				'bg-yellow-500 text-white hover:bg-yellow-600 dark:bg-yellow-600 dark:text-white dark:hover:bg-yellow-700',
-			answer === 'no' &&
-				'bg-red-600 text-white hover:bg-red-700 dark:bg-red-500 dark:text-white dark:hover:bg-red-600'
+			answer === 'yes' && 'bg-success text-success-foreground hover:bg-success/90',
+			answer === 'maybe' && 'bg-highlight text-highlight-foreground hover:bg-highlight/90',
+			answer === 'no' && 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
 		)
 	);
 </script>

--- a/src/lib/components/events/admin/TierCard.svelte
+++ b/src/lib/components/events/admin/TierCard.svelte
@@ -153,9 +153,23 @@
 {/snippet}
 
 {#snippet meta()}
-	<!-- Tier details. Price and type are promoted to the card's display price
-	     above, so this grid states everything the price line cannot. -->
+	<!-- Tier details. The price is ALSO promoted to the card's display number
+	     above, but it keeps its labelled `<dt>` row here: this is an organizer's
+	     config summary, where every configured field is expected to be readable
+	     as a labelled pair, and dropping the label orphaned `tierCard.price` /
+	     `tierCard.type`. The display number is the emphasis; the grid is the
+	     record. -->
 	<dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+		<!-- Price & Type -->
+		<div>
+			<dt class="text-muted-foreground">{m['tierCard.price']()}</dt>
+			<dd class="font-bold">{priceDisplay()}</dd>
+		</div>
+		<div>
+			<dt class="text-muted-foreground">{m['tierCard.type']()}</dt>
+			<dd class="font-bold">{priceTypeDisplay()}</dd>
+		</div>
+
 		<!-- Payment Method -->
 		<div>
 			<dt class="text-muted-foreground">{m['tierCard.paymentMethod']()}</dt>

--- a/src/lib/components/events/admin/TierCard.svelte
+++ b/src/lib/components/events/admin/TierCard.svelte
@@ -2,9 +2,18 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { TicketTierDetailSchema } from '$lib/api/generated/types.gen';
 	import { Button } from '$lib/components/ui/button';
-	import { Card } from '$lib/components/ui/card';
+	import PricingCard from '$lib/components/common/PricingCard.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
-	import { Edit, Building2, LayoutGrid, Armchair, ChevronUp, ChevronDown } from '@lucide/svelte';
+	import {
+		Edit,
+		Building2,
+		LayoutGrid,
+		Armchair,
+		ChevronUp,
+		ChevronDown,
+		Ticket
+	} from '@lucide/svelte';
 	import { formatDateTime } from '$lib/utils/date';
 
 	interface Props {
@@ -137,158 +146,152 @@
 	});
 </script>
 
-<Card class="p-4">
-	<div class="flex items-start justify-between">
-		<div class="flex-1">
-			<!-- Header -->
-			<div class="flex items-center gap-2">
-				<h3 class="text-lg font-semibold">🎟️ {tier.name}</h3>
-				{#if tier.name === 'General Admission'}
-					<span
-						class="rounded bg-blue-100 px-2 py-1 text-xs text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-						>{m['tierCard.default']()}</span
-					>
-				{/if}
-			</div>
+{#snippet badges()}
+	{#if tier.name === 'General Admission'}
+		<StatusBadge tone="info" size="sm" label={m['tierCard.default']()} />
+	{/if}
+{/snippet}
 
-			<!-- Description -->
-			{#if tier.description}
-				<MarkdownContent content={tier.description} class="mt-1 text-sm text-muted-foreground" />
-			{/if}
+{#snippet meta()}
+	<!-- Tier details. Price and type are promoted to the card's display price
+	     above, so this grid states everything the price line cannot. -->
+	<dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+		<!-- Payment Method -->
+		<div>
+			<dt class="text-muted-foreground">{m['tierCard.paymentMethod']()}</dt>
+			<dd class="font-bold">{paymentMethodDisplay()}</dd>
+		</div>
 
-			<!-- Tier Details Grid -->
-			<dl class="mt-3 grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
-				<!-- Price & Type -->
-				<div>
-					<dt class="text-muted-foreground">{m['tierCard.price']()}</dt>
-					<dd class="font-medium">{priceDisplay()}</dd>
-				</div>
-				<div>
-					<dt class="text-muted-foreground">{m['tierCard.type']()}</dt>
-					<dd class="font-medium">{priceTypeDisplay()}</dd>
-				</div>
+		<!-- Quantity -->
+		<div>
+			<dt class="text-muted-foreground">{m['tierCard.quantity']()}</dt>
+			<dd class="font-bold">{quantityDisplay()}</dd>
+		</div>
 
-				<!-- Payment Method -->
-				<div>
-					<dt class="text-muted-foreground">{m['tierCard.paymentMethod']()}</dt>
-					<dd class="font-medium">{paymentMethodDisplay()}</dd>
-				</div>
+		<!-- Visibility -->
+		<div>
+			<dt class="text-muted-foreground">{m['tierCard.visibility']()}</dt>
+			<dd class="font-bold capitalize">{visibilityDisplay()}</dd>
+		</div>
 
-				<!-- Quantity -->
-				<div>
-					<dt class="text-muted-foreground">{m['tierCard.quantity']()}</dt>
-					<dd class="font-medium">{quantityDisplay()}</dd>
-				</div>
+		<!-- Available To -->
+		<div>
+			<dt class="text-muted-foreground">{m['tierCard.availableTo']()}</dt>
+			<dd class="font-bold">{purchasableByDisplay()}</dd>
+		</div>
 
-				<!-- Visibility -->
-				<div>
-					<dt class="text-muted-foreground">{m['tierCard.visibility']()}</dt>
-					<dd class="font-medium capitalize">{visibilityDisplay()}</dd>
-				</div>
+		<!-- Sales Window (full width) -->
+		<div class="col-span-2">
+			<dt class="text-muted-foreground">{m['tierCard.salesWindow']()}</dt>
+			<dd class="font-bold">{salesWindowDisplay()}</dd>
+		</div>
 
-				<!-- Available To -->
-				<div>
-					<dt class="text-muted-foreground">{m['tierCard.availableTo']()}</dt>
-					<dd class="font-medium">{purchasableByDisplay()}</dd>
-				</div>
+		<!-- Seat Assignment -->
+		<div>
+			<dt class="text-muted-foreground">
+				<span class="flex items-center gap-1">
+					<Armchair class="h-3 w-3" aria-hidden="true" />
+					{m['tierCard.seatAssignment.label']()}
+				</span>
+			</dt>
+			<dd class="font-bold">{seatAssignmentDisplay()}</dd>
+		</div>
 
-				<!-- Sales Window (full width) -->
-				<div class="col-span-2">
-					<dt class="text-muted-foreground">{m['tierCard.salesWindow']()}</dt>
-					<dd class="font-medium">{salesWindowDisplay()}</dd>
-				</div>
+		<!-- Max Tickets Per User -->
+		<div>
+			<dt class="text-muted-foreground">
+				{m['tierCard.maxTicketsPerUser']()}
+			</dt>
+			<dd class="font-bold">{maxTicketsDisplay()}</dd>
+		</div>
 
-				<!-- Seat Assignment -->
-				<div>
-					<dt class="text-muted-foreground">
+		<!-- Venue/Sector (if configured) -->
+		{#if tier.venue || tier.sector}
+			<div class="col-span-2">
+				<dt class="text-muted-foreground">
+					<span class="flex items-center gap-1">
+						<Building2 class="h-3 w-3" aria-hidden="true" />
+						{m['tierCard.venueAndSector']()}
+					</span>
+				</dt>
+				<dd class="flex flex-wrap items-center gap-2 font-bold">
+					{#if tier.venue}
 						<span class="flex items-center gap-1">
-							<Armchair class="h-3 w-3" aria-hidden="true" />
-							{m['tierCard.seatAssignment.label']()}
+							<Building2 class="h-4 w-4 text-primary" aria-hidden="true" />
+							{tier.venue.name}
 						</span>
-					</dt>
-					<dd class="font-medium">{seatAssignmentDisplay()}</dd>
-				</div>
-
-				<!-- Max Tickets Per User -->
-				<div>
-					<dt class="text-muted-foreground">
-						{m['tierCard.maxTicketsPerUser']()}
-					</dt>
-					<dd class="font-medium">{maxTicketsDisplay()}</dd>
-				</div>
-
-				<!-- Venue/Sector (if configured) -->
-				{#if tier.venue || tier.sector}
-					<div class="col-span-2">
-						<dt class="text-muted-foreground">
-							<span class="flex items-center gap-1">
-								<Building2 class="h-3 w-3" aria-hidden="true" />
-								{m['tierCard.venueAndSector']()}
-							</span>
-						</dt>
-						<dd class="flex items-center gap-2 font-medium">
-							{#if tier.venue}
-								<span class="flex items-center gap-1">
-									<Building2 class="h-4 w-4 text-primary" aria-hidden="true" />
-									{tier.venue.name}
-								</span>
+					{/if}
+					{#if tier.venue && tier.sector}
+						<span class="text-muted-foreground">/</span>
+					{/if}
+					{#if tier.sector}
+						<span class="flex items-center gap-1">
+							<LayoutGrid class="h-4 w-4 text-primary" aria-hidden="true" />
+							{tier.sector.name}
+							{#if tier.sector.code}
+								<span class="text-xs font-normal text-muted-foreground">({tier.sector.code})</span>
 							{/if}
-							{#if tier.venue && tier.sector}
-								<span class="text-muted-foreground">/</span>
-							{/if}
-							{#if tier.sector}
-								<span class="flex items-center gap-1">
-									<LayoutGrid class="h-4 w-4 text-primary" aria-hidden="true" />
-									{tier.sector.name}
-									{#if tier.sector.code}
-										<span class="text-xs text-muted-foreground">({tier.sector.code})</span>
-									{/if}
-								</span>
-							{/if}
-						</dd>
-					</div>
-				{/if}
-			</dl>
+						</span>
+					{/if}
+				</dd>
+			</div>
+		{/if}
+	</dl>
 
-			<!-- Manual Payment Instructions -->
-			{#if tier.manual_payment_instructions}
-				<div class="mt-3 rounded-md border border-border bg-muted/50 p-2">
-					<p class="text-xs font-medium text-muted-foreground">
-						{m['tierCard.paymentInstructions']()}
-					</p>
-					<MarkdownContent content={tier.manual_payment_instructions} class="mt-1 text-sm" />
-				</div>
-			{/if}
+	<!-- Manual Payment Instructions -->
+	{#if tier.manual_payment_instructions}
+		<div class="mt-3 rounded-md border border-border bg-muted/50 p-2">
+			<p class="text-xs font-bold text-muted-foreground">
+				{m['tierCard.paymentInstructions']()}
+			</p>
+			<MarkdownContent content={tier.manual_payment_instructions} class="mt-1 text-sm" />
 		</div>
+	{/if}
+{/snippet}
 
-		<div class="flex flex-col items-center gap-1">
-			{#if onMoveUp || onMoveDown}
-				<div class="flex flex-col">
-					<Button
-						variant="ghost"
-						size="icon"
-						class="h-7 w-7"
-						onclick={onMoveUp}
-						disabled={!onMoveUp}
-						aria-label="Move {tier.name} up"
-					>
-						<ChevronUp class="h-4 w-4" />
-					</Button>
-					<Button
-						variant="ghost"
-						size="icon"
-						class="h-7 w-7"
-						onclick={onMoveDown}
-						disabled={!onMoveDown}
-						aria-label="Move {tier.name} down"
-					>
-						<ChevronDown class="h-4 w-4" />
-					</Button>
-				</div>
-			{/if}
-			<Button variant="ghost" size="icon" onclick={onEdit} aria-label="Edit {tier.name}">
-				<Edit class="h-4 w-4" />
-			</Button>
-		</div>
+{#snippet actions()}
+	<!-- Row on mobile (the card is a single column there), rail on sm+ -->
+	<div class="flex flex-row items-center gap-1 sm:flex-col">
+		{#if onMoveUp || onMoveDown}
+			<div class="flex flex-row sm:flex-col">
+				<Button
+					variant="ghost"
+					size="icon"
+					class="h-7 w-7"
+					onclick={onMoveUp}
+					disabled={!onMoveUp}
+					aria-label="Move {tier.name} up"
+				>
+					<ChevronUp class="h-4 w-4" />
+				</Button>
+				<Button
+					variant="ghost"
+					size="icon"
+					class="h-7 w-7"
+					onclick={onMoveDown}
+					disabled={!onMoveDown}
+					aria-label="Move {tier.name} down"
+				>
+					<ChevronDown class="h-4 w-4" />
+				</Button>
+			</div>
+		{/if}
+		<Button variant="ghost" size="icon" onclick={onEdit} aria-label="Edit {tier.name}">
+			<Edit class="h-4 w-4" />
+		</Button>
 	</div>
-</Card>
+{/snippet}
+
+<PricingCard
+	name={tier.name}
+	icon={Ticket}
+	price={priceDisplay()}
+	priceNote={priceTypeDisplay()}
+	{badges}
+	{meta}
+	{actions}
+>
+	{#if tier.description}
+		<MarkdownContent content={tier.description} class="text-sm text-muted-foreground" />
+	{/if}
+</PricingCard>

--- a/src/lib/components/events/filters/CityFilter.svelte
+++ b/src/lib/components/events/filters/CityFilter.svelte
@@ -92,7 +92,9 @@
 <div class={cn('space-y-3', className)}>
 	<div class="flex items-center gap-2">
 		<MapPin class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-		<h3 class="text-sm font-medium">{m['filters.city.heading']()}</h3>
+		<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+			{m['filters.city.heading']()}
+		</h3>
 	</div>
 
 	{#if selectedCity}

--- a/src/lib/components/events/filters/DateFilter.svelte
+++ b/src/lib/components/events/filters/DateFilter.svelte
@@ -19,7 +19,9 @@
 <div class={cn('space-y-3', className)}>
 	<div class="flex items-center gap-2">
 		<Calendar class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-		<h3 class="text-sm font-medium">{m['filters.date.heading']()}</h3>
+		<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+			{m['filters.date.heading']()}
+		</h3>
 	</div>
 
 	<div class="space-y-2">
@@ -28,7 +30,7 @@
 				type="checkbox"
 				checked={includePast}
 				onchange={handleToggle}
-				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
+				class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
 			/>
 			<span>{m['filters.date.includePast']()}</span>
 		</label>

--- a/src/lib/components/events/filters/EventFilters.svelte
+++ b/src/lib/components/events/filters/EventFilters.svelte
@@ -103,10 +103,10 @@
 	<div class="flex items-center justify-between">
 		<div class="flex items-center gap-2">
 			<Filter class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-			<h2 class="text-lg font-semibold">{m['common.filters_filters']()}</h2>
+			<h2 class="text-xl font-extrabold">{m['common.filters_filters']()}</h2>
 			{#if activeFilterCount > 0}
 				<span
-					class="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
+					class="rounded-full bg-primary px-2 py-0.5 text-xs font-bold text-primary-foreground"
 					aria-label="{activeFilterCount} {m['common.filters_activeFilters']()}"
 				>
 					{activeFilterCount}
@@ -143,7 +143,7 @@
 
 	<!-- Search Input -->
 	<div class="space-y-2">
-		<label for="event-search" class="text-sm font-medium">{m['common.search_label']()}</label>
+		<label for="event-search" class="text-sm font-bold">{m['common.search_label']()}</label>
 		<SearchInput
 			id="event-search"
 			value={filters.search ?? ''}

--- a/src/lib/components/events/filters/EventTypeFilter.svelte
+++ b/src/lib/components/events/filters/EventTypeFilter.svelte
@@ -31,7 +31,9 @@
 <div class={cn('space-y-3', className)}>
 	<div class="flex items-center gap-2">
 		<Eye class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-		<h3 class="text-sm font-medium">{m['filters.eventType.heading']()}</h3>
+		<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+			{m['filters.eventType.heading']()}
+		</h3>
 	</div>
 
 	<div class="flex flex-wrap gap-2">
@@ -41,7 +43,7 @@
 				type="button"
 				onclick={() => handleToggle(option.value)}
 				class={cn(
-					'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+					'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 					isSelected
 						? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
 						: 'border-input bg-background hover:bg-accent hover:text-accent-foreground'

--- a/src/lib/components/events/filters/MobileFilterSheet.svelte
+++ b/src/lib/components/events/filters/MobileFilterSheet.svelte
@@ -183,7 +183,7 @@
 {#if isOpen}
 	<!-- Backdrop -->
 	<div
-		class="fixed inset-0 z-40 bg-black/50 transition-opacity lg:hidden"
+		class="fixed inset-0 z-40 bg-poster-ink/50 transition-opacity lg:hidden"
 		onclick={onClose}
 		role="presentation"
 		aria-hidden="true"

--- a/src/lib/components/events/filters/MobileFilterSheet.svelte
+++ b/src/lib/components/events/filters/MobileFilterSheet.svelte
@@ -219,7 +219,7 @@
 				</h2>
 				{#if activeFilterCount > 0}
 					<span
-						class="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
+						class="rounded-full bg-primary px-2 py-0.5 text-xs font-bold text-primary-foreground"
 						aria-label="{activeFilterCount} {m['common.filters_activeFilters']()}"
 					>
 						{activeFilterCount}
@@ -251,7 +251,7 @@
 
 				<!-- Search Input -->
 				<div class="space-y-2">
-					<label for="mobile-event-search" class="text-sm font-medium"
+					<label for="mobile-event-search" class="text-sm font-bold"
 						>{m['common.search_label']()}</label
 					>
 					<SearchInput
@@ -315,7 +315,7 @@
 					<button
 						type="button"
 						onclick={onClearFilters}
-						class="flex items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						class="flex items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<X class="h-4 w-4" aria-hidden="true" />
 						{m['filters.mobile.clearAll']()}
@@ -325,7 +325,7 @@
 				<button
 					type="button"
 					onclick={handleApply}
-					class="rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					class="rounded-md bg-primary px-4 py-2.5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 				>
 					{m['filters.mobile.showResults']({
 						count: totalCount,

--- a/src/lib/components/events/filters/OrderByFilter.svelte
+++ b/src/lib/components/events/filters/OrderByFilter.svelte
@@ -41,7 +41,9 @@
 <div class={cn('space-y-3', className)}>
 	<div class="flex items-center gap-2">
 		<ArrowUpDown class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-		<h3 class="text-sm font-medium">{m['filters.orderBy.heading']()}</h3>
+		<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+			{m['filters.orderBy.heading']()}
+		</h3>
 		<!-- Info Tooltip -->
 		<div class="relative">
 			<button

--- a/src/lib/components/events/filters/OrganizationFilter.svelte
+++ b/src/lib/components/events/filters/OrganizationFilter.svelte
@@ -90,7 +90,9 @@
 <div class={cn('space-y-3', className)}>
 	<div class="flex items-center gap-2">
 		<Building2 class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-		<h3 class="text-sm font-medium">{m['filters.organization.heading']()}</h3>
+		<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+			{m['filters.organization.heading']()}
+		</h3>
 	</div>
 
 	{#if selectedOrganization}

--- a/src/lib/components/events/filters/TagsFilter.svelte
+++ b/src/lib/components/events/filters/TagsFilter.svelte
@@ -64,7 +64,9 @@
 <div class={cn('space-y-3', className)}>
 	<div class="flex items-center gap-2">
 		<Tag class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-		<h3 class="text-sm font-medium">{m['filters.tags.heading']()}</h3>
+		<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+			{m['filters.tags.heading']()}
+		</h3>
 	</div>
 
 	{#if isLoading}
@@ -84,7 +86,7 @@
 					type="button"
 					onclick={() => handleTagClick(tag)}
 					class={cn(
-						'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+						'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 						isSelected
 							? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
 							: 'border-input bg-background hover:bg-accent hover:text-accent-foreground'

--- a/src/lib/components/events/filters/TicketedFilter.svelte
+++ b/src/lib/components/events/filters/TicketedFilter.svelte
@@ -29,7 +29,9 @@
 <div class={cn('space-y-3', className)}>
 	<div class="flex items-center gap-2">
 		<Ticket class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-		<h3 class="text-sm font-medium">{m['filters.ticketType.heading']()}</h3>
+		<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+			{m['filters.ticketType.heading']()}
+		</h3>
 	</div>
 
 	<div class="flex flex-wrap gap-2">
@@ -39,7 +41,7 @@
 				type="button"
 				onclick={() => handleToggle(option.value)}
 				class={cn(
-					'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+					'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 					isSelected
 						? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
 						: 'border-input bg-background hover:bg-accent hover:text-accent-foreground'

--- a/src/lib/components/events/waitlist/ActiveOfferBanner.svelte
+++ b/src/lib/components/events/waitlist/ActiveOfferBanner.svelte
@@ -37,6 +37,16 @@
 	const isUrgent = $derived(!expired && remainingMs < 60 * 60 * 1000);
 	const isWarning = $derived(!expired && !isUrgent && remainingMs < 24 * 60 * 60 * 1000);
 
+	/**
+	 * Urgency bands on semantic tokens instead of hand-picked red/amber/emerald.
+	 *
+	 * The fill is a 10% tint, which composites to ~the page colour — so the body
+	 * text stays `text-foreground` and inherits the token contract's own AA
+	 * guarantee rather than needing a per-band foreground. The band itself is
+	 * carried by the 4px rail and the icon (>= 3:1 non-text in both modes, the
+	 * same tints ToneTile measures), never by the text colour, and never by
+	 * colour alone: the heading and the countdown say which band this is.
+	 */
 	const tone = $derived.by(() => {
 		if (expired) {
 			return {
@@ -47,24 +57,21 @@
 		}
 		if (isUrgent) {
 			return {
-				container:
-					'border-l-4 border-red-500 bg-red-50 text-red-950 dark:bg-red-950/30 dark:text-red-100',
-				icon: 'text-red-600 dark:text-red-300 animate-pulse',
+				container: 'border-l-4 border-destructive bg-destructive/10 text-foreground',
+				icon: 'text-destructive animate-pulse',
 				pulse: true
 			};
 		}
 		if (isWarning) {
 			return {
-				container:
-					'border-l-4 border-amber-500 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100',
-				icon: 'text-amber-600 dark:text-amber-300',
+				container: 'border-l-4 border-highlight bg-highlight/10 text-foreground',
+				icon: 'text-highlight-foreground dark:text-highlight',
 				pulse: false
 			};
 		}
 		return {
-			container:
-				'border-l-4 border-emerald-500 bg-emerald-50 text-emerald-950 dark:bg-emerald-950/30 dark:text-emerald-100',
-			icon: 'text-emerald-600 dark:text-emerald-300',
+			container: 'border-l-4 border-success bg-success/10 text-foreground',
+			icon: 'text-success',
 			pulse: false
 		};
 	});
@@ -98,12 +105,10 @@
 		<div class="flex items-start gap-3 sm:items-center">
 			<Sparkles class={cn('h-8 w-8 shrink-0', tone.icon)} aria-hidden="true" />
 			<div class="flex flex-col gap-1">
-				<span
-					class="text-xs font-semibold uppercase tracking-wider text-muted-foreground sm:text-[0.7rem]"
-				>
+				<span class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
 					{m['activeOffer.eyebrow']()}
 				</span>
-				<h2 class="text-xl font-bold leading-tight sm:text-2xl">
+				<h2 class="text-xl font-extrabold leading-tight sm:text-2xl">
 					{expired ? m['activeOffer.expired']() : m['activeOffer.header']()}
 				</h2>
 				{#if !expired}
@@ -123,7 +128,7 @@
 						compact
 						class={cn(
 							'font-mono tabular-nums',
-							isUrgent || isWarning ? 'text-lg font-semibold' : 'text-base font-medium'
+							isUrgent || isWarning ? 'text-lg font-extrabold' : 'text-base font-bold'
 						)}
 					/>
 				</div>

--- a/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte
+++ b/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte
@@ -17,15 +17,13 @@
 				return {
 					label: m['offerStatus.pending'](),
 					icon: Clock,
-					classes:
-						'bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200 ring-1 ring-amber-300/60 dark:ring-amber-800/60'
+					classes: 'bg-highlight text-highlight-foreground'
 				};
 			case 'claimed':
 				return {
 					label: m['offerStatus.claimed'](),
 					icon: Check,
-					classes:
-						'bg-emerald-100 text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200 ring-1 ring-emerald-300/60 dark:ring-emerald-800/60'
+					classes: 'bg-success text-success-foreground'
 				};
 			case 'expired':
 				return {
@@ -37,8 +35,7 @@
 				return {
 					label: m['offerStatus.revoked'](),
 					icon: Ban,
-					classes:
-						'bg-red-100 text-red-900 dark:bg-red-950/40 dark:text-red-200 ring-1 ring-red-300/60 dark:ring-red-800/60'
+					classes: 'bg-destructive text-destructive-foreground'
 				};
 		}
 	});

--- a/src/lib/components/organization/OrgContactButton.svelte
+++ b/src/lib/components/organization/OrgContactButton.svelte
@@ -127,9 +127,9 @@
 			{#if submitted}
 				<div class="py-8 text-center">
 					<div
-						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900"
+						class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-success/10"
 					>
-						<Check class="h-8 w-8 text-green-600 dark:text-green-300" aria-hidden="true" />
+						<Check class="h-8 w-8 text-success" aria-hidden="true" />
 					</div>
 					<Dialog.Title class="text-xl font-semibold">
 						{m['orgContactButton.successTitle']()}
@@ -166,7 +166,7 @@
 							maxlength="200"
 							disabled={contactMutation.isPending}
 							placeholder={m['orgContactButton.subjectPlaceholder']()}
-							class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+							class="mt-1 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50"
 						/>
 					</div>
 
@@ -182,7 +182,7 @@
 							required
 							disabled={contactMutation.isPending}
 							placeholder={m['orgContactButton.messagePlaceholder']()}
-							class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+							class="mt-1 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50"
 						></textarea>
 						<p class="mt-1 text-xs text-muted-foreground">
 							{message.length}/2000 {m['orgContactButton.characters']()}
@@ -191,7 +191,7 @@
 
 					{#if contactMutation.isError}
 						<div
-							class="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+							class="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-foreground"
 							role="alert"
 						>
 							{contactMutation.error?.message || m['orgContactButton.errors_genericFailure']()}

--- a/src/lib/components/organization/OrgContactEmailModal.svelte
+++ b/src/lib/components/organization/OrgContactEmailModal.svelte
@@ -142,17 +142,14 @@
 			{#if emailSent}
 				<!-- Success state -->
 				<div class="space-y-4">
-					<div class="rounded-md bg-green-50 p-4 dark:bg-green-950">
+					<div class="rounded-md bg-success/10 p-4">
 						<div class="flex gap-3">
-							<Check
-								class="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400"
-								aria-hidden="true"
-							/>
+							<Check class="h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />
 							<div>
-								<h4 class="font-medium text-green-900 dark:text-green-100">
+								<h4 class="font-bold text-foreground">
 									{m['orgContactEmailModal.verificationSentTitle']()}
 								</h4>
-								<p class="mt-1 text-sm text-green-800 dark:text-green-200">
+								<p class="mt-1 text-sm text-foreground">
 									{m['orgContactEmailModal.verificationSentPrefix']()}
 									<strong>{newEmail}</strong>.
 									{m['orgContactEmailModal.verificationSentSuffix']()}
@@ -191,7 +188,7 @@
 							bind:value={newEmail}
 							disabled={isUpdatingEmail}
 							placeholder={m['orgContactEmailModal.emailPlaceholder']()}
-							class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800"
+							class="mt-1 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50"
 						/>
 						<p class="mt-1 text-xs text-muted-foreground">
 							{m['orgContactEmailModal.helperText']()}
@@ -199,13 +196,10 @@
 					</div>
 
 					{#if emailUpdateError}
-						<div class="rounded-md bg-red-50 p-3 dark:bg-red-950">
+						<div class="rounded-md bg-destructive/10 p-3">
 							<div class="flex gap-2">
-								<AlertCircle
-									class="h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400"
-									aria-hidden="true"
-								/>
-								<p class="text-sm text-red-800 dark:text-red-200">
+								<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />
+								<p class="text-sm text-foreground">
 									{emailUpdateError}
 								</p>
 							</div>

--- a/src/lib/components/organization/OrgContactEmailModal.svelte
+++ b/src/lib/components/organization/OrgContactEmailModal.svelte
@@ -107,7 +107,7 @@
 
 {#if open}
 	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+		class="fixed inset-0 z-50 flex items-center justify-center bg-poster-ink/50 p-4"
 		onclick={(e) => {
 			if (e.target === e.currentTarget) {
 				close();

--- a/src/lib/components/organization/membership/ApplyDialog.svelte
+++ b/src/lib/components/organization/membership/ApplyDialog.svelte
@@ -250,7 +250,7 @@
 		{#if showOutcome}
 			<div class="space-y-3">
 				{#if showMemberBadge}
-					<p class="flex items-center gap-2 text-sm font-medium text-green-700 dark:text-green-300">
+					<p class="flex items-center gap-2 text-sm font-bold text-success">
 						<CheckCircle2 class="h-5 w-5" aria-hidden="true" />
 						{m['membershipEligibility.memberBadge']()}
 					</p>

--- a/src/lib/components/organization/membership/CheckoutReturnCard.svelte
+++ b/src/lib/components/organization/membership/CheckoutReturnCard.svelte
@@ -218,9 +218,9 @@
 {#if isConfirming}
 	<Card
 		class={phase === 'done'
-			? 'border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-950/40'
+			? 'border-success/50 bg-success/10'
 			: phase === 'timed_out'
-				? 'border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40'
+				? 'border-highlight/60 bg-highlight/10'
 				: ''}
 	>
 		<CardContent class="p-4">
@@ -234,17 +234,17 @@
 						<p class="mt-1 text-sm">{activationDetail}</p>
 					{/if}
 				{:else if phase === 'done'}
-					<h2 class="text-lg font-semibold">{m['subscribe.return.welcome']()}</h2>
+					<h2 class="text-lg font-extrabold">{m['subscribe.return.welcome']()}</h2>
 					<p class="mt-1 text-sm">{m['subscribe.return.welcomeBody']()}</p>
 				{:else}
-					<h2 class="text-lg font-semibold">{m['subscribe.return.slowTitle']()}</h2>
+					<h2 class="text-lg font-extrabold">{m['subscribe.return.slowTitle']()}</h2>
 					<p class="mt-1 text-sm">{m['subscribe.return.slow']()}</p>
 				{/if}
 			</div>
 			{#if phase === 'timed_out'}
 				<a
 					href={membershipsHref}
-					class="mt-3 inline-block text-sm font-medium text-primary underline-offset-4 hover:underline"
+					class="mt-3 inline-block text-sm font-bold text-primary underline-offset-4 hover:underline"
 				>
 					{m['subscribe.return.checkAccount']()}
 				</a>
@@ -252,9 +252,9 @@
 		</CardContent>
 	</Card>
 {:else}
-	<Card class="border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40">
+	<Card class="border-highlight/60 bg-highlight/10">
 		<CardContent class="p-4">
-			<h2 class="text-lg font-semibold">{m['subscribe.return.cancelledTitle']()}</h2>
+			<h2 class="text-lg font-extrabold">{m['subscribe.return.cancelledTitle']()}</h2>
 			<p class="mt-1 text-sm">{m['subscribe.return.cancelledBody']()}</p>
 
 			{#if resumableSub}

--- a/src/lib/components/organization/membership/MembershipCta.svelte
+++ b/src/lib/components/organization/membership/MembershipCta.svelte
@@ -112,12 +112,14 @@
 		return plan && inline;
 	});
 
-	// Status badge styling, kept in step with MemberCard.svelte.
+	// Status badge styling, on the semantic tone tokens rather than a
+	// hand-picked green/yellow/grey/red ramp — each pill still carries its own
+	// translated label (`memberStatus.*`), so the fill never says it alone.
 	const statusStyles: Record<MembershipStatus, string> = {
-		active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100',
-		paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100',
-		cancelled: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100',
-		banned: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100'
+		active: 'bg-success text-success-foreground',
+		paused: 'bg-highlight text-highlight-foreground',
+		cancelled: 'bg-muted text-muted-foreground',
+		banned: 'bg-destructive text-destructive-foreground'
 	};
 
 	const accessToken = $derived(authStore.accessToken);
@@ -241,7 +243,7 @@
 
 		{#if membershipTier}
 			<span
-				class="inline-flex items-center gap-1.5 rounded-full bg-blue-100 px-3 py-1.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-100"
+				class="inline-flex items-center gap-1.5 rounded-full bg-info px-3 py-1.5 text-xs font-bold text-info-foreground"
 				aria-label={m['membershipEligibility.memberTierAriaLabel']({ tier: membershipTier.name })}
 			>
 				<Award class="h-3 w-3" aria-hidden="true" />
@@ -250,7 +252,7 @@
 		{:else if !membershipStatus}
 			<!-- Eligibility-derived membership: no server props to describe it. -->
 			<span
-				class="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-100"
+				class="inline-flex items-center gap-1.5 rounded-full bg-success px-3 py-1.5 text-xs font-bold text-success-foreground"
 				aria-label={m['membershipEligibility.memberBadgeAriaLabel']()}
 			>
 				<Check class="h-3 w-3" aria-hidden="true" />
@@ -263,7 +265,7 @@
 {#if isOwner}
 	<div
 		class={cn(
-			'inline-flex items-center gap-2 rounded-md border border-primary bg-primary/10 px-4 py-2 text-sm font-medium text-primary dark:border-primary dark:bg-primary/20',
+			'inline-flex items-center gap-2 rounded-md border border-primary bg-primary/10 px-4 py-2 text-sm font-bold text-primary',
 			className
 		)}
 		role="status"
@@ -275,7 +277,7 @@
 {:else if isStaff}
 	<div
 		class={cn(
-			'inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300',
+			'inline-flex items-center gap-2 rounded-md border border-info/40 bg-info/10 px-4 py-2 text-sm font-bold text-foreground',
 			className
 		)}
 		role="status"

--- a/src/lib/components/organization/membership/MembershipCta.svelte
+++ b/src/lib/components/organization/membership/MembershipCta.svelte
@@ -229,7 +229,7 @@
 	<div class={cn('inline-flex flex-wrap items-center gap-2', className)} role="status">
 		{#if membershipStatus}
 			<span
-				class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium {statusStyles[
+				class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-bold {statusStyles[
 					membershipStatus
 				]}"
 				aria-label={m['membershipEligibility.memberStatusAriaLabel']({

--- a/src/lib/components/organization/membership/MembershipSection.svelte
+++ b/src/lib/components/organization/membership/MembershipSection.svelte
@@ -14,6 +14,9 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { myOrgSubscriptionQueryOptions } from '$lib/queries/my-org-subscription';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import { Users } from '@lucide/svelte';
 	import MembershipCta from './MembershipCta.svelte';
 	import TierCard from './TierCard.svelte';
 	import SubscribeDialog from './SubscribeDialog.svelte';
@@ -139,9 +142,12 @@
 	});
 </script>
 
+<!-- `aria-label` rather than `aria-labelledby`: the page h1 now comes from the
+     shared PageHeader, which owns its own heading element and exposes no id to
+     point at. The region keeps exactly the same accessible name. -->
 <section
 	id="membership"
-	aria-labelledby="membership-heading"
+	aria-label={m['membershipTiers.heading']()}
 	class="space-y-6"
 	bind:this={sectionEl}
 >
@@ -155,14 +161,12 @@
 		/>
 	{/if}
 
-	<div class="space-y-2">
-		<h1 id="membership-heading" class="text-3xl font-bold tracking-tight md:text-4xl">
-			{m['membershipTiers.heading']()}
-		</h1>
-		<p class="text-muted-foreground">
-			{m['membershipTiers.subtitle']({ organizationName: organization.name })}
-		</p>
-	</div>
+	<PageHeader
+		volume="celebration"
+		kicker={organization.name}
+		title={m['membershipTiers.heading']()}
+		subtitle={m['membershipTiers.subtitle']({ organizationName: organization.name })}
+	/>
 
 	{#if hasStanding}
 		<!-- Summary mode (no tierId): the badge branches only, no eligibility
@@ -180,9 +184,11 @@
 	{/if}
 
 	{#if tiers.length === 0}
-		<p class="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-			{m['membershipTiers.empty']({ organizationName: organization.name })}
-		</p>
+		<EmptyState
+			icon={Users}
+			title={m['membershipTiers.tiersHeading']()}
+			body={m['membershipTiers.empty']({ organizationName: organization.name })}
+		/>
 	{:else}
 		<div aria-labelledby="tiers-heading">
 			<h2 id="tiers-heading" class="sr-only">{m['membershipTiers.tiersHeading']()}</h2>
@@ -208,7 +214,7 @@
 	{#if refundPolicy}
 		<details class="rounded-lg border p-3">
 			<summary
-				class="cursor-pointer text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				class="cursor-pointer text-sm font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 			>
 				{m['membershipPlans.refundPolicy']()}
 			</summary>

--- a/src/lib/components/organization/membership/MembershipSection.svelte
+++ b/src/lib/components/organization/membership/MembershipSection.svelte
@@ -184,7 +184,10 @@
 	{/if}
 
 	{#if tiers.length === 0}
+		<!-- level 2: this sits directly under the page h1 that PageHeader renders,
+		     and EmptyState's default level 3 would skip a rank (axe heading-order). -->
 		<EmptyState
+			level={2}
 			icon={Users}
 			title={m['membershipTiers.tiersHeading']()}
 			body={m['membershipTiers.empty']({ organizationName: organization.name })}

--- a/src/lib/components/organization/membership/PlanCard.svelte
+++ b/src/lib/components/organization/membership/PlanCard.svelte
@@ -6,8 +6,8 @@
 		PublicPlanSchema
 	} from '$lib/api/generated/types.gen';
 	import type { MembershipGateAction } from '$lib/utils/membership-eligibility';
-	import { Card, CardContent } from '$lib/components/ui/card';
-	import { Badge } from '$lib/components/ui/badge';
+	import PricingCard from '$lib/components/common/PricingCard.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import OrgContactButton from '$lib/components/organization/OrgContactButton.svelte';
 	import {
@@ -237,67 +237,54 @@
 	}
 </script>
 
-<!-- No `h-full`. It equalised heights back when plan cards were siblings in a
-     `grid gap-4 sm:grid-cols-2` ROW; since #720 they are stacked vertically in
-     TierCard's `space-y-3` block, where `height: 100%` makes EVERY card claim
-     the container's full height. Two cards then need 200% of a box sized for
-     100%, and the surplus escaped the card (`overflow: visible`) and painted
-     over the page footer. -->
-<Card class="flex flex-col">
-	<CardContent class="flex flex-1 flex-col gap-3 p-4">
-		<div class="flex flex-wrap items-start justify-between gap-2">
-			<h4 class="font-semibold">{plan.name}</h4>
-			{#if state === 'current'}
-				<Badge variant="secondary">{m['membershipPlans.yourPlan']()}</Badge>
-			{:else if state === 'sold_out'}
-				<Badge variant="secondary">{m['membershipPlans.soldOut']()}</Badge>
-			{:else if state === 'paused'}
-				<Badge variant="secondary">{m['membershipPlans.paused']()}</Badge>
-			{/if}
-		</div>
+{#snippet badges()}
+	<!-- Tones separated by what the state MEANS, not merely "this is a state":
+	     sold out is a hard stop, paused is temporary, "your plan" is good news.
+	     Every one carries its own words, so nothing is conveyed by fill alone. -->
+	{#if state === 'current'}
+		<StatusBadge tone="success" size="sm" label={m['membershipPlans.yourPlan']()} />
+	{:else if state === 'sold_out'}
+		<StatusBadge tone="danger" size="sm" label={m['membershipPlans.soldOut']()} />
+	{:else if state === 'paused'}
+		<StatusBadge tone="warning" size="sm" label={m['membershipPlans.paused']()} />
+	{/if}
+{/snippet}
 
-		<p class="text-xl font-semibold">{formatPlanPrice(plan)}</p>
+{#snippet meta()}
+	{#if state === 'sold_out'}
+		<p class="text-sm text-muted-foreground">{m['membershipPlans.soldOutHelper']()}</p>
+	{:else if state === 'paused'}
+		<p class="text-sm text-muted-foreground">{m['membershipPlans.pausedHelper']()}</p>
+	{/if}
+{/snippet}
 
-		{#if neverExpires}
-			<p class="-mt-2 text-sm text-muted-foreground">{m['subscriptions.neverExpires']()}</p>
-		{/if}
-
-		{#if plan.description}
-			<p class="whitespace-pre-line text-sm text-muted-foreground">{plan.description}</p>
-		{/if}
-
-		{#if state === 'sold_out'}
-			<p class="text-sm text-muted-foreground">{m['membershipPlans.soldOutHelper']()}</p>
-		{:else if state === 'paused'}
-			<p class="text-sm text-muted-foreground">{m['membershipPlans.pausedHelper']()}</p>
-		{/if}
-
-		<div class="mt-auto pt-1">
-			{#if action === 'current'}
-				<!-- A marker, not a control: there is nothing to press here, so
+{#snippet actions()}
+	<div class="w-full">
+		{#if action === 'current'}
+			<!-- A marker, not a control: there is nothing to press here, so
 				     nothing takes focus. The reason is plain text, never colour. -->
-				<p class="text-sm text-muted-foreground">
-					{isPendingCheckout
-						? m['membershipPlans.pendingCheckoutHelper']()
-						: m['membershipPlans.yourPlanHelper']()}
-				</p>
-			{:else if action === 'member'}
-				<p class="text-sm text-muted-foreground">{m['membershipPlans.alreadySubscribed']()}</p>
-				{#if canSwitch}
-					<!-- The switch itself lives in the account hub's ChangePlanDialog;
+			<p class="text-sm text-muted-foreground">
+				{isPendingCheckout
+					? m['membershipPlans.pendingCheckoutHelper']()
+					: m['membershipPlans.yourPlanHelper']()}
+			</p>
+		{:else if action === 'member'}
+			<p class="text-sm text-muted-foreground">{m['membershipPlans.alreadySubscribed']()}</p>
+			{#if canSwitch}
+				<!-- The switch itself lives in the account hub's ChangePlanDialog;
 					     this only navigates, so it can never 400. Labelled with the
 					     plan name for screen-reader users, who hear these links out
 					     of context and would otherwise get N identical "Change plan". -->
-					<a
-						href={membershipsHref}
-						aria-label={m['membershipPlans.changePlanCtaAria']({ plan: plan.name })}
-						class="mt-2 inline-block text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-					>
-						{m['membershipPlans.changePlanCta']()}<span aria-hidden="true"> →</span>
-					</a>
-				{/if}
-			{:else if action === 'offline'}
-				<!-- The one branch with no self-serve path at all: the plan is settled
+				<a
+					href={membershipsHref}
+					aria-label={m['membershipPlans.changePlanCtaAria']({ plan: plan.name })}
+					class="mt-2 inline-block text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				>
+					{m['membershipPlans.changePlanCta']()}<span aria-hidden="true"> →</span>
+				</a>
+			{/if}
+		{:else if action === 'offline'}
+			<!-- The one branch with no self-serve path at all: the plan is settled
 				     with the organizers, so the sentence states that constraint and
 				     the CTA beneath it is how you reach them. The sentence stands
 				     alone when there is nobody to reach — it says what is true of the
@@ -308,25 +295,25 @@
 				     org's two contact channels (mailto and a dialog) already live in
 				     OrgContactButton, and splicing would mean cutting a translated
 				     string around an anchor. -->
-				<p class="text-sm text-muted-foreground">{m['membershipPlans.offlineManaged']()}</p>
-				{#if canContactOrganization}
-					<!-- Named for the org, not just "Contact organizer": these buttons
+			<p class="text-sm text-muted-foreground">{m['membershipPlans.offlineManaged']()}</p>
+			{#if canContactOrganization}
+				<!-- Named for the org, not just "Contact organizer": these buttons
 					     repeat down a page of plans and a screen-reader user hears them
 					     out of context. Full width on mobile like every other CTA here,
 					     so it cannot overflow a narrow card. -->
-					<OrgContactButton
-						{organizationSlug}
-						{organizationName}
-						{contactMethod}
-						{contactEmail}
-						{isAuthenticated}
-						variant="outline"
-						ariaLabel={m['orgContactButton.contactAriaLabel']({ organizationName })}
-						class="mt-2 w-full justify-center sm:w-auto"
-					/>
-				{/if}
-			{:else if isApplyAction}
-				<!-- #735. The one branch where a blocked gate still leaves the member
+				<OrgContactButton
+					{organizationSlug}
+					{organizationName}
+					{contactMethod}
+					{contactEmail}
+					{isAuthenticated}
+					variant="outline"
+					ariaLabel={m['orgContactButton.contactAriaLabel']({ organizationName })}
+					class="mt-2 w-full justify-center sm:w-auto"
+				/>
+			{/if}
+		{:else if isApplyAction}
+			<!-- #735. The one branch where a blocked gate still leaves the member
 				     something to press: the backend is waiting for an application that
 				     does not exist yet (`submit_application`), or for a fresh one after
 				     a rejection (`reapply`).
@@ -334,58 +321,80 @@
 				     sit on one tier, a screen-reader user hears them out of context,
 				     and the plan is exactly what distinguishes them — it is the id the
 				     application will carry. -->
-				<Button
-					class="w-full sm:w-auto"
-					onclick={handleApply}
-					disabled={ctaHeld}
-					aria-label={action === 'reapply'
-						? m['membershipPlans.reapplyCtaAria']({ plan: plan.name })
-						: m['membershipPlans.applyCtaAria']({ plan: plan.name })}
-				>
-					{action === 'reapply'
-						? m['membershipPlans.reapplyCta']()
-						: m['membershipPlans.applyCta']()}
-				</Button>
-				<!-- The order matters and is not obvious: approval comes BEFORE the
+			<Button
+				class="w-full sm:w-auto"
+				onclick={handleApply}
+				disabled={ctaHeld}
+				aria-label={action === 'reapply'
+					? m['membershipPlans.reapplyCtaAria']({ plan: plan.name })
+					: m['membershipPlans.applyCtaAria']({ plan: plan.name })}
+			>
+				{action === 'reapply' ? m['membershipPlans.reapplyCta']() : m['membershipPlans.applyCta']()}
+			</Button>
+			<!-- The order matters and is not obvious: approval comes BEFORE the
 				     charge (the backend's PaymentReadyGate is last), so this says so
 				     rather than letting the member expect a checkout. -->
-				<p class="mt-2 text-sm text-muted-foreground">
-					{isFree
-						? m['membershipPlans.applyJoinHelper']()
-						: m['membershipPlans.applySubscribeHelper']()}
-				</p>
-			{:else if action === 'gated'}
-				<!-- What replaces the CTA carries the reason itself, rather than
+			<p class="mt-2 text-sm text-muted-foreground">
+				{isFree
+					? m['membershipPlans.applyJoinHelper']()
+					: m['membershipPlans.applySubscribeHelper']()}
+			</p>
+		{:else if action === 'gated'}
+			<!-- What replaces the CTA carries the reason itself, rather than
 				     leaving a bare gap next to a requirement stated elsewhere on the
 				     card: the note IS the explanation, and `aria-describedby` ties it
 				     to the tier's full requirement list so the association is
 				     programmatic and not merely visual (WCAG 1.3.1). -->
-				<p
-					role="note"
-					class="text-sm text-muted-foreground"
-					aria-describedby={gateRequirementsId ?? undefined}
-				>
-					{isFree
-						? m['membershipPlans.gatedJoinHelper']()
-						: m['membershipPlans.gatedSubscribeHelper']()}
-					{#if gateReason}
-						<span class="block">{gateReason}</span>
-					{/if}
-				</p>
-			{:else if action === 'subscribe'}
-				<Button class="w-full sm:w-auto" onclick={handleSubscribe} disabled={ctaHeld}>
-					{isFree ? m['membershipPlans.joinFreeCta']() : m['membershipPlans.subscribeCta']()}
-				</Button>
-				{#if isFree}
-					<p class="mt-2 text-sm text-muted-foreground">{m['membershipPlans.freeHelper']()}</p>
+			<p
+				role="note"
+				class="text-sm text-muted-foreground"
+				aria-describedby={gateRequirementsId ?? undefined}
+			>
+				{isFree
+					? m['membershipPlans.gatedJoinHelper']()
+					: m['membershipPlans.gatedSubscribeHelper']()}
+				{#if gateReason}
+					<span class="block">{gateReason}</span>
 				{/if}
-			{:else if action === 'login'}
-				<!-- A real link, not a scripted redirect: it survives no-JS,
-				     middle-click and "open in new tab". -->
-				<Button href={loginHref} class="w-full sm:w-auto">
-					{isFree ? m['membershipPlans.loginToJoin']() : m['membershipPlans.loginToSubscribe']()}
-				</Button>
+			</p>
+		{:else if action === 'subscribe'}
+			<Button class="w-full sm:w-auto" onclick={handleSubscribe} disabled={ctaHeld}>
+				{isFree ? m['membershipPlans.joinFreeCta']() : m['membershipPlans.subscribeCta']()}
+			</Button>
+			{#if isFree}
+				<p class="mt-2 text-sm text-muted-foreground">{m['membershipPlans.freeHelper']()}</p>
 			{/if}
-		</div>
-	</CardContent>
-</Card>
+		{:else if action === 'login'}
+			<!-- A real link, not a scripted redirect: it survives no-JS,
+			     middle-click and "open in new tab". -->
+			<Button href={loginHref} class="w-full sm:w-auto">
+				{isFree ? m['membershipPlans.loginToJoin']() : m['membershipPlans.loginToSubscribe']()}
+			</Button>
+		{/if}
+	</div>
+{/snippet}
+
+<!-- No `h-full`. It equalised heights back when plan cards were siblings in a
+     `grid gap-4 sm:grid-cols-2` ROW; since #720 they are stacked vertically in
+     TierCard's `space-y-3` block, where `height: 100%` makes EVERY card claim
+     the container's full height. Two cards then need 200% of a box sized for
+     100%, and the surplus escaped the card (`overflow: visible`) and painted
+     over the page footer.
+
+     This IS the membership pricing moment — the number a would-be member
+     decides on — so it gets the shared PricingCard's display price rather than
+     the old `text-xl`. `level={4}`: the tier's own name is the h3 above it. -->
+<PricingCard
+	name={plan.name}
+	level={4}
+	layout="stack"
+	price={formatPlanPrice(plan)}
+	priceNote={neverExpires ? m['subscriptions.neverExpires']() : undefined}
+	{badges}
+	{meta}
+	{actions}
+>
+	{#if plan.description}
+		<p class="whitespace-pre-line text-sm text-muted-foreground">{plan.description}</p>
+	{/if}
+</PricingCard>

--- a/src/lib/components/organization/membership/TierCard.svelte
+++ b/src/lib/components/organization/membership/TierCard.svelte
@@ -16,7 +16,8 @@
 		getMembershipStatusMessage
 	} from '$lib/utils/membership-eligibility';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
-	import { Card, CardContent } from '$lib/components/ui/card';
+	import PricingCard from '$lib/components/common/PricingCard.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import { ClipboardList, Gift, ShieldCheck } from '@lucide/svelte';
 	import ApplyDialog from './ApplyDialog.svelte';
 	import MembershipCta from './MembershipCta.svelte';
@@ -237,133 +238,124 @@
 	}
 </script>
 
+{#snippet badges()}
+	{#if isFree}
+		<StatusBadge tone="neutral" size="sm" icon={Gift} label={m['membershipTiers.freeBadge']()} />
+	{/if}
+{/snippet}
+
+{#snippet meta()}
+	<!-- What it takes to get in — and, once a verdict lands, where THIS viewer
+	     stands against it (#740). The tier's own fields decide which lines
+	     exist at all (they are facts about the tier, server-rendered and true
+	     for everyone); the verdict decides what each one says.
+
+	     A polite live region, and pre-mounted rather than injected with its
+	     first message: the lines are server-rendered with the tier's standing
+	     rules, the verdict arrives later over the same DOM, and a text swap
+	     that moves no focus is otherwise silent for a screen-reader user
+	     (WCAG 4.1.3). Every state is words — no colour, no icon-only cue. -->
+	{#if tier.requires_approval || tier.questionnaire_id}
+		<ul id={requirementsId} class="space-y-1.5 text-sm" aria-live="polite">
+			{#if tier.requires_approval}
+				<li class="flex items-start gap-2">
+					<ShieldCheck class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+					<span>
+						{#if approvalState === 'status' && verdictMessage}
+							{verdictMessage}
+						{:else if approvalState === 'satisfied'}
+							{m['membershipTiers.approvalCleared']()}
+						{:else}
+							{m['membershipTiers.requiresApproval']()}
+						{/if}
+					</span>
+				</li>
+			{/if}
+			{#if tier.questionnaire_id}
+				<li class="flex items-start gap-2">
+					<ClipboardList class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+					<span>
+						{#if questionnaireState === 'status' && verdictMessage}
+							<!-- Under review, on cooldown, or refused: there is nothing to
+						     open, so the link goes with the copy that offered it. -->
+							{verdictMessage}
+						{:else if questionnaireState === 'satisfied'}
+							{m['membershipTiers.questionnaireCleared']()}
+						{:else}
+							{m['membershipTiers.questionnaireRequired']()}
+							{#if tier.questionnaire_id}
+								<!-- Named with the tier: a screen-reader user tabbing the page
+							     would otherwise hear the same link text on every card. -->
+								<a
+									href={resolve('/(public)/org/[slug]/questionnaire/[id]', {
+										slug: organizationSlug,
+										id: tier.questionnaire_id
+									})}
+									aria-label={m['membershipTiers.questionnaireLinkAria']({ tier: tier.name })}
+									class="font-bold text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+								>
+									{m['membershipTiers.questionnaireLink']()}
+								</a>
+							{/if}
+						{/if}
+					</span>
+				</li>
+			{/if}
+		</ul>
+	{/if}
+
+	{#if plans.length > 0}
+		<div class="mt-4 space-y-3">
+			{#each plans as plan (plan.id ?? `${tier.id}-${plan.name}`)}
+				<PlanCard
+					{plan}
+					{isAuthenticated}
+					{subscription}
+					{subscriptionLoading}
+					{organizationSlug}
+					{organizationName}
+					{contactMethod}
+					{contactEmail}
+					{onSubscribe}
+					{gateAction}
+					{gateReason}
+					{gatePending}
+					onApply={handleApply}
+					gateRequirementsId={requirementsId}
+				/>
+			{/each}
+		</div>
+	{/if}
+{/snippet}
+
+{#snippet actions()}
+	{#if showJoinCta && tierId}
+		<MembershipCta
+			{organizationSlug}
+			{organizationName}
+			{isAuthenticated}
+			{tierId}
+			tierName={tier.name}
+			planId={ctaPlanId}
+			plansInline={plans.length > 0}
+		/>
+	{/if}
+{/snippet}
+
 <!-- `<article>` + `aria-labelledby`, not a labelled `region`: the cards are peers
      in a list and each must announce which tier it is, but N landmarks on one
-     page would drown the page's real ones. -->
+     page would drown the page's real ones.
+
+     The card chrome itself is the shared PricingCard shell (the tier/pricing
+     look is one design across buyer tickets, organizer config and membership) —
+     this tier has no single price of its own, so the price slot stays empty and
+     the plan cards carry the numbers. -->
 <article class="h-full" aria-labelledby={headingId}>
-	<Card class="flex h-full flex-col">
-		<CardContent class="flex flex-1 flex-col gap-4 p-4 sm:p-5">
-			<div class="space-y-2">
-				<div class="flex flex-wrap items-start justify-between gap-2">
-					<h3 id={headingId} class="text-lg font-semibold">{tier.name}</h3>
-					{#if isFree}
-						<span
-							class="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground"
-						>
-							<Gift class="h-3 w-3" aria-hidden="true" />
-							{m['membershipTiers.freeBadge']()}
-						</span>
-					{/if}
-				</div>
-
-				{#if tier.description}
-					<MarkdownContent content={tier.description} class="text-sm text-muted-foreground" />
-				{/if}
-			</div>
-
-			<!-- What it takes to get in — and, once a verdict lands, where THIS viewer
-		     stands against it (#740). The tier's own fields decide which lines
-		     exist at all (they are facts about the tier, server-rendered and true
-		     for everyone); the verdict decides what each one says.
-
-		     A polite live region, and pre-mounted rather than injected with its
-		     first message: the lines are server-rendered with the tier's standing
-		     rules, the verdict arrives later over the same DOM, and a text swap
-		     that moves no focus is otherwise silent for a screen-reader user
-		     (WCAG 4.1.3). Every state is words — no colour, no icon-only cue. -->
-			{#if tier.requires_approval || tier.questionnaire_id}
-				<ul id={requirementsId} class="space-y-1.5 text-sm" aria-live="polite">
-					{#if tier.requires_approval}
-						<li class="flex items-start gap-2">
-							<ShieldCheck
-								class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
-								aria-hidden="true"
-							/>
-							<span>
-								{#if approvalState === 'status' && verdictMessage}
-									{verdictMessage}
-								{:else if approvalState === 'satisfied'}
-									{m['membershipTiers.approvalCleared']()}
-								{:else}
-									{m['membershipTiers.requiresApproval']()}
-								{/if}
-							</span>
-						</li>
-					{/if}
-					{#if tier.questionnaire_id}
-						<li class="flex items-start gap-2">
-							<ClipboardList
-								class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
-								aria-hidden="true"
-							/>
-							<span>
-								{#if questionnaireState === 'status' && verdictMessage}
-									<!-- Under review, on cooldown, or refused: there is nothing to
-								     open, so the link goes with the copy that offered it. -->
-									{verdictMessage}
-								{:else if questionnaireState === 'satisfied'}
-									{m['membershipTiers.questionnaireCleared']()}
-								{:else}
-									{m['membershipTiers.questionnaireRequired']()}
-									{#if tier.questionnaire_id}
-										<!-- Named with the tier: a screen-reader user tabbing the page
-									     would otherwise hear the same link text on every card. -->
-										<a
-											href={resolve('/(public)/org/[slug]/questionnaire/[id]', {
-												slug: organizationSlug,
-												id: tier.questionnaire_id
-											})}
-											aria-label={m['membershipTiers.questionnaireLinkAria']({ tier: tier.name })}
-											class="font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-										>
-											{m['membershipTiers.questionnaireLink']()}
-										</a>
-									{/if}
-								{/if}
-							</span>
-						</li>
-					{/if}
-				</ul>
-			{/if}
-
-			{#if plans.length > 0}
-				<div class="space-y-3">
-					{#each plans as plan (plan.id ?? `${tier.id}-${plan.name}`)}
-						<PlanCard
-							{plan}
-							{isAuthenticated}
-							{subscription}
-							{subscriptionLoading}
-							{organizationSlug}
-							{organizationName}
-							{contactMethod}
-							{contactEmail}
-							{onSubscribe}
-							{gateAction}
-							{gateReason}
-							{gatePending}
-							onApply={handleApply}
-							gateRequirementsId={requirementsId}
-						/>
-					{/each}
-				</div>
-			{/if}
-
-			<div class="mt-auto pt-1">
-				{#if showJoinCta && tierId}
-					<MembershipCta
-						{organizationSlug}
-						{organizationName}
-						{isAuthenticated}
-						{tierId}
-						tierName={tier.name}
-						planId={ctaPlanId}
-						plansInline={plans.length > 0}
-					/>
-				{/if}
-			</div>
-		</CardContent>
-	</Card>
+	<PricingCard name={tier.name} {headingId} layout="stack" {badges} {meta} {actions} class="h-full">
+		{#if tier.description}
+			<MarkdownContent content={tier.description} class="text-sm text-muted-foreground" />
+		{/if}
+	</PricingCard>
 </article>
 
 <!--

--- a/src/lib/components/organizations/OrganizationCard.svelte
+++ b/src/lib/components/organizations/OrganizationCard.svelte
@@ -5,6 +5,7 @@
 	import { getImageUrl } from '$lib/utils/url';
 	import { stripMarkdown } from '$lib/seo';
 	import { MapPin, Users, Tag } from '@lucide/svelte';
+	import { getPosterFallbackGradient } from '$lib/utils/fallback-gradient';
 	import * as m from '$lib/paraglide/messages.js';
 
 	interface Props {
@@ -35,15 +36,9 @@
 	const imageUrl = $derived(!imageError ? coverArtSocialUrl || coverArtUrl : null);
 	const logoDisplayUrl = $derived(logoThumbnailUrl || logoUrl);
 
-	// Fallback gradient based on organization ID
-	const gradients = [
-		'from-blue-500 to-purple-600',
-		'from-green-500 to-teal-600',
-		'from-orange-500 to-pink-600',
-		'from-purple-500 to-indigo-600',
-		'from-red-500 to-orange-600'
-	];
-	const fallbackGradient = $derived(gradients[organization.id.charCodeAt(0) % gradients.length]);
+	// Fallback gradient based on organization ID — shared poster ramp, so an org,
+	// its series and its events fall back to the same visual family.
+	const fallbackGradient = $derived(getPosterFallbackGradient(organization.id));
 
 	// Get clean description text (strip markdown formatting for plain text display)
 	const descriptionText = $derived(
@@ -67,7 +62,8 @@
 	const containerClasses = $derived(
 		cn(
 			'group relative overflow-hidden rounded-lg border bg-card transition-all',
-			'hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+			// Same lift on all three discovery cards (event / series / organization).
+			'hover:-translate-y-0.5 hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',
 			className
@@ -112,7 +108,7 @@
 					<div class="flex h-full w-full items-center justify-center p-4">
 						<!-- Square container for logo -->
 						<div
-							class="aspect-square w-full max-w-[60%] overflow-hidden rounded-lg bg-white/10 p-4 backdrop-blur-sm"
+							class="aspect-square w-full max-w-[60%] overflow-hidden rounded-lg bg-poster-white/10 p-4 backdrop-blur-sm"
 						>
 							<img
 								src={logoDisplayUrl}
@@ -125,7 +121,7 @@
 				{:else}
 					<!-- Ultimate fallback: Building icon -->
 					<div class="flex h-full w-full items-center justify-center">
-						<Users class="h-16 w-16 text-white opacity-50" aria-hidden="true" />
+						<Users class="h-16 w-16 text-poster-white/60" aria-hidden="true" />
 					</div>
 				{/if}
 			</div>
@@ -143,7 +139,7 @@
 		<div class="space-y-1">
 			<h3
 				class={cn(
-					'line-clamp-2 font-semibold leading-tight',
+					'line-clamp-2 font-bold leading-tight',
 					variant === 'compact' ? 'text-base md:text-lg' : 'text-lg'
 				)}
 			>
@@ -174,9 +170,13 @@
 				<div class="flex items-start gap-2 text-sm">
 					<Tag class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
 					<div class="flex flex-wrap gap-1">
+						<!-- Tag chips: primary on a 10% primary tint. The tint composites to
+						     ~the card colour, so primary-vs-card governs — 5.9:1 light /
+						     5.3:1 dark (hand-recomputed; a composited alpha is invisible to
+						     scripts/audit-brand-themes.py). -->
 						{#each organization.tags.slice(0, 3) as tag (tag)}
 							<span
-								class="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+								class="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary"
 							>
 								{tag}
 							</span>

--- a/src/lib/components/organizations/filters/MobileOrganizationFilterSheet.svelte
+++ b/src/lib/components/organizations/filters/MobileOrganizationFilterSheet.svelte
@@ -92,7 +92,7 @@
 {#if isOpen}
 	<!-- Backdrop -->
 	<div
-		class="fixed inset-0 z-40 bg-black/50 transition-opacity lg:hidden"
+		class="fixed inset-0 z-40 bg-poster-ink/50 transition-opacity lg:hidden"
 		onclick={onClose}
 		role="presentation"
 		aria-hidden="true"

--- a/src/lib/components/organizations/filters/MobileOrganizationFilterSheet.svelte
+++ b/src/lib/components/organizations/filters/MobileOrganizationFilterSheet.svelte
@@ -122,7 +122,7 @@
 				</h2>
 				{#if activeFilterCount > 0}
 					<span
-						class="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
+						class="rounded-full bg-primary px-2 py-0.5 text-xs font-bold text-primary-foreground"
 						aria-label={m['mobileOrganizationFilterSheet.activeFiltersLabel']({
 							count: activeFilterCount
 						})}
@@ -162,7 +162,7 @@
 
 				<!-- Search Input -->
 				<div class="space-y-2">
-					<label for="mobile-organization-search" class="text-sm font-medium"
+					<label for="mobile-organization-search" class="text-sm font-bold"
 						>{m['mobileOrganizationFilterSheet.search']()}</label
 					>
 					<SearchInput
@@ -189,7 +189,7 @@
 					<button
 						type="button"
 						onclick={onClearFilters}
-						class="flex items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						class="flex items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2.5 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<X class="h-4 w-4" aria-hidden="true" />
 						{m['mobileOrganizationFilterSheet.clearAllFilters']()}
@@ -199,7 +199,7 @@
 				<button
 					type="button"
 					onclick={handleApply}
-					class="rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					class="rounded-md bg-primary px-4 py-2.5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 				>
 					{totalCount === 1
 						? m['mobileOrganizationFilterSheet.showCountOne']({ count: totalCount })

--- a/src/lib/components/organizations/filters/OrganizationFilters.svelte
+++ b/src/lib/components/organizations/filters/OrganizationFilters.svelte
@@ -63,10 +63,10 @@
 	<div class="flex items-center justify-between">
 		<div class="flex items-center gap-2">
 			<Filter class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-			<h2 class="text-lg font-semibold">{m['common.filters_filters']()}</h2>
+			<h2 class="text-xl font-extrabold">{m['common.filters_filters']()}</h2>
 			{#if activeFilterCount > 0}
 				<span
-					class="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
+					class="rounded-full bg-primary px-2 py-0.5 text-xs font-bold text-primary-foreground"
 					aria-label={m['organizationFilters.activeFiltersLabel']({ count: activeFilterCount })}
 				>
 					{activeFilterCount}
@@ -106,8 +106,7 @@
 
 	<!-- Search Input -->
 	<div class="space-y-2">
-		<label for="organization-search" class="text-sm font-medium">{m['common.search_label']()}</label
-		>
+		<label for="organization-search" class="text-sm font-bold">{m['common.search_label']()}</label>
 		<SearchInput
 			id="organization-search"
 			value={filters.search ?? ''}

--- a/src/lib/components/organizations/filters/OrganizationOrderByFilter.svelte
+++ b/src/lib/components/organizations/filters/OrganizationOrderByFilter.svelte
@@ -41,7 +41,9 @@
 <div class={cn('space-y-3', className)}>
 	<div class="flex items-center gap-2">
 		<ArrowUpDown class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-		<h3 class="text-sm font-medium">{m['filters.orderBy.heading']()}</h3>
+		<h3 class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+			{m['filters.orderBy.heading']()}
+		</h3>
 		<!-- Info Tooltip -->
 		<div class="relative">
 			<button

--- a/src/lib/components/polls/PollCard.svelte
+++ b/src/lib/components/polls/PollCard.svelte
@@ -120,11 +120,11 @@
 	});
 </script>
 
-<Card class="transition-all hover:shadow-md">
+<Card class="transition-all hover:-translate-y-0.5 hover:shadow-lg">
 	<CardHeader>
 		<div class="flex items-start justify-between gap-2">
 			<div class="min-w-0 flex-1">
-				<CardTitle class="line-clamp-1">{poll.questionnaire_name}</CardTitle>
+				<CardTitle class="line-clamp-1 font-bold">{poll.questionnaire_name}</CardTitle>
 				<CardDescription class="mt-1 flex flex-wrap gap-1">
 					<PollStatusBadge status={poll.status} />
 					<Badge variant="outline" class="text-xs">{poll.vote_visibility}</Badge>

--- a/src/lib/components/polls/PollPrivacySummary.svelte
+++ b/src/lib/components/polls/PollPrivacySummary.svelte
@@ -90,7 +90,7 @@
 			</div>
 		{:else}
 			<div
-				class="flex items-center gap-2 rounded-md border border-amber-500/50 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:bg-amber-950/20 dark:text-amber-200"
+				class="flex items-center gap-2 rounded-md border border-highlight/60 bg-highlight/10 px-3 py-2 text-sm text-foreground"
 				role="note"
 			>
 				<AlertTriangle class="h-4 w-4 shrink-0" aria-hidden="true" />
@@ -102,7 +102,7 @@
 	<!-- Anonymity to staff — only shown when staff can see voter identity -->
 	{#if !staffAnonymous}
 		<div
-			class="flex items-center gap-2 rounded-md border border-amber-500/50 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:bg-amber-950/20 dark:text-amber-200"
+			class="flex items-center gap-2 rounded-md border border-highlight/60 bg-highlight/10 px-3 py-2 text-sm text-foreground"
 			role="note"
 		>
 			<AlertTriangle class="h-4 w-4 shrink-0" aria-hidden="true" />

--- a/src/lib/components/polls/PollResultsView.svelte
+++ b/src/lib/components/polls/PollResultsView.svelte
@@ -59,7 +59,7 @@
 					{#each stat.options as opt (opt.option_id)}
 						{#if opt.voters && opt.voters.length > 0}
 							<li class="flex flex-wrap items-center gap-x-2 gap-y-1">
-								<span class="font-medium text-foreground">{opt.option_text}:</span>
+								<span class="font-bold text-foreground">{opt.option_text}:</span>
 								{#each opt.voters as voter (voter.user_id)}
 									{@render voterPill(voter.user_display_name, voter.user_email, voter.user_id)}
 								{/each}
@@ -73,7 +73,9 @@
 
 	{#if (results.free_text_responses ?? []).length > 0}
 		<section class="space-y-2">
-			<h3 class="text-sm font-medium">{m['pollResults.freeTextHeading']()}</h3>
+			<h3 class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
+				{m['pollResults.freeTextHeading']()}
+			</h3>
 			<ul class="space-y-2">
 				{#each results.free_text_responses ?? [] as r, i (i)}
 					<li class="rounded-md border bg-muted/30 p-3 text-sm">

--- a/src/lib/components/polls/PollStatusBadge.svelte
+++ b/src/lib/components/polls/PollStatusBadge.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { Badge } from '$lib/components/ui/badge';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import type { PollStatus } from '$lib/api/generated/types.gen';
 
 	interface Props {
@@ -15,12 +16,15 @@
 				? m['pollCard.status_open']()
 				: m['pollCard.status_closed']()
 	);
+
+	/**
+	 * Domain→tone mapper (rebrand): the hand-picked amber-700/emerald-700 pair is
+	 * gone, so both fills are now audited `StatusBadge` token pairs. Each state
+	 * still carries its own word — the fill never says it alone.
+	 */
+	const tone = $derived<Tone>(
+		status === 'draft' ? 'warning' : status === 'open' ? 'success' : 'neutral'
+	);
 </script>
 
-{#if status === 'draft'}
-	<Badge class="bg-amber-700 text-xs text-white hover:bg-amber-800">{label}</Badge>
-{:else if status === 'open'}
-	<Badge class="bg-emerald-700 text-xs text-white hover:bg-emerald-800">{label}</Badge>
-{:else}
-	<Badge variant="secondary" class="text-xs">{label}</Badge>
-{/if}
+<StatusBadge {tone} {label} size="sm" />

--- a/src/lib/components/polls/PollVoteForm.svelte
+++ b/src/lib/components/polls/PollVoteForm.svelte
@@ -280,9 +280,14 @@
 
 	/**
 	 * The landing's QuestionnaireMock look, on theme tokens: rounded option rows
-	 * with a purple selected state. Purely presentational — the control inside
-	 * still owns selection, so the row itself is not clickable and nothing about
-	 * keyboard or screen-reader behaviour moves.
+	 * with a purple selected state.
+	 *
+	 * The row IS the `<label>`, so the whole padded box is the hit target the
+	 * hover state promises — a padded row that highlights on hover but only
+	 * activates on its 16px control is a lie, and a 44px-tall row is the mobile
+	 * target we want anyway. Purely markup: the native label/control association
+	 * (unchanged `for`/`id`) still drives selection, so keyboard and
+	 * screen-reader behaviour are untouched.
 	 *
 	 * The selected fill is `bg-primary/10`, which composites to ~the card colour,
 	 * so the label keeps `text-foreground` and the token contract's AA guarantee;
@@ -292,7 +297,7 @@
 	 */
 	function optionRowClass(selected: boolean): string {
 		return cn(
-			'flex items-center gap-2 rounded-lg border-2 px-3 py-2 transition-colors',
+			'flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border-2 px-3 py-2 transition-colors',
 			selected ? 'border-primary bg-primary/10' : 'border-border hover:border-primary/40'
 		);
 	}
@@ -405,20 +410,22 @@
 			>
 				{#each question.options ?? [] as option (option.id)}
 					<div class="space-y-2">
-						<div class={optionRowClass(isOptionSelected(question.id, option.id))}>
+						<label
+							for="{question.id}-{option.id}"
+							class={optionRowClass(isOptionSelected(question.id, option.id))}
+						>
 							<Checkbox
 								id="{question.id}-{option.id}"
 								checked={isOptionSelected(question.id, option.id)}
 								onCheckedChange={(checked) =>
 									handleMultipleChoiceChange(question.id, option.id, !!checked, true)}
 							/>
-							<label
-								for="{question.id}-{option.id}"
-								class="flex-1 cursor-pointer text-sm font-bold leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+							<span
+								class="flex-1 text-sm font-bold leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 							>
 								{option.option}
-							</label>
-						</div>
+							</span>
+						</label>
 						{@render conditionalContent(option.id, question.id)}
 					</div>
 				{/each}
@@ -433,12 +440,13 @@
 			>
 				{#each question.options ?? [] as option (option.id)}
 					<div class="space-y-2">
-						<div class={optionRowClass(isOptionSelected(question.id, option.id))}>
+						<Label
+							for="{question.id}-{option.id}"
+							class={optionRowClass(isOptionSelected(question.id, option.id))}
+						>
 							<RadioGroupItem value={option.id} id="{question.id}-{option.id}" />
-							<Label for="{question.id}-{option.id}" class="flex-1 cursor-pointer"
-								>{option.option}</Label
-							>
-						</div>
+							<span class="flex-1">{option.option}</span>
+						</Label>
 						{@render conditionalContent(option.id, question.id)}
 					</div>
 				{/each}

--- a/src/lib/components/polls/PollVoteForm.svelte
+++ b/src/lib/components/polls/PollVoteForm.svelte
@@ -277,6 +277,25 @@
 	function isOptionSelected(questionId: string, optionId: string): boolean {
 		return multipleChoiceAnswers.get(questionId)?.includes(optionId) ?? false;
 	}
+
+	/**
+	 * The landing's QuestionnaireMock look, on theme tokens: rounded option rows
+	 * with a purple selected state. Purely presentational — the control inside
+	 * still owns selection, so the row itself is not clickable and nothing about
+	 * keyboard or screen-reader behaviour moves.
+	 *
+	 * The selected fill is `bg-primary/10`, which composites to ~the card colour,
+	 * so the label keeps `text-foreground` and the token contract's AA guarantee;
+	 * the 2px `border-primary` is >= 3:1 non-text against the card in both modes
+	 * (5.9 light / 5.3 dark, the same measurement as ToneTile's brand row).
+	 * Selection is never carried by the fill alone — the radio/checkbox state is.
+	 */
+	function optionRowClass(selected: boolean): string {
+		return cn(
+			'flex items-center gap-2 rounded-lg border-2 px-3 py-2 transition-colors',
+			selected ? 'border-primary bg-primary/10' : 'border-border hover:border-primary/40'
+		);
+	}
 </script>
 
 <form onsubmit={handleSubmit} class="space-y-8">
@@ -285,7 +304,7 @@
 		.filter((s) => !s.depends_on_option_id)
 		.sort((a, b) => a.order - b.order) as section (section.id)}
 		<div class="rounded-lg border bg-card p-6">
-			<h3 class="mb-2 text-xl font-semibold">{section.name}</h3>
+			<h3 class="mb-2 text-xl font-extrabold">{section.name}</h3>
 			{#if section.description}
 				<div class="mb-6">
 					<MarkdownContent content={section.description} class="text-muted-foreground" />
@@ -386,7 +405,7 @@
 			>
 				{#each question.options ?? [] as option (option.id)}
 					<div class="space-y-2">
-						<div class="flex items-center space-x-2">
+						<div class={optionRowClass(isOptionSelected(question.id, option.id))}>
 							<Checkbox
 								id="{question.id}-{option.id}"
 								checked={isOptionSelected(question.id, option.id)}
@@ -395,7 +414,7 @@
 							/>
 							<label
 								for="{question.id}-{option.id}"
-								class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+								class="flex-1 cursor-pointer text-sm font-bold leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 							>
 								{option.option}
 							</label>
@@ -414,9 +433,11 @@
 			>
 				{#each question.options ?? [] as option (option.id)}
 					<div class="space-y-2">
-						<div class="flex items-center space-x-2">
+						<div class={optionRowClass(isOptionSelected(question.id, option.id))}>
 							<RadioGroupItem value={option.id} id="{question.id}-{option.id}" />
-							<Label for="{question.id}-{option.id}">{option.option}</Label>
+							<Label for="{question.id}-{option.id}" class="flex-1 cursor-pointer"
+								>{option.option}</Label
+							>
 						</div>
 						{@render conditionalContent(option.id, question.id)}
 					</div>
@@ -520,7 +541,7 @@
 
 			{#each getSectionsForOption(flattened, optionId).sort((a, b) => a.order - b.order) as conditionalSection (conditionalSection.id)}
 				<div class="ml-4 rounded-lg border border-primary/20 bg-primary/5 p-4">
-					<h4 class="mb-2 text-lg font-semibold">{conditionalSection.name}</h4>
+					<h4 class="mb-2 text-lg font-extrabold">{conditionalSection.name}</h4>
 					{#if conditionalSection.description}
 						<div class="mb-4">
 							<MarkdownContent

--- a/src/lib/components/resources/ResourceCard.svelte
+++ b/src/lib/components/resources/ResourceCard.svelte
@@ -48,11 +48,14 @@
 	 * purple/grey ramp. Each row pairs its own icon AND its own label, so the
 	 * colour is redundant reinforcement, never the message (WCAG 1.4.1).
 	 *
-	 * These are 12px text directly on the card, so each needs >= 4.5:1. Measured
-	 * token-vs-card (light | dark), same computation as ToneTile's table:
-	 *   success 4.9 | 7.8 · info 9.3 | 7.2 · primary 5.9 | 5.3
-	 *   highlight-foreground 13.9 (light) / highlight 6.0 (dark) — amber itself is
-	 *   1.8:1 on a light card, which is why warning flips its token by mode.
+	 * These are 12px text sitting DIRECTLY on the card — no tint underneath — so
+	 * each needs >= 4.5:1 against the card itself. Hand-computed token-vs-card
+	 * (light | dark); do NOT reuse ToneTile's table here, those numbers are for an
+	 * icon on a 10% tint:
+	 *   success 5.68 | 9.53 · info 11.13 | 8.71 · primary 6.99 | 6.27
+	 *   muted-foreground 9.06 | 7.44
+	 *   highlight-foreground 15.90 (light) / highlight 9.17 (dark) — amber itself
+	 *   is 1.94:1 on a light card, which is why warning flips its token by mode.
 	 */
 	const visibilityInfo = $derived.by(() => {
 		switch (resource.visibility) {

--- a/src/lib/components/resources/ResourceCard.svelte
+++ b/src/lib/components/resources/ResourceCard.svelte
@@ -16,6 +16,7 @@
 		Ticket
 	} from '@lucide/svelte';
 	import { cn } from '$lib/utils/cn';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import { getBackendUrl } from '$lib/config/api';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 
@@ -42,44 +43,54 @@
 		}
 	});
 
-	// Get visibility icon and label
+	/**
+	 * Visibility, on semantic tokens instead of a hand-picked green/blue/orange/
+	 * purple/grey ramp. Each row pairs its own icon AND its own label, so the
+	 * colour is redundant reinforcement, never the message (WCAG 1.4.1).
+	 *
+	 * These are 12px text directly on the card, so each needs >= 4.5:1. Measured
+	 * token-vs-card (light | dark), same computation as ToneTile's table:
+	 *   success 4.9 | 7.8 · info 9.3 | 7.2 · primary 5.9 | 5.3
+	 *   highlight-foreground 13.9 (light) / highlight 6.0 (dark) — amber itself is
+	 *   1.8:1 on a light card, which is why warning flips its token by mode.
+	 */
 	const visibilityInfo = $derived.by(() => {
 		switch (resource.visibility) {
 			case 'public':
 				return {
 					icon: Globe,
 					label: m['resourceCard.visibilityPublic'](),
-					color: 'text-green-600 dark:text-green-400'
+					color: 'text-success'
 				};
 			case 'members-only':
 				return {
 					icon: Users,
 					label: m['resourceCard.visibilityMembersOnly'](),
-					color: 'text-blue-600 dark:text-blue-400'
+					color: 'text-info'
 				};
 			case 'staff-only':
 				return {
 					icon: Shield,
 					label: m['resourceCard.visibilityStaffOnly'](),
-					color: 'text-orange-600 dark:text-orange-400'
+					color: 'text-highlight-foreground dark:text-highlight'
 				};
 			case 'attendees-only':
 				return {
 					icon: Ticket,
 					label: m['resourceCard.visibilityAttendeesOnly'](),
-					color: 'text-purple-600 dark:text-purple-400'
+					color: 'text-primary'
 				};
 			case 'private':
 				return {
 					icon: Lock,
 					label: m['resourceCard.visibilityPrivate'](),
-					color: 'text-gray-600 dark:text-gray-400'
+					color: 'text-muted-foreground'
 				};
 			default:
 				return {
 					icon: Lock,
 					label: m['resourceCard.visibilityPrivate'](),
-					color: 'text-gray-600 dark:text-gray-400'
+					color: 'text-muted-foreground'
 				};
 		}
 	});
@@ -153,7 +164,7 @@
 
 <article
 	class={cn(
-		'group relative flex flex-col gap-4 rounded-lg border bg-card p-4 transition-all hover:shadow-md',
+		'group relative flex flex-col gap-4 rounded-lg border bg-card p-4 transition-all hover:-translate-y-0.5 hover:shadow-lg',
 		isDeleting && 'opacity-50'
 	)}
 >
@@ -163,16 +174,12 @@
 			<!-- Icon -->
 			{#if icon}
 				{@const IconComponent = icon}
-				<div
-					class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary"
-				>
-					<IconComponent class="h-5 w-5" aria-hidden="true" />
-				</div>
+				<ToneTile tone="brand" icon={IconComponent} />
 			{/if}
 
 			<!-- Title and Type -->
 			<div class="min-w-0 flex-1">
-				<h3 class="truncate text-lg font-semibold leading-tight">
+				<h3 class="truncate text-lg font-bold leading-tight">
 					{resource.name || m['resourceCard.untitledResource']()}
 				</h3>
 				<p class="text-sm text-muted-foreground">

--- a/src/lib/components/series-passes/EventSeriesPassOffers.svelte
+++ b/src/lib/components/series-passes/EventSeriesPassOffers.svelte
@@ -5,6 +5,7 @@
 	import { seriesPassQueryKeys } from '$lib/queries/series-passes';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { ArrowRight } from '@lucide/svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import SeriesPassCard from './SeriesPassCard.svelte';
 
 	interface Props {
@@ -39,15 +40,17 @@
 {#if passes.length > 0}
 	<section aria-labelledby="event-passes-heading" class="space-y-3">
 		<div class="flex flex-wrap items-baseline justify-between gap-2">
-			<h2 id="event-passes-heading" class="text-xl font-semibold">
-				{m['seriesPass.sectionHeading']()}
-			</h2>
+			<SectionHeader
+				volume="celebration"
+				id="event-passes-heading"
+				title={m['seriesPass.sectionHeading']()}
+			/>
 			<a
 				href={resolve('/(public)/events/[org_slug]/series/[series_slug]', {
 					org_slug: orgSlug,
 					series_slug: seriesSlug
 				})}
-				class="inline-flex items-center gap-1 text-sm text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				class="inline-flex items-center gap-1 text-sm font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 			>
 				{m['seriesPass.viewSeriesLink']()}
 				<ArrowRight class="h-3.5 w-3.5" aria-hidden="true" />

--- a/src/lib/components/series-passes/HeldPassCard.svelte
+++ b/src/lib/components/series-passes/HeldPassCard.svelte
@@ -65,7 +65,7 @@
 			<div class="min-w-0 flex-1">
 				<div class="mb-2 flex items-start justify-between gap-2">
 					<div class="min-w-0 flex-1">
-						<h3 class="text-lg font-semibold">{heldPass.series_pass.name}</h3>
+						<h3 class="text-lg font-bold">{heldPass.series_pass.name}</h3>
 						{#if seriesOrgSlug}
 							<a
 								href={resolve('/(public)/events/[org_slug]/series/[series_slug]', {
@@ -130,7 +130,7 @@
 				<button
 					type="button"
 					onclick={() => (showPassModal = true)}
-					class="inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+					class="inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 				>
 					<QrCode class="h-4 w-4" aria-hidden="true" />
 					{m['seriesPass.viewPass']()}

--- a/src/lib/components/series-passes/SeriesPassCard.svelte
+++ b/src/lib/components/series-passes/SeriesPassCard.svelte
@@ -4,7 +4,7 @@
 	import { seriespassGetSeriesPassQuote } from '$lib/api';
 	import { seriesPassQueryKeys } from '$lib/queries/series-passes';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { Card } from '$lib/components/ui/card';
+	import PricingCard from '$lib/components/common/PricingCard.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { formatPrice } from '$lib/utils/format';
 	import { Ticket, CreditCard, HandCoins } from '@lucide/svelte';
@@ -67,31 +67,17 @@
 	}
 </script>
 
-<Card class="flex flex-col gap-4 border-primary/30 p-4 md:p-6">
-	<div class="flex items-start justify-between gap-3">
-		<div class="min-w-0 flex-1">
-			<div class="flex items-center gap-2">
-				<Ticket class="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
-				<h3 class="truncate text-lg font-semibold">{pass.name}</h3>
-			</div>
-			{#if pass.description}
-				<div class="mt-2 text-sm text-muted-foreground">
-					<MarkdownContent content={pass.description} />
-				</div>
-			{/if}
-		</div>
+{#snippet badges()}
+	<!-- The pre-discount season price, struck through beside the name: the big
+	     number below is what the buyer would actually pay today. -->
+	{#if isDiscounted}
+		<s class="text-sm text-muted-foreground line-through">
+			{formatPrice(pass.price, pass.currency, m['seriesPass.free']())}
+		</s>
+	{/if}
+{/snippet}
 
-		<!-- Price block -->
-		<div class="shrink-0 text-right">
-			{#if isDiscounted}
-				<p class="text-sm text-muted-foreground line-through">
-					{formatPrice(pass.price, pass.currency, m['seriesPass.free']())}
-				</p>
-			{/if}
-			<p class="text-2xl font-bold text-primary">{currentPrice}</p>
-		</div>
-	</div>
-
+{#snippet meta()}
 	<!-- Coverage / pro-rata line -->
 	{#if quote}
 		<p class="text-sm text-muted-foreground">
@@ -104,35 +90,51 @@
 
 	<!-- Payment method hint -->
 	{#if pass.payment_method === 'offline' || pass.payment_method === 'at_the_door'}
-		<p class="flex items-center gap-1.5 text-xs text-muted-foreground">
+		<p class="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
 			<HandCoins class="h-3.5 w-3.5" aria-hidden="true" />
 			{m['seriesPass.payOffline']()}
 		</p>
 	{:else if pass.payment_method === 'online'}
-		<p class="flex items-center gap-1.5 text-xs text-muted-foreground">
+		<p class="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
 			<CreditCard class="h-3.5 w-3.5" aria-hidden="true" />
 			{m['seriesPass.payOnline']()}
 		</p>
 	{/if}
+{/snippet}
 
-	<!-- CTA -->
-	<div class="mt-auto">
-		{#if quote && !quote.purchasable}
-			<Button class="w-full" disabled>
-				{m['seriesPass.notAvailable']()}
-			</Button>
-			{#if quote.reason}
-				<p class="mt-2 text-center text-xs text-muted-foreground" role="status">
-					{quote.reason}
-				</p>
-			{/if}
-		{:else}
-			<Button class="w-full" onclick={handleBuyClick} disabled={isButtonDisabled}>
-				{m['seriesPass.buyButton']()}
-			</Button>
+{#snippet actions()}
+	{#if quote && !quote.purchasable}
+		<Button class="w-full" disabled>
+			{m['seriesPass.notAvailable']()}
+		</Button>
+		{#if quote.reason}
+			<p class="mt-2 text-center text-xs text-muted-foreground" role="status">
+				{quote.reason}
+			</p>
 		{/if}
-	</div>
-</Card>
+	{:else}
+		<Button class="w-full" onclick={handleBuyClick} disabled={isButtonDisabled}>
+			{m['seriesPass.buyButton']()}
+		</Button>
+	{/if}
+{/snippet}
+
+<PricingCard
+	name={pass.name}
+	icon={Ticket}
+	price={currentPrice}
+	layout="stack"
+	class="h-full border-primary/30"
+	{badges}
+	{meta}
+	{actions}
+>
+	{#if pass.description}
+		<div class="text-sm text-muted-foreground">
+			<MarkdownContent content={pass.description} />
+		</div>
+	{/if}
+</PricingCard>
 
 {#if showPurchaseDialog && quote && pass.id}
 	<SeriesPassPurchaseDialog

--- a/src/lib/components/tickets/TicketTierList.svelte
+++ b/src/lib/components/tickets/TicketTierList.svelte
@@ -13,6 +13,8 @@
 	import DemoCardInfo from '$lib/components/common/DemoCardInfo.svelte';
 	import EligibilityStatusDisplay from '$lib/components/events/EligibilityStatusDisplay.svelte';
 	import { Button } from '$lib/components/ui/button';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import Sticker from '$lib/components/brand/Sticker.svelte';
 	import { Map as MapIcon, Ticket } from '@lucide/svelte';
 
 	interface Props {
@@ -81,6 +83,20 @@
 		return !userStatus.allowed;
 	});
 
+	/**
+	 * Every visible tier is out of inventory — the one "moment" on this section
+	 * worth a Sticker (celebration volume allows at most one per viewport-height,
+	 * and this is the only one on the event page).
+	 *
+	 * Only `total_available === 0` counts: `null` is ambiguous since #825 (it can
+	 * mean "unlimited" OR "withheld"), so a page that hides capacity never claims
+	 * to be sold out. The sticker is a REPEAT of what each tier card already says
+	 * in words and in its own audited badge, so nothing is conveyed by it alone.
+	 */
+	const allSoldOut = $derived(
+		visibleTiers.length > 0 && visibleTiers.every((tier) => tier.total_available === 0)
+	);
+
 	// Check if user is eligible to purchase tickets
 	const isEligible = $derived.by(() => {
 		if (!userStatus) return true; // If no status, assume eligible (default behavior)
@@ -92,8 +108,15 @@
 {#if hasTiers}
 	<section class="rounded-lg border border-border bg-card p-6" aria-labelledby="ticket-tiers">
 		<div class="mb-4 flex items-center gap-2">
-			<Ticket class="h-5 w-5 text-primary" aria-hidden="true" />
-			<h2 id="ticket-tiers" class="text-xl font-bold">{m['ticketTierList.ticketOptions']()}</h2>
+			<Ticket class="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+			<SectionHeader
+				volume="celebration"
+				id="ticket-tiers"
+				title={m['ticketTierList.ticketOptions']()}
+			/>
+			{#if allSoldOut}
+				<Sticker tint="crimson" rotate={-3} class="text-sm">{m['tierCard.soldOut']()}</Sticker>
+			{/if}
 		</div>
 
 		<!-- Map-first entry point (#679): start from the seating map instead of
@@ -140,7 +163,7 @@
 
 		{#if !isAuthenticated && !canAttendWithoutLogin}
 			<p class="mt-4 text-sm text-muted-foreground">
-				<a href={resolve('/(public)/login', {})} class="font-medium text-primary hover:underline"
+				<a href={resolve('/(public)/login', {})} class="font-bold text-primary hover:underline"
 					>{m['ticketTierList.signIn']()}</a
 				>
 				to claim your ticket

--- a/src/lib/components/tickets/TierCard.svelte
+++ b/src/lib/components/tickets/TierCard.svelte
@@ -8,8 +8,9 @@
 	import { hasTierId } from '$lib/types/tickets';
 	import { tierPriceDisplay } from './tier-price-display';
 	import { Button } from '$lib/components/ui/button';
-	import { Card } from '$lib/components/ui/card';
-	import { Ticket, Clock, Users, AlertCircle } from '@lucide/svelte';
+	import PricingCard from '$lib/components/common/PricingCard.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import { Ticket, Clock, Users, AlertCircle, Check } from '@lucide/svelte';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import { formatDate } from '$lib/utils/date';
 
@@ -248,114 +249,107 @@
 	const membershipRestriction = $derived(checkMembershipTierRestriction());
 </script>
 
-<Card class="p-4 {tier.can_purchase === false ? 'opacity-60' : ''}">
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-		<!-- Tier Info -->
-		<div class="flex-1">
-			<div class="flex items-center gap-2">
-				<Ticket class="h-5 w-5 text-primary" aria-hidden="true" />
-				<h3 class="text-lg font-semibold">{tier.name}</h3>
-			</div>
+{#snippet badges()}
+	<!-- Inventory as a solid chip rather than a coloured line of text: sold out is
+	     the fact a buyer scans for, and StatusBadge's pairs are audited in both
+	     modes. Meaning is never carried by the fill alone — the label says it. -->
+	{#if availabilityStatus.message !== null && effectiveEligible}
+		<StatusBadge
+			tone={availabilityStatus.available ? 'neutral' : 'danger'}
+			icon={Users}
+			label={availabilityStatus.message}
+		/>
+	{/if}
+{/snippet}
 
-			<div class="mt-2 text-2xl font-bold text-primary">{priceDisplay()}</div>
+{#snippet meta()}
+	{#if !salesStatus.active}
+		<p class="flex items-center gap-1.5 text-sm text-muted-foreground">
+			<Clock class="h-4 w-4 shrink-0" aria-hidden="true" />
+			{salesStatus.message}
+		</p>
+	{/if}
+{/snippet}
 
-			{#if tier.description}
-				<MarkdownContent content={tier.description} class="mt-2 text-sm text-muted-foreground" />
-			{/if}
-
-			<!-- Status Indicators -->
-			<dl class="mt-3 flex flex-wrap gap-4 text-sm">
-				{#if !salesStatus.active}
-					<div class="flex items-center gap-1.5 text-muted-foreground">
-						<Clock class="h-4 w-4" aria-hidden="true" />
-						<dd>{salesStatus.message}</dd>
-					</div>
-				{/if}
-
-				{#if availabilityStatus.message !== null && effectiveEligible}
-					<div
-						class="flex items-center gap-1.5"
-						class:text-destructive={!availabilityStatus.available}
-					>
-						<Users class="h-4 w-4" aria-hidden="true" />
-						<dd>{availabilityStatus.message}</dd>
-					</div>
-				{/if}
-			</dl>
-		</div>
-
-		<!-- Action Button -->
-		<div class="flex shrink-0 flex-col items-end gap-2">
-			{#if !hasId}
-				<div class="rounded-md bg-destructive/10 px-4 py-2 text-sm text-destructive">
-					{m['tierCardAdmin.configError']()}
-				</div>
-			{:else if hasTicket}
-				<div
-					class="rounded-md bg-green-100 px-4 py-2 text-sm font-medium text-green-800 dark:bg-green-950 dark:text-green-100"
-				>
-					✓ {m['tierCardAdmin.youHaveTicket']()}
-				</div>
-			{:else if !salesStatus.active}
-				<Button disabled class="w-full sm:w-auto">{m['tierCardAdmin.notAvailable']()}</Button>
-			{:else if !availabilityStatus.available}
-				<Button disabled class="w-full sm:w-auto">{m['tierCardAdmin.soldOut']()}</Button>
-			{:else if !membershipRestriction.allowed}
-				<!-- User doesn't have required membership tier -->
-				<Button disabled class="w-full sm:w-auto">
-					<AlertCircle class="mr-2 h-4 w-4" />
-					{m['tierCardAdmin.notEligible']()}
-				</Button>
-				{#if membershipRestriction.reason}
-					<p class="max-w-[250px] text-right text-xs text-muted-foreground">
-						{membershipRestriction.reason}
-					</p>
-				{/if}
-			{:else if !isAuthenticated && !canAttendWithoutLogin}
-				<Button href="/login" variant="outline" class="w-full sm:w-auto"
-					>{m['tierCardAdmin.signInToGetTicket']()}</Button
-				>
-			{:else if !isAuthenticated && canAttendWithoutLogin}
-				<Button onclick={() => onGuestTierClick?.(tier)} class="w-full sm:w-auto">
-					{m['tierCardAdmin.getTicket']()}
-				</Button>
-			{:else if !effectiveEligible}
-				<!-- User is authenticated but not eligible for this tier - show reason -->
-				<Button disabled class="w-full sm:w-auto">
-					{#if tierPurchaseStatus.reason === 'Sold out'}
-						{m['tierCardAdmin.soldOut']()}
-					{:else if tierPurchaseStatus.reason === 'Limit reached'}
-						{m['tierCardAdmin.limitReached']()}
-					{:else}
-						{m['tierCardAdmin.notEligible']()}
-					{/if}
-				</Button>
-				{#if tierPurchaseStatus.reason && tierPurchaseStatus.reason !== 'Not eligible'}
-					<p class="max-w-[250px] text-right text-xs text-muted-foreground">
-						{tierPurchaseStatus.reason === 'Limit reached'
-							? m['tierCardAdmin.limitReachedDetail']()
-							: tierPurchaseStatus.reason === 'Sold out'
-								? m['tierCardAdmin.soldOutDetail']()
-								: m['tierCardAdmin.notAvailable']()}
-					</p>
-				{/if}
-			{:else if canClaim}
-				<Button onclick={() => onSelectTier(tier)} class="w-full sm:w-auto">
-					{m['tierCardAdmin.claimFreeTicket']()}
-				</Button>
-			{:else if canCheckout}
-				<Button onclick={() => onSelectTier(tier)} class="w-full sm:w-auto"
-					>{m['tierCardAdmin.buyTicket']()}</Button
-				>
-			{:else if canReserve}
-				<Button onclick={() => onSelectTier(tier)} variant="outline" class="w-full sm:w-auto">
-					{m['tierCardAdmin.reserveTicket']()}
-				</Button>
+{#snippet actions()}
+	{#if !hasId}
+		<p class="rounded-md bg-destructive/10 px-4 py-2 text-sm font-medium text-destructive">
+			{m['tierCardAdmin.configError']()}
+		</p>
+	{:else if hasTicket}
+		<StatusBadge tone="success" size="lg" icon={Check} label={m['tierCardAdmin.youHaveTicket']()} />
+	{:else if !salesStatus.active}
+		<Button disabled class="w-full sm:w-auto">{m['tierCardAdmin.notAvailable']()}</Button>
+	{:else if !availabilityStatus.available}
+		<Button disabled class="w-full sm:w-auto">{m['tierCardAdmin.soldOut']()}</Button>
+	{:else if !membershipRestriction.allowed}
+		<!-- User doesn't have required membership tier -->
+		<Button disabled class="w-full sm:w-auto">
+			<AlertCircle class="mr-2 h-4 w-4" />
+			{m['tierCardAdmin.notEligible']()}
+		</Button>
+		{#if membershipRestriction.reason}
+			<p class="max-w-[250px] text-xs text-muted-foreground sm:text-right">
+				{membershipRestriction.reason}
+			</p>
+		{/if}
+	{:else if !isAuthenticated && !canAttendWithoutLogin}
+		<Button href="/login" variant="outline" class="w-full sm:w-auto"
+			>{m['tierCardAdmin.signInToGetTicket']()}</Button
+		>
+	{:else if !isAuthenticated && canAttendWithoutLogin}
+		<Button onclick={() => onGuestTierClick?.(tier)} class="w-full sm:w-auto">
+			{m['tierCardAdmin.getTicket']()}
+		</Button>
+	{:else if !effectiveEligible}
+		<!-- User is authenticated but not eligible for this tier - show reason -->
+		<Button disabled class="w-full sm:w-auto">
+			{#if tierPurchaseStatus.reason === 'Sold out'}
+				{m['tierCardAdmin.soldOut']()}
+			{:else if tierPurchaseStatus.reason === 'Limit reached'}
+				{m['tierCardAdmin.limitReached']()}
 			{:else}
-				<div class="rounded-md bg-muted px-4 py-2 text-sm text-muted-foreground">
-					{m['tierCardAdmin.comingSoon']()}
-				</div>
+				{m['tierCardAdmin.notEligible']()}
 			{/if}
-		</div>
-	</div>
-</Card>
+		</Button>
+		{#if tierPurchaseStatus.reason && tierPurchaseStatus.reason !== 'Not eligible'}
+			<p class="max-w-[250px] text-xs text-muted-foreground sm:text-right">
+				{tierPurchaseStatus.reason === 'Limit reached'
+					? m['tierCardAdmin.limitReachedDetail']()
+					: tierPurchaseStatus.reason === 'Sold out'
+						? m['tierCardAdmin.soldOutDetail']()
+						: m['tierCardAdmin.notAvailable']()}
+			</p>
+		{/if}
+	{:else if canClaim}
+		<Button onclick={() => onSelectTier(tier)} class="w-full sm:w-auto">
+			{m['tierCardAdmin.claimFreeTicket']()}
+		</Button>
+	{:else if canCheckout}
+		<Button onclick={() => onSelectTier(tier)} class="w-full sm:w-auto"
+			>{m['tierCardAdmin.buyTicket']()}</Button
+		>
+	{:else if canReserve}
+		<Button onclick={() => onSelectTier(tier)} variant="outline" class="w-full sm:w-auto">
+			{m['tierCardAdmin.reserveTicket']()}
+		</Button>
+	{:else}
+		<p class="rounded-md bg-muted px-4 py-2 text-sm font-medium text-muted-foreground">
+			{m['tierCardAdmin.comingSoon']()}
+		</p>
+	{/if}
+{/snippet}
+
+<PricingCard
+	name={tier.name}
+	icon={Ticket}
+	price={priceDisplay()}
+	muted={tier.can_purchase === false}
+	{badges}
+	{meta}
+	{actions}
+>
+	{#if tier.description}
+		<MarkdownContent content={tier.description} class="text-sm text-muted-foreground" />
+	{/if}
+</PricingCard>

--- a/src/lib/utils/event.ts
+++ b/src/lib/utils/event.ts
@@ -7,6 +7,7 @@ import type {
 	EventDetailSchema,
 	MinimalEventSchema
 } from '$lib/api/generated/types.gen';
+import { getPosterFallbackGradient } from './fallback-gradient';
 
 /**
  * Get display string for event access/pricing
@@ -70,23 +71,17 @@ export function getSpotsRemaining(event: EventInListSchema): number | null {
 }
 
 /**
- * Generate a deterministic gradient class for event fallback images
+ * Generate a deterministic gradient class for event fallback images.
+ *
+ * Delegates to the shared poster-palette ramp so an event, its series and its
+ * organization all fall back to the same visual family (see
+ * `utils/fallback-gradient.ts` for why these stay mode-inert).
+ *
  * @param eventId Event UUID
- * @returns Tailwind gradient class string
+ * @returns Tailwind gradient color-stop classes (caller supplies the direction)
  */
 export function getEventFallbackGradient(eventId: string): string {
-	const gradients = [
-		'from-purple-500 to-pink-500',
-		'from-blue-500 to-cyan-500',
-		'from-green-500 to-emerald-500',
-		'from-orange-500 to-red-500',
-		'from-indigo-500 to-purple-500',
-		'from-teal-500 to-green-500'
-	];
-
-	// Hash event ID to select gradient (deterministic)
-	const hash = eventId.split('').reduce((acc, char) => char.charCodeAt(0) + acc, 0);
-	return gradients[Math.abs(hash) % gradients.length];
+	return getPosterFallbackGradient(eventId);
 }
 
 /**

--- a/src/lib/utils/fallback-gradient.ts
+++ b/src/lib/utils/fallback-gradient.ts
@@ -1,0 +1,35 @@
+/**
+ * Deterministic cover-art fallback gradients for events, series and
+ * organizations.
+ *
+ * These are IMAGERY, not surfaces: they stand in for a missing cover photo, so
+ * they keep the fixed poster palette in both light and dark mode (the same rule
+ * the landing panels and `brand/Sticker` follow). That is also why they are not
+ * theme tokens — a cover that flipped lightness with the theme would look like a
+ * different picture rather than the same picture on a different page.
+ *
+ * Every pair below is dark enough at BOTH stops to carry the white overlay art
+ * (logo watermark, fallback icon) the call sites paint on top; where real text
+ * sits over one (the event hero) the call site adds an ink scrim and states its
+ * measured ratio.
+ *
+ * Returned value is the color-stop pair only — call sites supply the direction
+ * utility (`bg-gradient-to-br`), so a caller can pick its own axis.
+ */
+export const POSTER_FALLBACK_GRADIENTS = [
+	'from-poster-purple to-poster-crimson-deep',
+	'from-poster-ink to-poster-purple',
+	'from-poster-crimson-deep to-poster-purple',
+	'from-poster-purple to-poster-lavender',
+	'from-poster-ink to-poster-crimson-deep',
+	'from-poster-lavender to-poster-crimson-deep'
+] as const;
+
+/**
+ * Pick a stable gradient for an entity id. Same id ⇒ same gradient, forever —
+ * a cover that reshuffled between renders would read as a loading glitch.
+ */
+export function getPosterFallbackGradient(seed: string): string {
+	const hash = seed.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+	return POSTER_FALLBACK_GRADIENTS[Math.abs(hash) % POSTER_FALLBACK_GRADIENTS.length];
+}

--- a/src/routes/(public)/events/+page.svelte
+++ b/src/routes/(public)/events/+page.svelte
@@ -19,6 +19,8 @@
 	} from '$lib/utils/filters';
 	import type { EventFilters as FilterState } from '$lib/utils/filters';
 	import { parseCalendarParams, getCurrentPeriod } from '$lib/utils/calendar';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { SeoHead } from '$lib/seo';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -172,28 +174,13 @@
 	</a>
 
 	<!-- Page Header -->
-	<header class="mb-8">
-		<div class="flex items-start justify-between gap-4">
-			<div>
-				<h1 class="text-4xl font-bold">{m['browse.events_title']()}</h1>
-				{#if !error && (viewMode === 'list' ? totalCount > 0 : calendarEvents.length > 0)}
-					<p class="mt-2 text-muted-foreground">
-						{#if viewMode === 'list'}
-							{m['browse.events_count']({
-								count: totalCount,
-								eventPlural:
-									totalCount === 1 ? m['common.plurals_event']() : m['common.plurals_events']()
-							})}
-						{:else}
-							{calendarEvents.length}
-							{calendarEvents.length === 1
-								? m['common.plurals_event']()
-								: m['common.plurals_events']()}
-						{/if}
-					</p>
-				{/if}
-			</div>
-
+	<PageHeader
+		volume="celebration"
+		kicker={m['browse.events_kicker']()}
+		title={m['browse.events_title']()}
+		class="mb-8"
+	>
+		{#snippet actions()}
 			<!-- View Toggle -->
 			<Button variant="outline" size="sm" onclick={toggleViewMode} class="flex items-center gap-2">
 				{#if viewMode === 'list'}
@@ -204,8 +191,21 @@
 					{m['calendar.list_view']()}
 				{/if}
 			</Button>
-		</div>
-	</header>
+		{/snippet}
+	</PageHeader>
+	{#if !error && (viewMode === 'list' ? totalCount > 0 : calendarEvents.length > 0)}
+		<p class="-mt-6 mb-8 text-muted-foreground" aria-live="polite">
+			{#if viewMode === 'list'}
+				{m['browse.events_count']({
+					count: totalCount,
+					eventPlural: totalCount === 1 ? m['common.plurals_event']() : m['common.plurals_events']()
+				})}
+			{:else}
+				{calendarEvents.length}
+				{calendarEvents.length === 1 ? m['common.plurals_event']() : m['common.plurals_events']()}
+			{/if}
+		</p>
+	{/if}
 
 	<!-- Main Content: Sidebar + Event Grid -->
 	<div class="flex flex-col gap-8 lg:flex-row">
@@ -237,27 +237,23 @@
 						</p>
 					</div>
 				{:else if events.length === 0}
-					<!-- Empty State -->
-					<div class="rounded-lg border bg-muted/50 p-12 text-center">
-						<Calendar class="mx-auto mb-4 h-16 w-16 text-muted-foreground" aria-hidden="true" />
-						<h2 class="text-2xl font-semibold">{m['browse.events_noEventsFound']()}</h2>
-						<p class="mt-2 text-muted-foreground">
+					<!-- level 2: the page's only other heading is the h1 above. -->
+					<EmptyState
+						level={2}
+						icon={Calendar}
+						title={m['browse.events_noEventsFound']()}
+						body={currentFilters.search || currentFilters.cityId || currentFilters.tags
+							? m['browse.events_tryAdjustingFilters']()
+							: m['browse.events_noUpcomingEvents']()}
+					>
+						{#snippet action()}
 							{#if currentFilters.search || currentFilters.cityId || currentFilters.tags}
-								{m['browse.events_tryAdjustingFilters']()}
-							{:else}
-								{m['browse.events_noUpcomingEvents']()}
+								<Button onclick={handleClearFilters}>
+									{m['browse.events_clearFilters']()}
+								</Button>
 							{/if}
-						</p>
-						{#if currentFilters.search || currentFilters.cityId || currentFilters.tags}
-							<button
-								type="button"
-								onclick={handleClearFilters}
-								class="mt-4 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-							>
-								{m['browse.events_clearFilters']()}
-							</button>
-						{/if}
-					</div>
+						{/snippet}
+					</EmptyState>
 				{:else}
 					<!-- Event Grid -->
 					<div

--- a/src/routes/(public)/events/+page.svelte
+++ b/src/routes/(public)/events/+page.svelte
@@ -92,6 +92,24 @@
 	const calendarEvents = $derived(calendarQuery.data || []);
 	const isCalendarLoading = $derived(calendarQuery.isLoading);
 
+	/**
+	 * "N events found", or the calendar period's tally — `undefined` when there is
+	 * nothing to count, which is what `PageHeader` reads as "no subtitle".
+	 */
+	const countLabel = $derived.by((): string | undefined => {
+		if (error) return undefined;
+		if (viewMode === 'list') {
+			if (totalCount <= 0) return undefined;
+			return m['browse.events_count']({
+				count: totalCount,
+				eventPlural: totalCount === 1 ? m['common.plurals_event']() : m['common.plurals_events']()
+			});
+		}
+		const count = calendarEvents.length;
+		if (count <= 0) return undefined;
+		return `${count} ${count === 1 ? m['common.plurals_event']() : m['common.plurals_events']()}`;
+	});
+
 	// Mobile filter sheet state
 	let isMobileFilterOpen = $state(false);
 
@@ -173,11 +191,14 @@
 		{m['browse.events_skipTo']()}
 	</a>
 
-	<!-- Page Header -->
+	<!-- Page Header. The result count rides `subtitle`, exactly as /organizations
+	     does, rather than a paragraph pulled back under the header with a
+	     negative margin that breaks the moment the header wraps. -->
 	<PageHeader
 		volume="celebration"
 		kicker={m['browse.events_kicker']()}
 		title={m['browse.events_title']()}
+		subtitle={countLabel}
 		class="mb-8"
 	>
 		{#snippet actions()}
@@ -193,19 +214,6 @@
 			</Button>
 		{/snippet}
 	</PageHeader>
-	{#if !error && (viewMode === 'list' ? totalCount > 0 : calendarEvents.length > 0)}
-		<p class="-mt-6 mb-8 text-muted-foreground" aria-live="polite">
-			{#if viewMode === 'list'}
-				{m['browse.events_count']({
-					count: totalCount,
-					eventPlural: totalCount === 1 ? m['common.plurals_event']() : m['common.plurals_events']()
-				})}
-			{:else}
-				{calendarEvents.length}
-				{calendarEvents.length === 1 ? m['common.plurals_event']() : m['common.plurals_events']()}
-			{/if}
-		</p>
-	{/if}
 
 	<!-- Main Content: Sidebar + Event Grid -->
 	<div class="flex flex-col gap-8 lg:flex-row">

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -27,6 +27,7 @@
 	import { eventHasSeatingMap } from '$lib/components/events/venue-overview';
 	import EventConfirmationBanners from '$lib/components/events/EventConfirmationBanners.svelte';
 	import { createCheckoutController } from '$lib/components/events/event-checkout-controller.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import { SeoHead } from '$lib/seo';
 	import {
 		isRSVP,
@@ -481,9 +482,11 @@
 						class="rounded-lg border bg-card lg:hidden"
 					>
 						<div class="border-b p-4">
-							<h2 id="series-heading-mobile" class="font-semibold">
-								{m['eventDetails.series_heading']()}
-							</h2>
+							<SectionHeader
+								volume="celebration"
+								id="series-heading-mobile"
+								title={m['eventDetails.series_heading']()}
+							/>
 						</div>
 						<a
 							href={resolve('/(public)/events/[org_slug]/series/[series_slug]', {
@@ -492,7 +495,7 @@
 							})}
 							class="block p-4 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 						>
-							<div class="font-medium">{event.event_series.name}</div>
+							<div class="font-bold">{event.event_series.name}</div>
 							{#if event.event_series.description}
 								<p class="mt-1 text-sm text-muted-foreground">
 									{event.event_series.description}
@@ -550,9 +553,11 @@
 					{#if event.event_series}
 						<section aria-labelledby="series-heading-desktop" class="rounded-lg border bg-card">
 							<div class="border-b p-4">
-								<h2 id="series-heading-desktop" class="font-semibold">
-									{m['eventDetails.series_heading']()}
-								</h2>
+								<SectionHeader
+									volume="celebration"
+									id="series-heading-desktop"
+									title={m['eventDetails.series_heading']()}
+								/>
 							</div>
 							<a
 								href={resolve('/(public)/events/[org_slug]/series/[series_slug]', {
@@ -561,7 +566,7 @@
 								})}
 								class="block p-4 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 							>
-								<div class="font-medium">{event.event_series.name}</div>
+								<div class="font-bold">{event.event_series.name}</div>
 								{#if event.event_series.description}
 									<p class="mt-1 text-sm text-muted-foreground">
 										{event.event_series.description}
@@ -587,12 +592,19 @@
 		<!-- Tags Section (bottom of page) -->
 		{#if event.tags && event.tags.length > 0}
 			<section aria-labelledby="tags-heading" class="container mx-auto border-t px-6 py-8 md:px-8">
-				<h2 id="tags-heading" class="mb-4 text-xl font-semibold">
-					{m['eventDetails.tags_heading']()}
-				</h2>
+				<SectionHeader
+					volume="celebration"
+					id="tags-heading"
+					title={m['eventDetails.tags_heading']()}
+					class="mb-4"
+				/>
+				<!-- Tag chips: primary on a 10% primary tint. The tint composites to
+				     ~the page colour, so primary-vs-background governs — 5.3:1 light /
+				     5.9:1 dark (hand-recomputed; a composited alpha is invisible to
+				     scripts/audit-brand-themes.py). -->
 				<div class="flex flex-wrap gap-2">
 					{#each event.tags as tag (tag)}
-						<span class="rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+						<span class="rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary">
 							{tag}
 						</span>
 					{/each}

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/questionnaire/[id]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/questionnaire/[id]/+page.svelte
@@ -9,6 +9,8 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { toast } from 'svelte-sonner';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import QuestionnaireFillForm from '$lib/components/questionnaires/QuestionnaireFillForm.svelte';
 	import type { QuestionnaireSubmissionSchema } from '$lib/api/generated';
 
@@ -111,10 +113,12 @@
 			<ArrowLeft class="h-4 w-4" />
 			{m['questionnaireSubmissionPage.backToEvent']()}
 		</a>
-		<h1 class="text-3xl font-bold">{data.questionnaire.name}</h1>
-		<p class="mt-2 text-muted-foreground">
-			{m['questionnaireSubmissionPage.subtitle']({ eventName: data.event.name })}
-		</p>
+		<PageHeader
+			volume="celebration"
+			kicker={data.event.name}
+			title={data.questionnaire.name}
+			subtitle={m['questionnaireSubmissionPage.subtitle']({ eventName: data.event.name })}
+		/>
 		{#if data.questionnaire.description}
 			<div class="mt-4 rounded-lg border bg-muted/50 p-4">
 				<MarkdownContent content={data.questionnaire.description} />
@@ -124,27 +128,24 @@
 
 	{#if autoAccepted}
 		<!-- Auto-accepted: no evaluation needed, the user is admitted immediately (#441) -->
-		<div class="rounded-lg border bg-card p-8 text-center" role="status">
-			<div
-				class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10"
-			>
-				<Check class="h-6 w-6 text-primary" aria-hidden="true" />
-			</div>
-			<h2 class="text-2xl font-semibold">
-				{m['questionnaireSubmissionPage.accepted_title']()}
-			</h2>
-			<p class="mx-auto mt-2 max-w-md text-muted-foreground">
-				{isTicketed
+		<div role="status">
+			<EmptyState
+				level={2}
+				tone="success"
+				icon={Check}
+				title={m['questionnaireSubmissionPage.accepted_title']()}
+				body={isTicketed
 					? m['questionnaireSubmissionPage.accepted_description_ticket']()
 					: m['questionnaireSubmissionPage.accepted_description_rsvp']()}
-			</p>
-			<div class="mt-6">
-				<Button href={eventUrl}>
-					{isTicketed
-						? m['questionnaireSubmissionPage.accepted_cta_ticket']()
-						: m['questionnaireSubmissionPage.accepted_cta_rsvp']()}
-				</Button>
-			</div>
+			>
+				{#snippet action()}
+					<Button href={eventUrl}>
+						{isTicketed
+							? m['questionnaireSubmissionPage.accepted_cta_ticket']()
+							: m['questionnaireSubmissionPage.accepted_cta_rsvp']()}
+					</Button>
+				{/snippet}
+			</EmptyState>
 		</div>
 	{:else}
 		<QuestionnaireFillForm

--- a/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import type { PageData } from './$types';
-	import { Calendar, ArrowLeft, Repeat, ArrowDownUp, Settings } from '@lucide/svelte';
+	import { Calendar, ArrowLeft, ArrowDownUp, Settings } from '@lucide/svelte';
 	import { EventCard } from '$lib/components/events';
 	import { getImageUrl } from '$lib/utils/url';
 	import { SeoHead } from '$lib/seo';
@@ -9,6 +9,11 @@
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
 	import FollowButton from '$lib/components/common/FollowButton.svelte';
 	import SeriesPassCard from '$lib/components/series-passes/SeriesPassCard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import Sticker from '$lib/components/brand/Sticker.svelte';
+	import { getPosterFallbackGradient } from '$lib/utils/fallback-gradient';
 
 	const { data }: { data: PageData } = $props();
 
@@ -28,20 +33,8 @@
 		getImageUrl(series.organization.logo_thumbnail_url || series.organization.logo)
 	);
 
-	// Fallback gradient
-	function getSeriesFallbackGradient(seriesId: string): string {
-		const hash = seriesId.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
-		const gradients = [
-			'bg-gradient-to-br from-blue-500 to-indigo-600',
-			'bg-gradient-to-br from-purple-500 to-pink-600',
-			'bg-gradient-to-br from-green-500 to-teal-600',
-			'bg-gradient-to-br from-orange-500 to-red-600',
-			'bg-gradient-to-br from-cyan-500 to-blue-600'
-		];
-		return gradients[hash % gradients.length];
-	}
-
-	const fallbackGradient = $derived(getSeriesFallbackGradient(series.id));
+	// Fallback cover, on the shared poster ramp (see utils/fallback-gradient.ts).
+	const fallbackGradient = $derived(getPosterFallbackGradient(series.id));
 
 	// Calculate pagination info
 	const totalPages = $derived(Math.ceil(totalCount / pageSize));
@@ -64,24 +57,21 @@
 				/>
 				<!-- Gradient overlay -->
 				<div
-					class="absolute inset-0 bg-gradient-to-b from-transparent via-black/20 to-black/60"
+					class="absolute inset-0 bg-gradient-to-b from-transparent via-poster-ink/20 to-poster-ink/60"
 				></div>
 			{:else}
 				<!-- Fallback gradient -->
-				<div class="h-full w-full {fallbackGradient}"></div>
-				<div class="absolute inset-0 bg-gradient-to-b from-black/10 to-black/60"></div>
+				<div class="h-full w-full bg-gradient-to-br {fallbackGradient}"></div>
+				<div class="absolute inset-0 bg-gradient-to-b from-poster-ink/10 to-poster-ink/60"></div>
 			{/if}
 
-			<!-- Series Badge -->
+			<!-- Series badge. The one Sticker on this page (celebration volume caps
+			     them at one per viewport-height): a fixed-palette white sticker reads
+			     identically over any cover art, in either theme. -->
 			<div class="absolute right-4 top-4">
-				<div class="rounded-full bg-primary px-4 py-2 shadow-lg">
-					<div class="flex items-center gap-2">
-						<Repeat class="h-4 w-4 text-primary-foreground" aria-hidden="true" />
-						<span class="text-sm font-semibold text-primary-foreground"
-							>{m['eventSeriesDetailPage.badge_eventSeries']()}</span
-						>
-					</div>
-				</div>
+				<Sticker tint="purple" rotate={-3} class="text-sm">
+					{m['eventSeriesDetailPage.badge_eventSeries']()}
+				</Sticker>
 			</div>
 		</div>
 	</section>
@@ -108,7 +98,9 @@
 					class="rounded-lg border border-border bg-card p-4 shadow-sm"
 					aria-label={m['seriesPublicPage.adminActionsLabel']()}
 				>
-					<h3 class="mb-3 text-sm font-semibold">{m['eventSeriesDetailPage.admin_title']()}</h3>
+					<h3 class="mb-3 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
+						{m['eventSeriesDetailPage.admin_title']()}
+					</h3>
 					<div class="space-y-2">
 						<a
 							href={resolve('/(auth)/org/[slug]/admin/event-series/[series_id]/edit', {
@@ -150,12 +142,17 @@
 
 						<!-- Series Info -->
 						<div class="min-w-0 flex-1">
-							<h1 class="mb-2 text-3xl font-bold md:text-4xl">{series.name}</h1>
+							<PageHeader
+								volume="celebration"
+								kicker={m['eventSeriesCard.eventSeries']()}
+								title={series.name}
+								class="mb-2"
+							/>
 
 							<!-- Organization Link -->
 							<a
 								href={resolve('/(public)/org/[slug]', { slug: series.organization.slug })}
-								class="mb-2 inline-block text-base font-medium text-primary hover:underline"
+								class="mb-2 inline-block text-base font-bold text-primary hover:underline"
 							>
 								{m['eventSeriesDetailPage.byOrganization']({
 									organizationName: series.organization.name
@@ -167,7 +164,7 @@
 								<div class="mt-3 flex flex-wrap gap-2">
 									{#each series.tags as tag (tag)}
 										<span
-											class="inline-block rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary"
+											class="inline-block rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary"
 										>
 											{tag}
 										</span>
@@ -206,9 +203,11 @@
 				{#if seriesPasses.length > 0}
 					<section aria-labelledby="passes-heading">
 						<div class="mb-6">
-							<h2 id="passes-heading" class="text-2xl font-bold">
-								{m['seriesPass.sectionHeading']()}
-							</h2>
+							<SectionHeader
+								volume="celebration"
+								id="passes-heading"
+								title={m['seriesPass.sectionHeading']()}
+							/>
 							<p class="mt-1 text-sm text-muted-foreground">
 								{m['seriesPass.sectionDescription']()}
 							</p>
@@ -229,9 +228,11 @@
 				<section aria-labelledby="events-heading">
 					<div class="mb-6 flex flex-wrap items-end justify-between gap-4">
 						<div>
-							<h2 id="events-heading" class="text-2xl font-bold">
-								{m['eventSeriesDetailPage.events_heading']()}
-							</h2>
+							<SectionHeader
+								volume="celebration"
+								id="events-heading"
+								title={m['eventSeriesDetailPage.events_heading']()}
+							/>
 							{#if totalCount > 0}
 								<p class="mt-1 text-sm text-muted-foreground">
 									{m['eventSeriesDetailPage.events_count']({
@@ -259,14 +260,11 @@
 					</div>
 
 					{#if events.length === 0}
-						<!-- Empty State -->
-						<div class="rounded-lg border bg-card p-8 text-center">
-							<Calendar class="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
-							<h3 class="mb-2 text-lg font-semibold">{m['eventSeriesDetailPage.empty_title']()}</h3>
-							<p class="text-sm text-muted-foreground">
-								{m['eventSeriesDetailPage.empty_description']()}
-							</p>
-						</div>
+						<EmptyState
+							icon={Calendar}
+							title={m['eventSeriesDetailPage.empty_title']()}
+							body={m['eventSeriesDetailPage.empty_description']()}
+						/>
 					{:else}
 						<!-- Event Cards Grid -->
 						<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -351,7 +349,9 @@
 				<aside class="hidden lg:col-span-1 lg:block">
 					<div class="sticky top-4 space-y-6">
 						<div class="rounded-lg border border-border bg-card p-4 shadow-sm">
-							<h3 class="mb-3 text-sm font-semibold">{m['eventSeriesDetailPage.admin_title']()}</h3>
+							<h3 class="mb-3 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
+								{m['eventSeriesDetailPage.admin_title']()}
+							</h3>
 							<div class="space-y-2">
 								<a
 									href={resolve('/(auth)/org/[slug]/admin/event-series/[series_id]/edit', {

--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -30,6 +30,10 @@
 	import ClaimMembershipButton from '$lib/components/organizations/ClaimMembershipButton.svelte';
 	import OrgMembershipInline from '$lib/components/account/OrgMembershipInline.svelte';
 	import FollowButton from '$lib/components/common/FollowButton.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import { getPosterFallbackGradient } from '$lib/utils/fallback-gradient';
 	import { SeoHead } from '$lib/seo';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -70,21 +74,9 @@
 			organization.telegram_url
 	);
 
-	// Fallback gradient for cover art
-	function getOrgFallbackGradient(orgId: string): string {
-		// Use org ID to generate consistent gradient
-		const hash = orgId.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
-		const gradients = [
-			'bg-gradient-to-br from-blue-500 to-indigo-600',
-			'bg-gradient-to-br from-purple-500 to-pink-600',
-			'bg-gradient-to-br from-green-500 to-teal-600',
-			'bg-gradient-to-br from-orange-500 to-red-600',
-			'bg-gradient-to-br from-cyan-500 to-blue-600'
-		];
-		return gradients[hash % gradients.length];
-	}
-
-	const fallbackGradient = $derived(getOrgFallbackGradient(organization.id));
+	// Fallback cover, on the shared poster ramp (see utils/fallback-gradient.ts):
+	// an org, its series and its events all fall back to the same visual family.
+	const fallbackGradient = $derived(getPosterFallbackGradient(organization.id));
 
 	// Filter resources to show only those marked for display on org page
 	const displayedResources = $derived(
@@ -188,12 +180,12 @@
 				/>
 				<!-- Gradient overlay -->
 				<div
-					class="absolute inset-0 bg-gradient-to-b from-transparent via-black/20 to-black/60"
+					class="absolute inset-0 bg-gradient-to-b from-transparent via-poster-ink/20 to-poster-ink/60"
 				></div>
 			{:else}
 				<!-- Fallback gradient -->
-				<div class="h-full w-full {fallbackGradient}"></div>
-				<div class="absolute inset-0 bg-gradient-to-b from-black/10 to-black/60"></div>
+				<div class="h-full w-full bg-gradient-to-br {fallbackGradient}"></div>
+				<div class="absolute inset-0 bg-gradient-to-b from-poster-ink/10 to-poster-ink/60"></div>
 			{/if}
 		</div>
 	</section>
@@ -222,7 +214,12 @@
 
 				<!-- Organization Info -->
 				<div class="min-w-0 flex-1">
-					<h1 class="mb-2 text-3xl font-bold md:text-4xl">{organization.name}</h1>
+					<PageHeader
+						volume="celebration"
+						kicker={m['organizationProfile.kicker']()}
+						title={organization.name}
+						class="mb-2"
+					/>
 
 					<!-- Metadata Row -->
 					<div class="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
@@ -243,7 +240,7 @@
 										href={organization.instagram_url}
 										target="_blank"
 										rel="noopener noreferrer"
-										class="text-muted-foreground transition-colors hover:text-pink-500"
+										class="text-muted-foreground transition-colors hover:text-primary"
 										aria-label={m['organizationProfile.social_instagram']()}
 									>
 										<Instagram class="h-5 w-5" aria-hidden="true" />
@@ -256,7 +253,7 @@
 										href={organization.facebook_url}
 										target="_blank"
 										rel="noopener noreferrer"
-										class="text-muted-foreground transition-colors hover:text-blue-600"
+										class="text-muted-foreground transition-colors hover:text-primary"
 										aria-label={m['organizationProfile.social_facebook']()}
 									>
 										<Facebook class="h-5 w-5" aria-hidden="true" />
@@ -269,7 +266,7 @@
 										href={organization.bluesky_url}
 										target="_blank"
 										rel="noopener noreferrer"
-										class="text-muted-foreground transition-colors hover:text-sky-500"
+										class="text-muted-foreground transition-colors hover:text-primary"
 										aria-label={m['organizationProfile.social_bluesky']()}
 									>
 										<AtSign class="h-5 w-5" aria-hidden="true" />
@@ -282,7 +279,7 @@
 										href={organization.telegram_url}
 										target="_blank"
 										rel="noopener noreferrer"
-										class="text-muted-foreground transition-colors hover:text-blue-400"
+										class="text-muted-foreground transition-colors hover:text-primary"
 										aria-label={m['organizationProfile.social_telegram']()}
 									>
 										<Send class="h-5 w-5" aria-hidden="true" />
@@ -379,15 +376,17 @@
 		     predate the move still land on something that explains itself. -->
 		{#if organization.accept_membership_requests || data.membershipPlans.length > 0}
 			<section id="membership" aria-labelledby="membership-heading" class="mb-12">
-				<h2 id="membership-heading" class="text-2xl font-bold">
-					{m['membershipPlans.heading']()}
-				</h2>
+				<SectionHeader
+					volume="celebration"
+					id="membership-heading"
+					title={m['membershipPlans.heading']()}
+				/>
 				<p class="mt-1 text-sm text-muted-foreground">
 					{m['membershipTiers.landingBlurb']({ organizationName: organization.name })}
 				</p>
 				<a
 					href={resolve('/(public)/org/[slug]/membership', { slug: organization.slug })}
-					class="mt-3 inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					class="mt-3 inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 				>
 					{m['membershipPlans.viewMembership']()}
 					<ArrowRight class="h-4 w-4" aria-hidden="true" />
@@ -400,9 +399,11 @@
 			<section aria-labelledby="resources-heading" class="mb-12">
 				<div class="mb-6 flex items-center justify-between">
 					<div>
-						<h2 id="resources-heading" class="text-2xl font-bold">
-							{m['organizationProfile.resources_heading']()}
-						</h2>
+						<SectionHeader
+							volume="celebration"
+							id="resources-heading"
+							title={m['organizationProfile.resources_heading']()}
+						/>
 						<p class="mt-1 text-sm text-muted-foreground">
 							{m['organizationProfile.resources_description']({
 								organizationName: organization.name
@@ -411,7 +412,7 @@
 					</div>
 					<a
 						href={resolve('/(public)/org/[slug]/resources', { slug: organization.slug })}
-						class="text-sm font-medium text-primary hover:underline"
+						class="text-sm font-bold text-primary hover:underline"
 					>
 						{m['organizationProfile.resources_viewAll']()}
 					</a>
@@ -429,9 +430,11 @@
 			<section aria-labelledby="series-heading" class="mb-12">
 				<div class="mb-6 flex items-center justify-between">
 					<div>
-						<h2 id="series-heading" class="text-2xl font-bold">
-							{m['organizationProfile.eventSeries_heading']()}
-						</h2>
+						<SectionHeader
+							volume="celebration"
+							id="series-heading"
+							title={m['organizationProfile.eventSeries_heading']()}
+						/>
 						<p class="mt-1 text-sm text-muted-foreground">
 							{m['organizationProfile.eventSeries_description']({
 								organizationName: organization.name
@@ -489,9 +492,11 @@
 		<section aria-labelledby="events-heading" class="mb-12">
 			<div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 				<div>
-					<h2 id="events-heading" class="text-2xl font-bold">
-						{m['organizationProfile.events_heading']()}
-					</h2>
+					<SectionHeader
+						volume="celebration"
+						id="events-heading"
+						title={m['organizationProfile.events_heading']()}
+					/>
 					<p class="mt-1 text-sm text-muted-foreground">
 						{m['organizationProfile.events_description']({ organizationName: organization.name })}
 					</p>
@@ -500,14 +505,14 @@
 				<div class="flex flex-wrap items-center gap-4">
 					<!-- Filter Toggle -->
 					<div class="flex items-center gap-2">
-						<label for="include-past" class="text-sm font-medium"
+						<label for="include-past" class="text-sm font-bold"
 							>{m['organizationProfile.events_includePast']()}</label
 						>
 						<input
 							id="include-past"
 							type="checkbox"
 							bind:checked={includePastEvents}
-							class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						/>
 					</div>
 
@@ -520,7 +525,7 @@
 								type="button"
 								onclick={() =>
 									(ticketType = isSelected ? undefined : (option.value as 'ticketed' | 'free'))}
-								class="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {isSelected
+								class="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {isSelected
 									? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
 									: 'border-input bg-background hover:bg-accent hover:text-accent-foreground'}"
 								aria-pressed={isSelected}
@@ -588,31 +593,29 @@
 					</p>
 				</div>
 			{:else if events.length === 0}
-				<!-- Empty State -->
-				<div class="rounded-lg border bg-card p-8 text-center">
-					<Calendar class="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
-					<h3 class="mb-2 text-lg font-semibold">
-						{includePastEvents
-							? m['organizationProfile.events_noEvents']()
-							: m['organizationProfile.events_noUpcoming']()}
-					</h3>
-					<p class="text-sm text-muted-foreground">
-						{includePastEvents
-							? m['organizationProfile.events_noEventsYet']({ organizationName: organization.name })
-							: m['organizationProfile.events_noUpcomingScheduled']({
-									organizationName: organization.name
-								})}
-					</p>
-					{#if !includePastEvents}
-						<button
-							type="button"
-							onclick={() => (includePastEvents = true)}
-							class="mt-4 text-sm font-medium text-primary hover:underline"
-						>
-							{m['organizationProfile.events_viewPast']()}
-						</button>
-					{/if}
-				</div>
+				<EmptyState
+					icon={Calendar}
+					title={includePastEvents
+						? m['organizationProfile.events_noEvents']()
+						: m['organizationProfile.events_noUpcoming']()}
+					body={includePastEvents
+						? m['organizationProfile.events_noEventsYet']({ organizationName: organization.name })
+						: m['organizationProfile.events_noUpcomingScheduled']({
+								organizationName: organization.name
+							})}
+				>
+					{#snippet action()}
+						{#if !includePastEvents}
+							<button
+								type="button"
+								onclick={() => (includePastEvents = true)}
+								class="text-sm font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+							>
+								{m['organizationProfile.events_viewPast']()}
+							</button>
+						{/if}
+					{/snippet}
+				</EmptyState>
 			{:else}
 				<!-- Event Cards Grid -->
 				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -654,12 +657,19 @@
 		<!-- Tags Section -->
 		{#if organization.tags && organization.tags.length > 0}
 			<section aria-labelledby="tags-heading" class="border-t pt-8">
-				<h2 id="tags-heading" class="mb-4 text-xl font-semibold">
-					{m['eventDetails.tags_heading']()}
-				</h2>
+				<SectionHeader
+					volume="celebration"
+					id="tags-heading"
+					title={m['eventDetails.tags_heading']()}
+					class="mb-4"
+				/>
+				<!-- Tag chips: primary on a 10% primary tint. The tint composites to
+				     ~the page colour, so primary-vs-background governs — 5.3:1 light /
+				     5.9:1 dark (hand-recomputed; a composited alpha is invisible to
+				     scripts/audit-brand-themes.py). -->
 				<div class="flex flex-wrap gap-2">
 					{#each organization.tags as tag (tag)}
-						<span class="rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+						<span class="rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary">
 							{tag}
 						</span>
 					{/each}

--- a/src/routes/(public)/org/[slug]/membership/+page.svelte
+++ b/src/routes/(public)/org/[slug]/membership/+page.svelte
@@ -20,7 +20,7 @@
 <div class="container mx-auto space-y-6 px-6 py-8 md:px-8 lg:py-12">
 	<a
 		href={resolve('/(public)/org/[slug]', { slug: organization.slug })}
-		class="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+		class="inline-flex items-center gap-2 text-sm font-bold text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 	>
 		<ArrowLeft class="h-4 w-4" aria-hidden="true" />
 		{m['membershipTiers.backToOrg']({ organizationName: organization.name })}

--- a/src/routes/(public)/org/[slug]/polls/[id]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/polls/[id]/+page.svelte
@@ -86,7 +86,7 @@
 			show a self-contained no-access page rather than falling through to
 			the global 404.
 		-->
-		<Card class="border-amber-500/50">
+		<Card class="border-highlight/60">
 			<CardHeader>
 				<CardTitle level={2}>{m['pollVoterPage.forbiddenTitle']()}</CardTitle>
 			</CardHeader>
@@ -125,7 +125,7 @@
 
 		<!-- State banners — order matters; first match wins -->
 		{#if poll.status === 'draft'}
-			<Card class="border-amber-500/50">
+			<Card class="border-highlight/60">
 				<CardContent class="py-4 text-sm">{m['pollVoterPage.draftBanner']()}</CardContent>
 			</Card>
 		{:else if requiresAuth}
@@ -135,7 +135,9 @@
 				generic "ineligible" banner (which implies they couldn't vote
 				even if signed in).
 			-->
-			<Card class="border-blue-500/50 bg-blue-50/30 dark:bg-blue-950/20">
+			<!-- Info tint: `bg-info/10` composites to ~the card colour, so the copy
+			     keeps `text-card-foreground` and the token contract's AA guarantee. -->
+			<Card class="border-info/60 bg-info/10">
 				<CardContent class="space-y-2 py-4 text-sm">
 					<p>{m['pollVoterPage.signInToVote']()}</p>
 					<Button href={`/login?next=${encodeURIComponent($page.url.pathname)}`}
@@ -161,7 +163,7 @@
 				the forbidden card which strips all poll details from
 				non-audience callers.
 			-->
-			<Card class="border-amber-500/50">
+			<Card class="border-highlight/60">
 				<CardContent class="py-4 text-sm">{m['pollVoterPage.ineligibleBanner']()}</CardContent>
 			</Card>
 		{:else if showVotedBanner}

--- a/src/routes/(public)/org/[slug]/questionnaire/[id]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/questionnaire/[id]/+page.svelte
@@ -11,6 +11,8 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { toast } from 'svelte-sonner';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import QuestionnaireFillForm from '$lib/components/questionnaires/QuestionnaireFillForm.svelte';
 
 	interface Props {
@@ -146,10 +148,12 @@
 			<ArrowLeft class="h-4 w-4" aria-hidden="true" />
 			{m['membershipQuestionnairePage.backToOrg']({ orgName: data.organization.name })}
 		</a>
-		<h1 class="text-3xl font-bold">{m['membershipQuestionnairePage.title']()}</h1>
-		<p class="mt-2 text-muted-foreground">
-			{m['membershipQuestionnairePage.subtitle']({ orgName: data.organization.name })}
-		</p>
+		<PageHeader
+			volume="celebration"
+			kicker={data.organization.name}
+			title={m['membershipQuestionnairePage.title']()}
+			subtitle={m['membershipQuestionnairePage.subtitle']({ orgName: data.organization.name })}
+		/>
 		{#if data.questionnaire.description}
 			<div class="mt-4 rounded-lg border bg-muted/50 p-4">
 				<MarkdownContent content={data.questionnaire.description} />
@@ -159,23 +163,20 @@
 
 	{#if autoAccepted}
 		<!-- Nothing left to review: the org page's eligibility CTA now advances to apply/join. -->
-		<div class="rounded-lg border bg-card p-8 text-center" role="status">
-			<div
-				class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10"
+		<div role="status">
+			<EmptyState
+				level={2}
+				tone="success"
+				icon={Check}
+				title={m['membershipQuestionnairePage.acceptedTitle']()}
+				body={m['membershipQuestionnairePage.acceptedBody']({ orgName: data.organization.name })}
 			>
-				<Check class="h-6 w-6 text-primary" aria-hidden="true" />
-			</div>
-			<h2 class="text-2xl font-semibold">
-				{m['membershipQuestionnairePage.acceptedTitle']()}
-			</h2>
-			<p class="mx-auto mt-2 max-w-md text-muted-foreground">
-				{m['membershipQuestionnairePage.acceptedBody']({ orgName: data.organization.name })}
-			</p>
-			<div class="mt-6">
-				<Button href={resolve('/(public)/org/[slug]', { slug: data.organization.slug })}>
-					{m['membershipQuestionnairePage.backToOrg']({ orgName: data.organization.name })}
-				</Button>
-			</div>
+				{#snippet action()}
+					<Button href={resolve('/(public)/org/[slug]', { slug: data.organization.slug })}>
+						{m['membershipQuestionnairePage.backToOrg']({ orgName: data.organization.name })}
+					</Button>
+				{/snippet}
+			</EmptyState>
 		</div>
 	{:else}
 		<QuestionnaireFillForm

--- a/src/routes/(public)/org/[slug]/resources/+page.svelte
+++ b/src/routes/(public)/org/[slug]/resources/+page.svelte
@@ -3,6 +3,9 @@
 	import { FileText, Search, Filter } from '@lucide/svelte';
 	import type { AdditionalResourceSchema } from '$lib/api/generated/types.gen';
 	import * as m from '$lib/paraglide/messages.js';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import { getBackendUrl } from '$lib/config/api';
 
 	const data = $derived($page.data);
@@ -55,12 +58,12 @@
      its children, so a page without a container renders edge to edge. -->
 <div class="container mx-auto space-y-6 px-6 py-8 md:px-8 lg:py-12">
 	<!-- Header -->
-	<div>
-		<h1 class="text-3xl font-bold tracking-tight md:text-4xl">{m['orgResourcesPage.title']()}</h1>
-		<p class="mt-2 text-muted-foreground">
-			{m['orgResourcesPage.subtitle']({ organizationName: organization.name })}
-		</p>
-	</div>
+	<PageHeader
+		volume="celebration"
+		kicker={organization.name}
+		title={m['orgResourcesPage.title']()}
+		subtitle={m['orgResourcesPage.subtitle']({ organizationName: organization.name })}
+	/>
 
 	<!-- Filters -->
 	<div class="flex flex-col gap-3 md:flex-row md:items-center">
@@ -94,32 +97,25 @@
 
 	<!-- Resources Grid -->
 	{#if filteredResources.length === 0}
-		<div
-			class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600"
-		>
-			<Filter class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-4 text-lg font-semibold">{m['orgResourcesPage.empty_title']()}</h3>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{searchQuery || typeFilter !== 'all'
-					? m['orgResourcesPage.empty_withFilters']()
-					: m['orgResourcesPage.empty_initial']()}
-			</p>
-		</div>
+		<EmptyState
+			level={2}
+			icon={Filter}
+			title={m['orgResourcesPage.empty_title']()}
+			body={searchQuery || typeFilter !== 'all'
+				? m['orgResourcesPage.empty_withFilters']()
+				: m['orgResourcesPage.empty_initial']()}
+		/>
 	{:else}
 		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 			{#each filteredResources as resource (resource.id)}
 				<article
-					class="flex flex-col gap-3 rounded-lg border bg-card p-4 transition-all hover:shadow-md"
+					class="flex flex-col gap-3 rounded-lg border bg-card p-4 transition-all hover:-translate-y-0.5 hover:shadow-lg"
 				>
 					<!-- Header -->
 					<div class="flex items-start gap-3">
-						<div
-							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary"
-						>
-							<FileText class="h-5 w-5" aria-hidden="true" />
-						</div>
+						<ToneTile tone="brand" icon={FileText} />
 						<div class="min-w-0 flex-1">
-							<h3 class="truncate font-semibold leading-tight">
+							<h3 class="truncate font-bold leading-tight">
 								{resource.name || m['orgResourcesPage.resource_untitled']()}
 							</h3>
 							<p class="text-xs capitalize text-muted-foreground">
@@ -140,7 +136,7 @@
 						<button
 							type="button"
 							onclick={() => openResource(resource)}
-							class="mt-auto rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+							class="mt-auto rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 						>
 							{resource.resource_type === 'file'
 								? m['orgResourcesPage.button_viewFile']()

--- a/src/routes/(public)/org/[slug]/verify-contact-email/+page.svelte
+++ b/src/routes/(public)/org/[slug]/verify-contact-email/+page.svelte
@@ -25,15 +25,16 @@
 		<!-- Icon -->
 		<div class="flex justify-center">
 			{#if data.isVerifying}
-				<div class="rounded-full bg-blue-500/10 p-6">
-					<Loader2
-						class="h-12 w-12 animate-spin text-blue-600 dark:text-blue-400"
-						aria-hidden="true"
-					/>
+				<!-- Tinted status discs on semantic tokens. Icon-vs-surface only (no
+				     text sits on these), independently >= 3:1 in both modes — the same
+				     tints ToneTile measures: info 8.3 light / 8.0 dark, success 4.4 /
+				     8.7. -->
+				<div class="rounded-full bg-info/10 p-6">
+					<Loader2 class="h-12 w-12 animate-spin text-info" aria-hidden="true" />
 				</div>
 			{:else if data.success}
-				<div class="rounded-full bg-green-500/10 p-6">
-					<CheckCircle class="h-12 w-12 text-green-600 dark:text-green-400" aria-hidden="true" />
+				<div class="rounded-full bg-success/10 p-6">
+					<CheckCircle class="h-12 w-12 text-success" aria-hidden="true" />
 				</div>
 			{:else}
 				<div class="rounded-full bg-destructive/10 p-6">
@@ -45,14 +46,14 @@
 		<!-- Message -->
 		<div class="space-y-2">
 			{#if data.isVerifying}
-				<h1 class="text-3xl font-bold tracking-tight">
+				<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
 					{m['orgVerifyContactEmail.verifying']()}
 				</h1>
 				<p class="text-muted-foreground">
 					{m['orgVerifyContactEmail.verifyingDescription']()}
 				</p>
 			{:else if data.success}
-				<h1 class="text-3xl font-bold tracking-tight">
+				<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
 					{m['orgVerifyContactEmail.success']()}
 				</h1>
 				<p class="text-muted-foreground">
@@ -61,7 +62,7 @@
 					})}
 				</p>
 			{:else}
-				<h1 class="text-3xl font-bold tracking-tight">
+				<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
 					{m['orgVerifyContactEmail.failure']()}
 				</h1>
 				<p class="text-muted-foreground">
@@ -76,7 +77,7 @@
 				{#if data.success && data.organizationSlug}
 					<a
 						href={resolve('/(auth)/org/[slug]/admin/settings', { slug: data.organizationSlug })}
-						class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+						class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 					>
 						{m['orgVerifyContactEmail.goToSettings']()}
 					</a>
@@ -87,13 +88,13 @@
 					<div class="flex flex-col gap-3 sm:flex-row sm:justify-center">
 						<a
 							href={resolve('/(auth)/dashboard', {})}
-							class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+							class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						>
 							{m['orgVerifyContactEmail.goToDashboard']()}
 						</a>
 						<a
 							href={resolve('/(public)/login', {})}
-							class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-6 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+							class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-6 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 						>
 							{m['orgVerifyContactEmail.backToLogin']()}
 						</a>

--- a/src/routes/(public)/organizations/+page.svelte
+++ b/src/routes/(public)/organizations/+page.svelte
@@ -16,6 +16,9 @@
 		countActiveOrganizationFilters
 	} from '$lib/utils/organizationFilters';
 	import type { OrganizationFilters as FilterState } from '$lib/utils/organizationFilters';
+	import { Button } from '$lib/components/ui/button';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { SeoHead } from '$lib/seo';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -94,20 +97,21 @@
 	</a>
 
 	<!-- Page Header -->
-	<header class="mb-8">
-		<h1 class="text-4xl font-bold">{m['browse.organizations_title']()}</h1>
-		{#if !error && totalCount > 0}
-			<p class="mt-2 text-muted-foreground">
-				{m['browse.organizations_count']({
+	<PageHeader
+		volume="celebration"
+		kicker={m['browse.organizations_kicker']()}
+		title={m['browse.organizations_title']()}
+		subtitle={!error && totalCount > 0
+			? m['browse.organizations_count']({
 					count: totalCount,
 					organizationPlural:
 						totalCount === 1
 							? m['common.plurals_organization']()
 							: m['common.plurals_organizations']()
-				})}
-			</p>
-		{/if}
-	</header>
+				})
+			: undefined}
+		class="mb-8"
+	/>
 
 	<!-- Main Content: Sidebar + Organization Grid -->
 	<div class="flex flex-col gap-8 lg:flex-row">
@@ -137,27 +141,23 @@
 					</p>
 				</div>
 			{:else if organizations.length === 0}
-				<!-- Empty State -->
-				<div class="rounded-lg border bg-muted/50 p-12 text-center">
-					<Users class="mx-auto mb-4 h-16 w-16 text-muted-foreground" aria-hidden="true" />
-					<h2 class="text-2xl font-semibold">{m['browse.organizations_noOrganizationsFound']()}</h2>
-					<p class="mt-2 text-muted-foreground">
+				<!-- level 2: the page's only other heading is the h1 above. -->
+				<EmptyState
+					level={2}
+					icon={Users}
+					title={m['browse.organizations_noOrganizationsFound']()}
+					body={currentFilters.search || currentFilters.cityId || currentFilters.tags
+						? m['browse.organizations_tryAdjustingFilters']()
+						: m['browse.organizations_noOrganizations']()}
+				>
+					{#snippet action()}
 						{#if currentFilters.search || currentFilters.cityId || currentFilters.tags}
-							{m['browse.organizations_tryAdjustingFilters']()}
-						{:else}
-							{m['browse.organizations_noOrganizations']()}
+							<Button onclick={handleClearFilters}>
+								{m['browse.organizations_clearFilters']()}
+							</Button>
 						{/if}
-					</p>
-					{#if currentFilters.search || currentFilters.cityId || currentFilters.tags}
-						<button
-							type="button"
-							onclick={handleClearFilters}
-							class="mt-4 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-						>
-							{m['browse.organizations_clearFilters']()}
-						</button>
-					{/if}
-				</div>
+					{/snippet}
+				</EmptyState>
 			{:else}
 				<!-- Organization Grid -->
 				<div


### PR DESCRIPTION
## Platform rebrand, PR 3 of 10 — Public discovery

Vol. 2 pass over the highest-traffic surfaces: event detail, org profile, events/organizations discovery, series pages, public polls/questionnaire routes, membership purchase. 87 files.

### What's in it
- Display typography + kickers + `SectionHeader` rhythm on the two hero pages; SSR and structured data untouched (verified in review)
- **PricingCard consolidation**: new `common/PricingCard` shell (chrome + typography + slots); the three formerly-independent TierCards keep byte-identical props and now share it, plus `PlanCard` and `SeriesPassCard` — five pricing surfaces, one visual source of truth, with the landing's pricing-panel energy
- `EventCard`/`OrganizationCard`/`EventSeriesCard` card-title weights, normalized chips, hover lift; a real bug fixed in passing (EventHeader's no-cover branch painted no gradient)
- Fallback-cover color ramps consolidated into `utils/fallback-gradient.ts` (index-stable — same event keeps "its" color)
- Poll voting rows aligned with the landing's questionnaire-mock look, full-row hit targets
- 3 new kicker keys ×6 locales; full raw-hue sweep

### Review process
Whole-branch opus review + one fix round + scoped re-review, clean. Notable catches: `text-warning`/`border-warning` were DEAD classes (no `--warning` token exists — proven via the built CSS bundle emitting zero rules), so capacity/deadline warnings had been rendering unstyled — now on the highlight recipes with mode flips; a heading-level skip on the membership empty state; the admin TierCard had dropped its Price/Type labels (restored — keys un-orphaned); and the dietary severity ladder had collapsed to one hue (restored to a four-step destructive→highlight→muted ladder — safety-relevant surface).

### Cross-PR handoffs (also in the wave ledger)
- **PR 8**: four more dead `-warning` files in `event-series/admin/**`; screenshot the restyled admin TierCard call sites
- **PR 9**: `QuestionnaireFillForm` mock-alignment (public questionnaire routes intentionally deferred to avoid file conflicts); `PollCard` lift + `PollStatusBadge` mapper already done here — don't redo
- **PR 10**: `OrgContactEmailModal` (admin-only) already token-swept here
- Follow-up: `/events` calendar-mode count lost a (weak) aria-live in the subtitle move — clean fix is attribute pass-through on `PageHeader`

### Verification
`make check` 0 errors · full suite 202 files / 2426 green · brand audit 0 failures · `pnpm build` clean · implementer verified SSR + light/dark + 390px live · orchestrator screenshots: events list, event detail (light+dark), org profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)