### PR TITLE
feat(rebrand): admin money, settings & embed — studio pass, billing badge mappers, brand tokens (PR 10/10)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -53,6 +53,15 @@
 		   the literal appears once; deliberately NOT part of the semantic audit. */
 		--brand-telegram: 200 100% 33%; /* fill: white labels measure ~5.4:1 (hand-verified; audit-exempt) — deliberately darker than Telegram's #0088cc so text-sm white labels pass AA in both modes (fill is NOT redefined in .dark) */
 		--brand-telegram-text: 200 100% 33%; /* text-on-surface: 4.8:1 on --background, 5.4:1 on card (hand-verified) */
+		/* More third-party brand identity: social-icon marks on the org settings
+		   page (decorative, aria-hidden — never text — so the WCAG 1.4.11 non-text
+		   3:1 floor applies, not the 4.5:1 text floor). Same rationale as
+		   --brand-telegram; audit-exempt. Converted precisely from the official
+		   brand hexes, not redefined in .dark (icons don't need a dark variant —
+		   hand-verified below at both surfaces in both modes). */
+		--brand-instagram: 349 75% 57%; /* #E4405F — 3.60:1 on background, 4.06:1 on card (light); 4.50:1/4.12:1 (dark) */
+		--brand-facebook: 214 89% 52%; /* #1877F2 — 3.78:1 on background, 4.27:1 on card (light); 4.28:1/3.92:1 (dark) */
+		--brand-bluesky: 211 99% 53%; /* #1185FE — 3.26:1 on background, 3.68:1 on card (light); 4.97:1/4.55:1 (dark) */
 		--border: 268 35% 84%;
 		--input: 268 35% 84%;
 		--ring: 270 70% 48%;

--- a/src/lib/components/embed/EmbedHeader.svelte
+++ b/src/lib/components/embed/EmbedHeader.svelte
@@ -33,7 +33,7 @@
 	{/if}
 
 	<div class="min-w-0 flex-1">
-		<h2 id={headingId} class="truncate text-sm font-semibold leading-tight">
+		<h2 id={headingId} class="truncate text-sm font-bold leading-tight">
 			<a
 				{href}
 				target="_blank"

--- a/src/lib/components/financials/CombinedTotalsSummary.svelte
+++ b/src/lib/components/financials/CombinedTotalsSummary.svelte
@@ -33,7 +33,8 @@
 		{#each figures as figure (figure.label)}
 			<div>
 				<dt class="text-xs text-muted-foreground">{figure.label}</dt>
-				<dd class="mt-0.5 tabular-nums {figure.strong ? 'text-lg font-semibold' : 'font-medium'}">
+				<!-- Headline revenue figure: studio's one permitted font-black flourish. -->
+				<dd class="mt-0.5 tabular-nums {figure.strong ? 'text-xl font-black' : 'font-medium'}">
 					{figure.value}
 				</dd>
 			</div>

--- a/src/lib/components/financials/CurrencyFinancialsSummary.svelte
+++ b/src/lib/components/financials/CurrencyFinancialsSummary.svelte
@@ -31,7 +31,8 @@
 		{#each figures as figure (figure.label)}
 			<div>
 				<dt class="text-xs text-muted-foreground">{figure.label}</dt>
-				<dd class="mt-0.5 tabular-nums {figure.strong ? 'text-lg font-semibold' : 'font-medium'}">
+				<!-- Headline revenue figure: studio's one permitted font-black flourish. -->
+				<dd class="mt-0.5 tabular-nums {figure.strong ? 'text-xl font-black' : 'font-medium'}">
 					{figure.value}
 				</dd>
 			</div>

--- a/src/lib/components/financials/MembershipFinancialsSummary.svelte
+++ b/src/lib/components/financials/MembershipFinancialsSummary.svelte
@@ -26,7 +26,8 @@
 		{#each figures as figure (figure.label)}
 			<div>
 				<dt class="text-xs text-muted-foreground">{figure.label}</dt>
-				<dd class="mt-0.5 tabular-nums {figure.strong ? 'text-lg font-semibold' : 'font-medium'}">
+				<!-- Headline revenue figure: studio's one permitted font-black flourish. -->
+				<dd class="mt-0.5 tabular-nums {figure.strong ? 'text-xl font-black' : 'font-medium'}">
 					{figure.value}
 				</dd>
 			</div>

--- a/src/lib/components/members/SubscriptionPaymentsShared.test.ts
+++ b/src/lib/components/members/SubscriptionPaymentsShared.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
 	partialRefundAmount,
-	getPaymentStatusConfig,
 	platformFeeBreakdown,
 	canRefundLedgerPayment,
 	type PlatformFeePayment
@@ -244,14 +243,5 @@ describe('canRefundLedgerPayment', () => {
 			expect(canRefundLedgerPayment({ status, payment_method: 'offline' })).toBe(false);
 			expect(canRefundLedgerPayment({ status, payment_method: 'online' })).toBe(false);
 		}
-	});
-});
-
-describe('getPaymentStatusConfig', () => {
-	it('covers every payment status with a distinct tint', () => {
-		const statuses: PaymentStatus[] = ['pending', 'succeeded', 'failed', 'refunded'];
-		const classNames = statuses.map((s) => getPaymentStatusConfig(s).className);
-		expect(classNames.every(Boolean)).toBe(true);
-		expect(new Set(classNames).size).toBe(statuses.length);
 	});
 });

--- a/src/lib/components/members/SubscriptionPaymentsShared.ts
+++ b/src/lib/components/members/SubscriptionPaymentsShared.ts
@@ -8,37 +8,8 @@
  */
 import type {
 	OrganizationMembershipPaymentSchema,
-	PaymentStatus,
 	SubscriptionPaymentMethod
 } from '$lib/api/generated/types.gen';
-
-export interface PaymentStatusConfig {
-	/** Tailwind tint. Decoration only — always paired with the label and an icon. */
-	className: string;
-}
-
-/**
- * Separated by *lightness* as much as by hue, so protanopia/deuteranopia
- * viewers still see four distinct chips; the label and icon carry the meaning.
- */
-const PAYMENT_STATUS_CONFIG: Record<PaymentStatus, PaymentStatusConfig> = {
-	succeeded: {
-		className: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-100'
-	},
-	pending: {
-		className: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-100'
-	},
-	failed: {
-		className: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-100'
-	},
-	refunded: {
-		className: 'bg-muted text-muted-foreground'
-	}
-};
-
-export function getPaymentStatusConfig(status: PaymentStatus): PaymentStatusConfig {
-	return PAYMENT_STATUS_CONFIG[status];
-}
 
 /**
  * A *partial* refund deliberately leaves `status = 'succeeded'` (the member

--- a/src/lib/components/members/SubscriptionPaymentsStatusBadge.svelte
+++ b/src/lib/components/members/SubscriptionPaymentsStatusBadge.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import type { PaymentStatus } from '$lib/api/generated/types.gen';
-	import { getPaymentStatusConfig } from './SubscriptionPaymentsShared';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import { CircleCheck, CircleX, Clock, Undo2 } from '@lucide/svelte';
 
 	interface Props {
@@ -10,27 +11,38 @@
 
 	const { status }: Props = $props();
 
-	const config = $derived(getPaymentStatusConfig(status));
+	/**
+	 * Thin mapper over the shared `StatusBadge` primitive. `refunded` collapses
+	 * onto `neutral` rather than `danger`/`warning`: unlike a failed charge, a
+	 * refund is a completed, intentional action — the icon (Undo2) and the
+	 * label carry that it happened, the tone doesn't need to alarm.
+	 */
+	const TONE_MAP: Record<PaymentStatus, Tone> = {
+		pending: 'info',
+		succeeded: 'success',
+		failed: 'danger',
+		refunded: 'neutral'
+	};
 
-	const label = $derived(
-		{
-			pending: m['orgAdmin.members.payments.status.pending'](),
-			succeeded: m['orgAdmin.members.payments.status.succeeded'](),
-			failed: m['orgAdmin.members.payments.status.failed'](),
-			refunded: m['orgAdmin.members.payments.status.refunded']()
-		}[status]
-	);
+	const LABEL_MAP: Record<PaymentStatus, () => string> = {
+		pending: () => m['orgAdmin.members.payments.status.pending'](),
+		succeeded: () => m['orgAdmin.members.payments.status.succeeded'](),
+		failed: () => m['orgAdmin.members.payments.status.failed'](),
+		refunded: () => m['orgAdmin.members.payments.status.refunded']()
+	};
 
-	// Meaning is carried by the icon + the visible label; the tint is layered on
+	// Meaning is carried by the icon + the visible label; the tone is layered on
 	// top and is never the only signal (WCAG 1.4.1).
-	const Icon = $derived(
-		{ pending: Clock, succeeded: CircleCheck, failed: CircleX, refunded: Undo2 }[status]
-	);
+	const ICON_MAP = { pending: Clock, succeeded: CircleCheck, failed: CircleX, refunded: Undo2 };
+
+	const tone = $derived(TONE_MAP[status]);
+	const label = $derived(LABEL_MAP[status]());
+	const Icon = $derived(ICON_MAP[status]);
 </script>
 
-<span
-	class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium {config.className}"
->
-	<Icon class="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-	<span>{label}</span>
-</span>
+<!--
+	`aria-label` is deliberate, not redundant: this pill is how the org-wide
+	payments ledger row/card is addressed by tests, and `common/StatusBadge`
+	only names itself from visible text content.
+-->
+<CommonStatusBadge {tone} {label} icon={Icon} size="sm" aria-label={label} />

--- a/src/lib/components/members/SubscriptionPaymentsStatusBadge.test.ts
+++ b/src/lib/components/members/SubscriptionPaymentsStatusBadge.test.ts
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import * as m from '$lib/paraglide/messages.js';
+import type { PaymentStatus } from '$lib/api/generated/types.gen';
+import SubscriptionPaymentsStatusBadge from './SubscriptionPaymentsStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD. `common/StatusBadge` names itself from its text content,
+ * not from an implicit prop — a mapper that forgets `aria-label` silently
+ * un-names its pill for every `getByLabel` lookup on the org-wide payments
+ * ledger row/card. See `src/lib/components/members/StatusBadge.test.ts` for
+ * the incident this pattern guards against (19 e2e specs broke on exactly
+ * this omission).
+ */
+const PAYMENT_STATUS_ORDER: PaymentStatus[] = ['pending', 'succeeded', 'failed', 'refunded'];
+
+const LABELS: Record<PaymentStatus, string> = {
+	pending: m['orgAdmin.members.payments.status.pending'](),
+	succeeded: m['orgAdmin.members.payments.status.succeeded'](),
+	failed: m['orgAdmin.members.payments.status.failed'](),
+	refunded: m['orgAdmin.members.payments.status.refunded']()
+};
+
+describe('members/SubscriptionPaymentsStatusBadge', () => {
+	it.each(PAYMENT_STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+		render(SubscriptionPaymentsStatusBadge, { props: { status } });
+		const label = LABELS[status];
+		expect(screen.getByLabelText(label)).toBeInTheDocument();
+		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+	});
+
+	it('maps status to the primitive tone (succeeded -> success, failed -> danger, refunded -> neutral)', () => {
+		const succeeded = render(SubscriptionPaymentsStatusBadge, { props: { status: 'succeeded' } });
+		expect(succeeded.container.querySelector('span')?.className).toContain('bg-success');
+
+		const failed = render(SubscriptionPaymentsStatusBadge, { props: { status: 'failed' } });
+		expect(failed.container.querySelector('span')?.className).toContain('bg-destructive');
+
+		const refunded = render(SubscriptionPaymentsStatusBadge, { props: { status: 'refunded' } });
+		expect(refunded.container.querySelector('span')?.className).toContain('bg-muted');
+	});
+});

