### PR TITLE
fix(rebrand): restore subscription status accessible names lost in wave

### DIFF
--- a/src/lib/components/members/StatusBadge.svelte
+++ b/src/lib/components/members/StatusBadge.svelte
@@ -33,4 +33,14 @@
 	const label = $derived(getStatusLabel(status));
 </script>
 
-<CommonStatusBadge {tone} {label} size="sm" class={extraClass} />
+<!--
+	`aria-label` is deliberate and load-bearing, not redundant with the visible
+	text: the subscription status is the one bit of this pill that other surfaces
+	address it by, and the status word alone ("Active", "Past due") is what names
+	it. It predates the shared primitive — every subscription surface (account
+	hub card, org landing inline card, admin subs table/drawer) is located by it,
+	so dropping it when this became a mapper silently un-named every one of them.
+	Passed through here rather than baked into `common/StatusBadge`: the primitive
+	has other consumers whose accessible name should keep coming from its content.
+-->
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} aria-label={label} />

--- a/src/lib/components/members/StatusBadge.test.ts
+++ b/src/lib/components/members/StatusBadge.test.ts
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import type { SubscriptionStatus } from '$lib/api/generated/types.gen';
+import { getStatusLabel, STATUS_ORDER } from '$lib/utils/subscriptions';
+import StatusBadge from './StatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD. This badge's accessible NAME is a cross-surface contract,
+ * not decoration: the e2e suite addresses every subscription pill by
+ * `getByLabel('Active' | 'Pending' | 'Past due' | …)` — on the account hub
+ * card, the org landing page's inline card, the admin subs table/mobile card
+ * and the admin subscription drawer — and the admin metrics strip deliberately
+ * leaves its own chips unlabelled so those lookups resolve to badges ONLY.
+ *
+ * The 2026-08 rebrand wave turned this component into a thin mapper over
+ * `common/StatusBadge` and dropped its `aria-label` in the process. The
+ * primitive names itself from its text content, `getByLabel` never matches text
+ * content, and 19 e2e tests went red while every unit test stayed green —
+ * because nothing here asserted the name. Hence this file.
+ */
+describe('members/StatusBadge', () => {
+	// Every status, not just a sample: the whole failure mode was a name that
+	// vanished for all six at once, and a spot-check of one would have caught
+	// that only by luck.
+	it.each(STATUS_ORDER as SubscriptionStatus[])(
+		'exposes the %s label as the pill accessible name',
+		(status) => {
+			render(StatusBadge, { props: { status } });
+			const label = getStatusLabel(status);
+			expect(screen.getByLabelText(label)).toBeInTheDocument();
+			// The name is an alias for what is on screen, never a substitute for it.
+			expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		}
+	);
+
+	it('names past_due "Past due" — the label carries the distinction the tone cannot', () => {
+		render(StatusBadge, { props: { status: 'past_due' } });
+		expect(screen.getByLabelText('Past due')).toBeInTheDocument();
+		expect(screen.queryByLabelText('Active')).toBeNull();
+	});
+
+	it('maps status to the primitive tone (active → success, past_due → danger)', () => {
+		const active = render(StatusBadge, { props: { status: 'active' } });
+		expect(active.container.querySelector('span')?.className).toContain('bg-success');
+
+		const pastDue = render(StatusBadge, { props: { status: 'past_due' } });
+		expect(pastDue.container.querySelector('span')?.className).toContain('bg-destructive');
+	});
+
+	it('keeps the caller class alongside the tone classes', () => {
+		const { container } = render(StatusBadge, { props: { status: 'active', class: 'shrink-0' } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('shrink-0');
+		expect(el.className).toContain('bg-success');
+	});
+});


### PR DESCRIPTION
E2E checkpoint fix 2/2. The wave's PR 6 rewrote `members/StatusBadge` as a mapper over `common/StatusBadge` and dropped its `aria-label={label}` — the single line behind all 19 j23-subscriptions failures (every `getByLabel('Active'/'Pending'/…)` across the account hub, org landing card, admin subscription rows, and drawer lost its accessible name at once). A whole-wave sweep confirms it was the only net aria-label removal.

- Fix: one line restored; j23 now **43 passed / 0 failed / 1 by-design skip** in both projects against the live stack.
- Guard: new `members/StatusBadge.test.ts` pins the accessible-name contract for all six statuses (driven off `STATUS_ORDER`, so future statuses are auto-covered) — canary-verified: reverting the fix fails 7/9 cases. Only e2e caught this originally; now units do.
- Follow-up (deliberate decision, ledgered): defaulting `aria-label={label}` inside `common/StatusBadge` would prevent this bug class in future mappers but changes accessible names app-wide.

`make check` 0 errors · members/account/memberships unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)