### PR TITLE
feat(rebrand): admin shell + dashboard — studio pass, ToneTile identity tints, primitive extensions (PR 7/10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1067,16 +1067,24 @@ clamped [-3, 3]). Tone vocabulary: `common/tones.ts` (`brand | info | success |
 warning | danger | neutral`). `StatusBadge` is solid-fill only by design (audit-
 enforced pairs; no soft variant) — sizes `sm | md | lg`. `ToneTile`'s `tone` axis
 stays semantic only; identity/destination coloring (the admin quick-actions grid)
-uses the additive, mutually-exclusive `tint` prop (PR 7) — a fixed poster-palette
-axis (`purple | lavender | periwinkle | amber | crimson | ink | paper`, type
-`PosterTint` in `common/tones.ts`) that renders a SOLID chip, identical in both
-modes (imagery rule), and wins over `tone` when both are set. Never overload
-`tone` for identity — reach for `tint` instead. `PageHeader` spreads arbitrary
-HTML attributes onto its `<header>` (`restProps`, PR 7, mirrors `StatusBadge`)
-so routed adopters can attach `id`/`aria-label`/etc; `SectionHeader` already took
-a plain `id` prop (forwarded to the heading) instead. `PageHeader`'s `decoration`
-slot is aria-hidden ornament only — status text goes through `actions` or
-`StatusBadge`, never `decoration`.
+uses the additive `tint` prop (PR 7) — a fixed poster-palette axis (`purple |
+lavender | periwinkle | amber | crimson | ink | paper`, type `PosterTint` in
+`common/tones.ts`) that renders a SOLID chip, identical in both modes (imagery
+rule), and wins over `tone` when both are set. `Props` is a union
+(`{ tone: Tone; tint?: PosterTint } | { tone?: Tone; tint: PosterTint }`) — at
+least one of `tone`/`tint` is required, both may be given, tint-only is legal
+(no filler tone needed). Never overload `tone` for identity — reach for `tint`
+instead. **Every tint chip carries `ring-1 ring-inset ring-border`** (PR 7 fix
+round) — the chip itself is mode-inert by design, but the card/page surface
+under it is NOT, and at least one tint/surface pairing measured under 1.2:1
+(effectively invisible) in the flipped mode; the ring gives every tint chip a
+theme-aware boundary regardless of what it sits on. Don't drop it when adding a
+call site or a new tint. `PageHeader` spreads arbitrary HTML attributes onto its
+`<header>` (`restProps` via `Omit<HTMLAttributes<HTMLElement>, 'children'>`,
+PR 7, mirrors `StatusBadge`) so routed adopters can attach `id`/`aria-label`/etc;
+`SectionHeader` already took a plain `id` prop (forwarded to the heading)
+instead. `PageHeader`'s `decoration` slot is aria-hidden ornament only — status
+text goes through `actions` or `StatusBadge`, never `decoration`.
 
 **Typography scale** (encoded in the primitives; use the same classes when
 composing manually):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1066,10 +1066,17 @@ The poster language extends app-wide at three volumes (master spec:
 clamped [-3, 3]). Tone vocabulary: `common/tones.ts` (`brand | info | success |
 warning | danger | neutral`). `StatusBadge` is solid-fill only by design (audit-
 enforced pairs; no soft variant) — sizes `sm | md | lg`. `ToneTile`'s `tone` axis
-is semantic only; the admin quick-actions identity-color grid gets an additive
-poster-tint axis when PR 7 lands — don't overload `tone` for identity.
-`PageHeader`'s `decoration` slot is aria-hidden ornament only — status text
-goes through `actions` or `StatusBadge`, never `decoration`.
+stays semantic only; identity/destination coloring (the admin quick-actions grid)
+uses the additive, mutually-exclusive `tint` prop (PR 7) — a fixed poster-palette
+axis (`purple | lavender | periwinkle | amber | crimson | ink | paper`, type
+`PosterTint` in `common/tones.ts`) that renders a SOLID chip, identical in both
+modes (imagery rule), and wins over `tone` when both are set. Never overload
+`tone` for identity — reach for `tint` instead. `PageHeader` spreads arbitrary
+HTML attributes onto its `<header>` (`restProps`, PR 7, mirrors `StatusBadge`)
+so routed adopters can attach `id`/`aria-label`/etc; `SectionHeader` already took
+a plain `id` prop (forwarded to the heading) instead. `PageHeader`'s `decoration`
+slot is aria-hidden ornament only — status text goes through `actions` or
+`StatusBadge`, never `decoration`.
 
 **Typography scale** (encoded in the primitives; use the same classes when
 composing manually):

--- a/scripts/audit-brand-themes.py
+++ b/scripts/audit-brand-themes.py
@@ -136,6 +136,7 @@ TEXT_PAIRS = [  # (fg, bg, min_ratio, note)
     ("poster-white", "poster-purple", 4.5, "poster close panel body"),
     ("poster-purple", "poster-white", 4.5, "sticker text on white sticker"),
     ("poster-crimson-deep", "poster-white", 4.5, "sticker text on white sticker"),
+    ("poster-ink", "poster-lavender", 4.5, "identity tile: ink icon on lavender"),
 ]
 
 SEMANTIC = ["primary", "secondary", "accent", "destructive", "highlight", "success", "info"]

--- a/src/lib/components/common/PageHeader.svelte
+++ b/src/lib/components/common/PageHeader.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
 	import { cn } from '$lib/utils';
 