--- a/src/lib/components/organization/OrgImageUploader.svelte
+++ b/src/lib/components/organization/OrgImageUploader.svelte
@@ -192,11 +192,14 @@
 	<SectionHeader title={m['orgAdmin.settings.branding.heading']()} />
 
 	{#if uploadError}
+		<!-- Icon carries the tone, not the body text: dark --destructive as TEXT on
+		     this composite measures ~2.7-2.95:1 (fails both the 3:1 non-text and
+		     4.5:1 text floors). -->
 		<div
-			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive"
+			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-foreground"
 			role="alert"
 		>
-			<AlertCircle class="h-5 w-5 shrink-0" aria-hidden="true" />
+			<AlertCircle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
 			<p class="text-sm font-medium">{uploadError}</p>
 		</div>
 	{/if}

--- a/src/lib/components/organization/OrgImageUploader.svelte
+++ b/src/lib/components/organization/OrgImageUploader.svelte
@@ -11,6 +11,7 @@
 		organizationadmincoreDeleteCoverArt
 	} from '$lib/api/generated/sdk.gen';
 	import { backendMessage } from '$lib/utils/api-error-detail';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 
 	interface Props {
 		slug: string;
@@ -188,11 +189,11 @@
 </script>
 
 <section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-	<h2 class="text-lg font-semibold">{m['orgAdmin.settings.branding.heading']()}</h2>
+	<SectionHeader title={m['orgAdmin.settings.branding.heading']()} />
 
 	{#if uploadError}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive"
 			role="alert"
 		>
 			<AlertCircle class="h-5 w-5 shrink-0" aria-hidden="true" />

--- a/src/lib/components/organization/OrgSubscriptionPolicySection.svelte
+++ b/src/lib/components/organization/OrgSubscriptionPolicySection.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import MarkdownEditor from '$lib/components/forms/MarkdownEditor.svelte';
 	import type { OrganizationAdminDetailSchema } from '$lib/api/generated';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -33,9 +34,7 @@
 </script>
 
 <section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-	<h2 class="text-lg font-semibold">
-		{m['orgSettingsPage.subscriptionPolicy.heading']()}
-	</h2>
+	<SectionHeader title={m['orgSettingsPage.subscriptionPolicy.heading']()} />
 	<p class="text-sm text-muted-foreground">
 		{m['orgSettingsPage.subscriptionPolicy.description']()}
 	</p>
@@ -53,7 +52,7 @@
 			step="1"
 			inputmode="numeric"
 			bind:value={gracePeriodDays}
-			class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:max-w-xs"
+			class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 sm:max-w-xs"
 		/>
 		<p class="mt-1 text-xs text-muted-foreground">
 			{m['orgSettingsPage.subscriptionPolicy.gracePeriodHelp']()}
@@ -73,7 +72,7 @@
 			step="1"
 			inputmode="numeric"
 			bind:value={revivalWindowDays}
-			class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:max-w-xs"
+			class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 sm:max-w-xs"
 		/>
 		<p class="mt-1 text-xs text-muted-foreground">
 			{m['orgSettingsPage.subscriptionPolicy.revivalWindowHelp']()}

--- a/src/lib/components/organization/StripeConnect.svelte
+++ b/src/lib/components/organization/StripeConnect.svelte
@@ -323,7 +323,16 @@
 									<Check class="h-3 w-3 text-success" aria-hidden="true" />
 									<span class="text-foreground">{m['stripeConnect.yes']()}</span>
 								{:else}
-									<AlertCircle class="h-3 w-3 text-destructive" aria-hidden="true" />
+									<!-- This dl can render inside ANY status card (e.g. the
+									     warning-tone "incomplete" card, bg-highlight/20), not
+									     just the danger-tone one — plain text-destructive there
+									     measured 1.85:1 in dark (destructive's dark hue sits too
+									     close to the amber tint's lightness). destructive-foreground
+									     (white) on that same composite measures 10.88:1. -->
+									<AlertCircle
+										class="h-3 w-3 text-destructive dark:text-destructive-foreground"
+										aria-hidden="true"
+									/>
 									<span class="text-foreground">{m['stripeConnect.no']()}</span>
 								{/if}
 							</dd>
@@ -337,20 +346,24 @@
 	<!-- Error Display -->
 	{#if connectMutation?.error}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-destructive"
+			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-foreground"
 			role="alert"
 		>
-			<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
+			<!-- Icon carries the tone, not the body text: dark --destructive as TEXT
+			     on this composite measures ~2.7-2.95:1 (fails both the 3:1 non-text
+			     and 4.5:1 text floors) — see StripeConnect's status-card comment for
+			     the same trap. -->
+			<AlertCircle class="h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
 			<p class="text-sm">{connectMutation.error.message}</p>
 		</div>
 	{/if}
 
 	{#if verifyQuery?.error}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-destructive"
+			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-foreground"
 			role="alert"
 		>
-			<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
+			<AlertCircle class="h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
 			<p class="text-sm">{m['stripeConnect.failedToVerify']()}</p>
 		</div>
 	{/if}

--- a/src/lib/components/organization/StripeConnect.svelte
+++ b/src/lib/components/organization/StripeConnect.svelte
@@ -145,12 +145,7 @@
 	}
 
 	type StripeStatusType =
-		| 'not-connected'
-		| 'loading'
-		| 'fully-connected'
-		| 'incomplete'
-		| 'restricted'
-		| 'unknown';
+		'not-connected' | 'loading' | 'fully-connected' | 'incomplete' | 'restricted' | 'unknown';
 
 	// Determine overall status
 	// Use query data if available (manual refresh), otherwise use props
@@ -457,7 +452,10 @@
 		     border-highlight/40 bg-highlight/20 + text-highlight-foreground
 		     (light) / text-highlight dark: matches the hand-verified pattern in
 		     tickets/MyTicket.svelte. -->
-		<div class="flex items-start gap-3 rounded-lg border border-highlight/40 bg-highlight/20 p-4" role="alert">
+		<div
+			class="flex items-start gap-3 rounded-lg border border-highlight/40 bg-highlight/20 p-4"
+			role="alert"
+		>
 			<AlertCircle
 				class="mt-0.5 h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
 				aria-hidden="true"

--- a/src/lib/components/organization/StripeConnect.svelte
+++ b/src/lib/components/organization/StripeConnect.svelte
@@ -20,6 +20,8 @@
 	} from '$lib/api/generated/sdk.gen';
 	import StripeConnectModal from './StripeConnectModal.svelte';
 	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		organizationSlug: string;
@@ -142,15 +144,22 @@
 		verifyQuery?.refetch();
 	}
 
+	type StripeStatusType =
+		| 'not-connected'
+		| 'loading'
+		| 'fully-connected'
+		| 'incomplete'
+		| 'restricted'
+		| 'unknown';
+
 	// Determine overall status
 	// Use query data if available (manual refresh), otherwise use props
-	const status = $derived.by(() => {
+	const status = $derived.by((): { type: StripeStatusType; title: string; message: string } => {
 		if (!isConnected) {
 			return {
 				type: 'not-connected',
 				title: m['stripeConnect.statusNotConnectedTitle'](),
-				message: m['stripeConnect.statusNotConnectedMessage'](),
-				color: 'gray'
+				message: m['stripeConnect.statusNotConnectedMessage']()
 			};
 		}
 
@@ -163,8 +172,7 @@
 			return {
 				type: 'loading',
 				title: m['stripeConnect.statusVerifyingTitle'](),
-				message: m['stripeConnect.statusVerifyingMessage'](),
-				color: 'blue'
+				message: m['stripeConnect.statusVerifyingMessage']()
 			};
 		}
 
@@ -175,8 +183,7 @@
 			return {
 				type: 'fully-connected',
 				title: m['stripeConnect.statusConnectedTitle'](),
-				message: `${m['stripeConnect.statusConnectedMessage']()}${emailMsg}`,
-				color: 'green'
+				message: `${m['stripeConnect.statusConnectedMessage']()}${emailMsg}`
 			};
 		}
 
@@ -184,8 +191,7 @@
 			return {
 				type: 'incomplete',
 				title: m['stripeConnect.statusIncompleteTitle'](),
-				message: m['stripeConnect.statusIncompleteMessage'](),
-				color: 'yellow'
+				message: m['stripeConnect.statusIncompleteMessage']()
 			};
 		}
 
@@ -193,101 +199,101 @@
 			return {
 				type: 'restricted',
 				title: m['stripeConnect.statusRestrictedTitle'](),
-				message: m['stripeConnect.statusRestrictedMessage'](),
-				color: 'red'
+				message: m['stripeConnect.statusRestrictedMessage']()
 			};
 		}
 
 		return {
 			type: 'unknown',
 			title: m['stripeConnect.statusUnknownTitle'](),
-			message: m['stripeConnect.statusUnknownMessage'](),
-			color: 'gray'
+			message: m['stripeConnect.statusUnknownMessage']()
 		};
 	});
+
+	// `unknown` collapses onto `neutral`, same as `not-connected`: neither is an
+	// error the organizer caused, so neither should read as alarming.
+	const STATUS_TONE: Record<StripeStatusType, Tone> = {
+		'not-connected': 'neutral',
+		loading: 'info',
+		'fully-connected': 'success',
+		incomplete: 'warning',
+		restricted: 'danger',
+		unknown: 'neutral'
+	};
+	const statusTone = $derived(STATUS_TONE[status.type]);
+
+	// Soft tint on the status Card — background/border only, never text (see the
+	// heading/message markup below: tone lives in the icon chip + this tint, not
+	// in colored body text, which is how dark --destructive as TEXT fails AA).
+	const CARD_TONE_CLASSES: Record<Tone, string> = {
+		brand: 'border-primary/40 bg-primary/10',
+		info: 'border-info/40 bg-info/10',
+		success: 'border-success/40 bg-success/10',
+		warning: 'border-highlight/40 bg-highlight/20',
+		danger: 'border-destructive/40 bg-destructive/10',
+		neutral: 'border-border bg-muted'
+	};
+
+	// Solid icon-chip fill — every pair is an audited *-foreground/* token pair.
+	const ICON_CHIP_CLASSES: Record<Tone, string> = {
+		brand: 'bg-primary text-primary-foreground',
+		info: 'bg-info text-info-foreground',
+		success: 'bg-success text-success-foreground',
+		warning: 'bg-highlight text-highlight-foreground',
+		danger: 'bg-destructive text-destructive-foreground',
+		neutral: 'bg-muted text-muted-foreground'
+	};
 </script>
 
 <section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
 	<div class="mb-4 flex items-center gap-2">
-		<CreditCard class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-		<h2 class="text-lg font-semibold">{m['stripeConnect.paymentProcessing']()}</h2>
+		<CreditCard class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+		<SectionHeader title={m['stripeConnect.paymentProcessing']()} class="flex-1" />
 	</div>
 
 	<!-- Success Message (when returning from Stripe) -->
 	{#if justConnected}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
+			class="flex items-center gap-2 rounded-lg border border-success/40 bg-success/10 p-4 text-foreground"
 			role="alert"
 		>
-			<Check class="h-5 w-5 shrink-0" aria-hidden="true" />
+			<Check class="h-5 w-5 shrink-0 text-success" aria-hidden="true" />
 			<div>
 				<p class="font-medium">{m['stripeConnect.welcomeBack']()}</p>
-				<p class="text-sm">{m['stripeConnect.verifyingAccount']()}</p>
+				<p class="text-sm text-muted-foreground">{m['stripeConnect.verifyingAccount']()}</p>
 			</div>
 		</div>
 	{/if}
 
 	<!-- Connection Status Card -->
-	<Card
-		class="border-2 p-4 {status.color === 'green'
-			? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30'
-			: status.color === 'yellow'
-				? 'border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950/30'
-				: status.color === 'red'
-					? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/30'
-					: 'border-border bg-muted'}"
-	>
+	<Card class="border-2 p-4 {CARD_TONE_CLASSES[statusTone]}">
 		<div class="flex items-start gap-3">