-	interface Props {
+	interface Props extends HTMLAttributes<HTMLElement> {
 		/** Already-translated strings — i18n stays at the call site. */
 		title: string;
 		kicker?: string;
@@ -22,11 +23,15 @@
 		volume = 'studio',
 		actions,
 		decoration,
-		class: className = ''
+		class: className = '',
+		...restProps
 	}: Props = $props();
 </script>
 
-<header class={cn('flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between', className)}>
+<header
+	class={cn('flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between', className)}
+	{...restProps}
+>
 	<div class="min-w-0">
 		{#if kicker}
 			<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">{kicker}</p>

--- a/src/lib/components/common/PageHeader.svelte
+++ b/src/lib/components/common/PageHeader.svelte
@@ -3,7 +3,7 @@
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { cn } from '$lib/utils';
 
-	interface Props extends HTMLAttributes<HTMLElement> {
+	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
 		/** Already-translated strings — i18n stays at the call site. */
 		title: string;
 		kicker?: string;

--- a/src/lib/components/common/PageHeader.test.ts
+++ b/src/lib/components/common/PageHeader.test.ts
@@ -56,6 +56,14 @@ describe('PageHeader', () => {
 		expect(screen.getByText('Invite')).toBeInTheDocument();
 	});
 
+	it('passes through arbitrary attributes to the header element', () => {
+		render(PageHeader, {
+			props: { title: 'Members', id: 'members-header', 'aria-label': 'Members admin header' }
+		});
+		const header = screen.getByRole('banner', { name: 'Members admin header' });
+		expect(header.id).toBe('members-header');
+	});
+
 	it('decoration renders in celebration and is decorative; ignored in studio', () => {
 		const { container, unmount } = render(PageHeader, {
 			props: { title: 'Hey', volume: 'celebration', decoration: snip('New!') }

--- a/src/lib/components/common/PageHeader.test.ts
+++ b/src/lib/components/common/PageHeader.test.ts
@@ -57,11 +57,17 @@ describe('PageHeader', () => {
 	});
 
 	it('passes through arbitrary attributes to the header element', () => {
-		render(PageHeader, {
+		// Asserts on the <header> element directly rather than its implicit
+		// `banner` role: that role only holds here because the test renders the
+		// header straight into <body> — in real usage it can sit inside a
+		// sectioning element (losing the landmark role), so asserting role=banner
+		// would overstate what this test actually locks down (restProps spread).
+		const { container } = render(PageHeader, {
 			props: { title: 'Members', id: 'members-header', 'aria-label': 'Members admin header' }
 		});
-		const header = screen.getByRole('banner', { name: 'Members admin header' });
+		const header = container.querySelector('header') as HTMLElement;
 		expect(header.id).toBe('members-header');
+		expect(header.getAttribute('aria-label')).toBe('Members admin header');
 	});
 
 	it('decoration renders in celebration and is decorative; ignored in studio', () => {

--- a/src/lib/components/common/ToneTile.svelte
+++ b/src/lib/components/common/ToneTile.svelte
@@ -1,17 +1,29 @@
 <script lang="ts">
 	import type { Component } from 'svelte';
 	import { cn } from '$lib/utils';
-	import type { Tone } from './tones';
+	import type { Tone, PosterTint } from './tones';
 
 	interface Props {
 		tone: Tone;
+		/**
+		 * Identity-color axis (fixed poster palette), additive to `tone` and
+		 * mutually exclusive with it: when `tint` is set it takes over the
+		 * tile's styling entirely (solid fixed poster chip — imagery rule,
+		 * identical in light/dark) and `tone` is ignored for rendering. `tone`
+		 * stays a required prop for type stability across the ~20 existing
+		 * semantic call sites; pass any value when using `tint` (e.g. 'neutral').
+		 * Use `tint` only for pure destination/identity coloring (e.g. the admin
+		 * quick-actions grid) — semantic meaning (danger/success/...) must keep
+		 * using `tone`.
+		 */
+		tint?: PosterTint;
 		icon: Component;
 		size?: 'sm' | 'md' | 'lg';
 		/** Accessible name; omit when the tile sits next to visible text (decorative). */
 		label?: string;
 		class?: string;
 	}
-	const { tone, icon: Icon, size = 'md', label, class: className = '' }: Props = $props();
+	const { tone, tint, icon: Icon, size = 'md', label, class: className = '' }: Props = $props();
 
 	// Soft tint + strong icon (replaces the app's hand-picked bg-blue-50
 	// dark:bg-blue-950 tiles). The composited tint is ~the surface color, so the
@@ -32,6 +44,18 @@
 			'bg-destructive/10 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground',
 		neutral: 'bg-muted text-muted-foreground'
 	};
+	// Identity tint axis: SOLID fixed poster chips, same classes in both modes
+	// (imagery rule). Every pair is audited in scripts/audit-brand-themes.py
+	// TEXT_PAIRS (poster panels + "identity tile: ink icon on lavender").
+	const tintClasses: Record<PosterTint, string> = {
+		purple: 'bg-poster-purple text-poster-white',
+		lavender: 'bg-poster-lavender text-poster-ink',
+		periwinkle: 'bg-poster-periwinkle text-poster-ink',
+		amber: 'bg-poster-amber text-poster-ink',
+		crimson: 'bg-poster-crimson-deep text-poster-white',
+		ink: 'bg-poster-ink text-poster-white',
+		paper: 'bg-poster-paper text-poster-ink'
+	};
 	const sizeClasses = {
 		sm: 'h-8 w-8 rounded-md',
 		md: 'h-10 w-10 rounded-md',
@@ -44,7 +68,7 @@
 	class={cn(
 		'inline-flex shrink-0 items-center justify-center',
 		sizeClasses[size],
-		toneClasses[tone],
+		tint ? tintClasses[tint] : toneClasses[tone],
 		className
 	)}
 	role={label ? 'img' : undefined}

--- a/src/lib/components/common/ToneTile.svelte
+++ b/src/lib/components/common/ToneTile.svelte
@@ -3,26 +3,25 @@
 	import { cn } from '$lib/utils';
 	import type { Tone, PosterTint } from './tones';
 
-	interface Props {
-		tone: Tone;
-		/**
-		 * Identity-color axis (fixed poster palette), additive to `tone` and
-		 * mutually exclusive with it: when `tint` is set it takes over the
-		 * tile's styling entirely (solid fixed poster chip — imagery rule,
-		 * identical in light/dark) and `tone` is ignored for rendering. `tone`
-		 * stays a required prop for type stability across the ~20 existing
-		 * semantic call sites; pass any value when using `tint` (e.g. 'neutral').
-		 * Use `tint` only for pure destination/identity coloring (e.g. the admin
-		 * quick-actions grid) — semantic meaning (danger/success/...) must keep
-		 * using `tone`.
-		 */
-		tint?: PosterTint;
+	interface Base {
 		icon: Component;
 		size?: 'sm' | 'md' | 'lg';
 		/** Accessible name; omit when the tile sits next to visible text (decorative). */
 		label?: string;
 		class?: string;
 	}
+	/**
+	 * `tone` (semantic, e.g. danger/success) and `tint` (fixed poster-palette
+	 * identity, e.g. the admin quick-actions grid) are additive and at least
+	 * one is required — this union enforces that at the type level. Three
+	 * legal shapes: tone-only, tint-only, or both (in which case `tint` wins —
+	 * see the tintClasses branch below; this lets a caller migrate from tone
+	 * to tint without an intermediate broken state). Fixed by PR 7's follow-up
+	 * round once `tint` gained callers with no semantic tone to fall back to —
+	 * an earlier "tone always required" design forced pointless filler tones.
+	 */
+	type Props = Base & ({ tone: Tone; tint?: PosterTint } | { tone?: Tone; tint: PosterTint });
+
 	const { tone, tint, icon: Icon, size = 'md', label, class: className = '' }: Props = $props();
 
 	// Soft tint + strong icon (replaces the app's hand-picked bg-blue-50
@@ -46,15 +45,20 @@
 	};
 	// Identity tint axis: SOLID fixed poster chips, same classes in both modes
 	// (imagery rule). Every pair is audited in scripts/audit-brand-themes.py
-	// TEXT_PAIRS (poster panels + "identity tile: ink icon on lavender").
+	// TEXT_PAIRS (poster panels + "identity tile: ink icon on lavender"). The
+	// chip itself is mode-inert, but the card/page surface it sits on is NOT
+	// (bg-card flips light<->dark) — ink-on-dark-card measured 1.04:1 and
+	// paper-on-light-card 1.15:1, both invisible boundaries. `ring-1 ring-inset
+	// ring-border` gives every tint chip a theme-aware edge so it reads against
+	// either surface; verified visually in both modes (see rebrand-report.md).
 	const tintClasses: Record<PosterTint, string> = {
-		purple: 'bg-poster-purple text-poster-white',
-		lavender: 'bg-poster-lavender text-poster-ink',
-		periwinkle: 'bg-poster-periwinkle text-poster-ink',
-		amber: 'bg-poster-amber text-poster-ink',
-		crimson: 'bg-poster-crimson-deep text-poster-white',
-		ink: 'bg-poster-ink text-poster-white',
-		paper: 'bg-poster-paper text-poster-ink'
+		purple: 'bg-poster-purple text-poster-white ring-1 ring-inset ring-border',
+		lavender: 'bg-poster-lavender text-poster-ink ring-1 ring-inset ring-border',
+		periwinkle: 'bg-poster-periwinkle text-poster-ink ring-1 ring-inset ring-border',
+		amber: 'bg-poster-amber text-poster-ink ring-1 ring-inset ring-border',
+		crimson: 'bg-poster-crimson-deep text-poster-white ring-1 ring-inset ring-border',
+		ink: 'bg-poster-ink text-poster-white ring-1 ring-inset ring-border',
+		paper: 'bg-poster-paper text-poster-ink ring-1 ring-inset ring-border'
 	};
 	const sizeClasses = {
 		sm: 'h-8 w-8 rounded-md',

--- a/src/lib/components/common/ToneTile.test.ts
+++ b/src/lib/components/common/ToneTile.test.ts
@@ -46,19 +46,32 @@ describe('ToneTile', () => {
 			paper: ['bg-poster-paper', 'text-poster-ink']
 		};
 
+		// tint-only (no tone at all) is a legal shape on its own — the union
+		// requires only one of tone/tint, and the admin quick-actions grid is a
+		// tint-only consumer (no semantic tone to fall back to).
 		for (const [tint, [bg, fg]] of Object.entries(expectedClasses) as [
 			PosterTint,
 			[string, string]
 		][]) {
-			it(`renders the audited solid pair for tint="${tint}"`, () => {
+			it(`renders the audited solid pair for tint="${tint}" (tint-only, no tone)`, () => {
 				const { container } = render(ToneTile, {
-					props: { tone: 'neutral', tint, icon: Calendar }
+					props: { tint, icon: Calendar }
 				});
 				const el = container.querySelector('span') as HTMLElement;
 				expect(el.className).toContain(bg);
 				expect(el.className).toContain(fg);
 			});
 		}
+
+		it('always carries a theme-aware ring so the fixed chip reads against either card surface', () => {
+			const { container } = render(ToneTile, {
+				props: { tint: 'ink', icon: Calendar }
+			});
+			const el = container.querySelector('span') as HTMLElement;
+			expect(el.className).toContain('ring-1');
+			expect(el.className).toContain('ring-inset');
+			expect(el.className).toContain('ring-border');
+		});
 
 		it('takes precedence over tone when both are set', () => {
 			const { container } = render(ToneTile, {
@@ -71,7 +84,7 @@ describe('ToneTile', () => {
 
 		it('stays a decorative aria-hidden icon next to visible text (no label)', () => {
 			const { container } = render(ToneTile, {
-				props: { tone: 'neutral', tint: 'amber', icon: Calendar }
+				props: { tint: 'amber', icon: Calendar }
 			});
 			const el = container.querySelector('span') as HTMLElement;
 			expect(el.getAttribute('aria-hidden')).toBe('true');
@@ -80,7 +93,7 @@ describe('ToneTile', () => {
 
 		it('is an accessibly named img when a label is given', () => {
 			const { container } = render(ToneTile, {
-				props: { tone: 'neutral', tint: 'ink', icon: Calendar, label: 'Settings' }
+				props: { tint: 'ink', icon: Calendar, label: 'Settings' }
 			});
 			const el = container.querySelector('span') as HTMLElement;
 			expect(el.getAttribute('role')).toBe('img');

--- a/src/lib/components/common/ToneTile.test.ts
+++ b/src/lib/components/common/ToneTile.test.ts
@@ -2,6 +2,7 @@ import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 import { Calendar } from '@lucide/svelte';
 import ToneTile from './ToneTile.svelte';
+import type { PosterTint } from './tones';
 
 describe('ToneTile', () => {
 	it('is aria-hidden when no label is given (decorative next to visible text)', () => {
@@ -32,5 +33,58 @@ describe('ToneTile', () => {
 		const el = container.querySelector('span') as HTMLElement;
 		expect(el.className).toContain('text-highlight-foreground');
 		expect(el.className).toContain('dark:text-highlight');
+	});
+
+	describe('tint (identity axis)', () => {
+		const expectedClasses: Record<PosterTint, [string, string]> = {
+			purple: ['bg-poster-purple', 'text-poster-white'],
+			lavender: ['bg-poster-lavender', 'text-poster-ink'],
+			periwinkle: ['bg-poster-periwinkle', 'text-poster-ink'],
+			amber: ['bg-poster-amber', 'text-poster-ink'],
+			crimson: ['bg-poster-crimson-deep', 'text-poster-white'],
+			ink: ['bg-poster-ink', 'text-poster-white'],
+			paper: ['bg-poster-paper', 'text-poster-ink']
+		};
+
+		for (const [tint, [bg, fg]] of Object.entries(expectedClasses) as [
+			PosterTint,
+			[string, string]
+		][]) {
+			it(`renders the audited solid pair for tint="${tint}"`, () => {
+				const { container } = render(ToneTile, {
+					props: { tone: 'neutral', tint, icon: Calendar }
+				});
+				const el = container.querySelector('span') as HTMLElement;
+				expect(el.className).toContain(bg);
+				expect(el.className).toContain(fg);
+			});
+		}
+
+		it('takes precedence over tone when both are set', () => {
+			const { container } = render(ToneTile, {
+				props: { tone: 'danger', tint: 'purple', icon: Calendar }
+			});
+			const el = container.querySelector('span') as HTMLElement;
+			expect(el.className).toContain('bg-poster-purple');
+			expect(el.className).not.toContain('bg-destructive');
+		});
+
+		it('stays a decorative aria-hidden icon next to visible text (no label)', () => {
+			const { container } = render(ToneTile, {
+				props: { tone: 'neutral', tint: 'amber', icon: Calendar }
+			});
+			const el = container.querySelector('span') as HTMLElement;
+			expect(el.getAttribute('aria-hidden')).toBe('true');
+			expect(el.getAttribute('role')).toBeNull();
+		});
+
+		it('is an accessibly named img when a label is given', () => {
+			const { container } = render(ToneTile, {
+				props: { tone: 'neutral', tint: 'ink', icon: Calendar, label: 'Settings' }
+			});
+			const el = container.querySelector('span') as HTMLElement;
+			expect(el.getAttribute('role')).toBe('img');
+			expect(el.getAttribute('aria-label')).toBe('Settings');
+		});
 	});
 });

--- a/src/lib/components/common/tones.ts
+++ b/src/lib/components/common/tones.ts
@@ -4,3 +4,12 @@
  * this is what replaces the app's scattered bg-blue-50/text-emerald-600 pattern.
  */
 export type Tone = 'brand' | 'info' | 'success' | 'warning' | 'danger' | 'neutral';
+
+/**
+ * Fixed poster-palette identity axis for `ToneTile`'s `tint` prop. Unlike
+ * `Tone`, this carries no semantic meaning — it's for destination/identity
+ * coloring (e.g. the admin quick-actions grid) and is mode-inert by design
+ * (imagery rule: same tint in light and dark).
+ */
+export type PosterTint =
+	'purple' | 'lavender' | 'periwinkle' | 'amber' | 'crimson' | 'ink' | 'paper';

--- a/src/routes/(auth)/org/[slug]/admin/+layout.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/+layout.svelte
@@ -161,12 +161,17 @@
 						<Menu class="h-5 w-5" />
 					</button>
 
-					<h1 class="min-w-0 truncate text-base font-extrabold tracking-tight sm:text-xl">
+					<!-- Not a heading: this sticky top bar's org name is chrome, not page
+					     content — every admin page renders its own h1 (PageHeader in the
+					     dashboard; PRs 8-10 for the rest), so a second h1 here would give
+					     each admin page two top-level headings. No e2e spec asserts a
+					     heading role here (grepped tests/e2e before demoting). -->
+					<p class="min-w-0 truncate text-base font-extrabold tracking-tight sm:text-xl">
 						{data.organization.name}
 						<span class="ml-2 text-sm font-normal text-muted-foreground"
 							>{m['orgAdmin.layout.adminBadge']()}</span
 						>
-					</h1>
+					</p>
 				</div>
 
 				<!-- Right: Role Badge -->

--- a/src/routes/(auth)/org/[slug]/admin/+layout.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/+layout.svelte
@@ -3,6 +3,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { page } from '$app/stores';
 	import { Menu, ChevronRight, Home } from '@lucide/svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { LayoutData } from './$types';
 
 	interface Props {
@@ -160,7 +161,7 @@
 						<Menu class="h-5 w-5" />
 					</button>
 
-					<h1 class="min-w-0 truncate text-base font-semibold sm:text-xl">
+					<h1 class="min-w-0 truncate text-base font-extrabold tracking-tight sm:text-xl">
 						{data.organization.name}
 						<span class="ml-2 text-sm font-normal text-muted-foreground"
 							>{m['orgAdmin.layout.adminBadge']()}</span
@@ -171,13 +172,9 @@
 				<!-- Right: Role Badge -->
 				<div class="flex shrink-0 items-center gap-2">
 					{#if data.isOwner}
-						<span class="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
-							{m['orgAdminLayout.ownerBadge']()}
-						</span>
+						<StatusBadge tone="brand" label={m['orgAdminLayout.ownerBadge']()} size="sm" />
 					{:else if data.isStaff}
-						<span class="rounded-md bg-accent px-2 py-1 text-xs font-medium"
-							>{m['orgAdmin.layout.staffBadge']()}</span
-						>
+						<StatusBadge tone="neutral" label={m['orgAdmin.layout.staffBadge']()} size="sm" />
 					{/if}
 				</div>
 			</div>
@@ -223,11 +220,9 @@
 							<!-- eslint-disable svelte/no-navigation-without-resolve -- href is a ResolvedPathname produced by resolve() in the nav item list above -->
 							<a
 								href={item.href}
-								class="relative block border-b-2 py-4 text-sm font-medium transition-colors {isActive(
-									item.href
-								)
-									? 'border-primary text-foreground'
-									: 'border-transparent text-muted-foreground hover:text-foreground'}"
+								class="relative block border-b-2 py-4 text-sm transition-colors {isActive(item.href)
+									? 'border-primary font-bold text-primary'
+									: 'border-transparent font-semibold text-muted-foreground hover:text-foreground'}"
 								aria-current={isActive(item.href) ? 'page' : undefined}
 							>
 								{item.label}
@@ -261,7 +256,7 @@
 			>
 				<!-- Breadcrumbs -->
 				<div class="mb-4 border-b pb-3">
-					<h2 class="mb-2 text-xs font-semibold uppercase text-muted-foreground">
+					<h2 class="mb-2 text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
 						{m['orgAdmin.layout.navigationHeading']()}
 					</h2>
 					<ol class="flex flex-wrap items-center gap-1.5 text-xs">
@@ -298,11 +293,11 @@
 							<a
 								href={item.href}
 								onclick={closeMobileMenu}
-								class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors {isActive(
+								class="flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors {isActive(
 									item.href
 								)
-									? 'bg-primary/10 text-primary'
-									: 'text-muted-foreground hover:bg-accent hover:text-foreground'}"
+									? 'bg-primary/10 font-bold text-primary'
+									: 'font-semibold text-muted-foreground hover:bg-accent hover:text-foreground'}"
 								aria-current={isActive(item.href) ? 'page' : undefined}
 							>
 								{item.label}

--- a/src/routes/(auth)/org/[slug]/admin/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/+page.svelte
@@ -30,7 +30,8 @@
 	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
-	import type { Tone, PosterTint } from '$lib/components/common/tones';
+	import type { PosterTint } from '$lib/components/common/tones';
+	import { assignQuickActionTints } from './quick-action-tints';
 	import { createQuery } from '@tanstack/svelte-query';
 	import {
 		eventpublicdiscoveryListEvents,
@@ -80,108 +81,83 @@
 	const eventsList = $derived(eventsQuery.data?.results ?? []);
 	const tiersList = $derived(tiersQuery.data ?? []);
 
-	// Identity-tint cycle for destinations with no semantic meaning of their
-	// own (ToneTile's tint axis, spec §4.3). Assigned in array order below via
-	// nextTint() so consecutive tiles never repeat a tint; the two tiles with
-	// real semantic meaning (Blacklist, Financials) use `tone` instead and are
-	// skipped from the cycle.
-	const TINTS: PosterTint[] = [
-		'purple',
-		'lavender',
-		'periwinkle',
-		'amber',
-		'crimson',
-		'ink',
-		'paper'
-	];
-
 	interface QuickAction {
 		title: string;
 		description: string;
 		icon: Component;
 		href: ResolvedPathname;
-		tone?: Tone;
-		tint?: PosterTint;
+		tint: PosterTint;
 		badge?: string;
 	}
 
 	// Quick action cards (derived to properly track organization reactivity).
 	// Kept in sync with the admin nav in +layout.svelte: same destinations, same
-	// owner-gating for the financial surfaces (financials + billing).
-	const quickActions = $derived.by((): QuickAction[] => {
-		let tintIndex = 0;
-		const nextTint = (): PosterTint => TINTS[tintIndex++ % TINTS.length];
-
-		return [
+	// owner-gating for the financial surfaces (financials + billing). Every
+	// tile is pure destination identity — navigating to Blacklist or
+	// Financials isn't itself danger/success, the Ban/Wallet icons + labels
+	// already carry that meaning — so all 14 go through the shared `tint`
+	// cycle (assignQuickActionTints) rather than ToneTile's semantic `tone`.
+	const quickActions: QuickAction[] = $derived.by((): QuickAction[] => {
+		const base: Omit<QuickAction, 'tint'>[] = [
 			{
 				title: m['orgAdmin.dashboard.quickActions.events.title'](),
 				description: m['orgAdmin.dashboard.quickActions.events.description'](),
 				icon: Calendar,
-				href: resolve('/(auth)/org/[slug]/admin/events', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/events', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.eventSeries.title'](),
 				description: m['orgAdmin.dashboard.quickActions.eventSeries.description'](),
 				icon: Repeat,
-				href: resolve('/(auth)/org/[slug]/admin/event-series', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/event-series', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.tickets.title'](),
 				description: m['orgAdmin.dashboard.quickActions.tickets.description'](),
 				icon: Ticket,
-				href: resolve('/(auth)/org/[slug]/admin/tickets', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/tickets', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.discountCodes.title'](),
 				description: m['orgAdmin.dashboard.quickActions.discountCodes.description'](),
 				icon: Tag,
-				href: resolve('/(auth)/org/[slug]/admin/discount-codes', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/discount-codes', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.members.title'](),
 				description: m['orgAdmin.dashboard.quickActions.members.description'](),
 				icon: Users,
-				href: resolve('/(auth)/org/[slug]/admin/members', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/members', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.polls.title'](),
 				description: m['orgAdmin.dashboard.quickActions.polls.description'](),
 				icon: BarChart3,
-				href: resolve('/(auth)/org/[slug]/admin/polls', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/polls', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.questionnaires.title'](),
 				description: m['orgAdmin.dashboard.quickActions.questionnaires.description'](),
 				icon: ClipboardList,
-				href: resolve('/(auth)/org/[slug]/admin/questionnaires', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/questionnaires', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.resources.title'](),
 				description: m['orgAdmin.dashboard.quickActions.resources.description'](),
 				icon: FolderOpen,
-				href: resolve('/(auth)/org/[slug]/admin/resources', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/resources', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.venues.title'](),
 				description: m['orgAdmin.dashboard.quickActions.venues.description'](),
 				icon: MapPin,
-				href: resolve('/(auth)/org/[slug]/admin/venues', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/venues', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.blacklist.title'](),
 				description: m['orgAdmin.dashboard.quickActions.blacklist.description'](),
 				icon: Ban,
-				href: resolve('/(auth)/org/[slug]/admin/blacklist', { slug: organization.slug }),
-				tone: 'danger'
+				href: resolve('/(auth)/org/[slug]/admin/blacklist', { slug: organization.slug })
 			},
 			// Owner-only financial surfaces (mirrors the nav's isOwner gating)
 			...(data.isOwner
@@ -190,15 +166,13 @@
 							title: m['orgAdmin.dashboard.quickActions.billing.title'](),
 							description: m['orgAdmin.dashboard.quickActions.billing.description'](),
 							icon: CreditCard,
-							href: resolve('/(auth)/org/[slug]/admin/billing', { slug: organization.slug }),
-							tint: nextTint()
+							href: resolve('/(auth)/org/[slug]/admin/billing', { slug: organization.slug })
 						},
 						{
 							title: m['orgAdmin.dashboard.quickActions.financials.title'](),
 							description: m['orgAdmin.dashboard.quickActions.financials.description'](),
 							icon: Wallet,
-							href: resolve('/(auth)/org/[slug]/admin/financials', { slug: organization.slug }),
-							tone: 'success' as Tone
+							href: resolve('/(auth)/org/[slug]/admin/financials', { slug: organization.slug })
 						}
 					]
 				: []),
@@ -206,17 +180,16 @@
 				title: m['announcements.title'](),
 				description: m['announcements.pageDescription'](),
 				icon: Megaphone,
-				href: resolve('/(auth)/org/[slug]/admin/announcements', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/announcements', { slug: organization.slug })
 			},
 			{
 				title: m['orgAdmin.dashboard.quickActions.settings.title'](),
 				description: m['orgAdmin.dashboard.quickActions.settings.description'](),
 				icon: Settings,
-				href: resolve('/(auth)/org/[slug]/admin/settings', { slug: organization.slug }),
-				tint: nextTint()
+				href: resolve('/(auth)/org/[slug]/admin/settings', { slug: organization.slug })
 			}
 		];
+		return assignQuickActionTints(base);
 	});
 
 	function navigateTo(href: ResolvedPathname, disabled = false) {
@@ -243,7 +216,6 @@
 <div class="space-y-6 px-4 md:px-0">
 	<PageHeader
 		title={m['orgAdmin.dashboard.pageTitle']({ orgName: organization.name })}
-		kicker={m['orgAdmin.layout.adminBadge']()}
 		subtitle={m['orgAdmin.dashboard.pageDescription']()}
 		volume="studio"
 	/>
@@ -295,14 +267,8 @@
 						</span>
 					{/if}
 
-					<!-- Icon: tint = pure destination identity, tone = semantic (danger/success) -->
-					<ToneTile
-						tone={action.tone ?? 'neutral'}
-						tint={action.tint}
-						icon={Icon}
-						size="lg"
-						class="mb-4"
-					/>
+					<!-- Every tile is pure destination identity -> tint, not tone (see quickActions above) -->
+					<ToneTile tint={action.tint} icon={Icon} size="lg" class="mb-4" />
 
 					<!-- Content -->
 					<div class="space-y-1">

--- a/src/routes/(auth)/org/[slug]/admin/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/+page.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import type { ResolvedPathname } from '$app/types';
+	import type { Component } from 'svelte';
 	import type { PageData } from './$types';
 	import {
 		Calendar,
@@ -25,6 +26,11 @@
 	} from '@lucide/svelte';
 	import { OrganizationDescription } from '$lib/components/organizations';
 	import AnnouncementModal from '$lib/components/announcements/AnnouncementModal.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone, PosterTint } from '$lib/components/common/tones';
 	import { createQuery } from '@tanstack/svelte-query';
 	import {
 		eventpublicdiscoveryListEvents,
@@ -74,142 +80,144 @@
 	const eventsList = $derived(eventsQuery.data?.results ?? []);
 	const tiersList = $derived(tiersQuery.data ?? []);
 
+	// Identity-tint cycle for destinations with no semantic meaning of their
+	// own (ToneTile's tint axis, spec §4.3). Assigned in array order below via
+	// nextTint() so consecutive tiles never repeat a tint; the two tiles with
+	// real semantic meaning (Blacklist, Financials) use `tone` instead and are
+	// skipped from the cycle.
+	const TINTS: PosterTint[] = [
+		'purple',
+		'lavender',
+		'periwinkle',
+		'amber',
+		'crimson',
+		'ink',
+		'paper'
+	];
+
+	interface QuickAction {
+		title: string;
+		description: string;
+		icon: Component;
+		href: ResolvedPathname;
+		tone?: Tone;
+		tint?: PosterTint;
+		badge?: string;
+	}
+
 	// Quick action cards (derived to properly track organization reactivity).
 	// Kept in sync with the admin nav in +layout.svelte: same destinations, same
 	// owner-gating for the financial surfaces (financials + billing).
-	const quickActions = $derived([
-		{
-			title: m['orgAdmin.dashboard.quickActions.events.title'](),
-			description: m['orgAdmin.dashboard.quickActions.events.description'](),
-			icon: Calendar,
-			href: resolve('/(auth)/org/[slug]/admin/events', { slug: organization.slug }),
-			color: 'text-blue-600 dark:text-blue-400',
-			bgColor: 'bg-blue-50 dark:bg-blue-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.eventSeries.title'](),
-			description: m['orgAdmin.dashboard.quickActions.eventSeries.description'](),
-			icon: Repeat,
-			href: resolve('/(auth)/org/[slug]/admin/event-series', { slug: organization.slug }),
-			color: 'text-indigo-600 dark:text-indigo-400',
-			bgColor: 'bg-indigo-50 dark:bg-indigo-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.tickets.title'](),
-			description: m['orgAdmin.dashboard.quickActions.tickets.description'](),
-			icon: Ticket,
-			href: resolve('/(auth)/org/[slug]/admin/tickets', { slug: organization.slug }),
-			color: 'text-teal-600 dark:text-teal-400',
-			bgColor: 'bg-teal-50 dark:bg-teal-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.discountCodes.title'](),
-			description: m['orgAdmin.dashboard.quickActions.discountCodes.description'](),
-			icon: Tag,
-			href: resolve('/(auth)/org/[slug]/admin/discount-codes', { slug: organization.slug }),
-			color: 'text-amber-600 dark:text-amber-400',
-			bgColor: 'bg-amber-50 dark:bg-amber-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.members.title'](),
-			description: m['orgAdmin.dashboard.quickActions.members.description'](),
-			icon: Users,
-			href: resolve('/(auth)/org/[slug]/admin/members', { slug: organization.slug }),
-			color: 'text-green-600 dark:text-green-400',
-			bgColor: 'bg-green-50 dark:bg-green-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.polls.title'](),
-			description: m['orgAdmin.dashboard.quickActions.polls.description'](),
-			icon: BarChart3,
-			href: resolve('/(auth)/org/[slug]/admin/polls', { slug: organization.slug }),
-			color: 'text-cyan-600 dark:text-cyan-400',
-			bgColor: 'bg-cyan-50 dark:bg-cyan-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.questionnaires.title'](),
-			description: m['orgAdmin.dashboard.quickActions.questionnaires.description'](),
-			icon: ClipboardList,
-			href: resolve('/(auth)/org/[slug]/admin/questionnaires', { slug: organization.slug }),
-			color: 'text-orange-600 dark:text-orange-400',
-			bgColor: 'bg-orange-50 dark:bg-orange-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.resources.title'](),
-			description: m['orgAdmin.dashboard.quickActions.resources.description'](),
-			icon: FolderOpen,
-			href: resolve('/(auth)/org/[slug]/admin/resources', { slug: organization.slug }),
-			color: 'text-cyan-600 dark:text-cyan-400',
-			bgColor: 'bg-cyan-50 dark:bg-cyan-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.venues.title'](),
-			description: m['orgAdmin.dashboard.quickActions.venues.description'](),
-			icon: MapPin,
-			href: resolve('/(auth)/org/[slug]/admin/venues', { slug: organization.slug }),
-			color: 'text-pink-600 dark:text-pink-400',
-			bgColor: 'bg-pink-50 dark:bg-pink-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.blacklist.title'](),
-			description: m['orgAdmin.dashboard.quickActions.blacklist.description'](),
-			icon: Ban,
-			href: resolve('/(auth)/org/[slug]/admin/blacklist', { slug: organization.slug }),
-			color: 'text-red-600 dark:text-red-400',
-			bgColor: 'bg-red-50 dark:bg-red-950',
-			badge: undefined as string | undefined
-		},
-		// Owner-only financial surfaces (mirrors the nav's isOwner gating)
-		...(data.isOwner
-			? [
-					{
-						title: m['orgAdmin.dashboard.quickActions.billing.title'](),
-						description: m['orgAdmin.dashboard.quickActions.billing.description'](),
-						icon: CreditCard,
-						href: resolve('/(auth)/org/[slug]/admin/billing', { slug: organization.slug }),
-						color: 'text-slate-600 dark:text-slate-400',
-						bgColor: 'bg-slate-50 dark:bg-slate-950',
-						badge: undefined as string | undefined
-					},
-					{
-						title: m['orgAdmin.dashboard.quickActions.financials.title'](),
-						description: m['orgAdmin.dashboard.quickActions.financials.description'](),
-						icon: Wallet,
-						href: resolve('/(auth)/org/[slug]/admin/financials', { slug: organization.slug }),
-						color: 'text-emerald-600 dark:text-emerald-400',
-						bgColor: 'bg-emerald-50 dark:bg-emerald-950',
-						badge: undefined as string | undefined
-					}
-				]
-			: []),
-		{
-			title: m['announcements.title'](),
-			description: m['announcements.pageDescription'](),
-			icon: Megaphone,
-			href: resolve('/(auth)/org/[slug]/admin/announcements', { slug: organization.slug }),
-			color: 'text-yellow-600 dark:text-yellow-400',
-			bgColor: 'bg-yellow-50 dark:bg-yellow-950',
-			badge: undefined as string | undefined
-		},
-		{
-			title: m['orgAdmin.dashboard.quickActions.settings.title'](),
-			description: m['orgAdmin.dashboard.quickActions.settings.description'](),
-			icon: Settings,
-			href: resolve('/(auth)/org/[slug]/admin/settings', { slug: organization.slug }),
-			color: 'text-purple-600 dark:text-purple-400',
-			bgColor: 'bg-purple-50 dark:bg-purple-950',
-			badge: undefined as string | undefined
-		}
-	]);
+	const quickActions = $derived.by((): QuickAction[] => {
+		let tintIndex = 0;
+		const nextTint = (): PosterTint => TINTS[tintIndex++ % TINTS.length];
+
+		return [
+			{
+				title: m['orgAdmin.dashboard.quickActions.events.title'](),
+				description: m['orgAdmin.dashboard.quickActions.events.description'](),
+				icon: Calendar,
+				href: resolve('/(auth)/org/[slug]/admin/events', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.eventSeries.title'](),
+				description: m['orgAdmin.dashboard.quickActions.eventSeries.description'](),
+				icon: Repeat,
+				href: resolve('/(auth)/org/[slug]/admin/event-series', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.tickets.title'](),
+				description: m['orgAdmin.dashboard.quickActions.tickets.description'](),
+				icon: Ticket,
+				href: resolve('/(auth)/org/[slug]/admin/tickets', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.discountCodes.title'](),
+				description: m['orgAdmin.dashboard.quickActions.discountCodes.description'](),
+				icon: Tag,
+				href: resolve('/(auth)/org/[slug]/admin/discount-codes', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.members.title'](),
+				description: m['orgAdmin.dashboard.quickActions.members.description'](),
+				icon: Users,
+				href: resolve('/(auth)/org/[slug]/admin/members', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.polls.title'](),
+				description: m['orgAdmin.dashboard.quickActions.polls.description'](),
+				icon: BarChart3,
+				href: resolve('/(auth)/org/[slug]/admin/polls', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.questionnaires.title'](),
+				description: m['orgAdmin.dashboard.quickActions.questionnaires.description'](),
+				icon: ClipboardList,
+				href: resolve('/(auth)/org/[slug]/admin/questionnaires', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.resources.title'](),
+				description: m['orgAdmin.dashboard.quickActions.resources.description'](),
+				icon: FolderOpen,
+				href: resolve('/(auth)/org/[slug]/admin/resources', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.venues.title'](),
+				description: m['orgAdmin.dashboard.quickActions.venues.description'](),
+				icon: MapPin,
+				href: resolve('/(auth)/org/[slug]/admin/venues', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.blacklist.title'](),
+				description: m['orgAdmin.dashboard.quickActions.blacklist.description'](),
+				icon: Ban,
+				href: resolve('/(auth)/org/[slug]/admin/blacklist', { slug: organization.slug }),
+				tone: 'danger'
+			},
+			// Owner-only financial surfaces (mirrors the nav's isOwner gating)
+			...(data.isOwner
+				? [
+						{
+							title: m['orgAdmin.dashboard.quickActions.billing.title'](),
+							description: m['orgAdmin.dashboard.quickActions.billing.description'](),
+							icon: CreditCard,
+							href: resolve('/(auth)/org/[slug]/admin/billing', { slug: organization.slug }),
+							tint: nextTint()
+						},
+						{
+							title: m['orgAdmin.dashboard.quickActions.financials.title'](),
+							description: m['orgAdmin.dashboard.quickActions.financials.description'](),
+							icon: Wallet,
+							href: resolve('/(auth)/org/[slug]/admin/financials', { slug: organization.slug }),
+							tone: 'success' as Tone
+						}
+					]
+				: []),
+			{
+				title: m['announcements.title'](),
+				description: m['announcements.pageDescription'](),
+				icon: Megaphone,
+				href: resolve('/(auth)/org/[slug]/admin/announcements', { slug: organization.slug }),
+				tint: nextTint()
+			},
+			{
+				title: m['orgAdmin.dashboard.quickActions.settings.title'](),
+				description: m['orgAdmin.dashboard.quickActions.settings.description'](),
+				icon: Settings,
+				href: resolve('/(auth)/org/[slug]/admin/settings', { slug: organization.slug }),
+				tint: nextTint()
+			}
+		];
+	});
 
 	function navigateTo(href: ResolvedPathname, disabled = false) {
 		if (!disabled) {
@@ -233,41 +241,39 @@
 </svelte:head>
 
 <div class="space-y-6 px-4 md:px-0">
-	<!-- Welcome Header -->
-	<div>
-		<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-			{m['orgAdmin.dashboard.pageTitle']({ orgName: organization.name })}
-		</h1>
-		<p class="mt-1 text-sm text-muted-foreground">
-			{m['orgAdmin.dashboard.pageDescription']()}
-		</p>
-	</div>
+	<PageHeader
+		title={m['orgAdmin.dashboard.pageTitle']({ orgName: organization.name })}
+		kicker={m['orgAdmin.layout.adminBadge']()}
+		subtitle={m['orgAdmin.dashboard.pageDescription']()}
+		volume="studio"
+	/>
 
 	<!-- Quick Actions Section -->
 	<div class="space-y-4">
-		<div class="flex items-center justify-between">
-			<h2 class="text-lg font-semibold">{m['orgAdmin.dashboard.quickActionsHeading']()}</h2>
-			<div class="flex items-center gap-2">
+		{#snippet quickActionsHeaderActions()}
+			<button
+				type="button"
+				onclick={() => (announcementModalOpen = true)}
+				class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+			>
+				<Megaphone class="h-4 w-4" aria-hidden="true" />
+				{m['announcements.new']()}
+			</button>
+			{#if canCreateEvent}
 				<button
 					type="button"
-					onclick={() => (announcementModalOpen = true)}
-					class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					onclick={createEvent}
+					class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 				>
-					<Megaphone class="h-4 w-4" aria-hidden="true" />
-					{m['announcements.new']()}
+					<Plus class="h-4 w-4" aria-hidden="true" />
+					{m['orgAdmin.dashboard.createEventButton']()}
 				</button>
-				{#if canCreateEvent}
-					<button
-						type="button"
-						onclick={createEvent}
-						class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-					>
-						<Plus class="h-4 w-4" aria-hidden="true" />
-						{m['orgAdmin.dashboard.createEventButton']()}
-					</button>
-				{/if}
-			</div>
-		</div>
+			{/if}
+		{/snippet}
+		<SectionHeader
+			title={m['orgAdmin.dashboard.quickActionsHeading']()}
+			actions={quickActionsHeaderActions}
+		/>
 
 		<!-- Action Cards Grid -->
 		<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
@@ -289,14 +295,18 @@
 						</span>
 					{/if}
 
-					<!-- Icon -->
-					<div class="mb-4 inline-flex rounded-lg {action.bgColor} p-3">
-						<Icon class="h-6 w-6 {action.color}" aria-hidden="true" />
-					</div>
+					<!-- Icon: tint = pure destination identity, tone = semantic (danger/success) -->
+					<ToneTile
+						tone={action.tone ?? 'neutral'}
+						tint={action.tint}
+						icon={Icon}
+						size="lg"
+						class="mb-4"
+					/>
 
 					<!-- Content -->
 					<div class="space-y-1">
-						<h3 class="font-semibold">{action.title}</h3>
+						<h3 class="font-bold">{action.title}</h3>
 						<p class="text-sm text-muted-foreground">{action.description}</p>
 					</div>
 
@@ -314,7 +324,7 @@
 
 	<!-- Organization Info Section -->
 	<div class="space-y-4">
-		<h2 class="text-lg font-semibold">{m['orgAdmin.dashboard.organizationDetailsHeading']()}</h2>
+		<SectionHeader title={m['orgAdmin.dashboard.organizationDetailsHeading']()} />
 
 		<div class="rounded-lg border border-border bg-card p-6 shadow-sm">
 			<dl class="grid gap-4 md:grid-cols-2">
@@ -353,17 +363,9 @@
 					</dt>
 					<dd class="mt-1">
 						{#if data.isOwner}
-							<span
-								class="inline-flex items-center rounded-md bg-primary/10 px-2 py-1 text-sm font-medium text-primary"
-							>
-								{m['orgAdmin.layout.ownerBadge']()}
-							</span>
+							<StatusBadge tone="brand" label={m['orgAdmin.layout.ownerBadge']()} />
 						{:else if data.isStaff}
-							<span
-								class="inline-flex items-center rounded-md bg-accent px-2 py-1 text-sm font-medium"
-							>
-								{m['orgAdmin.layout.staffBadge']()}
-							</span>
+							<StatusBadge tone="neutral" label={m['orgAdmin.layout.staffBadge']()} />
 						{/if}
 					</dd>
 				</div>
@@ -389,16 +391,14 @@
 
 	<!-- Permissions Notice (for staff members) -->
 	{#if data.isStaff && !data.isOwner}
-		<div
-			class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950"
-		>
+		<div class="rounded-lg border border-info/30 bg-info/10 p-4">
 			<div class="flex gap-3">
-				<FileText class="h-5 w-5 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+				<ToneTile tone="info" icon={FileText} size="sm" />
 				<div class="flex-1">
-					<h3 class="font-medium text-blue-900 dark:text-blue-100">
+					<h3 class="font-bold">
 						{m['orgAdmin.dashboard.permissions.staffNoticeTitle']()}
 					</h3>
-					<p class="mt-1 text-sm text-blue-700 dark:text-blue-300">
+					<p class="mt-1 text-sm text-muted-foreground">
 						{m['orgAdmin.dashboard.permissions.staffNoticeDescription']()}
 					</p>
 				</div>

--- a/src/routes/(auth)/org/[slug]/admin/quick-action-tints.test.ts
+++ b/src/routes/(auth)/org/[slug]/admin/quick-action-tints.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { assignQuickActionTints, TINTS } from './quick-action-tints';
+
+/**
+ * Locks the "no grid-adjacent tile repeats a tint" property for both
+ * quick-actions grid variants (12 tiles = non-owner, 14 = owner) across both
+ * column counts the grid actually uses (md:grid-cols-2 -> offset 2,
+ * lg:grid-cols-4 -> offset 4), plus the horizontal same-row offset of 1.
+ */
+function expectNoAdjacentRepeats(length: number) {
+	const items = Array.from({ length }, (_, i) => ({ id: i }));
+	const tinted = assignQuickActionTints(items);
+
+	for (const offset of [1, 2, 4]) {
+		for (let i = 0; i + offset < tinted.length; i++) {
+			expect(tinted[i].tint, `offset=${offset} i=${i} length=${length}`).not.toBe(
+				tinted[i + offset].tint
+			);
+		}
+	}
+}
+
+describe('assignQuickActionTints', () => {
+	it('never repeats a tint at grid-adjacent offsets — non-owner grid (12 tiles)', () => {
+		expectNoAdjacentRepeats(12);
+	});
+
+	it('never repeats a tint at grid-adjacent offsets — owner grid (14 tiles)', () => {
+		expectNoAdjacentRepeats(14);
+	});
+
+	it('cycles through every tint at least once across 14 tiles', () => {
+		const tinted = assignQuickActionTints(Array.from({ length: 14 }, (_, i) => i));
+		expect(new Set(tinted.map((t) => t.tint)).size).toBe(TINTS.length);
+	});
+
+	it('preserves the original item fields alongside the assigned tint', () => {
+		const [first] = assignQuickActionTints([{ title: 'Events', href: '/events' }]);
+		expect(first.title).toBe('Events');
+		expect(first.href).toBe('/events');
+		expect(first.tint).toBe(TINTS[0]);
+	});
+});

--- a/src/routes/(auth)/org/[slug]/admin/quick-action-tints.ts
+++ b/src/routes/(auth)/org/[slug]/admin/quick-action-tints.ts
@@ -1,0 +1,32 @@
+import type { PosterTint } from '$lib/components/common/tones';
+
+/**
+ * Identity-tint cycle for the admin dashboard's quick-actions grid (spec §4.3,
+ * PR 7 fix round — Blacklist/Financials moved off semantic `tone` onto `tint`
+ * like their 12 siblings, since navigating to a page is identity, not
+ * danger/success; the Ban/Wallet icons + visible labels already carry that
+ * meaning). Pure array-order assignment: item `i` gets `TINTS[i % TINTS.length]`.
+ *
+ * This uniform cycle (no skipped/special-cased tiles) guarantees "no
+ * grid-adjacent tile repeats a tint" for BOTH quick-actions grid variants
+ * (12 tiles non-owner, 14 owner) at BOTH column counts the grid uses
+ * (`md:grid-cols-2` -> vertical offset 2, `lg:grid-cols-4` -> vertical offset
+ * 4), plus the horizontal offset of 1 — because `TINTS.length` (7) is prime
+ * and every one of those offsets is smaller than 7 and non-zero, so it can
+ * never land back on the same index mod 7. See quick-action-tints.test.ts for
+ * the property test.
+ */
+export const TINTS: readonly PosterTint[] = [
+	'purple',
+	'lavender',
+	'periwinkle',
+	'amber',
+	'crimson',
+	'ink',
+	'paper'
+];
+
+/** Assigns an identity tint to each item by array order (see module docs). */
+export function assignQuickActionTints<T>(items: readonly T[]): (T & { tint: PosterTint })[] {
+	return items.map((item, i) => ({ ...item, tint: TINTS[i % TINTS.length] }));
+}


### PR DESCRIPTION
## Platform rebrand, PR 7 of 10 — Admin shell + dashboard

The PR that unlocks the final admin wave (PRs 8–10 branch after this merges).

### What's in it
- **ToneTile identity `tint` axis** (spec §4.3 ruling): seven fixed poster-palette solid chips (`purple | lavender | periwinkle | amber | crimson | ink | paper`), audited pairs only (one new audit entry: ink-on-lavender 5.69:1), mode-inert per the imagery rule — with `ring-1 ring-inset ring-border` on every chip because the surface UNDER a mode-inert chip flips (ink-on-dark-card measured 1.04:1 without it). Props are now a union: at least one of `tone`/`tint` required, no filler args; strictly additive for all ~30 existing call sites.
- **PageHeader restProps** (`Omit<HTMLAttributes, 'children'>`) — unblocks aria-live/id adopters in PRs 8–10.
- **Admin dashboard**: the 14-tile quick-actions grid — the app's single worst raw-hue offender (11+ hand-picked hues) — is now the tint cycle, with a unit test proving the no-adjacent-repeat property for both grid variants at both column counts (holds unconditionally: 7 is prime, offsets {1,2,4}).
- **Admin layout**: studio nav typography, kicker section labels, `StatusBadge` owner/staff pills; the sticky-bar org name demoted h1→p (every admin page was heading toward two h1s as PRs 8–10 adopt PageHeader; e2e-verified no spec depends on it).

### Review process
Whole-branch opus review + one fix round + scoped re-review, clean. Review highlights: caught the invisible-chip problem (structurally invisible to the audit script — chip-vs-surface isn't a text pair), overruled tone-for-identity on two tiles (Blacklist/Financials now tints, consistent with the CLAUDE.md rule this PR ships), and pushed the props union while there were 2 call sites instead of 40.

### Verification
Full suite 203 files / 2442 green (all existing primitive tests unmodified) · `make check` 0 errors · brand audit 0 failures incl. the new pair · screenshots at 1280/375 × light/dark with chip close-ups confirming the ring fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)