-			<!-- Icon -->
-			<div class="shrink-0">
+			<!-- Icon: this is where the status tone lives (WCAG-safe — the audited
+			     *-foreground/* pair — rather than on the heading/message text below). -->
+			<div class="shrink-0 rounded-full p-2 {ICON_CHIP_CLASSES[statusTone]}">
 				{#if status.type === 'fully-connected'}
-					<div class="rounded-full bg-green-600 p-2">
-						<Check class="h-5 w-5 text-white" aria-hidden="true" />
-					</div>
+					<Check class="h-5 w-5" aria-hidden="true" />
 				{:else if status.type === 'incomplete'}
-					<div class="rounded-full bg-yellow-600 p-2">
-						<AlertTriangle class="h-5 w-5 text-white" aria-hidden="true" />
-					</div>
+					<AlertTriangle class="h-5 w-5" aria-hidden="true" />
 				{:else if status.type === 'restricted'}
-					<div class="rounded-full bg-red-600 p-2">
-						<AlertCircle class="h-5 w-5 text-white" aria-hidden="true" />
-					</div>
+					<AlertCircle class="h-5 w-5" aria-hidden="true" />
 				{:else if status.type === 'loading'}
-					<div class="rounded-full bg-blue-600 p-2">
-						<div
-							class="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent"
-							aria-hidden="true"
-						></div>
-					</div>
+					<div
+						class="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent"
+						aria-hidden="true"
+					></div>
 				{:else}
-					<div class="rounded-full bg-gray-400 p-2">
-						<CreditCard class="h-5 w-5 text-white" aria-hidden="true" />
-					</div>
+					<CreditCard class="h-5 w-5" aria-hidden="true" />
 				{/if}
 			</div>
 
-			<!-- Content -->
+			<!-- Content: heading/message stay on theme foreground tokens regardless of
+			     tone — see the icon chip above for why. -->
 			<div class="flex-1">
-				<h3
-					class="font-semibold {status.color === 'green'
-						? 'text-green-900 dark:text-green-100'
-						: status.color === 'yellow'
-							? 'text-yellow-900 dark:text-yellow-100'
-							: status.color === 'red'
-								? 'text-red-900 dark:text-red-100'
-								: 'text-foreground'}"
-				>
+				<h3 class="font-bold text-foreground">
 					{status.title}
 				</h3>
-				<p
-					class="mt-1 text-sm {status.color === 'green'
-						? 'text-green-800 dark:text-green-200'
-						: status.color === 'yellow'
-							? 'text-yellow-800 dark:text-yellow-200'
-							: status.color === 'red'
-								? 'text-red-800 dark:text-red-200'
-								: 'text-muted-foreground'}"
-				>
+				<p class="mt-1 text-sm text-muted-foreground">
 					{status.message}
 				</p>
 
@@ -302,12 +308,14 @@
 							</dt>
 							<dd class="mt-0.5 flex items-center gap-1">
 								{#if detailsSubmitted}
-									<Check class="h-3 w-3 text-green-600" aria-hidden="true" />
-									<span class="text-green-700 dark:text-green-300">{m['stripeConnect.yes']()}</span>
+									<Check class="h-3 w-3 text-success" aria-hidden="true" />
+									<span class="text-foreground">{m['stripeConnect.yes']()}</span>
 								{:else}
-									<AlertCircle class="h-3 w-3 text-yellow-600" aria-hidden="true" />
-									<span class="text-yellow-700 dark:text-yellow-300">{m['stripeConnect.no']()}</span
-									>
+									<AlertCircle
+										class="h-3 w-3 text-highlight-foreground dark:text-highlight"
+										aria-hidden="true"
+									/>
+									<span class="text-foreground">{m['stripeConnect.no']()}</span>
 								{/if}
 							</dd>
 						</div>
@@ -317,11 +325,11 @@
 							</dt>
 							<dd class="mt-0.5 flex items-center gap-1">
 								{#if chargesEnabled}
-									<Check class="h-3 w-3 text-green-600" aria-hidden="true" />
-									<span class="text-green-700 dark:text-green-300">{m['stripeConnect.yes']()}</span>
+									<Check class="h-3 w-3 text-success" aria-hidden="true" />
+									<span class="text-foreground">{m['stripeConnect.yes']()}</span>
 								{:else}
-									<AlertCircle class="h-3 w-3 text-red-600" aria-hidden="true" />
-									<span class="text-red-700 dark:text-red-300">{m['stripeConnect.no']()}</span>
+									<AlertCircle class="h-3 w-3 text-destructive" aria-hidden="true" />
+									<span class="text-foreground">{m['stripeConnect.no']()}</span>
 								{/if}
 							</dd>
 						</div>
@@ -334,7 +342,7 @@
 	<!-- Error Display -->
 	{#if connectMutation?.error}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-destructive"
 			role="alert"
 		>
 			<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
@@ -344,7 +352,7 @@
 
 	{#if verifyQuery?.error}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-destructive"
 			role="alert"
 		>
 			<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
@@ -445,24 +453,25 @@
 
 	<!-- Billing Info Nudge -->
 	{#if billingInfoMissing && status.type === 'fully-connected'}
-		<div
-			class="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-950/30"
-			role="alert"
-		>
+		<!-- No --warning token exists; highlight/amber IS the warning tone.
+		     border-highlight/40 bg-highlight/20 + text-highlight-foreground
+		     (light) / text-highlight dark: matches the hand-verified pattern in
+		     tickets/MyTicket.svelte. -->
+		<div class="flex items-start gap-3 rounded-lg border border-highlight/40 bg-highlight/20 p-4" role="alert">
 			<AlertCircle
-				class="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400"
+				class="mt-0.5 h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
 				aria-hidden="true"
 			/>
 			<div class="flex-1">
-				<p class="font-medium text-amber-900 dark:text-amber-100">
+				<p class="font-bold text-highlight-foreground dark:text-highlight">
 					{m['orgAdmin.billing.nudge.title']()}
 				</p>
-				<p class="mt-1 text-sm text-amber-800 dark:text-amber-200">
+				<p class="mt-1 text-sm text-highlight-foreground dark:text-highlight">
 					{m['orgAdmin.billing.nudge.message']()}
 				</p>
 				<a
 					href={resolve('/(auth)/org/[slug]/admin/billing', { slug: organizationSlug })}
-					class="mt-2 inline-flex items-center gap-1.5 rounded-md bg-amber-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					class="mt-2 inline-flex items-center gap-1.5 rounded-md bg-highlight px-3 py-1.5 text-sm font-medium text-highlight-foreground transition-colors hover:bg-highlight/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 				>
 					{m['orgAdmin.billing.nudge.action']()}
 				</a>

--- a/src/lib/components/organization/StripeConnectModal.svelte
+++ b/src/lib/components/organization/StripeConnectModal.svelte
@@ -77,7 +77,7 @@
 					<div class="rounded-full bg-primary/10 p-2">
 						<Mail class="h-5 w-5 text-primary" aria-hidden="true" />
 					</div>
-					<h3 id="stripe-connect-modal-title" class="text-lg font-semibold">
+					<h3 id="stripe-connect-modal-title" class="text-lg font-bold">
 						{m['stripeConnectModal.title']()}
 					</h3>
 				</div>

--- a/src/lib/components/tickets/RefundStatusBadge.svelte
+++ b/src/lib/components/tickets/RefundStatusBadge.svelte
@@ -1,6 +1,13 @@
+<script module lang="ts">
+	/** Every status this mapper understands, in the order the regression test walks them. */
+	export const REFUND_STATUS_ORDER = ['succeeded', 'pending', 'failed'] as const;
+	export type KnownRefundStatus = (typeof REFUND_STATUS_ORDER)[number];
+</script>
+
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { cn } from '$lib/utils/cn';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		/** Refund status from the backend payment record. May be null/unknown. */
@@ -15,32 +22,37 @@
 	// Whitelist the statuses we know how to render. An unknown value (future
 	// status, empty string, null) renders nothing instead of being silently
 	// mislabeled as "failed".
-	const known = $derived.by((): 'succeeded' | 'pending' | 'failed' | null => {
+	const known = $derived.by((): KnownRefundStatus | null => {
 		if (status === 'succeeded' || status === 'pending' || status === 'failed') return status;
 		return null;
 	});
 
+	// `pending` takes `warning` rather than `info`: a refund sitting in "pending"
+	// is money not yet back in the attendee's hands, which is closer to "needs
+	// attention" than to a neutral in-progress state.
+	const TONE_MAP: Record<KnownRefundStatus, Tone> = {
+		succeeded: 'success',
+		pending: 'warning',
+		failed: 'danger'
+	};
+
+	const LABEL_MAP: Record<KnownRefundStatus, () => string> = {
+		succeeded: () => m['adminTicketTable.refundStatus.succeeded'](),
+		pending: () => m['adminTicketTable.refundStatus.pending'](),
+		failed: () => m['adminTicketTable.refundStatus.failed']()
+	};
+
+	const tone = $derived(known ? TONE_MAP[known] : 'neutral');
+	const label = $derived(known ? LABEL_MAP[known]() : '');
 	const tooltip = $derived(amount && currency ? `${amount} ${currency}` : undefined);
 </script>
 
+<!--
+	`aria-label` is deliberate, not redundant: this pill's accessible name is how
+	the ticket table/card list surfaces are addressed by tests, and the
+	`common/StatusBadge` primitive only names itself from visible text content.
+	`title` carries the optional amount+currency tooltip via restProps.
+-->
 {#if known}
-	<span
-		class={cn(
-			'inline-flex w-fit items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium',
-			known === 'succeeded' &&
-				'border-green-300 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-300',
-			known === 'pending' &&
-				'border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300',
-			known === 'failed' && 'border-destructive/50 bg-destructive/10 text-destructive'
-		)}
-		title={tooltip}
-	>
-		{#if known === 'succeeded'}
-			{m['adminTicketTable.refundStatus.succeeded']()}
-		{:else if known === 'pending'}
-			{m['adminTicketTable.refundStatus.pending']()}
-		{:else}
-			{m['adminTicketTable.refundStatus.failed']()}
-		{/if}
-	</span>
+	<CommonStatusBadge {tone} {label} size="sm" title={tooltip} aria-label={label} />
 {/if}

--- a/src/lib/components/tickets/RefundStatusBadge.svelte
+++ b/src/lib/components/tickets/RefundStatusBadge.svelte
@@ -54,5 +54,7 @@
 	`title` carries the optional amount+currency tooltip via restProps.
 -->
 {#if known}
-	<CommonStatusBadge {tone} {label} size="sm" title={tooltip} aria-label={label} />
+	<!-- w-fit: this sits in TicketTable/TicketCardList's flex flex-col cell, which
+	     would otherwise stretch the pill to the cell's full width. -->
+	<CommonStatusBadge {tone} {label} size="sm" title={tooltip} aria-label={label} class="w-fit" />
 {/if}

--- a/src/lib/components/tickets/RefundStatusBadge.test.ts
+++ b/src/lib/components/tickets/RefundStatusBadge.test.ts
@@ -1,7 +1,10 @@
 import { render, screen } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 import * as m from '$lib/paraglide/messages.js';
-import RefundStatusBadge, { REFUND_STATUS_ORDER, type KnownRefundStatus } from './RefundStatusBadge.svelte';
+import RefundStatusBadge, {
+	REFUND_STATUS_ORDER,
+	type KnownRefundStatus
+} from './RefundStatusBadge.svelte';
 
 /**
  * REGRESSION GUARD. `common/StatusBadge` names itself from its text content,

--- a/src/lib/components/tickets/RefundStatusBadge.test.ts
+++ b/src/lib/components/tickets/RefundStatusBadge.test.ts
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import * as m from '$lib/paraglide/messages.js';
+import RefundStatusBadge, { REFUND_STATUS_ORDER, type KnownRefundStatus } from './RefundStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD. `common/StatusBadge` names itself from its text content,
+ * not from an implicit prop — a mapper that forgets `aria-label` silently
+ * un-names its pill for every `getByLabel` lookup in the ticket table / card
+ * list, even though its own unit tests (which query by text) stay green. See
+ * `src/lib/components/members/StatusBadge.test.ts` for the incident this
+ * pattern guards against (19 e2e specs broke on exactly this omission).
+ */
+const LABELS: Record<KnownRefundStatus, string> = {
+	succeeded: m['adminTicketTable.refundStatus.succeeded'](),
+	pending: m['adminTicketTable.refundStatus.pending'](),
+	failed: m['adminTicketTable.refundStatus.failed']()
+};
+
+describe('tickets/RefundStatusBadge', () => {
+	it.each(REFUND_STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+		render(RefundStatusBadge, { props: { status } });
+		const label = LABELS[status];
+		expect(screen.getByLabelText(label)).toBeInTheDocument();
+		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+	});
+
+	it('renders nothing for an unknown/null status — never mislabels as "failed"', () => {
+		const { container } = render(RefundStatusBadge, { props: { status: null } });
+		expect(container.querySelector('span')).toBeNull();
+	});
+
+	it('maps status to the primitive tone (succeeded -> success, failed -> danger)', () => {
+		const succeeded = render(RefundStatusBadge, { props: { status: 'succeeded' } });
+		expect(succeeded.container.querySelector('span')?.className).toContain('bg-success');
+
+		const failed = render(RefundStatusBadge, { props: { status: 'failed' } });
+		expect(failed.container.querySelector('span')?.className).toContain('bg-destructive');
+	});
+
+	it('carries the amount+currency tooltip via title', () => {
+		render(RefundStatusBadge, {
+			props: { status: 'succeeded', amount: '12.00', currency: 'EUR' }
+		});
+		expect(screen.getByLabelText(LABELS.succeeded)).toHaveAttribute('title', '12.00 EUR');
+	});
+});

--- a/src/routes/(auth)/org/[slug]/admin/billing/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/+page.svelte
@@ -582,6 +582,7 @@
 				<StatusBadge
 					tone={VAT_STATUS_TONE[vatStatus.type]}
 					label={vatStatus.label}
+					aria-label={vatStatus.label}
 					icon={vatStatus.type === 'validated'
 						? Check
 						: vatStatus.type === 'pending'

--- a/src/routes/(auth)/org/[slug]/admin/billing/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/+page.svelte
@@ -42,6 +42,10 @@
 		DialogDescription,
 		DialogFooter
 	} from '$lib/components/ui/dialog';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		data: LayoutData;
@@ -286,18 +290,25 @@
 		: null;
 
 	// ─── VAT Validation Status ──────────────────────────────────────
-	const vatStatus = $derived.by(() => {
+	type VatStatusType = 'not-set' | 'validated' | 'pending';
+
+	const vatStatus = $derived.by((): { type: VatStatusType; label: string } => {
 		if (!billingQuery?.data?.vat_id) {
-			return { type: 'not-set' as const, label: m['orgAdmin.billing.vatId.statusNotSet']() };
+			return { type: 'not-set', label: m['orgAdmin.billing.vatId.statusNotSet']() };
 		}
 		if (billingQuery.data.vat_id_validated) {
-			return {
-				type: 'validated' as const,
-				label: m['orgAdmin.billing.vatId.statusValidated']()
-			};
+			return { type: 'validated', label: m['orgAdmin.billing.vatId.statusValidated']() };
 		}
-		return { type: 'pending' as const, label: m['orgAdmin.billing.vatId.statusPending']() };
+		return { type: 'pending', label: m['orgAdmin.billing.vatId.statusPending']() };
 	});
+
+	// `pending` (awaiting the VIES check) is `info`, not `warning`: it is an
+	// ordinary in-progress state, not something the organizer needs to act on.
+	const VAT_STATUS_TONE: Record<VatStatusType, Tone> = {
+		validated: 'success',
+		pending: 'info',
+		'not-set': 'neutral'
+	};
 </script>
 
 <svelte:head>
@@ -305,13 +316,10 @@
 </svelte:head>
 
 <div class="space-y-8 px-4">
-	<!-- Page Header -->
-	<div>
-		<h1 class="text-2xl font-bold tracking-tight">{m['orgAdmin.billing.pageTitle']()}</h1>
-		<p class="mt-1 text-sm text-muted-foreground">
-			{m['orgAdmin.billing.pageDescription']()}
-		</p>
-	</div>
+	<PageHeader
+		title={m['orgAdmin.billing.pageTitle']()}
+		subtitle={m['orgAdmin.billing.pageDescription']()}
+	/>
 
 	<!-- Quick Links -->
 	<div class="flex flex-wrap gap-3">
@@ -366,16 +374,12 @@
 		     ──────────────────────────────────────────────────────────── -->
 		<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
 			<div class="flex items-center gap-2">
-				<Users class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-				<div>
-					<h2 class="text-lg font-semibold">
-						{m['orgAdmin.billing.invoicingMode.title']()}
-					</h2>
-					<p class="text-sm text-muted-foreground">
-						{m['orgAdmin.billing.invoicingMode.description']()}
-					</p>
-				</div>
+				<Users class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+				<SectionHeader title={m['orgAdmin.billing.invoicingMode.title']()} class="flex-1" />
 			</div>
+			<p class="text-sm text-muted-foreground">
+				{m['orgAdmin.billing.invoicingMode.description']()}
+			</p>
 
 			<RadioGroup.Root
 				value={invoicingMode}
@@ -440,14 +444,12 @@
 		     ──────────────────────────────────────────────────────────── -->
 		<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
 			<div class="flex items-center gap-2">
-				<Receipt class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-				<div>
-					<h2 class="text-lg font-semibold">{m['orgAdmin.billing.billingInfo.title']()}</h2>
-					<p class="text-sm text-muted-foreground">
-						{m['orgAdmin.billing.billingInfo.description']()}
-					</p>
-				</div>
+				<Receipt class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+				<SectionHeader title={m['orgAdmin.billing.billingInfo.title']()} class="flex-1" />
 			</div>
+			<p class="text-sm text-muted-foreground">
+				{m['orgAdmin.billing.billingInfo.description']()}
+			</p>
 
 			<form onsubmit={handleSaveBillingInfo} class="space-y-4">
 				<!-- Country -->
@@ -568,43 +570,29 @@
 		     ──────────────────────────────────────────────────────────── -->
 		<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
 			<div class="flex items-center gap-2">
-				<Shield class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-				<div>
-					<h2 class="text-lg font-semibold">{m['orgAdmin.billing.vatId.title']()}</h2>
-					<p class="text-sm text-muted-foreground">
-						{m['orgAdmin.billing.vatId.description']()}
-					</p>
-				</div>
+				<Shield class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+				<SectionHeader title={m['orgAdmin.billing.vatId.title']()} class="flex-1" />
 			</div>
+			<p class="text-sm text-muted-foreground">
+				{m['orgAdmin.billing.vatId.description']()}
+			</p>
 
 			<!-- VAT Status Badge -->
 			<div class="flex items-center gap-2">
-				{#if vatStatus.type === 'validated'}
-					<span
-						class="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300"
-					>
-						<Check class="h-3.5 w-3.5" aria-hidden="true" />
-						{vatStatus.label}
-					</span>
-					{#if billingQuery?.data?.vat_id_validated_at}
-						<span class="text-xs text-muted-foreground">
-							{m['orgAdmin.billing.vatId.validatedAt']({
-								date: formatDate(billingQuery.data.vat_id_validated_at)
-							})}
-						</span>
-					{/if}
-				{:else if vatStatus.type === 'pending'}
-					<span
-						class="inline-flex items-center gap-1.5 rounded-full bg-yellow-100 px-3 py-1 text-xs font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300"
-					>
-						<CircleDot class="h-3.5 w-3.5" aria-hidden="true" />
-						{vatStatus.label}
-					</span>
-				{:else}
-					<span
-						class="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground"
-					>
-						{vatStatus.label}
+				<StatusBadge
+					tone={VAT_STATUS_TONE[vatStatus.type]}
+					label={vatStatus.label}
+					icon={vatStatus.type === 'validated'
+						? Check
+						: vatStatus.type === 'pending'
+							? CircleDot
+							: undefined}
+				/>
+				{#if vatStatus.type === 'validated' && billingQuery?.data?.vat_id_validated_at}
+					<span class="text-xs text-muted-foreground">
+						{m['orgAdmin.billing.vatId.validatedAt']({
+							date: formatDate(billingQuery.data.vat_id_validated_at)
+						})}
 					</span>
 				{/if}
 			</div>

--- a/src/routes/(auth)/org/[slug]/admin/billing/attendee-credit-notes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/attendee-credit-notes/+page.svelte
@@ -20,6 +20,8 @@
 	import { organizationadminvatListAttendeeCreditNotes } from '$lib/api/generated/sdk.gen';
 	import type { LayoutData } from '../../$types';
 	import { formatDate } from '$lib/utils/date';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		data: LayoutData;
@@ -91,14 +93,12 @@
 		>
 			<ArrowLeft class="h-5 w-5" />
 		</a>
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight">
-				{m['orgAdmin.billing.attendeeCreditNotes.title']()}
-			</h1>
-			<p class="text-sm text-muted-foreground">
-				{m['orgAdmin.billing.attendeeCreditNotes.description']()}
-			</p>
-		</div>
+		<!-- No kicker: the back-to-billing link above already says it. -->
+		<PageHeader
+			title={m['orgAdmin.billing.attendeeCreditNotes.title']()}
+			subtitle={m['orgAdmin.billing.attendeeCreditNotes.description']()}
+			class="flex-1"
+		/>
 	</div>
 
 	<!-- Search -->
@@ -132,32 +132,27 @@
 			<p class="text-sm">{extractErrorMessage(creditNotesQuery.error)}</p>
 		</div>
 	{:else if !creditNotesQuery?.data?.results?.length}
-		<!-- Empty State -->
-		<div
-			class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center"
-		>
-			<FileText class="mb-3 h-10 w-10 text-muted-foreground/50" aria-hidden="true" />
-			<h3 class="font-medium">{m['orgAdmin.billing.attendeeCreditNotes.empty']()}</h3>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['orgAdmin.billing.attendeeCreditNotes.emptyDescription']()}
-			</p>
-		</div>
+		<EmptyState
+			icon={FileText}
+			title={m['orgAdmin.billing.attendeeCreditNotes.empty']()}
+			body={m['orgAdmin.billing.attendeeCreditNotes.emptyDescription']()}
+		/>
 	{:else}
 		<!-- Credit Notes Table -->
 		<div class="overflow-x-auto rounded-lg border">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/50">
-					<tr>
-						<th class="px-4 py-3 text-left font-medium">
+					<tr class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+						<th class="px-4 py-3 text-left">
 							{m['orgAdmin.billing.attendeeCreditNotes.creditNoteNumber']()}
 						</th>
-						<th class="px-4 py-3 text-left font-medium">
+						<th class="px-4 py-3 text-left">
 							{m['orgAdmin.billing.attendeeCreditNotes.linkedInvoice']()}
 						</th>
-						<th class="px-4 py-3 text-right font-medium">
+						<th class="px-4 py-3 text-right">
 							{m['orgAdmin.billing.attendeeCreditNotes.amount']()}
 						</th>
-						<th class="px-4 py-3 text-left font-medium">
+						<th class="px-4 py-3 text-left">
 							{m['orgAdmin.billing.attendeeCreditNotes.issuedAt']()}
 						</th>
 					</tr>

--- a/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
@@ -350,6 +350,7 @@
 								<StatusBadge
 									tone={statusTone(invoice.status)}
 									label={statusLabel(invoice.status)}
+									aria-label={statusLabel(invoice.status)}
 								/>
 							</td>
 							<td class="px-4 py-3 text-right font-mono"
@@ -469,7 +470,12 @@
 						</p>
 						<p class="text-lg font-semibold">{inv.invoice_number}</p>
 					</div>
-					<StatusBadge tone={statusTone(inv.status)} label={statusLabel(inv.status)} class="mt-1" />
+					<StatusBadge
+						tone={statusTone(inv.status)}
+						label={statusLabel(inv.status)}
+						aria-label={statusLabel(inv.status)}
+						class="mt-1"
+					/>
 				</div>
 
 				{#if isEditing}

--- a/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
@@ -43,6 +43,10 @@
 	import type { AttendeeInvoiceDetailSchema } from '$lib/api/generated/types.gen';
 	import type { LayoutData } from '../../$types';
 	import { formatDate } from '$lib/utils/date';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		data: LayoutData;
@@ -213,13 +217,13 @@
 		return formatMoney(amount, currency);
 	}
 
-	const STATUS_COLORS: Record<string, string> = {
-		issued: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-		draft: 'bg-muted text-muted-foreground',
-		cancelled: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+	const STATUS_TONES: Record<string, Tone> = {
+		issued: 'info',
+		draft: 'neutral',
+		cancelled: 'danger'
 	};
-	function statusColor(s: string) {
-		return STATUS_COLORS[s] ?? 'bg-muted text-muted-foreground';
+	function statusTone(s: string): Tone {
+		return STATUS_TONES[s] ?? 'neutral';
 	}
 	function statusLabel(s: string) {
 		const l: Record<string, () => string> = {
@@ -266,14 +270,12 @@
 		>
 			<ArrowLeft class="h-5 w-5" />
 		</a>
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight">
-				{m['orgAdmin.billing.attendeeInvoices.title']()}
-			</h1>
-			<p class="text-sm text-muted-foreground">
-				{m['orgAdmin.billing.attendeeInvoices.description']()}
-			</p>
-		</div>
+		<!-- No kicker: the back-to-billing link above already says it. -->
+		<PageHeader
+			title={m['orgAdmin.billing.attendeeInvoices.title']()}
+			subtitle={m['orgAdmin.billing.attendeeInvoices.description']()}
+			class="flex-1"
+		/>
 	</div>
 
 	<div class="relative max-w-sm">
@@ -306,36 +308,24 @@
 			<p class="text-sm">{extractErrorMessage(invoicesQuery.error)}</p>
 		</div>
 	{:else if !invoicesQuery?.data?.results?.length}
-		<div
-			class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center"
-		>
-			<FileText class="mb-3 h-10 w-10 text-muted-foreground/50" aria-hidden="true" />
-			<h3 class="font-medium">{m['orgAdmin.billing.attendeeInvoices.empty']()}</h3>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['orgAdmin.billing.attendeeInvoices.emptyDescription']()}
-			</p>
-		</div>
+		<EmptyState
+			icon={FileText}
+			title={m['orgAdmin.billing.attendeeInvoices.empty']()}
+			body={m['orgAdmin.billing.attendeeInvoices.emptyDescription']()}
+		/>
 	{:else}
 		<div class="overflow-x-auto rounded-lg border">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/50">
-					<tr>
-						<th class="px-4 py-3 text-left font-medium"
+					<tr class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+						<th class="px-4 py-3 text-left"
 							>{m['orgAdmin.billing.attendeeInvoices.invoiceNumber']()}</th
 						>
-						<th class="px-4 py-3 text-left font-medium"
-							>{m['orgAdmin.billing.attendeeInvoices.buyer']()}</th
-						>
-						<th class="px-4 py-3 text-left font-medium"
-							>{m['orgAdmin.billing.attendeeInvoices.status']()}</th
-						>
-						<th class="px-4 py-3 text-right font-medium"
-							>{m['orgAdmin.billing.attendeeInvoices.amount']()}</th
-						>
-						<th class="px-4 py-3 text-left font-medium"
-							>{m['orgAdmin.billing.attendeeInvoices.date']()}</th
-						>
-						<th class="px-4 py-3 text-center font-medium"
+						<th class="px-4 py-3 text-left">{m['orgAdmin.billing.attendeeInvoices.buyer']()}</th>
+						<th class="px-4 py-3 text-left">{m['orgAdmin.billing.attendeeInvoices.status']()}</th>
+						<th class="px-4 py-3 text-right">{m['orgAdmin.billing.attendeeInvoices.amount']()}</th>
+						<th class="px-4 py-3 text-left">{m['orgAdmin.billing.attendeeInvoices.date']()}</th>
+						<th class="px-4 py-3 text-center"
 							><span class="sr-only">{m['common.actions']()}</span></th
 						>
 					</tr>
@@ -357,11 +347,7 @@
 								<div class="text-xs text-muted-foreground">{invoice.buyer_email}</div>
 							</td>
 							<td class="px-4 py-3">
-								<span
-									class="rounded-full px-2.5 py-0.5 text-xs font-medium {statusColor(
-										invoice.status
-									)}">{statusLabel(invoice.status)}</span
-								>
+								<StatusBadge tone={statusTone(invoice.status)} label={statusLabel(invoice.status)} />
 							</td>
 							<td class="px-4 py-3 text-right font-mono"
 								>{formatCurrency(invoice.total_gross, invoice.currency)}</td
@@ -480,10 +466,7 @@
 						</p>
 						<p class="text-lg font-semibold">{inv.invoice_number}</p>
 					</div>
-					<span
-						class="mt-1 rounded-full px-2.5 py-0.5 text-xs font-medium {statusColor(inv.status)}"
-						>{statusLabel(inv.status)}</span
-					>
+					<StatusBadge tone={statusTone(inv.status)} label={statusLabel(inv.status)} class="mt-1" />
 				</div>
 
 				{#if isEditing}

--- a/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
@@ -347,7 +347,10 @@
 								<div class="text-xs text-muted-foreground">{invoice.buyer_email}</div>
 							</td>
 							<td class="px-4 py-3">
-								<StatusBadge tone={statusTone(invoice.status)} label={statusLabel(invoice.status)} />
+								<StatusBadge
+									tone={statusTone(invoice.status)}
+									label={statusLabel(invoice.status)}
+								/>
 							</td>
 							<td class="px-4 py-3 text-right font-mono"
 								>{formatCurrency(invoice.total_gross, invoice.currency)}</td

--- a/src/routes/(auth)/org/[slug]/admin/billing/credit-notes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/credit-notes/+page.svelte
@@ -17,6 +17,8 @@
 	import { extractErrorMessage } from '$lib/utils/errors';
 	import { organizationadminvatListCreditNotes } from '$lib/api/generated/sdk.gen';
 	import type { LayoutData } from '../../$types';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		data: LayoutData;
@@ -71,14 +73,12 @@
 		>
 			<ArrowLeft class="h-5 w-5" />
 		</a>
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight">
-				{m['orgAdmin.billing.creditNotes.title']()}
-			</h1>
-			<p class="text-sm text-muted-foreground">
-				{m['orgAdmin.billing.creditNotes.description']()}
-			</p>
-		</div>
+		<!-- No kicker: the back-to-billing link above already says it. -->
+		<PageHeader
+			title={m['orgAdmin.billing.creditNotes.title']()}
+			subtitle={m['orgAdmin.billing.creditNotes.description']()}
+			class="flex-1"
+		/>
 	</div>
 
 	{#if creditNotesQuery?.isLoading}
@@ -97,29 +97,24 @@
 			<p class="text-sm">{extractErrorMessage(creditNotesQuery.error)}</p>
 		</div>
 	{:else if !creditNotesQuery?.data?.results?.length}
-		<!-- Empty State -->
-		<div
-			class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center"
-		>
-			<FileText class="mb-3 h-10 w-10 text-muted-foreground/50" aria-hidden="true" />
-			<h3 class="font-medium">{m['orgAdmin.billing.creditNotes.empty']()}</h3>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['orgAdmin.billing.creditNotes.emptyDescription']()}
-			</p>
-		</div>
+		<EmptyState
+			icon={FileText}
+			title={m['orgAdmin.billing.creditNotes.empty']()}
+			body={m['orgAdmin.billing.creditNotes.emptyDescription']()}
+		/>
 	{:else}
 		<!-- Credit Notes Table -->
 		<div class="overflow-x-auto rounded-lg border">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/50">
-					<tr>
-						<th class="px-4 py-3 text-left font-medium">
+					<tr class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+						<th class="px-4 py-3 text-left">
 							{m['orgAdmin.billing.creditNotes.columns.creditNoteNumber']()}
 						</th>
-						<th class="px-4 py-3 text-left font-medium">
+						<th class="px-4 py-3 text-left">
 							{m['orgAdmin.billing.creditNotes.columns.linkedInvoice']()}
 						</th>
-						<th class="px-4 py-3 text-right font-medium">
+						<th class="px-4 py-3 text-right">
 							{m['orgAdmin.billing.creditNotes.columns.grossAmount']()}
 						</th>
 					</tr>

--- a/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
@@ -27,6 +27,10 @@
 	import type { PlatformFeeInvoiceSchema } from '$lib/api/generated';
 	import type { LayoutData } from '../../$types';
 	import { formatMonthYearLabel } from '$lib/utils/date';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		data: LayoutData;
@@ -116,18 +120,18 @@
 		return formatMoney(amount, currency);
 	}
 
-	function statusColor(status: string): string {
+	/** Thin mapper: raw invoice status -> StatusBadge tone. `draft` and any
+	 * future/unknown status fall back to neutral rather than guessing. */
+	function statusTone(status: string): Tone {
 		switch (status) {
 			case 'paid':
-				return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+				return 'success';
 			case 'issued':
-				return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
-			case 'draft':
-				return 'bg-muted text-muted-foreground';
+				return 'info';
 			case 'cancelled':
-				return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+				return 'danger';
 			default:
-				return 'bg-muted text-muted-foreground';
+				return 'neutral';
 		}
 	}
 
@@ -164,14 +168,12 @@
 		>
 			<ArrowLeft class="h-5 w-5" />
 		</a>
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight">
-				{m['orgAdmin.billing.invoices.title']()}
-			</h1>
-			<p class="text-sm text-muted-foreground">
-				{m['orgAdmin.billing.invoices.description']()}
-			</p>
-		</div>
+		<!-- No kicker: the back-to-billing link above already says it. -->
+		<PageHeader
+			title={m['orgAdmin.billing.invoices.title']()}
+			subtitle={m['orgAdmin.billing.invoices.description']()}
+			class="flex-1"
+		/>
 	</div>
 
 	{#if invoicesQuery?.isLoading}
@@ -190,35 +192,30 @@
 			<p class="text-sm">{extractErrorMessage(invoicesQuery.error)}</p>
 		</div>
 	{:else if !invoicesQuery?.data?.results?.length}
-		<!-- Empty State -->
-		<div
-			class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center"
-		>
-			<FileText class="mb-3 h-10 w-10 text-muted-foreground/50" aria-hidden="true" />
-			<h3 class="font-medium">{m['orgAdmin.billing.invoices.empty']()}</h3>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['orgAdmin.billing.invoices.emptyDescription']()}
-			</p>
-		</div>
+		<EmptyState
+			icon={FileText}
+			title={m['orgAdmin.billing.invoices.empty']()}
+			body={m['orgAdmin.billing.invoices.emptyDescription']()}
+		/>
 	{:else}
 		<!-- Invoice Table -->
 		<div class="overflow-x-auto rounded-lg border">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/50">
-					<tr>
-						<th class="px-4 py-3 text-left font-medium">
+					<tr class="text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+						<th class="px-4 py-3 text-left">
 							{m['orgAdmin.billing.invoices.columns.invoiceNumber']()}
 						</th>
-						<th class="px-4 py-3 text-left font-medium">
+						<th class="px-4 py-3 text-left">
 							{m['orgAdmin.billing.invoices.columns.period']()}
 						</th>
-						<th class="px-4 py-3 text-left font-medium">
+						<th class="px-4 py-3 text-left">
 							{m['orgAdmin.billing.invoices.columns.status']()}
 						</th>
-						<th class="px-4 py-3 text-right font-medium">
+						<th class="px-4 py-3 text-right">
 							{m['orgAdmin.billing.invoices.columns.grossAmount']()}
 						</th>
-						<th class="px-4 py-3 text-center font-medium">
+						<th class="px-4 py-3 text-center">
 							<span class="sr-only">{m['common.actions']()}</span>
 						</th>
 					</tr>
@@ -239,13 +236,7 @@
 								{formatPeriod(invoice.period_start, invoice.period_end)}
 							</td>
 							<td class="px-4 py-3">
-								<span
-									class="rounded-full px-2.5 py-0.5 text-xs font-medium {statusColor(
-										invoice.status
-									)}"
-								>
-									{statusLabel(invoice.status)}
-								</span>
+								<StatusBadge tone={statusTone(invoice.status)} label={statusLabel(invoice.status)} />
 							</td>
 							<td class="px-4 py-3 text-right font-mono">
 								{formatCurrency(invoice.fee_gross, invoice.currency)}
@@ -359,9 +350,7 @@
 						</p>
 						<p class="text-lg font-semibold">{inv.invoice_number}</p>
 					</div>
-					<span class="rounded-full px-3 py-1 text-xs font-medium {statusColor(inv.status)}">
-						{statusLabel(inv.status)}
-					</span>
+					<StatusBadge tone={statusTone(inv.status)} label={statusLabel(inv.status)} />
 				</div>
 
 				<!-- Period -->

--- a/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
@@ -239,6 +239,7 @@
 								<StatusBadge
 									tone={statusTone(invoice.status)}
 									label={statusLabel(invoice.status)}
+									aria-label={statusLabel(invoice.status)}
 								/>
 							</td>
 							<td class="px-4 py-3 text-right font-mono">
@@ -353,7 +354,11 @@
 						</p>
 						<p class="text-lg font-semibold">{inv.invoice_number}</p>
 					</div>
-					<StatusBadge tone={statusTone(inv.status)} label={statusLabel(inv.status)} />
+					<StatusBadge
+						tone={statusTone(inv.status)}
+						label={statusLabel(inv.status)}
+						aria-label={statusLabel(inv.status)}
+					/>
 				</div>
 
 				<!-- Period -->

--- a/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
@@ -236,7 +236,10 @@
 								{formatPeriod(invoice.period_start, invoice.period_end)}
 							</td>
 							<td class="px-4 py-3">
-								<StatusBadge tone={statusTone(invoice.status)} label={statusLabel(invoice.status)} />
+								<StatusBadge
+									tone={statusTone(invoice.status)}
+									label={statusLabel(invoice.status)}
+								/>
 							</td>
 							<td class="px-4 py-3 text-right font-mono">
 								{formatCurrency(invoice.fee_gross, invoice.currency)}

--- a/src/routes/(auth)/org/[slug]/admin/embed/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/embed/+page.svelte
@@ -3,6 +3,7 @@
 	import { Alert, AlertDescription } from '$lib/components/ui/alert';
 	import { AlertCircle } from '@lucide/svelte';
 	import EmbedBuilder from '$lib/components/embed/EmbedBuilder.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -17,10 +18,7 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div class="space-y-1">
-		<h1 class="text-3xl font-bold">{m['orgAdminEmbedPage.title']()}</h1>
-		<p class="text-muted-foreground">{m['orgAdminEmbedPage.subtitle']()}</p>
-	</div>
+	<PageHeader title={m['orgAdminEmbedPage.title']()} subtitle={m['orgAdminEmbedPage.subtitle']()} />
 
 	{#if data.pickersFailed}
 		<Alert variant="destructive">

--- a/src/routes/(auth)/org/[slug]/admin/financials/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/financials/+page.svelte
@@ -20,6 +20,9 @@
 	import { entryFor, selectSections } from '$lib/components/financials/entries';
 	import RevenueReportButton from '$lib/components/financials/RevenueReportButton.svelte';
 	import { BarChart3, ChevronDown, Loader2, ArrowUpDown } from '@lucide/svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import type { PageData } from './$types';
 
 	const { data }: { data: PageData } = $props();
@@ -122,13 +125,14 @@
 </svelte:head>
 
 <section class="space-y-6">
-	<header class="flex flex-wrap items-start justify-between gap-4">
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight">{m['financials.title']()}</h1>
-			<p class="mt-1 text-sm text-muted-foreground">{m['financials.subtitle']()}</p>
-		</div>
+	{#snippet financialsActions()}
 		<RevenueReportButton {slug} {period} />
-	</header>
+	{/snippet}
+	<PageHeader
+		title={m['financials.title']()}
+		subtitle={m['financials.subtitle']()}
+		actions={financialsActions}
+	/>
 
 	<!-- Filters -->
 	<div
@@ -216,18 +220,17 @@
 		</p>
 
 		{#if sections.nothingAtAll}
-			<div class="rounded-lg border border-border bg-card p-12 text-center">
-				<BarChart3 class="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
-				<h3 class="mt-4 text-lg font-semibold">{m['financials.empty.title']()}</h3>
-				<p class="mt-2 text-sm text-muted-foreground">{m['financials.empty.description']()}</p>
-			</div>
+			<EmptyState
+				icon={BarChart3}
+				level={2}
+				title={m['financials.empty.title']()}
+				body={m['financials.empty.description']()}
+			/>
 		{:else}
 			<!-- Ticket totals -->
 			{#if sections.totals}
 				<div class="space-y-4 rounded-lg border border-border bg-card p-5">
-					<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-						{m['financials.totalsHeading']()}
-					</h2>
+					<SectionHeader title={m['financials.totalsHeading']()} />
 					<CurrencyFinancialsSummary data={sections.totals} />
 					<FinancialsNote>{m['financials.netTaxableNote']()}</FinancialsNote>
 				</div>
@@ -236,9 +239,7 @@
 			<!-- Membership revenue (org-level, no VAT treatment) -->
 			{#if sections.memberships}
 				<div class="space-y-4 rounded-lg border border-border bg-card p-5">
-					<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-						{m['financials.membershipsHeading']()}
-					</h2>
+					<SectionHeader title={m['financials.membershipsHeading']()} />
 					<MembershipFinancialsSummary data={sections.memberships} />
 				</div>
 			{/if}
@@ -246,27 +247,22 @@
 			<!-- Tickets + memberships -->
 			{#if sections.combined}
 				<div class="space-y-4 rounded-lg border border-primary/40 bg-card p-5">
-					<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-						{m['financials.combinedHeading']()}
-					</h2>
+					<SectionHeader title={m['financials.combinedHeading']()} />
 					<CombinedTotalsSummary data={sections.combined} />
 				</div>
 			{/if}
 
 			<!-- Per-event breakdown -->
 			<div>
-				<h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-					{m['financials.byEventHeading']()}
-				</h2>
+				<SectionHeader title={m['financials.byEventHeading']()} class="mb-3" />
 
 				{#if financials.events.length === 0}
-					<div class="rounded-lg border border-border bg-card p-12 text-center">
-						<BarChart3 class="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
-						<h3 class="mt-4 text-lg font-semibold">{m['financials.empty.eventsTitle']()}</h3>
-						<p class="mt-2 text-sm text-muted-foreground">
-							{m['financials.empty.eventsDescription']()}
-						</p>
-					</div>
+					<EmptyState
+						icon={BarChart3}
+						level={3}
+						title={m['financials.empty.eventsTitle']()}
+						body={m['financials.empty.eventsDescription']()}
+					/>
 				{:else}
 					<ul class="space-y-2">
 						{#each financials.events as event (event.event_id)}
@@ -279,7 +275,7 @@
 									aria-expanded={expanded[event.event_id] ?? false}
 								>
 									<div class="min-w-0 flex-1">
-										<span class="block truncate font-semibold">{event.event_name}</span>
+										<span class="block truncate font-bold">{event.event_name}</span>
 										<span class="text-sm text-muted-foreground">
 											{formatEventDate(event.event_start)}
 										</span>
@@ -296,7 +292,8 @@
 
 									<div class="shrink-0 text-right">
 										<span class="block text-xs text-muted-foreground">{m['financials.net']()}</span>
-										<span class="font-semibold tabular-nums">
+										<!-- Headline revenue figure: studio's one permitted font-black flourish. -->
+										<span class="font-black tabular-nums">
 											{formatMoney(entry?.net ?? 0, entry?.currency ?? activeCurrency)}
 										</span>
 									</div>

--- a/src/routes/(auth)/org/[slug]/admin/financials/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/financials/+page.svelte
@@ -229,8 +229,13 @@
 		{:else}
 			<!-- Ticket totals -->
 			{#if sections.totals}
+				<!-- Bare h2, not SectionHeader: e2e locates this card as the deepest div
+				     containing the "Totals" heading (financials.spec.ts) — SectionHeader's
+				     two wrapper divs would make that innermost div hold only the heading,
+				     not the money figures below it. E2E specs are frozen; the app
+				     accommodates. Same reasoning for the two cards below. -->
 				<div class="space-y-4 rounded-lg border border-border bg-card p-5">
-					<SectionHeader title={m['financials.totalsHeading']()} />
+					<h2 class="text-lg font-bold">{m['financials.totalsHeading']()}</h2>
 					<CurrencyFinancialsSummary data={sections.totals} />
 					<FinancialsNote>{m['financials.netTaxableNote']()}</FinancialsNote>
 				</div>
@@ -239,7 +244,7 @@
 			<!-- Membership revenue (org-level, no VAT treatment) -->
 			{#if sections.memberships}
 				<div class="space-y-4 rounded-lg border border-border bg-card p-5">
-					<SectionHeader title={m['financials.membershipsHeading']()} />
+					<h2 class="text-lg font-bold">{m['financials.membershipsHeading']()}</h2>
 					<MembershipFinancialsSummary data={sections.memberships} />
 				</div>
 			{/if}
@@ -247,7 +252,7 @@
 			<!-- Tickets + memberships -->
 			{#if sections.combined}
 				<div class="space-y-4 rounded-lg border border-primary/40 bg-card p-5">
-					<SectionHeader title={m['financials.combinedHeading']()} />
+					<h2 class="text-lg font-bold">{m['financials.combinedHeading']()}</h2>
 					<CombinedTotalsSummary data={sections.combined} />
 				</div>
 			{/if}

--- a/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
@@ -17,6 +17,10 @@
 	import Facebook from '$lib/components/icons/brand/Facebook.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { toast } from 'svelte-sonner';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	interface Props {
 		data: PageData;
@@ -112,35 +116,31 @@
 </svelte:head>
 
 <div class="space-y-6 px-4 md:px-0">
-	<!-- Header with Public Profile Button -->
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['orgAdmin.settings.pageTitle']()}
-			</h1>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['orgAdmin.settings.pageDescription']()}
-			</p>
-		</div>
-
-		<a
+	{#snippet publicProfileAction()}
+		<Button
 			href={resolve('/(public)/org/[slug]', { slug: data.organization.slug })}
 			target="_blank"
 			rel="noopener noreferrer"
-			class="inline-flex items-center gap-2 rounded-md bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+			variant="secondary"
+			class="gap-2"
 		>
 			<Eye class="h-4 w-4" aria-hidden="true" />
 			{m['orgAdmin.settings.viewPublicProfile']()}
-		</a>
-	</div>
+		</Button>
+	{/snippet}
+	<PageHeader
+		title={m['orgAdmin.settings.pageTitle']()}
+		subtitle={m['orgAdmin.settings.pageDescription']()}
+		actions={publicProfileAction}
+	/>
 
 	<!-- Success Message -->
 	{#if form?.success}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
+			class="flex items-center gap-2 rounded-lg border border-success/40 bg-success/10 p-4 text-foreground"
 			role="alert"
 		>
-			<Check class="h-5 w-5 shrink-0" aria-hidden="true" />
+			<Check class="h-5 w-5 shrink-0 text-success" aria-hidden="true" />
 			<p class="text-sm font-medium">{m['orgAdmin.settings.successMessage']()}</p>
 		</div>
 	{/if}
@@ -148,7 +148,7 @@
 	<!-- Error Message -->
 	{#if form?.errors && 'form' in form.errors}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive"
 			role="alert"
 		>
 			<AlertCircle class="h-5 w-5 shrink-0" aria-hidden="true" />
@@ -159,8 +159,8 @@
 	<!-- Organization Identity (Read-only) -->
 	<section class="rounded-lg border border-border bg-card p-6 shadow-sm">
 		<div class="mb-4 flex items-center gap-2">
-			<Building2 class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-			<h2 class="text-lg font-semibold">{m['orgAdmin.settings.identity.heading']()}</h2>
+			<Building2 class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+			<SectionHeader title={m['orgAdmin.settings.identity.heading']()} class="flex-1" />
 		</div>
 
 		<div class="grid gap-4 md:grid-cols-2">
@@ -195,8 +195,8 @@
 	<!-- Platform Fees (Read-only) -->
 	<section class="rounded-lg border border-border bg-card p-6 shadow-sm">
 		<div class="mb-4 flex items-center gap-2">
-			<Building2 class="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-			<h2 class="text-lg font-semibold">{m['orgAdmin.settings.platformFees.heading']()}</h2>
+			<Building2 class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+			<SectionHeader title={m['orgAdmin.settings.platformFees.heading']()} class="flex-1" />
 		</div>
 
 		<div class="grid gap-4 md:grid-cols-2">
@@ -271,7 +271,7 @@
 	>
 		<!-- Profile Information -->
 		<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-			<h2 class="text-lg font-semibold">{m['orgAdmin.settings.profile.heading']()}</h2>
+			<SectionHeader title={m['orgAdmin.settings.profile.heading']()} />
 
 			<!-- Description -->
 			<div>
@@ -309,7 +309,7 @@
 					name="address"
 					bind:value={address}
 					placeholder={m['orgAdmin.settings.profile.addressPlaceholder']()}
-					class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+					class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 				/>
 			</div>
 
@@ -322,7 +322,7 @@
 					id="visibility"
 					name="visibility"
 					bind:value={visibility}
-					class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+					class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 				>
 					<option value="public">{m['orgAdmin.settings.profile.visibilityPublic']()}</option>
 					<option value="members-only"
@@ -352,14 +352,14 @@
 
 		<!-- Social Media Links -->
 		<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-			<h2 class="text-lg font-semibold">{m['orgAdmin.settings.social.heading']()}</h2>
+			<SectionHeader title={m['orgAdmin.settings.social.heading']()} />
 			<p class="text-sm text-muted-foreground">{m['orgAdmin.settings.social.description']()}</p>
 
 			<div class="grid gap-4 md:grid-cols-2">
 				<!-- Instagram -->
 				<div>
 					<label for="instagram_url" class="flex items-center gap-2 text-sm font-medium">
-						<Instagram class="h-4 w-4 text-pink-500" aria-hidden="true" />
+						<Instagram class="h-4 w-4 text-[#E4405F]" aria-hidden="true" />
 						Instagram
 					</label>
 					<input
@@ -368,14 +368,14 @@
 						name="instagram_url"
 						bind:value={instagramUrl}
 						placeholder="https://instagram.com/yourorg"
-						class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+						class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 					/>
 				</div>
 
 				<!-- Facebook -->
 				<div>
 					<label for="facebook_url" class="flex items-center gap-2 text-sm font-medium">
-						<Facebook class="h-4 w-4 text-blue-600" aria-hidden="true" />
+						<Facebook class="h-4 w-4 text-[#1877F2]" aria-hidden="true" />
 						Facebook
 					</label>
 					<input
@@ -384,14 +384,14 @@
 						name="facebook_url"
 						bind:value={facebookUrl}
 						placeholder="https://facebook.com/yourorg"
-						class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+						class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 					/>
 				</div>
 
 				<!-- Bluesky -->
 				<div>
 					<label for="bluesky_url" class="flex items-center gap-2 text-sm font-medium">
-						<AtSign class="h-4 w-4 text-sky-500" aria-hidden="true" />
+						<AtSign class="h-4 w-4 text-[#1185FE]" aria-hidden="true" />
 						Bluesky
 					</label>
 					<input
@@ -400,7 +400,7 @@
 						name="bluesky_url"
 						bind:value={blueskyUrl}
 						placeholder="https://bsky.app/profile/yourorg.bsky.social"
-						class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+						class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 					/>
 				</div>
 
@@ -408,7 +408,7 @@
 				{#if features.telegram}
 					<div>
 						<label for="telegram_url" class="flex items-center gap-2 text-sm font-medium">
-							<Send class="h-4 w-4 text-blue-400" aria-hidden="true" />
+							<Send class="h-4 w-4 text-[hsl(var(--brand-telegram-text))]" aria-hidden="true" />
 							Telegram
 						</label>
 						<input
@@ -417,7 +417,7 @@
 							name="telegram_url"
 							bind:value={telegramUrl}
 							placeholder="https://t.me/yourorg"
-							class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+							class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						/>
 					</div>
 				{/if}
@@ -426,7 +426,7 @@
 
 		<!-- Membership Settings -->
 		<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-			<h2 class="text-lg font-semibold">{m['orgAdmin.settings.membership.heading']()}</h2>
+			<SectionHeader title={m['orgAdmin.settings.membership.heading']()} />
 
 			<!-- Accept New Members -->
 			<div class="space-y-2">
@@ -437,7 +437,7 @@
 						name="accept_membership_requests"
 						value="true"
 						bind:checked={acceptNewMembers}
-						class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+						class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 					/>
 					<label for="accept_membership_requests" class="text-sm font-medium">
 						{m['orgAdmin.settings.membership.acceptRequestsLabel']()}
@@ -457,7 +457,7 @@
 					id="default_membership_questionnaire_id"
 					name="default_membership_questionnaire_id"
 					bind:value={defaultQuestionnaireId}
-					class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:max-w-xs"
+					class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 sm:max-w-xs"
 				>
 					<option value="">{m['orgAdmin.settings.membership.defaultQuestionnaireNone']()}</option>
 					{#each data.membershipQuestionnaires as oq (oq.id)}
@@ -492,7 +492,7 @@
 						name="default_requires_membership_approval"
 						value="true"
 						bind:checked={defaultRequiresApproval}
-						class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+						class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 					/>
 					<label for="default_requires_membership_approval" class="text-sm font-medium">
 						{m['orgAdmin.settings.membership.requireApprovalLabel']()}
@@ -509,9 +509,7 @@
 					{m['orgAdmin.settings.membership.contactEmailLabel']()}
 				</span>
 				<div class="mt-1 flex items-center gap-2">
-					<div
-						class="flex-1 rounded-md border-2 border-gray-300 bg-gray-50 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
-					>
+					<div class="flex-1 rounded-md border-2 border-input bg-muted px-3 py-2 text-sm">
 						{data.organization.contact_email || m['orgSettingsPage.noContactEmail']()}
 					</div>
 					<button
@@ -526,15 +524,21 @@
 					</button>
 				</div>
 				{#if data.organization.contact_email_verified}
-					<p class="mt-1 flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
-						<Check class="h-3 w-3" aria-hidden="true" />
-						{m['orgAdmin.settings.membership.emailVerified']()}
-					</p>
+					<!-- No icon: the label copy already carries its own "✓" glyph. -->
+					<StatusBadge
+						tone="success"
+						label={m['orgAdmin.settings.membership.emailVerified']()}
+						size="sm"
+						class="mt-1"
+					/>
 				{:else if data.organization.contact_email}
-					<p class="mt-1 flex items-center gap-1 text-xs text-orange-600 dark:text-orange-400">
-						<AlertCircle class="h-3 w-3" aria-hidden="true" />
-						{m['orgAdmin.settings.membership.emailNotVerified']()}
-					</p>
+					<StatusBadge
+						tone="warning"
+						icon={AlertCircle}
+						label={m['orgAdmin.settings.membership.emailNotVerified']()}
+						size="sm"
+						class="mt-1"
+					/>
 				{/if}
 				<p class="mt-1 text-xs text-muted-foreground">
 					{m['orgAdmin.settings.membership.contactEmailHelp']()}
@@ -550,7 +554,7 @@
 					id="contact_method"
 					name="contact_method"
 					bind:value={contactMethod}
-					class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:max-w-xs"
+					class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 sm:max-w-xs"
 				>
 					<option value="none">
 						{m['orgAdmin.settings.membership.contactMethodNone']()}
@@ -574,7 +578,7 @@
 
 				{#if !canEnableContact}
 					<div
-						class="mt-2 flex items-start gap-2 rounded-md border border-orange-200 bg-orange-50 p-3 text-xs text-orange-800 dark:border-orange-900 dark:bg-orange-950 dark:text-orange-200"
+						class="mt-2 flex items-start gap-2 rounded-md border border-highlight/40 bg-highlight/20 p-3 text-xs text-highlight-foreground dark:text-highlight"
 						role="note"
 					>
 						<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
@@ -593,7 +597,7 @@
 		     endpoints; staff with edit_organization must not change report delivery) -->
 		{#if data.isOwner}
 			<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-				<h2 class="text-lg font-semibold">{m['orgSettingsPage.reports.heading']()}</h2>
+				<SectionHeader title={m['orgSettingsPage.reports.heading']()} />
 				<p class="text-sm text-muted-foreground">{m['orgSettingsPage.reports.description']()}</p>
 
 				<div>
@@ -615,7 +619,7 @@
 						value={billingEmailMissing ? 'none' : reportCadence}
 						onchange={(e) => (reportCadence = e.currentTarget.value as RevenueReportCadence)}
 						disabled={billingEmailMissing}
-						class="mt-1 flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 sm:max-w-xs"
+						class="mt-1 flex w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 sm:max-w-xs"
 					>
 						<option value="none">{m['orgSettingsPage.reports.cadenceNone']()}</option>
 						<option value="quarterly">{m['orgSettingsPage.reports.cadenceQuarterly']()}</option>
@@ -627,7 +631,7 @@
 
 					{#if billingEmailMissing}
 						<div
-							class="mt-2 flex items-start gap-2 rounded-md border border-orange-200 bg-orange-50 p-3 text-xs text-orange-800 dark:border-orange-900 dark:bg-orange-950 dark:text-orange-200"
+							class="mt-2 flex items-start gap-2 rounded-md border border-highlight/40 bg-highlight/20 p-3 text-xs text-highlight-foreground dark:text-highlight"
 							role="note"
 						>
 							<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />

--- a/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
@@ -147,11 +147,14 @@
 
 	<!-- Error Message -->
 	{#if form?.errors && 'form' in form.errors}
+		<!-- Icon carries the tone, not the body text: dark --destructive as TEXT on
+		     this composite measures ~2.7-2.95:1 (fails both the 3:1 non-text and
+		     4.5:1 text floors). -->
 		<div
-			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive"
+			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-foreground"
 			role="alert"
 		>
-			<AlertCircle class="h-5 w-5 shrink-0" aria-hidden="true" />
+			<AlertCircle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
 			<p class="text-sm font-medium">{form.errors.form}</p>
 		</div>
 	{/if}
@@ -359,7 +362,7 @@
 				<!-- Instagram -->
 				<div>
 					<label for="instagram_url" class="flex items-center gap-2 text-sm font-medium">
-						<Instagram class="h-4 w-4 text-[#E4405F]" aria-hidden="true" />
+						<Instagram class="h-4 w-4 text-[hsl(var(--brand-instagram))]" aria-hidden="true" />
 						Instagram
 					</label>
 					<input
@@ -375,7 +378,7 @@
 				<!-- Facebook -->
 				<div>
 					<label for="facebook_url" class="flex items-center gap-2 text-sm font-medium">
-						<Facebook class="h-4 w-4 text-[#1877F2]" aria-hidden="true" />
+						<Facebook class="h-4 w-4 text-[hsl(var(--brand-facebook))]" aria-hidden="true" />
 						Facebook
 					</label>
 					<input
@@ -391,7 +394,7 @@
 				<!-- Bluesky -->
 				<div>
 					<label for="bluesky_url" class="flex items-center gap-2 text-sm font-medium">
-						<AtSign class="h-4 w-4 text-[#1185FE]" aria-hidden="true" />
+						<AtSign class="h-4 w-4 text-[hsl(var(--brand-bluesky))]" aria-hidden="true" />
 						Bluesky
 					</label>
 					<input
@@ -528,6 +531,7 @@
 					<StatusBadge
 						tone="success"
 						label={m['orgAdmin.settings.membership.emailVerified']()}
+						aria-label={m['orgAdmin.settings.membership.emailVerified']()}
 						size="sm"
 						class="mt-1"
 					/>
@@ -536,6 +540,7 @@
 						tone="warning"
 						icon={AlertCircle}
 						label={m['orgAdmin.settings.membership.emailNotVerified']()}
+						aria-label={m['orgAdmin.settings.membership.emailNotVerified']()}
 						size="sm"
 						class="mt-1"
 					/>

--- a/src/routes/(auth)/org/[slug]/admin/tickets/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/tickets/+page.svelte
@@ -5,6 +5,9 @@
 	import { formatEventDate } from '$lib/utils/date';
 	import EventStatusBadge from '$lib/components/events/EventStatusBadge.svelte';
 	import { Ticket, ChevronRight, Users } from '@lucide/svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	const { data }: { data: PageData } = $props();
 
@@ -18,25 +21,21 @@
 </svelte:head>
 
 <section class="space-y-6">
-	<header>
-		<h1 class="text-2xl font-bold tracking-tight">{m['orgAdmin.tickets.title']()}</h1>
-		<p class="mt-1 text-sm text-muted-foreground">{m['orgAdmin.tickets.subtitle']()}</p>
-	</header>
+	<PageHeader title={m['orgAdmin.tickets.title']()} subtitle={m['orgAdmin.tickets.subtitle']()} />
 
 	{#if events.length === 0}
-		<div class="rounded-lg border border-border bg-card p-12 text-center">
-			<Ticket class="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
-			<h2 class="mt-4 text-lg font-semibold">{m['orgAdmin.tickets.empty.title']()}</h2>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{m['orgAdmin.tickets.empty.description']()}
-			</p>
-			<a
-				href={resolve('/(auth)/org/[slug]/admin/events', { slug: slug })}
-				class="mt-4 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			>
+		{#snippet goToEventsAction()}
+			<Button href={resolve('/(auth)/org/[slug]/admin/events', { slug: slug })}>
 				{m['orgAdmin.tickets.empty.cta']()}
-			</a>
-		</div>
+			</Button>
+		{/snippet}
+		<EmptyState
+			icon={Ticket}
+			level={2}
+			title={m['orgAdmin.tickets.empty.title']()}
+			body={m['orgAdmin.tickets.empty.description']()}
+			action={goToEventsAction}
+		/>
 	{:else}
 		<ul class="space-y-3">
 			{#each events as event (event.id)}
@@ -65,7 +64,7 @@
 
 						<div class="min-w-0 flex-1">
 							<div class="flex flex-wrap items-center gap-2">
-								<span class="truncate font-semibold">{event.name}</span>
+								<span class="truncate font-bold">{event.name}</span>
 								<EventStatusBadge {event} />
 							</div>
 							<div


### PR DESCRIPTION
## Platform rebrand, PR 10 of 10 — Admin money + settings + embed

Studio pass over billing ×5 routes, financials, org settings, org tickets overview, the embed builder, and the public embed surface (tokens-only: one font-weight line changed, auto-resize and `?theme=` contracts untouched).

### What's in it
- `RefundStatusBadge` + `SubscriptionPaymentsStatusBadge` as thin mappers over `common/StatusBadge` — with explicit `aria-label` and enum-driven unit-test guards (the j23 lesson, now institutional); inline billing pills also carry aria-labels
- `PageHeader`/`SectionHeader` rhythm, kicker table headers, full raw-hue sweep; dead `PAYMENT_STATUS_CONFIG` map deleted
- Social brand colors centralized: `--brand-instagram/facebook/bluesky` tokens beside `--brand-telegram` (hex→HSL conversions independently verified)
- Dark-destructive discipline: four alert boxes moved to the established `text-foreground` + tone-carrying-icon pattern with honest per-mode ratio comments

### Review process
Opus whole-branch review + one fix round + scoped re-review, clean. Best catch: the financials `SectionHeader` adoption would have silently broken j25's totals-card locator (the spec derives the card as the deepest div containing the heading — SectionHeader's wrappers change that ancestry). Totals-card headings are bare h2s now; e2e specs stay frozen, the app accommodates.

### Verification
`make check` 0 errors · full suite 206 files / 2461 green · brand audit 0 failures incl. 3 new tokens · orchestrator screenshots (billing light, settings dark, financials light).

🤖 Generated with [Claude Code](https://claude.com/claude-code)