### PR TITLE
feat(rebrand): admin engagement & people — questionnaire alignment, 12 badge mappers, studio pass (PR 9/10)

### DIFF
--- a/src/lib/components/announcements/AnnouncementCard.svelte
+++ b/src/lib/components/announcements/AnnouncementCard.svelte
@@ -3,6 +3,7 @@
 	import type { AnnouncementListSchema } from '$lib/api/generated/types.gen';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
+	import AnnouncementStatusBadge from './AnnouncementStatusBadge.svelte';
 	import {
 		Edit,
 		Trash2,
@@ -76,16 +77,8 @@
 	<!-- Content -->
 	<div class="min-w-0 flex-1">
 		<div class="mb-2 flex items-center gap-2">
-			<h3 class="truncate font-medium">{announcement.title}</h3>
-			<Badge variant={isDraft ? 'secondary' : isScheduled ? 'outline' : 'default'}>
-				{#if isDraft}
-					{m['announcements.card.draft']()}
-				{:else if isScheduled}
-					{m['announcements.card.scheduled']()}
-				{:else}
-					{m['announcements.card.sent']()}
-				{/if}
-			</Badge>
+			<h3 class="truncate font-bold">{announcement.title}</h3>
+			<AnnouncementStatusBadge status={announcement.status} />
 		</div>
 
 		<div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">

--- a/src/lib/components/announcements/AnnouncementStatusBadge.svelte
+++ b/src/lib/components/announcements/AnnouncementStatusBadge.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
+	import type { AnnouncementStatus } from '$lib/api/generated/types.gen';
+
+	interface Props {
+		status: AnnouncementStatus;
+	}
+	const { status }: Props = $props();
+
+	const label = $derived(
+		status === 'draft'
+			? m['announcements.card.draft']()
+			: status === 'scheduled'
+				? m['announcements.card.scheduled']()
+				: m['announcements.card.sent']()
+	);
+
+	/**
+	 * Domain→tone mapper (rebrand): replaces the shadcn `Badge`
+	 * secondary/outline/default variant switch (which carried no semantic
+	 * weight of its own) with the audited `StatusBadge` token pairs. Draft is
+	 * neutral (not yet acted on), scheduled is informational (queued, not
+	 * final), sent is a completed/positive state — mirrors the tone reasoning
+	 * `polls/PollStatusBadge` already uses for its own draft/open/closed axis.
+	 */
+	const tone = $derived<Tone>(
+		status === 'draft' ? 'neutral' : status === 'scheduled' ? 'info' : 'success'
+	);
+</script>
+
+<StatusBadge {tone} {label} size="sm" aria-label={label} />

--- a/src/lib/components/announcements/AnnouncementStatusBadge.test.ts
+++ b/src/lib/components/announcements/AnnouncementStatusBadge.test.ts
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import type { AnnouncementStatus } from '$lib/api/generated/types.gen';
+import AnnouncementStatusBadge from './AnnouncementStatusBadge.svelte';
+
+const STATUSES: AnnouncementStatus[] = ['draft', 'scheduled', 'sent'];
+
+const LABELS: Record<AnnouncementStatus, string> = {
+	draft: 'Draft',
+	scheduled: 'Scheduled',
+	sent: 'Sent'
+};
+
+/**
+ * REGRESSION GUARD, same shape as `members/StatusBadge.test.ts`: this mapper
+ * wraps `common/StatusBadge`, which names itself from visible text content —
+ * `aria-label` here is what lets callers (and any future e2e lookup) address
+ * the pill via `getByLabelText`. Assert it for every enum value, not a
+ * sample, so a status silently losing its name doesn't slip through.
+ */
+describe('announcements/AnnouncementStatusBadge', () => {
+	it.each(STATUSES)('exposes the %s label as the pill accessible name', (status) => {
+		render(AnnouncementStatusBadge, { props: { status } });
+		const label = LABELS[status];
+		expect(screen.getByLabelText(label)).toBeInTheDocument();
+		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+	});
+
+	it('maps status to the primitive tone (draft → neutral, scheduled → info, sent → success)', () => {
+		const draft = render(AnnouncementStatusBadge, { props: { status: 'draft' } });
+		expect(draft.container.querySelector('span')?.className).toContain('bg-muted');
+
+		const scheduled = render(AnnouncementStatusBadge, { props: { status: 'scheduled' } });
+		expect(scheduled.container.querySelector('span')?.className).toContain('bg-info');
+
+		const sent = render(AnnouncementStatusBadge, { props: { status: 'sent' } });
+		expect(sent.container.querySelector('span')?.className).toContain('bg-success');
+	});
+});

--- a/src/lib/components/blacklist/BlacklistEntryCard.svelte
+++ b/src/lib/components/blacklist/BlacklistEntryCard.svelte
@@ -45,14 +45,14 @@
 		<!-- Entry Info -->
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2">
-				<h3 class="truncate font-semibold text-foreground">
+				<h3 class="truncate font-bold text-foreground">
 					{displayName}
 				</h3>
 				{#if isLinkedUser}
 					<span
-						class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-100"
+						class="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
 					>
-						<User class="mr-1 h-3 w-3" />
+						<User class="mr-1 h-3 w-3" aria-hidden="true" />
 						{m['blacklistEntryCard.registeredUser']()}
 					</span>
 				{/if}

--- a/src/lib/components/blacklist/BlacklistEntryModal.svelte
+++ b/src/lib/components/blacklist/BlacklistEntryModal.svelte
@@ -138,14 +138,14 @@
 				<div class="flex items-center gap-2">
 					{#if isLinkedUser}
 						<span
-							class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-100"
+							class="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
 						>
-							<User class="mr-1 h-3 w-3" />
+							<User class="mr-1 h-3 w-3" aria-hidden="true" />
 							{m['blacklistEntry.registeredUserBadge']()}
 						</span>
 					{:else}
 						<span
-							class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-800 dark:text-gray-100"
+							class="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
 						>
 							{m['blacklistEntry.manualEntryBadge']()}
 						</span>
@@ -247,7 +247,7 @@
 				<!-- Delete Confirmation -->
 				{#if showDeleteConfirm}
 					<div class="rounded-md border border-destructive/50 bg-destructive/10 p-3">
-						<p role="heading" aria-level="4" class="text-sm font-medium text-destructive">
+						<p role="heading" aria-level="4" class="text-sm font-medium text-foreground">
 							{m['blacklistEntry.deleteConfirmTitle']()}
 						</p>
 						<p class="mt-1 text-xs text-muted-foreground">

--- a/src/lib/components/blacklist/CreateBlacklistModal.svelte
+++ b/src/lib/components/blacklist/CreateBlacklistModal.svelte
@@ -98,21 +98,22 @@
 		>
 			<div class="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
 				<!-- Warning -->
-				<div
-					class="flex gap-3 rounded-md border border-amber-500/50 bg-amber-50 p-3 dark:bg-amber-950/30"
-				>
-					<AlertTriangle class="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
-					<div class="text-sm">
-						<p class="font-medium text-amber-900 dark:text-amber-100">
+				<div class="flex gap-3 rounded-md border border-highlight bg-highlight/10 p-3">
+					<AlertTriangle
+						class="h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
+						aria-hidden="true"
+					/>
+					<div class="text-sm text-foreground">
+						<p class="font-medium">
 							{m['blacklistModal.importantHeader']()}
 						</p>
-						<p class="mt-1 text-amber-800 dark:text-amber-200">
+						<p class="mt-1">
 							{m['blacklistModal.identifierMatchInfo']()}
 						</p>
-						<p class="mt-2 text-amber-800 dark:text-amber-200">
+						<p class="mt-2">
 							{m['membershipLoss.subscriptionCancelledOnMatch']()}
 						</p>
-						<p class="mt-2 text-amber-800 dark:text-amber-200">
+						<p class="mt-2">
 							{m['blacklistModal.gdprPersistInfo']()}
 						</p>
 					</div>

--- a/src/lib/components/blacklist/WhitelistEntryCard.svelte
+++ b/src/lib/components/blacklist/WhitelistEntryCard.svelte
@@ -4,6 +4,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Trash2, Mail, Calendar, ShieldCheck, AlertCircle } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
 
 	interface Props {
 		entry: WhitelistEntrySchema;
@@ -33,15 +34,15 @@
 		<!-- Entry Info -->
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2">
-				<h3 class="truncate font-semibold text-foreground">
+				<h3 class="truncate font-bold text-foreground">
 					{entry.user_display_name}
 				</h3>
-				<span
-					class="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-100"
-				>
-					<ShieldCheck class="h-3 w-3" />
-					{m['whitelistEntryCard.verified']()}
-				</span>
+				<CommonStatusBadge
+					tone="success"
+					icon={ShieldCheck}
+					label={m['whitelistEntryCard.verified']()}
+					size="sm"
+				/>
 			</div>
 
 			<!-- Email -->
@@ -52,18 +53,18 @@
 
 			<!-- Matched blacklist entries info -->
 			<div class="mt-2">
-				<span
-					class="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-950 dark:text-amber-200"
-				>
-					<AlertCircle class="h-3 w-3" />
-					{entry.matched_entries_count === 1
+				<CommonStatusBadge
+					tone="warning"
+					icon={AlertCircle}
+					size="sm"
+					label={entry.matched_entries_count === 1
 						? m['whitelistEntryCard.clearedMatchingSingular']({
 								count: String(entry.matched_entries_count)
 							})
 						: m['whitelistEntryCard.clearedMatchingPlural']({
 								count: String(entry.matched_entries_count)
 							})}
-				</span>
+				/>
 			</div>
 
 			<!-- Metadata -->

--- a/src/lib/components/blacklist/WhitelistRequestCard.svelte
+++ b/src/lib/components/blacklist/WhitelistRequestCard.svelte
@@ -2,8 +2,10 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { WhitelistRequestSchema } from '$lib/api/generated/types.gen';
 	import { Button } from '$lib/components/ui/button';
-	import { Check, X, Clock, AlertCircle, Calendar, Mail } from '@lucide/svelte';
+	import { Check, X, AlertCircle, Calendar, Mail } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
+	import WhitelistRequestStatusBadge from './WhitelistRequestStatusBadge.svelte';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
 
 	interface Props {
 		request: WhitelistRequestSchema;
@@ -35,27 +37,6 @@
 			: null
 	);
 
-	// Status badge styling
-	const statusStyles = {
-		pending: {
-			class: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100',
-			icon: Clock
-		},
-		approved: {
-			class: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100',
-			icon: Check
-		},
-		rejected: {
-			class: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100',
-			icon: X
-		}
-	};
-
-	const statusStyle = $derived(
-		statusStyles[request.status as keyof typeof statusStyles] || statusStyles.pending
-	);
-	const StatusIcon = $derived(statusStyle.icon);
-
 	function handleApprove() {
 		onApprove(request);
 	}
@@ -72,15 +53,10 @@
 		<!-- Request Info -->
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2">
-				<h3 class="truncate font-semibold text-foreground">
+				<h3 class="truncate font-bold text-foreground">
 					{request.user_display_name}
 				</h3>
-				<span
-					class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium {statusStyle.class}"
-				>
-					<StatusIcon class="h-3 w-3" />
-					{request.status}
-				</span>
+				<WhitelistRequestStatusBadge status={request.status ?? 'pending'} />
 			</div>
 
 			<!-- Email -->
@@ -91,18 +67,18 @@
 
 			<!-- Matched blacklist entries count -->
 			<div class="mt-2">
-				<span
-					class="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-950 dark:text-red-200"
-				>
-					<AlertCircle class="h-3 w-3" />
-					{request.matched_entries_count === 1
+				<CommonStatusBadge
+					tone="danger"
+					icon={AlertCircle}
+					size="sm"
+					label={request.matched_entries_count === 1
 						? m['whitelistRequestCard.matchesSingular']({
 								count: String(request.matched_entries_count)
 							})
 						: m['whitelistRequestCard.matchesPlural']({
 								count: String(request.matched_entries_count)
 							})}
-				</span>
+				/>
 			</div>
 
 			<!-- Message from user -->

--- a/src/lib/components/blacklist/WhitelistRequestStatusBadge.svelte
+++ b/src/lib/components/blacklist/WhitelistRequestStatusBadge.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import type { Tone } from '$lib/components/common/tones';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+
+	interface Props {
+		/**
+		 * `WhitelistRequestSchema.status` is a loose `string` on the wire (#782),
+		 * not a narrowed enum — so this stays unlocalized and rendered verbatim
+		 * (matches the pre-rebrand behaviour exactly; a copy change is out of
+		 * scope here). Only the TONE is derived, with a safe fallback for any
+		 * value outside the three known ones.
+		 */
+		status: string;
+		class?: string;
+	}
+
+	const { status, class: extraClass = '' }: Props = $props();
+
+	const TONE_MAP: Record<string, Tone> = {
+		pending: 'warning',
+		approved: 'success',
+		rejected: 'danger'
+	};
+
+	const tone = $derived(TONE_MAP[status] ?? 'warning');
+</script>
+
+<!-- aria-label mirrors the visible (unlocalized) status text, per the house
+     `common/StatusBadge` mapper pattern (see `members/StatusBadge.svelte`). -->
+<CommonStatusBadge {tone} label={status} size="sm" class={extraClass} aria-label={status} />

--- a/src/lib/components/blacklist/WhitelistRequestStatusBadge.svelte
+++ b/src/lib/components/blacklist/WhitelistRequestStatusBadge.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Clock, Check, X } from '@lucide/svelte';
 	import type { Tone } from '$lib/components/common/tones';
 	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
 
@@ -7,8 +8,9 @@
 		 * `WhitelistRequestSchema.status` is a loose `string` on the wire (#782),
 		 * not a narrowed enum — so this stays unlocalized and rendered verbatim
 		 * (matches the pre-rebrand behaviour exactly; a copy change is out of
-		 * scope here). Only the TONE is derived, with a safe fallback for any
-		 * value outside the three known ones.
+		 * scope here). Only the TONE and ICON are derived, both with a safe
+		 * fallback (pending's) for any value outside the three known ones —
+		 * mirrors the pre-rebrand `statusStyles[...] || statusStyles.pending`.
 		 */
 		status: string;
 		class?: string;
@@ -22,9 +24,20 @@
 		rejected: 'danger'
 	};
 
+	// Restores the per-status icon the pre-rebrand pill carried (its sibling,
+	// `WhitelistRequestCard`'s own action buttons, still use the same
+	// Clock/Check/X set) — dropped when this became a `common/StatusBadge`
+	// mapper, since the primitive's `icon` prop is opt-in.
+	const ICON_MAP: Record<string, typeof Clock> = {
+		pending: Clock,
+		approved: Check,
+		rejected: X
+	};
+
 	const tone = $derived(TONE_MAP[status] ?? 'warning');
+	const icon = $derived(ICON_MAP[status] ?? Clock);
 </script>
 
 <!-- aria-label mirrors the visible (unlocalized) status text, per the house
      `common/StatusBadge` mapper pattern (see `members/StatusBadge.svelte`). -->
-<CommonStatusBadge {tone} label={status} size="sm" class={extraClass} aria-label={status} />
+<CommonStatusBadge {tone} label={status} {icon} size="sm" class={extraClass} aria-label={status} />

--- a/src/lib/components/blacklist/WhitelistRequestStatusBadge.test.ts
+++ b/src/lib/components/blacklist/WhitelistRequestStatusBadge.test.ts
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import WhitelistRequestStatusBadge from './WhitelistRequestStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD, mirroring `members/StatusBadge.test.ts`: this pill's
+ * accessible NAME is what locates it on `WhitelistRequestCard`. The status
+ * text itself is intentionally unlocalized (matches the pre-rebrand
+ * behaviour) — this guard is about the aria-label surviving the move to the
+ * shared `common/StatusBadge` primitive, not about translation.
+ */
+describe('blacklist/WhitelistRequestStatusBadge', () => {
+	it.each(['pending', 'approved', 'rejected'])(
+		'exposes the raw "%s" status as the pill accessible name',
+		(status) => {
+			render(WhitelistRequestStatusBadge, { props: { status } });
+			expect(screen.getByLabelText(status)).toBeInTheDocument();
+			expect(screen.getByLabelText(status)).toHaveTextContent(status);
+		}
+	);
+
+	it('falls back to a warning tone for an unrecognized status rather than throwing', () => {
+		const { container } = render(WhitelistRequestStatusBadge, {
+			props: { status: 'some_future_status' }
+		});
+		expect(screen.getByLabelText('some_future_status')).toBeInTheDocument();
+		expect(container.querySelector('span')?.className).toContain('bg-highlight');
+	});
+
+	it('maps rejected to the danger tone', () => {
+		const { container } = render(WhitelistRequestStatusBadge, { props: { status: 'rejected' } });
+		expect(container.querySelector('span')?.className).toContain('bg-destructive');
+	});
+});

--- a/src/lib/components/blacklist/WhitelistRequestsTab.svelte
+++ b/src/lib/components/blacklist/WhitelistRequestsTab.svelte
@@ -4,6 +4,7 @@
 	import { ShieldAlert, Loader2, ChevronLeft, ChevronRight } from '@lucide/svelte';
 	import { WhitelistRequestCard } from '$lib/components/blacklist';
 	import type { WhitelistRequestSchema, Status } from '$lib/api/generated/types.gen';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface PaginationInfo {
 		page: number;
@@ -88,8 +89,8 @@
 </div>
 
 <!-- Info Box -->
-<div class="rounded-lg border border-blue-500/30 bg-blue-50 p-3 dark:bg-blue-950/30">
-	<p class="text-sm text-blue-900 dark:text-blue-100">
+<div class="rounded-lg border border-info bg-info/10 p-3">
+	<p class="text-sm text-foreground">
 		{m['blacklistAdminPage.requestsInfo']()}
 	</p>
 </div>
@@ -106,15 +107,13 @@
 		</p>
 	</div>
 {:else if requests.length === 0}
-	<div class="rounded-lg border border-dashed p-12 text-center">
-		<ShieldAlert class="mx-auto h-12 w-12 text-muted-foreground" />
-		<h3 class="mt-4 font-semibold">{m['blacklistAdminPage.noRequests']()}</h3>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{statusFilter === 'pending'
-				? m['blacklistAdminPage.noPendingRequests']()
-				: m['blacklistAdminPage.noRequestsMatchFilter']()}
-		</p>
-	</div>
+	<EmptyState
+		icon={ShieldAlert}
+		title={m['blacklistAdminPage.noRequests']()}
+		body={statusFilter === 'pending'
+			? m['blacklistAdminPage.noPendingRequests']()
+			: m['blacklistAdminPage.noRequestsMatchFilter']()}
+	/>
 {:else}
 	<div class="grid gap-4 md:grid-cols-2">
 		{#each requests as request (request.id)}

--- a/src/lib/components/blacklist/index.ts
+++ b/src/lib/components/blacklist/index.ts
@@ -2,5 +2,6 @@ export { default as BlacklistEntryCard } from './BlacklistEntryCard.svelte';
 export { default as BlacklistEntryModal } from './BlacklistEntryModal.svelte';
 export { default as CreateBlacklistModal } from './CreateBlacklistModal.svelte';
 export { default as WhitelistRequestCard } from './WhitelistRequestCard.svelte';
+export { default as WhitelistRequestStatusBadge } from './WhitelistRequestStatusBadge.svelte';
 export { default as WhitelistEntryCard } from './WhitelistEntryCard.svelte';
 export { default as WhitelistRequestsTab } from './WhitelistRequestsTab.svelte';

--- a/src/lib/components/discount-codes/DiscountCodeForm.svelte
+++ b/src/lib/components/discount-codes/DiscountCodeForm.svelte
@@ -468,7 +468,7 @@
 				aria-label={m['discountCodeForm.activeStatus']()}
 			/>
 			<div
-				class="peer h-6 w-11 rounded-full bg-gray-200 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:ring-2 peer-focus:ring-ring dark:bg-gray-700"
+				class="peer h-6 w-11 rounded-full bg-muted after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-border after:bg-background after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:translate-x-full peer-checked:after:border-primary-foreground peer-focus:ring-2 peer-focus:ring-ring"
 			></div>
 		</label>
 		<div>

--- a/src/lib/components/discount-codes/DiscountCodeStatusBadge.svelte
+++ b/src/lib/components/discount-codes/DiscountCodeStatusBadge.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
+
+	interface Props {
+		isActive: boolean;
+		class?: string;
+	}
+
+	const { isActive, class: extraClass = '' }: Props = $props();
+
+	const tone: Tone = $derived(isActive ? 'success' : 'neutral');
+	const label = $derived(
+		isActive ? m['discountCodesAdmin.status.active']() : m['discountCodesAdmin.status.inactive']()
+	);
+</script>
+
+<!-- aria-label explicit per the house `common/StatusBadge` mapper pattern
+     (see `members/StatusBadge.svelte`). -->
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} aria-label={label} />

--- a/src/lib/components/discount-codes/DiscountCodeStatusBadge.test.ts
+++ b/src/lib/components/discount-codes/DiscountCodeStatusBadge.test.ts
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import DiscountCodeStatusBadge from './DiscountCodeStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD, mirroring `members/StatusBadge.test.ts`: this pill's
+ * accessible NAME is what locates a code's active/inactive state in the
+ * discount-codes admin table and its mobile card twin.
+ */
+describe('discount-codes/DiscountCodeStatusBadge', () => {
+	it('exposes "Active" as the accessible name when active', () => {
+		render(DiscountCodeStatusBadge, { props: { isActive: true } });
+		expect(screen.getByLabelText('Active')).toBeInTheDocument();
+		expect(screen.getByLabelText('Active')).toHaveTextContent('Active');
+	});
+
+	it('exposes "Inactive" as the accessible name when inactive', () => {
+		render(DiscountCodeStatusBadge, { props: { isActive: false } });
+		expect(screen.getByLabelText('Inactive')).toBeInTheDocument();
+		expect(screen.getByLabelText('Inactive')).toHaveTextContent('Inactive');
+	});
+
+	it('maps active to the success tone and inactive to the neutral tone', () => {
+		const active = render(DiscountCodeStatusBadge, { props: { isActive: true } });
+		expect(active.container.querySelector('span')?.className).toContain('bg-success');
+
+		const inactive = render(DiscountCodeStatusBadge, { props: { isActive: false } });
+		expect(inactive.container.querySelector('span')?.className).toContain('bg-muted');
+	});
+});

--- a/src/lib/components/members/ApproveMembershipModal.svelte
+++ b/src/lib/components/members/ApproveMembershipModal.svelte
@@ -120,7 +120,7 @@
 				<Button
 					onclick={handleConfirm}
 					disabled={!selectedTierId || isProcessing}
-					class="bg-green-600 hover:bg-green-700"
+					class="bg-success text-success-foreground hover:bg-success/90"
 				>
 					{#if isProcessing}
 						<Loader2 class="mr-2 h-4 w-4 animate-spin" />

--- a/src/lib/components/members/MakeMemberModal.svelte
+++ b/src/lib/components/members/MakeMemberModal.svelte
@@ -71,7 +71,7 @@
 				<!-- Tier Selection -->
 				{#if tiers.length === 0}
 					<div
-						class="rounded-lg border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-200"
+						class="rounded-lg border border-highlight bg-highlight/10 p-3 text-sm text-foreground"
 					>
 						{m['makeMemberModal.noTiersWarning']()}
 					</div>

--- a/src/lib/components/members/ManageMemberModal.svelte
+++ b/src/lib/components/members/ManageMemberModal.svelte
@@ -302,10 +302,18 @@
 						{@render billingNotice('text-sm text-muted-foreground')}
 					{/if}
 					{#if selectedStatus === 'banned'}
+						<!-- dark:bg-destructive/25 dark:text-destructive-foreground
+						     (AutoEvalRecommendation's pattern): plain text-destructive on this
+						     /10 tint measured 2.69-2.95:1 in dark mode, under the 3:1 non-text
+						     floor; the /25 tint + destructive-foreground (white) icon pairing
+						     measures ~14-15:1 instead. -->
 						<div
-							class="flex gap-2 rounded-md border border-destructive bg-destructive/10 p-3 text-sm"
+							class="flex gap-2 rounded-md border border-destructive bg-destructive/10 p-3 text-sm dark:bg-destructive/25"
 						>
-							<AlertTriangle class="h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
+							<AlertTriangle
+								class="h-4 w-4 shrink-0 text-destructive dark:text-destructive-foreground"
+								aria-hidden="true"
+							/>
 							<div class="space-y-2 text-foreground">
 								<p>{m['manageMemberModal.bannedWarning']()}</p>
 								<!-- The confirm panel below restates this line, so show it here only
@@ -473,13 +481,26 @@
 					<!-- Blacklist Button/Confirmation -->
 					{#if onBlacklist}
 						{#if !showBlacklistConfirm}
+							<!-- Label stays text-foreground (danger framing rule): dark-mode
+							     `text-destructive` on this transparent/bg-background surface
+							     measured 3.13:1, under the 4.5:1 text floor (it replaced a
+							     passing pre-rebrand `dark:text-red-400`). Only the Ban icon
+							     carries the tone, split per mode since raw `text-destructive`
+							     has no audited page/background pair (trap 5): light keeps
+							     `text-destructive` (8.61:1 on background), dark swaps to
+							     `text-destructive-foreground` — white — which is 18.36:1 on
+							     the dark background. Hover keeps the same text-foreground
+							     label with the destructive/10 tint underneath.  -->
 							<Button
 								variant="outline"
 								onclick={handleBlacklistClick}
 								disabled={isProcessing}
-								class="w-full justify-start border-destructive bg-transparent text-destructive hover:bg-destructive/10 hover:text-destructive"
+								class="w-full justify-start border-destructive bg-transparent text-foreground hover:bg-destructive/10 hover:text-foreground"
 							>
-								<Ban class="mr-2 h-4 w-4" aria-hidden="true" />
+								<Ban
+									class="mr-2 h-4 w-4 text-destructive dark:text-destructive-foreground"
+									aria-hidden="true"
+								/>
 								{m['manageMemberModal.addToBlacklist']()}
 							</Button>
 						{:else}

--- a/src/lib/components/members/ManageMemberModal.svelte
+++ b/src/lib/components/members/ManageMemberModal.svelte
@@ -302,9 +302,11 @@
 						{@render billingNotice('text-sm text-muted-foreground')}
 					{/if}
 					{#if selectedStatus === 'banned'}
-						<div class="flex gap-2 rounded-md bg-red-50 p-3 text-sm dark:bg-red-950">
-							<AlertTriangle class="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
-							<div class="space-y-2 text-red-800 dark:text-red-200">
+						<div
+							class="flex gap-2 rounded-md border border-destructive bg-destructive/10 p-3 text-sm"
+						>
+							<AlertTriangle class="h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
+							<div class="space-y-2 text-foreground">
 								<p>{m['manageMemberModal.bannedWarning']()}</p>
 								<!-- The confirm panel below restates this line, so show it here only
 								     while that panel is closed — never the same sentence twice. -->
@@ -351,13 +353,13 @@
 							<div class="flex gap-2">
 								<AlertTriangle class="h-5 w-5 shrink-0 text-destructive" />
 								<div class="flex-1 space-y-2">
-									<p role="heading" aria-level="4" class="text-sm font-medium text-destructive">
+									<p role="heading" aria-level="4" class="text-sm font-medium text-foreground">
 										{m['manageMemberModal.banConfirmTitle']({ name: displayName })}
 									</p>
-									<p class="text-sm text-destructive/90">
+									<p class="text-sm text-foreground">
 										{m['manageMemberModal.banConfirmMessage']()}
 									</p>
-									{@render billingNotice('text-sm text-destructive/90')}
+									{@render billingNotice('text-sm text-foreground')}
 									<div class="flex gap-2">
 										<Button
 											bind:ref={banConfirmButton}
@@ -435,13 +437,13 @@
 							<div class="flex gap-2">
 								<AlertTriangle class="h-5 w-5 shrink-0 text-destructive" />
 								<div class="flex-1 space-y-2">
-									<p role="heading" aria-level="4" class="text-sm font-medium text-destructive">
+									<p role="heading" aria-level="4" class="text-sm font-medium text-foreground">
 										{m['manageMemberModal.removeConfirmTitle']()}
 									</p>
-									<p class="text-sm text-destructive/90">
+									<p class="text-sm text-foreground">
 										{m['manageMemberModal.removeConfirmMessage']({ name: displayName })}
 									</p>
-									{@render billingNotice('text-sm text-destructive/90')}
+									{@render billingNotice('text-sm text-foreground')}
 									<div class="flex gap-2">
 										<Button
 											variant="destructive"
@@ -475,33 +477,27 @@
 								variant="outline"
 								onclick={handleBlacklistClick}
 								disabled={isProcessing}
-								class="w-full justify-start border-red-500 text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-400 dark:text-red-400 dark:hover:bg-red-950 dark:hover:text-red-300"
+								class="w-full justify-start border-destructive bg-transparent text-destructive hover:bg-destructive/10 hover:text-destructive"
 							>
-								<Ban class="mr-2 h-4 w-4" />
+								<Ban class="mr-2 h-4 w-4" aria-hidden="true" />
 								{m['manageMemberModal.addToBlacklist']()}
 							</Button>
 						{:else}
-							<div
-								class="space-y-3 rounded-lg border-2 border-red-500 bg-red-50 p-4 dark:bg-red-950/50"
-							>
+							<div class="space-y-3 rounded-lg border-2 border-destructive bg-destructive/10 p-4">
 								<div class="flex gap-2">
-									<Ban class="h-5 w-5 shrink-0 text-red-600 dark:text-red-400" />
+									<Ban class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
 									<div class="flex-1 space-y-3">
 										<div>
-											<p
-												role="heading"
-												aria-level="4"
-												class="text-sm font-medium text-red-900 dark:text-red-100"
-											>
+											<p role="heading" aria-level="4" class="text-sm font-medium text-foreground">
 												{m['manageMemberModal.blacklistConfirmTitle']({ name: displayName })}
 											</p>
-											<p class="text-sm text-red-800 dark:text-red-200">
+											<p class="text-sm text-foreground">
 												{m['manageMemberModal.blacklistConfirmMessage']()}
 											</p>
-											{@render billingNotice('mt-1 text-sm text-red-800 dark:text-red-200')}
+											{@render billingNotice('mt-1 text-sm text-foreground')}
 										</div>
 										<div class="space-y-2">
-											<Label for="blacklist-reason" class="text-sm text-red-900 dark:text-red-100">
+											<Label for="blacklist-reason" class="text-sm text-foreground">
 												{m['manageMemberModal.reasonOptional']()}
 											</Label>
 											<Textarea
@@ -510,7 +506,7 @@
 												placeholder={m['manageMemberModal.blacklistReasonPlaceholder']()}
 												rows={2}
 												disabled={isBlacklisting}
-												class="border-red-300 dark:border-red-700"
+												class="border-destructive/40"
 											/>
 										</div>
 										<div class="flex gap-2">

--- a/src/lib/components/members/MemberCard.svelte
+++ b/src/lib/components/members/MemberCard.svelte
@@ -5,6 +5,7 @@
 	import { Settings } from '@lucide/svelte';
 	import { formatDistanceToNow } from 'date-fns';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
+	import MemberStatusBadge from './MemberStatusBadge.svelte';
 
 	interface Props {
 		member: OrganizationMemberSchema;
@@ -27,14 +28,6 @@
 				? `${member.user.first_name} ${member.user.last_name}`
 				: member.user.first_name || member.user.email || 'Unknown User')
 	);
-
-	// Status badge styling
-	const statusStyles = {
-		active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100',
-		paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100',
-		cancelled: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100',
-		banned: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100'
-	};
 
 	function handleManage() {
 		onManage(member);
@@ -59,7 +52,7 @@
 		<!-- Member Info -->
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2">
-				<h3 class="truncate font-semibold text-foreground">
+				<h3 class="truncate font-bold text-foreground">
 					{displayName}
 				</h3>
 				{#if isStaff}
@@ -78,18 +71,12 @@
 			<!-- Badges Row -->
 			<div class="mt-2 flex flex-wrap gap-2">
 				<!-- Status Badge -->
-				<span
-					class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {statusStyles[
-						member.status
-					]}"
-				>
-					{m[`memberStatus.${member.status}`]()}
-				</span>
+				<MemberStatusBadge status={member.status} />
 
 				<!-- Tier Badge -->
 				{#if member.tier}
 					<span
-						class="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-100"
+						class="inline-flex items-center rounded-full bg-info/10 px-2 py-0.5 text-xs font-medium text-info"
 					>
 						{member.tier.name}
 					</span>

--- a/src/lib/components/members/MemberStatusBadge.svelte
+++ b/src/lib/components/members/MemberStatusBadge.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { MembershipStatus } from '$lib/api/generated/types.gen';
+	import { getMemberStatusLabel, getMemberStatusTone } from '$lib/utils/member-status';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+
+	interface Props {
+		status: MembershipStatus;
+		class?: string;
+	}
+
+	const { status, class: extraClass = '' }: Props = $props();
+
+	const tone = $derived(getMemberStatusTone(status));
+	const label = $derived(getMemberStatusLabel(status));
+</script>
+
+<!--
+	`aria-label` is deliberate, not redundant with the visible text: this is the
+	canonical `common/StatusBadge` mapper pattern (see `members/StatusBadge.svelte`
+	for the subscription-status sibling) — the primitive names itself off its
+	content only, so the mapper supplies the accessible name explicitly.
+-->
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} aria-label={label} />

--- a/src/lib/components/members/MemberStatusBadge.test.ts
+++ b/src/lib/components/members/MemberStatusBadge.test.ts
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import type { MembershipStatus } from '$lib/api/generated/types.gen';
+import { getMemberStatusLabel, MEMBER_STATUS_ORDER } from '$lib/utils/member-status';
+import MemberStatusBadge from './MemberStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD, mirroring `members/StatusBadge.test.ts`: this pill's
+ * accessible NAME is what locates it in `MemberCard` (roster) — a mapper over
+ * `common/StatusBadge` that dropped its `aria-label` would still render the
+ * right text on screen while `getByLabelText` stopped finding it. Every enum
+ * value is asserted, not a sample, since the failure mode drops all of them
+ * at once.
+ */
+describe('members/MemberStatusBadge', () => {
+	it.each(MEMBER_STATUS_ORDER as MembershipStatus[])(
+		'exposes the %s label as the pill accessible name',
+		(status) => {
+			render(MemberStatusBadge, { props: { status } });
+			const label = getMemberStatusLabel(status);
+			expect(screen.getByLabelText(label)).toBeInTheDocument();
+			expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		}
+	);
+
+	it('maps banned to the danger tone', () => {
+		const { container } = render(MemberStatusBadge, { props: { status: 'banned' } });
+		expect(container.querySelector('span')?.className).toContain('bg-destructive');
+	});
+
+	it('maps active to the success tone', () => {
+		const { container } = render(MemberStatusBadge, { props: { status: 'active' } });
+		expect(container.querySelector('span')?.className).toContain('bg-success');
+	});
+});

--- a/src/lib/components/members/MembersTab.svelte
+++ b/src/lib/components/members/MembersTab.svelte
@@ -26,6 +26,7 @@
 	import { canPerformAction } from '$lib/utils/permissions';
 	import { backendMessage } from '$lib/utils/api-error-detail';
 	import { toast } from 'svelte-sonner';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -386,15 +387,13 @@
 		<p class="text-sm text-destructive">{m['orgAdmin.members.errors.loadMembers']()}</p>
 	</div>
 {:else if members.length === 0}
-	<div class="rounded-lg border border-dashed p-12 text-center">
-		<Users class="mx-auto h-12 w-12 text-muted-foreground" />
-		<h3 class="mt-4 font-semibold">{m['orgAdmin.members.empty.members.title']()}</h3>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{memberSearch
-				? m['orgAdmin.members.empty.members.withSearch']()
-				: m['orgAdmin.members.empty.members.noSearch']()}
-		</p>
-	</div>
+	<EmptyState
+		icon={Users}
+		title={m['orgAdmin.members.empty.members.title']()}
+		body={memberSearch
+			? m['orgAdmin.members.empty.members.withSearch']()
+			: m['orgAdmin.members.empty.members.noSearch']()}
+	/>
 {:else}
 	<div class="grid gap-4 md:grid-cols-2">
 		{#each members as member (member.user.email)}

--- a/src/lib/components/members/MembershipRequestCard.svelte
+++ b/src/lib/components/members/MembershipRequestCard.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import type {
-		MembershipRequestStatus,
-		OrganizationMembershipRequestRetrieve
-	} from '$lib/api/generated/types.gen';
+	import type { OrganizationMembershipRequestRetrieve } from '$lib/api/generated/types.gen';
 	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
 	import {
@@ -17,6 +14,7 @@
 	import { CheckCircle, XCircle, MessageSquare } from '@lucide/svelte';
 	import { formatRelativeTime } from '$lib/utils/date';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
+	import MembershipRequestStatusBadge from './MembershipRequestStatusBadge.svelte';
 
 	interface Props {
 		request: OrganizationMembershipRequestRetrieve;
@@ -36,31 +34,6 @@
 		isProcessing = false,
 		showActions = true
 	}: Props = $props();
-
-	// Every state the application state machine can be in. The label carries the
-	// meaning; the tint is decoration only (WCAG: never colour alone).
-	const STATUS_BADGES: Record<MembershipRequestStatus, { classes: string; label: () => string }> = {
-		pending: {
-			classes: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100',
-			label: () => m['membershipRequestCard.statusPending']()
-		},
-		approved: {
-			classes: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100',
-			label: () => m['membershipRequestCard.approved']()
-		},
-		completed: {
-			classes: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100',
-			label: () => m['membershipRequestCard.statusCompleted']()
-		},
-		rejected: {
-			classes: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100',
-			label: () => m['membershipRequestCard.rejected']()
-		},
-		cancelled: {
-			classes: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
-			label: () => m['membershipRequestCard.statusCancelled']()
-		}
-	};
 
 	// Dialog state
 	let dialogOpen = $state(false);
@@ -145,7 +118,7 @@
 				<div class="flex items-start justify-between gap-2">
 					<div class="min-w-0 flex-1">
 						<div class="flex flex-wrap items-center gap-2">
-							<h3 class="truncate font-semibold text-foreground">
+							<h3 class="truncate font-bold text-foreground">
 								{displayName}
 							</h3>
 							{#if request.tier}
@@ -235,15 +208,7 @@
 						{m['membershipRequestCard.requestedAt']({ time: createdAt })}
 					</p>
 					{#if !showActions && request.status}
-						<!-- `??` is not dead code: during a BE-ahead version skew the wire can
-						     carry a status this build has never heard of, and an unguarded
-						     lookup would TypeError every card in the tab. -->
-						{@const badge = STATUS_BADGES[request.status] ?? STATUS_BADGES.pending}
-						<span
-							class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {badge.classes}"
-						>
-							{badge.label()}
-						</span>
+						<MembershipRequestStatusBadge status={request.status} />
 					{/if}
 				</div>
 			</div>
@@ -269,7 +234,7 @@
 					onclick={handleApprove}
 					disabled={isProcessing}
 					aria-label={m['membershipRequestCard.approveRequestAria']({ name: displayName })}
-					class="bg-green-600 hover:bg-green-700"
+					class="bg-success text-success-foreground hover:bg-success/90"
 				>
 					<CheckCircle class="h-4 w-4" />
 					<span class="ml-2">{m['membershipRequestCard.approve']()}</span>
@@ -316,7 +281,7 @@
 		<div class="space-y-4 py-4">
 			<!-- User Information -->
 			<div class="space-y-2">
-				<h4 class="text-sm font-semibold">{m['membershipRequestCard.applicantInformation']()}</h4>
+				<h4 class="text-sm font-bold">{m['membershipRequestCard.applicantInformation']()}</h4>
 				<dl class="space-y-1 text-sm">
 					{#if request.user.first_name}
 						<div class="flex gap-2">
@@ -378,7 +343,7 @@
 			<!-- Message -->
 			{#if request.message}
 				<div class="space-y-2">
-					<h4 class="text-sm font-semibold">{m['membershipRequestCard.message']()}</h4>
+					<h4 class="text-sm font-bold">{m['membershipRequestCard.message']()}</h4>
 					<div
 						class="rounded-lg border border-border bg-muted/50 p-3 text-sm text-foreground"
 						style="white-space: pre-wrap; word-wrap: break-word;"
@@ -388,7 +353,7 @@
 				</div>
 			{:else}
 				<div class="space-y-2">
-					<h4 class="text-sm font-semibold">{m['membershipRequestCard.message']()}</h4>
+					<h4 class="text-sm font-bold">{m['membershipRequestCard.message']()}</h4>
 					<p class="text-sm italic text-muted-foreground">
 						{m['membershipRequestCard.noMessage']()}
 					</p>
@@ -398,7 +363,7 @@
 			<!-- Questionnaire submission -->
 			{#if submission}
 				<div class="space-y-2">
-					<h4 class="text-sm font-semibold">{m['membershipRequestCard.questionnaire']()}</h4>
+					<h4 class="text-sm font-bold">{m['membershipRequestCard.questionnaire']()}</h4>
 					<p class="text-sm">
 						<a
 							href={resolve(
@@ -446,7 +411,7 @@
 				variant="default"
 				onclick={handleApprove}
 				disabled={isProcessing}
-				class="bg-green-600 hover:bg-green-700"
+				class="bg-success text-success-foreground hover:bg-success/90"
 			>
 				<CheckCircle class="mr-2 h-4 w-4" />
 				{m['membershipRequestCard.approve']()}

--- a/src/lib/components/members/MembershipRequestStatusBadge.svelte
+++ b/src/lib/components/members/MembershipRequestStatusBadge.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { MembershipRequestStatus } from '$lib/api/generated/types.gen';
+	import {
+		getMembershipRequestStatusLabel,
+		getMembershipRequestStatusTone
+	} from '$lib/utils/membership-request-status';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+
+	interface Props {
+		status: MembershipRequestStatus;
+		class?: string;
+	}
+
+	const { status, class: extraClass = '' }: Props = $props();
+
+	const tone = $derived(getMembershipRequestStatusTone(status));
+	const label = $derived(getMembershipRequestStatusLabel(status));
+</script>
+
+<!-- aria-label is explicit per the house `common/StatusBadge` mapper pattern
+     (see `members/StatusBadge.svelte`) — the primitive names itself off
+     content only. -->
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} aria-label={label} />

--- a/src/lib/components/members/MembershipRequestStatusBadge.test.ts
+++ b/src/lib/components/members/MembershipRequestStatusBadge.test.ts
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import type { MembershipRequestStatus } from '$lib/api/generated/types.gen';
+import {
+	getMembershipRequestStatusLabel,
+	MEMBERSHIP_REQUEST_STATUS_ORDER
+} from '$lib/utils/membership-request-status';
+import MembershipRequestStatusBadge from './MembershipRequestStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD, mirroring `members/StatusBadge.test.ts`: this pill's
+ * accessible NAME is what locates the "not pending" branch of
+ * `MembershipRequestCard` (the review-history badge shown once actions are no
+ * longer offered). Every enum value is asserted, not a sample.
+ */
+describe('members/MembershipRequestStatusBadge', () => {
+	it.each(MEMBERSHIP_REQUEST_STATUS_ORDER as MembershipRequestStatus[])(
+		'exposes the %s label as the pill accessible name',
+		(status) => {
+			render(MembershipRequestStatusBadge, { props: { status } });
+			const label = getMembershipRequestStatusLabel(status);
+			expect(screen.getByLabelText(label)).toBeInTheDocument();
+			expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		}
+	);
+
+	it('maps rejected to the danger tone', () => {
+		const { container } = render(MembershipRequestStatusBadge, {
+			props: { status: 'rejected' }
+		});
+		expect(container.querySelector('span')?.className).toContain('bg-destructive');
+	});
+
+	it('maps approved and completed to the same success tone', () => {
+		const approved = render(MembershipRequestStatusBadge, { props: { status: 'approved' } });
+		expect(approved.container.querySelector('span')?.className).toContain('bg-success');
+
+		const completed = render(MembershipRequestStatusBadge, { props: { status: 'completed' } });
+		expect(completed.container.querySelector('span')?.className).toContain('bg-success');
+	});
+});

--- a/src/lib/components/members/MembershipRequestsTab.svelte
+++ b/src/lib/components/members/MembershipRequestsTab.svelte
@@ -44,6 +44,7 @@
 	import ApproveMembershipModal from '$lib/components/members/ApproveMembershipModal.svelte';
 	import { toast } from 'svelte-sonner';
 	import { backendMessage } from '$lib/utils/api-error-detail';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -333,13 +334,11 @@
 		</p>
 	</div>
 {:else if requests.length === 0}
-	<div class="rounded-lg border border-dashed p-12 text-center">
-		<UserPlus class="mx-auto h-12 w-12 text-muted-foreground" />
-		<h3 class="mt-4 font-semibold">{m['orgAdmin.members.empty.requests.title']()}</h3>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{m['orgAdmin.members.empty.requests.description']()}
-		</p>
-	</div>
+	<EmptyState
+		icon={UserPlus}
+		title={m['orgAdmin.members.empty.requests.title']()}
+		body={m['orgAdmin.members.empty.requests.description']()}
+	/>
 {:else}
 	<div class="grid gap-4 md:grid-cols-2">
 		{#each requests as request (request.id)}

--- a/src/lib/components/members/OrganizationTokensTab.svelte
+++ b/src/lib/components/members/OrganizationTokensTab.svelte
@@ -31,6 +31,7 @@
 	import TokenShareDialog from '$lib/components/tokens/TokenShareDialog.svelte';
 	import { getOrganizationTokenUrl } from '$lib/utils/tokens';
 	import { toast } from 'svelte-sonner';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -205,23 +206,15 @@
 		<p class="text-sm text-destructive">{m['organizationTokensTab.loadFailed']()}</p>
 	</div>
 {:else if tokens.length === 0}
-	<div class="rounded-lg border border-dashed p-12 text-center">
-		<Link class="mx-auto h-12 w-12 text-muted-foreground" />
-		<h3 class="mt-4 font-semibold">
-			{#if tokenSearch}
-				{m['organizationTokensTab.emptySearchTitle']()}
-			{:else}
-				{m['organizationTokensTab.emptyTitle']()}
-			{/if}
-		</h3>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{#if tokenSearch}
-				{m['organizationTokensTab.emptySearchDescription']()}
-			{:else}
-				{m['organizationTokensTab.emptyDescription']()}
-			{/if}
-		</p>
-	</div>
+	<EmptyState
+		icon={Link}
+		title={tokenSearch
+			? m['organizationTokensTab.emptySearchTitle']()
+			: m['organizationTokensTab.emptyTitle']()}
+		body={tokenSearch
+			? m['organizationTokensTab.emptySearchDescription']()
+			: m['organizationTokensTab.emptyDescription']()}
+	/>
 {:else}
 	<div class="space-y-4">
 		{#each tokens as token (token.id)}

--- a/src/lib/components/members/PaymentsTable.svelte
+++ b/src/lib/components/members/PaymentsTable.svelte
@@ -55,13 +55,19 @@
 		<table class="w-full text-sm">
 			<thead class="border-b text-left">
 				<tr>
-					<th scope="col" class="py-2"
+					<th
+						scope="col"
+						class="py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 						>{m['orgAdmin.members.subscriptions.drawer.paymentsCol.date']()}</th
 					>
-					<th scope="col" class="py-2"
+					<th
+						scope="col"
+						class="py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 						>{m['orgAdmin.members.subscriptions.drawer.paymentsCol.amount']()}</th
 					>
-					<th scope="col" class="py-2"
+					<th
+						scope="col"
+						class="py-2 text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 						>{m['orgAdmin.members.subscriptions.drawer.paymentsCol.status']()}</th
 					>
 					<th class="py-2"></th>

--- a/src/lib/components/members/PermissionsEditor.svelte
+++ b/src/lib/components/members/PermissionsEditor.svelte
@@ -225,7 +225,7 @@
 		<div class="space-y-6 py-4">
 			{#each permissionGroups as group (group.title)}
 				<div class="space-y-3">
-					<h3 class="text-sm font-semibold text-foreground">{group.title}</h3>
+					<h3 class="text-sm font-bold text-foreground">{group.title}</h3>
 					<div class="space-y-3">
 						{#each group.permissions as perm (perm.key)}
 							<div class="flex items-start gap-3">

--- a/src/lib/components/members/PlansList.svelte
+++ b/src/lib/components/members/PlansList.svelte
@@ -21,6 +21,7 @@
 	import { AlertTriangle, Pencil, Archive, Trash2, Plus, Loader2, RefreshCw } from '@lucide/svelte';
 	import PlanFormModal, { type PlanFormPayload } from './PlanFormModal.svelte';
 	import MigrateSubscribersDialog from './MigrateSubscribersDialog.svelte';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import { formatPlanPrice, isLifetimePlan } from '$lib/utils/subscriptions';
 	import { backendMessage } from '$lib/utils/api-error-detail';
 
@@ -209,7 +210,7 @@
 
 <div class="space-y-2">
 	<div class="flex items-center justify-between">
-		<h4 class="text-sm font-semibold">{m['orgAdmin.members.plans.title']()}</h4>
+		<h4 class="text-sm font-bold">{m['orgAdmin.members.plans.title']()}</h4>
 		<Button size="sm" variant="outline" onclick={openCreate}>
 			<Plus class="mr-1 h-3 w-3" />
 			{m['orgAdmin.members.plans.add']()}
@@ -258,18 +259,18 @@
 												})}
 									</span>
 									{#if p.max_subscriptions != null && p.active_subscription_count >= p.max_subscriptions}
-										<span
-											class="rounded-full bg-red-100 px-2 py-0.5 text-red-900 dark:bg-red-900/30 dark:text-red-100"
-										>
-											{m['orgAdmin.members.plans.badge.soldOut']()}
-										</span>
+										<CommonStatusBadge
+											tone="danger"
+											label={m['orgAdmin.members.plans.badge.soldOut']()}
+											size="sm"
+										/>
 									{/if}
 									{#if p.sales_status === 'paused'}
-										<span
-											class="rounded-full bg-amber-100 px-2 py-0.5 text-amber-900 dark:bg-amber-900/30 dark:text-amber-100"
-										>
-											{m['orgAdmin.members.plans.badge.paused']()}
-										</span>
+										<CommonStatusBadge
+											tone="warning"
+											label={m['orgAdmin.members.plans.badge.paused']()}
+											size="sm"
+										/>
 									{/if}
 								</div>
 								{#if p.is_active === false}

--- a/src/lib/components/members/PromoteToStaffDialog.svelte
+++ b/src/lib/components/members/PromoteToStaffDialog.svelte
@@ -66,19 +66,14 @@
 				{m['promoteToStaffDialog.confirmSuffix']()}
 			</p>
 
-			<div
-				class="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950"
-			>
+			<div class="rounded-lg border border-info bg-info/10 p-3">
 				<div class="flex gap-2">
-					<AlertCircle
-						class="h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400"
-						aria-hidden="true"
-					/>
+					<AlertCircle class="h-5 w-5 shrink-0 text-info" aria-hidden="true" />
 					<div class="text-sm">
-						<p class="font-medium text-blue-900 dark:text-blue-100">
+						<p class="font-medium text-foreground">
 							{m['promoteToStaffDialog.defaultPermissions']()}
 						</p>
-						<p class="mt-1 text-blue-700 dark:text-blue-300">
+						<p class="mt-1 text-muted-foreground">
 							{m['promoteToStaffDialog.defaultPermissionsDescription']()}
 						</p>
 					</div>

--- a/src/lib/components/members/RecordPaymentModal.svelte
+++ b/src/lib/components/members/RecordPaymentModal.svelte
@@ -80,7 +80,9 @@
 			</div>
 
 			{#if currencyWarning}
-				<p class="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+				<p
+					class="rounded border border-highlight bg-highlight/10 px-3 py-2 text-xs text-foreground"
+				>
 					{m['orgAdmin.members.subscriptions.recordPayment.currencyWarning']({
 						planCurrency: subscription.plan.currency,
 						selected: currency

--- a/src/lib/components/members/StaffCard.svelte
+++ b/src/lib/components/members/StaffCard.svelte
@@ -60,7 +60,7 @@
 		<!-- Staff Info -->
 		<div class="min-w-0 flex-1">
 			<div class="flex flex-wrap items-center gap-2">
-				<h3 class="truncate font-semibold text-foreground">
+				<h3 class="truncate font-bold text-foreground">
 					{displayName}
 				</h3>
 				<Badge variant="secondary" class="text-xs">{m['staffCard.staff']()}</Badge>

--- a/src/lib/components/members/StaffTab.svelte
+++ b/src/lib/components/members/StaffTab.svelte
@@ -16,6 +16,7 @@
 	import { Search, UserCog, Loader2 } from '@lucide/svelte';
 	import StaffCard from '$lib/components/members/StaffCard.svelte';
 	import PermissionsEditor from '$lib/components/members/PermissionsEditor.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -155,10 +156,8 @@
 
 <!-- Owner Notice -->
 {#if isOwner}
-	<div
-		class="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950 sm:p-4"
-	>
-		<p class="text-xs leading-relaxed text-blue-900 dark:text-blue-100 sm:text-sm">
+	<div class="rounded-lg border border-info bg-info/10 p-3 sm:p-4">
+		<p class="text-xs leading-relaxed text-foreground sm:text-sm">
 			{m['orgAdmin.members.ownerNotice']()}
 		</p>
 	</div>
@@ -174,15 +173,13 @@
 		<p class="text-sm text-destructive">{m['orgAdmin.members.errors.loadStaff']()}</p>
 	</div>
 {:else if staff.length === 0}
-	<div class="rounded-lg border border-dashed p-12 text-center">
-		<UserCog class="mx-auto h-12 w-12 text-muted-foreground" />
-		<h3 class="mt-4 font-semibold">{m['orgAdmin.members.empty.staff.title']()}</h3>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{staffSearch
-				? m['orgAdmin.members.empty.staff.withSearch']()
-				: m['orgAdmin.members.empty.staff.noSearch']()}
-		</p>
-	</div>
+	<EmptyState
+		icon={UserCog}
+		title={m['orgAdmin.members.empty.staff.title']()}
+		body={staffSearch
+			? m['orgAdmin.members.empty.staff.withSearch']()
+			: m['orgAdmin.members.empty.staff.noSearch']()}
+	/>
 {:else}
 	<div class="grid gap-4 md:grid-cols-2">
 		{#each staff as staffMember (staffMember.user.email)}

--- a/src/lib/components/members/StatusBadge.svelte
+++ b/src/lib/components/members/StatusBadge.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { getStatusLabel, type SubscriptionStatus } from '$lib/utils/subscriptions';
+	import { getStatusLabel, getStatusTone, type SubscriptionStatus } from '$lib/utils/subscriptions';
 	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
-	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		status: SubscriptionStatus;
@@ -10,26 +9,11 @@
 
 	const { status, class: extraClass = '' }: Props = $props();
 
-	/**
-	 * Thin mapper over the shared `StatusBadge` primitive. `brand` is reserved
-	 * for emphasis, not for a suspended state, so `paused` takes `warning`
-	 * (needs attention) instead — it does not share `active`'s `success`, and
-	 * it stays visually louder than the two terminal states. `past_due` is a
-	 * harder problem than "pending payment" (it risks losing access), so it
-	 * escalates to `danger`. `cancelled` and `expired` collapse onto the same
-	 * `neutral` tone deliberately: both are terminal/over, and the label text
-	 * ("Cancelled" vs "Expired") — not the tone — carries the distinction.
-	 */
-	const TONE_MAP: Record<SubscriptionStatus, Tone> = {
-		active: 'success',
-		pending: 'info',
-		past_due: 'danger',
-		paused: 'warning',
-		cancelled: 'neutral',
-		expired: 'neutral'
-	};
-
-	const tone = $derived(TONE_MAP[status]);
+	// Tone mapping lives in `utils/subscription-status.ts::getStatusTone` — the
+	// single source this badge and `members/SubscriptionMetrics`'s chip strip
+	// both render from (see that function's doc for the per-status reasoning),
+	// so the two surfaces can't drift onto different tones for the same status.
+	const tone = $derived(getStatusTone(status));
 	const label = $derived(getStatusLabel(status));
 </script>
 

--- a/src/lib/components/members/SubscriptionDrawer.svelte
+++ b/src/lib/components/members/SubscriptionDrawer.svelte
@@ -343,7 +343,7 @@
 					     being squeezed to a sliver once the email does yield. -->
 					<div class="flex items-start justify-between gap-4">
 						<div class="min-w-0">
-							<div class="text-base font-semibold">{sub.user_display_name}</div>
+							<div class="text-base font-bold">{sub.user_display_name}</div>
 							<div class="break-all text-xs text-muted-foreground">{sub.user_email}</div>
 						</div>
 						<StatusBadge status={sub.status} class="shrink-0" />
@@ -457,7 +457,7 @@
 			{/if}
 
 			<div class="pt-2">
-				<h4 class="mb-2 text-sm font-semibold">
+				<h4 class="mb-2 text-sm font-bold">
 					{m['orgAdmin.members.subscriptions.drawer.payments']()}
 				</h4>
 				{#if paymentsQuery.isLoading}

--- a/src/lib/components/members/SubscriptionMetrics.svelte
+++ b/src/lib/components/members/SubscriptionMetrics.svelte
@@ -11,11 +11,12 @@
 	import { TriangleAlert } from '@lucide/svelte';
 	import { formatMoney, formatPercent } from '$lib/utils/format';
 	import {
-		getStatusConfig,
 		getStatusLabel,
+		getStatusTone,
 		STATUS_ORDER,
 		type SubscriptionStatus
 	} from '$lib/utils/subscriptions';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -60,6 +61,20 @@
 		className: string;
 	}
 
+	// Solid tone fills, same audited token pairs as `common/StatusBadge`'s
+	// `toneClasses` — duplicated rather than imported because the primitive
+	// doesn't export its class map, and this chip's shape (label + count in one
+	// pill) isn't the primitive's own. Every pair here is enforced >= 4.5:1 by
+	// scripts/audit-brand-themes.py in both modes.
+	const CHIP_TONE_CLASSES: Record<Tone, string> = {
+		brand: 'bg-primary text-primary-foreground',
+		info: 'bg-info text-info-foreground',
+		success: 'bg-success text-success-foreground',
+		warning: 'bg-highlight text-highlight-foreground',
+		danger: 'bg-destructive text-destructive-foreground',
+		neutral: 'bg-muted text-muted-foreground'
+	};
+
 	// Zero-count statuses are dropped, so a young org shows a short strip instead
 	// of six "0" chips — and an org with no subscriptions at all shows nothing.
 	const statusChips = $derived.by<StatusChip[]>(() => {
@@ -69,7 +84,7 @@
 			status,
 			label: getStatusLabel(status),
 			count: breakdown[status],
-			className: getStatusConfig(status).className
+			className: CHIP_TONE_CLASSES[getStatusTone(status)]
 		}));
 	});
 </script>
@@ -87,10 +102,11 @@
 						{m['orgAdmin.members.subscriptions.metrics.mrr']()}
 					</p>
 					{#if metrics.mixed_currency_warning}
-						<p
-							class="flex items-center gap-1 text-sm font-medium text-amber-700 dark:text-amber-300"
-						>
-							<TriangleAlert class="h-4 w-4 shrink-0" aria-hidden="true" />
+						<p class="flex items-center gap-1 text-sm font-medium text-foreground">
+							<TriangleAlert
+								class="h-4 w-4 shrink-0 text-highlight-foreground dark:text-highlight"
+								aria-hidden="true"
+							/>
 							{m['orgAdmin.members.subscriptions.metrics.mixedCurrency']()}
 						</p>
 					{:else}

--- a/src/lib/components/members/SubscriptionPaymentsTab.svelte
+++ b/src/lib/components/members/SubscriptionPaymentsTab.svelte
@@ -247,22 +247,34 @@
 				<caption class="sr-only">{m['orgAdmin.members.payments.tableCaption']()}</caption>
 				<thead class="border-b">
 					<tr>
-						<th scope="col" class="px-3 py-2 text-left"
+						<th
+							scope="col"
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>{m['orgAdmin.members.payments.col.member']()}</th
 						>
-						<th scope="col" class="px-3 py-2 text-left"
+						<th
+							scope="col"
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>{m['orgAdmin.members.payments.col.plan']()}</th
 						>
-						<th scope="col" class="px-3 py-2 text-left"
+						<th
+							scope="col"
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>{m['orgAdmin.members.payments.col.amount']()}</th
 						>
-						<th scope="col" class="px-3 py-2 text-left"
+						<th
+							scope="col"
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>{m['orgAdmin.members.payments.col.status']()}</th
 						>
-						<th scope="col" class="px-3 py-2 text-left"
+						<th
+							scope="col"
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>{m['orgAdmin.members.payments.col.date']()}</th
 						>
-						<th scope="col" class="px-3 py-2 text-right"
+						<th
+							scope="col"
+							class="px-3 py-2 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>{m['orgAdmin.members.payments.col.actions']()}</th
 						>
 					</tr>

--- a/src/lib/components/members/SubscriptionsTab.svelte
+++ b/src/lib/components/members/SubscriptionsTab.svelte
@@ -171,11 +171,24 @@
 			<table class="w-full text-sm">
 				<thead class="border-b">
 					<tr>
-						<th class="px-3 py-2 text-left">{m['orgAdmin.members.subscriptions.col.user']()}</th>
-						<th class="px-3 py-2 text-left">{m['orgAdmin.members.subscriptions.col.tier']()}</th>
-						<th class="px-3 py-2 text-left">{m['orgAdmin.members.subscriptions.col.plan']()}</th>
-						<th class="px-3 py-2 text-left">{m['orgAdmin.members.subscriptions.col.status']()}</th>
-						<th class="px-3 py-2 text-left"
+						<th
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+							>{m['orgAdmin.members.subscriptions.col.user']()}</th
+						>
+						<th
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+							>{m['orgAdmin.members.subscriptions.col.tier']()}</th
+						>
+						<th
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+							>{m['orgAdmin.members.subscriptions.col.plan']()}</th
+						>
+						<th
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+							>{m['orgAdmin.members.subscriptions.col.status']()}</th
+						>
+						<th
+							class="px-3 py-2 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>{m['orgAdmin.members.subscriptions.col.periodEnd']()}</th
 						>
 					</tr>

--- a/src/lib/components/members/TierFormModal.svelte
+++ b/src/lib/components/members/TierFormModal.svelte
@@ -196,7 +196,7 @@
 					id="tier-questionnaire"
 					bind:value={questionnaireId}
 					disabled={isSaving}
-					class="flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+					class="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 				>
 					<option value="">{m['tierForm.questionnaireInherit']()}</option>
 					{#each membershipQuestionnaires as oq (oq.id)}
@@ -213,7 +213,7 @@
 					id="tier-approval"
 					bind:value={approvalMode}
 					disabled={isSaving}
-					class="flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+					class="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 				>
 					<option value="inherit">
 						{orgDefaultRequiresApproval

--- a/src/lib/components/members/TiersTab.svelte
+++ b/src/lib/components/members/TiersTab.svelte
@@ -26,6 +26,7 @@
 	} from '$lib/components/members/TierFormModal.svelte';
 	import PlansList from '$lib/components/members/PlansList.svelte';
 	import { toast } from 'svelte-sonner';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		organization: OrganizationAdminDetailSchema;
@@ -319,13 +320,11 @@
 		<p class="text-sm text-destructive">{m['orgAdmin.members.errors.loadTiers']()}</p>
 	</div>
 {:else if tiers.length === 0}
-	<div class="rounded-lg border border-dashed p-12 text-center">
-		<Shield class="mx-auto h-12 w-12 text-muted-foreground" />
-		<h3 class="mt-4 font-semibold">{m['orgAdmin.members.empty.tiers.title']()}</h3>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{m['orgAdmin.members.empty.tiers.description']()}
-		</p>
-	</div>
+	<EmptyState
+		icon={Shield}
+		title={m['orgAdmin.members.empty.tiers.title']()}
+		body={m['orgAdmin.members.empty.tiers.description']()}
+	/>
 {:else}
 	<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 		{#each tiers as tier, index (tier.id)}
@@ -333,7 +332,7 @@
 			<div class="rounded-lg border border-border bg-card p-4 shadow-sm">
 				<div class="flex items-start justify-between gap-2">
 					<div class="min-w-0 flex-1">
-						<h3 class="truncate font-semibold text-foreground">
+						<h3 class="truncate font-bold text-foreground">
 							{tier.name}
 						</h3>
 						{#if tier.description}
@@ -442,7 +441,7 @@
 						</svg>
 					</div>
 					<div class="flex-1 space-y-2">
-						<p class="text-sm font-medium text-destructive">
+						<p class="text-sm font-medium text-foreground">
 							{m['tierDelete.confirmMessage']({ name: tierToDelete.name })}
 						</p>
 						<p class="text-sm text-muted-foreground">

--- a/src/lib/components/polls/PollStatusBadge.svelte
+++ b/src/lib/components/polls/PollStatusBadge.svelte
@@ -27,4 +27,10 @@
 	);
 </script>
 
-<StatusBadge {tone} {label} size="sm" />
+<!--
+	`aria-label` is explicit: `common/StatusBadge` does not default one from its
+	content, and every poll surface (admin list/detail cards) locates this pill
+	by its status text — closing the same contract hole the other 11 mappers in
+	this program already guard against (see `members/StatusBadge.test.ts`).
+-->
+<StatusBadge {tone} {label} size="sm" aria-label={label} />

--- a/src/lib/components/polls/PollStatusBadge.test.ts
+++ b/src/lib/components/polls/PollStatusBadge.test.ts
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import type { PollStatus } from '$lib/api/generated/types.gen';
+import PollStatusBadge from './PollStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD, same shape as `members/StatusBadge.test.ts`: this pill's
+ * accessible NAME is a cross-surface contract (admin poll list/detail cards
+ * locate it by its status text), not decoration. `PollStatusBadge` shipped in
+ * an earlier wave as a `common/StatusBadge` mapper WITHOUT an `aria-label` —
+ * the primitive does not default one from its content — so this guards every
+ * status, not just a sample, against that name being silently absent.
+ */
+const STATUS_ORDER: PollStatus[] = ['draft', 'open', 'closed'];
+
+const LABELS: Record<PollStatus, string> = {
+	draft: 'Draft',
+	open: 'Open',
+	closed: 'Closed'
+};
+
+const EXPECTED_TONE_CLASS: Record<PollStatus, string> = {
+	draft: 'bg-highlight',
+	open: 'bg-success',
+	closed: 'bg-muted'
+};
+
+describe('polls/PollStatusBadge', () => {
+	it.each(STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+		render(PollStatusBadge, { props: { status } });
+		const label = LABELS[status];
+		expect(screen.getByLabelText(label)).toBeInTheDocument();
+		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+	});
+
+	it.each(STATUS_ORDER)('maps %s to its tone class', (status) => {
+		const { container } = render(PollStatusBadge, { props: { status } });
+		expect(container.querySelector('span')?.className).toContain(EXPECTED_TONE_CLASS[status]);
+	});
+});

--- a/src/lib/components/questionnaires/AudioRecorder.svelte
+++ b/src/lib/components/questionnaires/AudioRecorder.svelte
@@ -254,8 +254,8 @@
 				<div class="flex items-center gap-3">
 					<!-- Pulsing recording indicator -->
 					<div class="relative flex h-4 w-4 items-center justify-center">
-						<div class="absolute h-4 w-4 animate-ping rounded-full bg-red-500 opacity-75"></div>
-						<div class="relative h-3 w-3 rounded-full bg-red-500"></div>
+						<div class="absolute h-4 w-4 animate-ping rounded-full bg-destructive opacity-75"></div>
+						<div class="relative h-3 w-3 rounded-full bg-destructive"></div>
 					</div>
 
 					<!-- Timer -->
@@ -277,7 +277,7 @@
 				<Button
 					variant="default"
 					size="sm"
-					class="flex-1 gap-2 bg-red-600 hover:bg-red-700"
+					class="flex-1 gap-2 bg-destructive text-destructive-foreground hover:bg-destructive/90"
 					onclick={stopRecording}
 				>
 					<Square class="h-4 w-4" />

--- a/src/lib/components/questionnaires/AutoEvalRecommendation.svelte
+++ b/src/lib/components/questionnaires/AutoEvalRecommendation.svelte
@@ -21,15 +21,27 @@
 			evaluation.evaluator_id === null // Auto-eval has no evaluator
 	);
 
+	// Tone→class quads (rebrand): replaces hand-picked yellow/green/red
+	// bg+border+icon combos with token equivalents. The card-level `bgClass` is
+	// a flat, mode-invariant /10 tint (only default `text-foreground` heading/
+	// description sit on it, so no AA concern). The icon chip gets its own
+	// `iconBgClass`/`iconClass` pair copied verbatim from `ToneTile`'s audited
+	// tone table (`common/ToneTile.svelte`): `warning` has no `--warning` token,
+	// so it reuses `bg-highlight/20` + `text-highlight-foreground
+	// dark:text-highlight`; `danger`'s dark mode flips to a stronger /25 tint
+	// with `text-destructive-foreground` because plain `text-destructive` on a
+	// /10 tint measures 2.95:1 in dark mode (under the AA floor — see
+	// ToneTile's own ratio comment). `success` passes AA as direct icon color.
 	const statusConfig = $derived.by(() => {
 		if (!evaluation || (evaluation.status as QuestionnaireEvaluationStatus) === 'pending review') {
 			return {
 				icon: AlertCircle,
 				label: 'Awaiting Review',
 				description: 'This submission has not been evaluated yet.',
-				bgClass: 'bg-yellow-50 dark:bg-yellow-950/20',
-				borderClass: 'border-yellow-200 dark:border-yellow-800',
-				iconClass: 'text-yellow-700 dark:text-yellow-400'
+				bgClass: 'bg-highlight/10',
+				borderClass: 'border-highlight',
+				iconBgClass: 'bg-highlight/20',
+				iconClass: 'text-highlight-foreground dark:text-highlight'
 			};
 		}
 
@@ -38,9 +50,10 @@
 				icon: CheckCircle,
 				label: 'Recommended: Approve',
 				description: evaluation.comments || 'This submission meets the requirements.',
-				bgClass: 'bg-green-50 dark:bg-green-950/20',
-				borderClass: 'border-green-200 dark:border-green-800',
-				iconClass: 'text-green-700 dark:text-green-400'
+				bgClass: 'bg-success/10',
+				borderClass: 'border-success/50',
+				iconBgClass: 'bg-success/10',
+				iconClass: 'text-success'
 			};
 		}
 
@@ -48,9 +61,10 @@
 			icon: XCircle,
 			label: 'Recommended: Reject',
 			description: evaluation.comments || 'This submission does not meet the requirements.',
-			bgClass: 'bg-red-50 dark:bg-red-950/20',
-			borderClass: 'border-red-200 dark:border-red-800',
-			iconClass: 'text-red-700 dark:text-red-400'
+			bgClass: 'bg-destructive/10',
+			borderClass: 'border-destructive/50',
+			iconBgClass: 'bg-destructive/10 dark:bg-destructive/25',
+			iconClass: 'text-destructive dark:text-destructive-foreground'
 		};
 	});
 
@@ -78,7 +92,7 @@
 			<div
 				class={cn(
 					'flex h-12 w-12 shrink-0 items-center justify-center rounded-full',
-					statusConfig.bgClass
+					statusConfig.iconBgClass
 				)}
 			>
 				<IconComponent class={cn('h-6 w-6', statusConfig.iconClass)} aria-hidden="true" />
@@ -87,14 +101,14 @@
 			<!-- Content -->
 			<div class="flex-1 space-y-3">
 				<div class="flex items-center gap-2">
-					<Sparkles class="h-4 w-4 text-purple-500" aria-hidden="true" />
+					<Sparkles class="h-4 w-4 text-primary" aria-hidden="true" />
 					<Badge variant="outline" class="text-xs"
 						>{m['autoEvalRecommendation.aiRecommendation']()}</Badge
 					>
 				</div>
 
 				<div>
-					<h3 class="text-lg font-semibold">{statusConfig.label}</h3>
+					<h3 class="text-lg font-bold">{statusConfig.label}</h3>
 					<p class="mt-2 text-sm text-muted-foreground">{statusConfig.description}</p>
 				</div>
 
@@ -126,7 +140,7 @@
 
 			<div class="flex-1 space-y-3">
 				<div>
-					<h3 class="text-lg font-semibold">{m['autoEvalRecommendation.alreadyEvaluated']()}</h3>
+					<h3 class="text-lg font-bold">{m['autoEvalRecommendation.alreadyEvaluated']()}</h3>
 					<p class="mt-1 text-sm text-muted-foreground">
 						{#if evaluation.created_at}
 							{m['autoEvalRecommendation.evaluatedManuallyOn']({

--- a/src/lib/components/questionnaires/EvaluationForm.svelte
+++ b/src/lib/components/questionnaires/EvaluationForm.svelte
@@ -50,7 +50,7 @@
 	<input type="hidden" name="return_query" value={returnQuery} />
 
 	<Card class="p-6">
-		<h3 class="mb-4 text-lg font-semibold">{m['evaluationForm.yourEvaluation']()}</h3>
+		<h3 class="mb-4 text-lg font-bold">{m['evaluationForm.yourEvaluation']()}</h3>
 
 		<!-- Quick Actions -->
 		<div class="mb-6 grid gap-4 md:grid-cols-3">

--- a/src/lib/components/questionnaires/FileUploadQuestion.svelte
+++ b/src/lib/components/questionnaires/FileUploadQuestion.svelte
@@ -387,18 +387,18 @@
 				aria-label={m['fileUploadQuestion.uploadFile']()}
 				class={cn(
 					'flex flex-1 cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-4 transition-all',
-					'hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-800/50',
+					'hover:border-primary hover:bg-muted/50',
 					'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
 					isDragging && 'border-primary bg-primary/5',
-					error ? 'border-destructive' : 'border-gray-300 dark:border-gray-600',
-					disabled && 'cursor-not-allowed opacity-50 hover:border-gray-300 hover:bg-transparent'
+					error ? 'border-destructive' : 'border-input',
+					disabled && 'cursor-not-allowed opacity-50 hover:border-input hover:bg-transparent'
 				)}
 			>
 				<Upload
 					class={cn('mb-1 h-6 w-6', isDragging ? 'text-primary' : 'text-muted-foreground')}
 					aria-hidden="true"
 				/>
-				<p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+				<p class="text-sm font-medium text-foreground">
 					{#if isDragging}
 						{m['fileUploadQuestion.dropFilesHere']()}
 					{:else}

--- a/src/lib/components/questionnaires/QuestionTypeBadge.svelte
+++ b/src/lib/components/questionnaires/QuestionTypeBadge.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
+
+	type QuestionType = 'multiple_choice' | 'free_text' | 'file_upload';
+
+	interface Props {
+		type: QuestionType;
+		/**
+		 * Already-translated label — i18n stays at the call site. Existing call
+		 * sites use different strings for the same type (full names in the
+		 * top-level question list vs "MC"/"FT" abbreviations in nested previews),
+		 * so this mapper stays label-agnostic rather than owning the copy.
+		 */
+		label: string;
+		size?: 'sm' | 'md' | 'lg';
+		class?: string;
+	}
+	const { type, label, size = 'sm', class: className }: Props = $props();
+
+	/**
+	 * Question-type→tone mapper (rebrand): replaces hand-picked
+	 * blue-100/purple-100/green-100 pills (`QuestionnaireReadOnlyView`, the
+	 * closed-poll admin question list) with the shared `StatusBadge` token set.
+	 * Not a lifecycle status — a fixed type tag — but the same thin-mapper shape
+	 * applies. `info` (multiple choice), `brand` (free text), `success` (file
+	 * upload) keep each type visually distinct without a raw hue.
+	 */
+	const TONE_MAP: Record<QuestionType, Tone> = {
+		multiple_choice: 'info',
+		free_text: 'brand',
+		file_upload: 'success'
+	};
+	const tone = $derived(TONE_MAP[type]);
+</script>
+
+<StatusBadge {tone} {label} {size} class={className} aria-label={label} />

--- a/src/lib/components/questionnaires/QuestionTypeBadge.test.ts
+++ b/src/lib/components/questionnaires/QuestionTypeBadge.test.ts
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import QuestionTypeBadge from './QuestionTypeBadge.svelte';
+
+type QuestionType = 'multiple_choice' | 'free_text' | 'file_upload';
+
+/**
+ * REGRESSION GUARD, same shape as the other rebrand `StatusBadge` mappers:
+ * this pill's accessible NAME is not decoration, and `common/StatusBadge`
+ * does not default an `aria-label` from its text content. This guards every
+ * question type, not just a sample, against that name silently vanishing.
+ */
+const TYPE_ORDER: QuestionType[] = ['multiple_choice', 'free_text', 'file_upload'];
+const LABELS: Record<QuestionType, string> = {
+	multiple_choice: 'Multiple Choice',
+	free_text: 'Free Text',
+	file_upload: 'File Upload'
+};
+const EXPECTED_TONE_CLASS: Record<QuestionType, string> = {
+	multiple_choice: 'bg-info',
+	free_text: 'bg-primary',
+	file_upload: 'bg-success'
+};
+
+describe('questionnaires/QuestionTypeBadge', () => {
+	it.each(TYPE_ORDER)('exposes the %s label as the pill accessible name', (type) => {
+		const label = LABELS[type];
+		render(QuestionTypeBadge, { props: { type, label } });
+		expect(screen.getByLabelText(label)).toBeInTheDocument();
+		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+	});
+
+	it.each(TYPE_ORDER)('maps %s to its tone class', (type) => {
+		const { container } = render(QuestionTypeBadge, { props: { type, label: LABELS[type] } });
+		expect(container.querySelector('span')?.className).toContain(EXPECTED_TONE_CLASS[type]);
+	});
+
+	it('keeps the caller class alongside the tone classes', () => {
+		const { container } = render(QuestionTypeBadge, {
+			props: { type: 'multiple_choice', label: 'MC', class: 'shrink-0' }
+		});
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('shrink-0');
+	});
+});

--- a/src/lib/components/questionnaires/QuestionnaireAssignmentModal.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireAssignmentModal.svelte
@@ -362,9 +362,9 @@
 			<!-- Series Tab -->
 			<TabsContent value="series">
 				<!-- Info banner -->
-				<div class="mx-6 mt-4 flex gap-2 rounded-md bg-blue-50 p-3 text-sm dark:bg-blue-950">
-					<Info class="h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" aria-hidden="true" />
-					<p class="text-blue-900 dark:text-blue-100">
+				<div class="mx-6 mt-4 flex gap-2 rounded-md border border-info/30 bg-info/10 p-3 text-sm">
+					<Info class="h-4 w-4 shrink-0 text-info" aria-hidden="true" />
+					<p class="text-info">
 						{m['questionnaireAssignmentModal.assigningToSeries']()}
 						<strong>{m['questionnaireAssignmentModal.allEvents']()}</strong> in that series.
 					</p>

--- a/src/lib/components/questionnaires/QuestionnaireCard.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireCard.svelte
@@ -32,6 +32,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import QuestionnaireAssignmentModal from './QuestionnaireAssignmentModal.svelte';
 	import DuplicateQuestionnaireModal from './DuplicateQuestionnaireModal.svelte';
+	import QuestionnaireStatusBadge from './QuestionnaireStatusBadge.svelte';
 	import {
 		Tooltip,
 		TooltipContent,
@@ -112,15 +113,6 @@
 	const statusLabel = $derived(
 		statusLabels[questionnaire.questionnaire.status]?.() || questionnaire.questionnaire.status
 	);
-
-	// Get status badge variant
-	const statusVariants: Record<string, 'default' | 'secondary' | 'outline' | 'destructive'> = {
-		draft: 'outline',
-		ready: 'secondary',
-		published: 'default'
-	};
-
-	const statusVariant = $derived(statusVariants[questionnaire.questionnaire.status] || 'outline');
 
 	// Event assignment count (events + series)
 	const assignmentCount = $derived(
@@ -220,15 +212,10 @@
 					<Badge variant={typeVariant} class="text-xs">
 						{typeLabel}
 					</Badge>
-					{#if questionnaire.questionnaire.status === 'draft'}
-						<Badge class="bg-amber-500 text-xs text-white hover:bg-amber-600">
-							{statusLabel}
-						</Badge>
-					{:else}
-						<Badge variant={statusVariant} class="text-xs">
-							{statusLabel}
-						</Badge>
-					{/if}
+					<QuestionnaireStatusBadge
+						status={questionnaire.questionnaire.status}
+						label={statusLabel}
+					/>
 				</CardDescription>
 			</div>
 			<FileText class="h-5 w-5 flex-shrink-0 text-muted-foreground" aria-hidden="true" />
@@ -239,10 +226,13 @@
 			<!-- Pending Evaluations Alert -->
 			{#if questionnaire.pending_evaluations_count && questionnaire.pending_evaluations_count > 0}
 				<div
-					class="flex items-center gap-2 rounded-md border border-orange-500/50 bg-orange-50 px-3 py-2 text-sm text-orange-900 dark:border-orange-500/30 dark:bg-orange-950/20 dark:text-orange-200"
+					class="flex items-center gap-2 rounded-md border border-highlight bg-highlight/10 px-3 py-2 text-sm text-foreground"
 					role="status"
 				>
-					<AlertCircle class="h-4 w-4 shrink-0" aria-hidden="true" />
+					<AlertCircle
+						class="h-4 w-4 shrink-0 text-highlight-foreground dark:text-highlight"
+						aria-hidden="true"
+					/>
 					<p class="font-medium">
 						{questionnaire.pending_evaluations_count}
 						{questionnaire.pending_evaluations_count === 1

--- a/src/lib/components/questionnaires/QuestionnaireCreateAdvancedSettings.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireCreateAdvancedSettings.svelte
@@ -57,7 +57,7 @@
 					id="shuffle-questions"
 					type="checkbox"
 					bind:checked={shuffleQuestions}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 				/>
 				<Label for="shuffle-questions" class="font-normal"
 					>{m['questionnaireNewPage.shuffleQuestionsLabel']()}</Label
@@ -68,7 +68,7 @@
 					id="shuffle-sections"
 					type="checkbox"
 					bind:checked={shuffleSections}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 				/>
 				<Label for="shuffle-sections" class="font-normal"
 					>{m['questionnaireNewPage.shuffleSectionsLabel']()}</Label
@@ -83,7 +83,7 @@
 					id="members-exempt"
 					type="checkbox"
 					bind:checked={membersExempt}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 				/>
 				<Label for="members-exempt" class="font-normal"
 					>{m['questionnaireNewPage.membersExemptLabel']()}</Label
@@ -102,7 +102,7 @@
 						id="per-event"
 						type="checkbox"
 						bind:checked={perEvent}
-						class="h-4 w-4 rounded border-gray-300"
+						class="h-4 w-4 rounded border-input"
 					/>
 					<Label for="per-event" class="font-normal"
 						>{m['questionnaireNewPage.perEventLabel']()}</Label

--- a/src/lib/components/questionnaires/QuestionnaireCreateBasicInfo.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireCreateBasicInfo.svelte
@@ -194,7 +194,7 @@
 					id="requires-evaluation"
 					type="checkbox"
 					bind:checked={requiresEvaluation}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 					disabled={questionnaireType === 'feedback'}
 				/>
 				<Label for="requires-evaluation" class="font-normal"

--- a/src/lib/components/questionnaires/QuestionnaireFillForm.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireFillForm.svelte
@@ -280,6 +280,36 @@
 	function isOptionSelected(questionId: string, optionId: string): boolean {
 		return multipleChoiceAnswers.get(questionId)?.includes(optionId) || false;
 	}
+
+	/**
+	 * The landing's QuestionnaireMock look, on theme tokens: rounded option rows
+	 * with a purple selected state. Mirrors `polls/PollVoteForm`'s
+	 * `optionRowClass` exactly — this is the mock-alignment ledger handoff from
+	 * the public-discovery PR, which built the poll side of this pattern and
+	 * left the questionnaire side (this component, shared by both PUBLIC
+	 * questionnaire routes) for the owning cluster.
+	 *
+	 * The row IS the `<label>`, so the whole padded box is the hit target the
+	 * hover state promises — a padded row that highlights on hover but only
+	 * activates on its 16px control is a lie, and a 44px-tall row is the mobile
+	 * target we want anyway. Purely markup: the native label/control
+	 * association (unchanged `for`/`id`) still drives selection, so keyboard,
+	 * screen-reader, and `getByRole('radio'|'checkbox', { name })` behaviour
+	 * are untouched.
+	 *
+	 * The selected fill is `bg-primary/10`, which composites to ~the card
+	 * colour, so the label keeps `text-foreground` and the token contract's AA
+	 * guarantee; the 2px `border-primary` is >= 3:1 non-text against the card
+	 * in both modes (5.9 light / 5.3 dark, the same measurement as ToneTile's
+	 * brand row). Selection is never carried by the fill alone — the
+	 * radio/checkbox state is.
+	 */
+	function optionRowClass(selected: boolean): string {
+		return cn(
+			'flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border-2 px-3 py-2 transition-colors',
+			selected ? 'border-primary bg-primary/10' : 'border-border hover:border-primary/40'
+		);
+	}
 </script>
 
 <!-- Form -->
@@ -289,7 +319,7 @@
 		.filter((s) => !s.depends_on_option_id)
 		.sort((a, b) => a.order - b.order) as section (section.id)}
 		<div class="rounded-lg border bg-card p-6">
-			<h2 class="mb-2 text-xl font-semibold">{section.name}</h2>
+			<h2 class="mb-2 text-xl font-extrabold">{section.name}</h2>
 			{#if section.description}
 				<div class="mb-6">
 					<MarkdownContent content={section.description} class="text-muted-foreground" />
@@ -404,23 +434,29 @@
 
 		{#if useCheckboxes}
 			<!-- Checkboxes: for multiple answers OR single option (single option = yes/no choice) -->
-			<div class="space-y-2">
+			<div
+				class="space-y-2"
+				role="group"
+				aria-describedby={validationErrors.has(question.id) ? `${question.id}-error` : undefined}
+			>
 				{#each question.options || [] as option (option.id)}
 					<div class="space-y-2">
-						<div class="flex items-center space-x-2">
+						<label
+							for="{question.id}-{option.id}"
+							class={optionRowClass(isOptionSelected(question.id, option.id))}
+						>
 							<Checkbox
 								id="{question.id}-{option.id}"
 								checked={isOptionSelected(question.id, option.id)}
 								onCheckedChange={(checked) =>
 									handleMultipleChoiceChange(question.id, option.id, !!checked, true)}
 							/>
-							<label
-								for="{question.id}-{option.id}"
-								class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+							<span
+								class="flex-1 text-sm font-bold leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 							>
 								{option.option}
-							</label>
-						</div>
+							</span>
+						</label>
 						<!-- Conditional questions/sections for this option -->
 						{@render conditionalContent(option.id, question.id)}
 					</div>
@@ -432,13 +468,18 @@
 				value={multipleChoiceAnswers.get(question.id)?.[0] || ''}
 				onValueChange={(value: string) =>
 					handleMultipleChoiceChange(question.id, value, true, false)}
+				aria-invalid={validationErrors.has(question.id) ? true : undefined}
+				aria-describedby={validationErrors.has(question.id) ? `${question.id}-error` : undefined}
 			>
 				{#each question.options || [] as option (option.id)}
 					<div class="space-y-2">
-						<div class="flex items-center space-x-2">
+						<Label
+							for="{question.id}-{option.id}"
+							class={optionRowClass(isOptionSelected(question.id, option.id))}
+						>
 							<RadioGroupItem value={option.id} id="{question.id}-{option.id}" />
-							<Label for="{question.id}-{option.id}">{option.option}</Label>
-						</div>
+							<span class="flex-1">{option.option}</span>
+						</Label>
 						<!-- Conditional questions/sections for this option -->
 						{@render conditionalContent(option.id, question.id)}
 					</div>
@@ -447,7 +488,9 @@
 		{/if}
 
 		{#if validationErrors.has(question.id)}
-			<p class="text-sm text-destructive">{validationErrors.get(question.id)}</p>
+			<p id="{question.id}-error" class="text-sm text-destructive">
+				{validationErrors.get(question.id)}
+			</p>
 		{/if}
 	</div>
 {/snippet}
@@ -507,21 +550,32 @@
 			</div>
 		</div>
 
-		<!-- AI Evaluation Warning -->
+		<!-- AI Evaluation Warning. Both branches share the same `warning` tone
+		     (there is no `--warning` token — `border-highlight bg-highlight/10`
+		     is the audited pair); the copy, not the tint, distinguishes automatic
+		     from hybrid. Heading/lead text stays `text-foreground` per the dark
+		     `--destructive`-style trap for `--highlight` too — only the icon
+		     carries the tone. -->
 		{#if questionnaire.evaluation_mode === 'automatic'}
 			<div
-				class="flex items-start gap-2 rounded-md border border-orange-500/50 bg-orange-50 p-3 text-sm text-orange-900 dark:border-orange-500/30 dark:bg-orange-950/20 dark:text-orange-200"
+				class="flex items-start gap-2 rounded-md border border-highlight bg-highlight/10 p-3 text-sm text-foreground"
 				role="status"
 			>
-				<AlertCircle class="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+				<AlertCircle
+					class="mt-0.5 h-4 w-4 shrink-0 text-highlight-foreground dark:text-highlight"
+					aria-hidden="true"
+				/>
 				<p>{m['questionnaireSubmissionPage.aiWarning_automatic']()}</p>
 			</div>
 		{:else if questionnaire.evaluation_mode === 'hybrid'}
 			<div
-				class="flex items-start gap-2 rounded-md border border-yellow-500/50 bg-yellow-50 p-3 text-sm text-yellow-900 dark:border-yellow-500/30 dark:bg-yellow-950/20 dark:text-yellow-200"
+				class="flex items-start gap-2 rounded-md border border-highlight bg-highlight/10 p-3 text-sm text-foreground"
 				role="status"
 			>
-				<AlertCircle class="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+				<AlertCircle
+					class="mt-0.5 h-4 w-4 shrink-0 text-highlight-foreground dark:text-highlight"
+					aria-hidden="true"
+				/>
 				<p>{m['questionnaireSubmissionPage.aiWarning_hybrid']()}</p>
 			</div>
 		{/if}
@@ -564,7 +618,7 @@
 			<!-- Conditional sections for this option -->
 			{#each getSectionsForOption(flattened, optionId).sort((a, b) => a.order - b.order) as conditionalSection (conditionalSection.id)}
 				<div class="ml-4 rounded-lg border border-primary/20 bg-primary/5 p-4">
-					<h3 class="mb-2 text-lg font-semibold">{conditionalSection.name}</h3>
+					<h3 class="mb-2 text-lg font-extrabold">{conditionalSection.name}</h3>
 					{#if conditionalSection.description}
 						<div class="mb-4">
 							<MarkdownContent

--- a/src/lib/components/questionnaires/QuestionnaireFillForm.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireFillForm.svelte
@@ -300,9 +300,8 @@
 	 * The selected fill is `bg-primary/10`, which composites to ~the card
 	 * colour, so the label keeps `text-foreground` and the token contract's AA
 	 * guarantee; the 2px `border-primary` is >= 3:1 non-text against the card
-	 * in both modes (5.9 light / 5.3 dark, the same measurement as ToneTile's
-	 * brand row). Selection is never carried by the fill alone — the
-	 * radio/checkbox state is.
+	 * in both modes (6.99 light / 6.27 dark, hand-verified against `--card`).
+	 * Selection is never carried by the fill alone — the radio/checkbox state is.
 	 */
 	function optionRowClass(selected: boolean): string {
 		return cn(

--- a/src/lib/components/questionnaires/QuestionnaireFormFields.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireFormFields.svelte
@@ -238,7 +238,7 @@
 					type="checkbox"
 					checked={requiresEvaluation}
 					onchange={(e) => onRequiresEvaluationChange(e.currentTarget.checked)}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 					disabled={!canEdit || questionnaireType === 'feedback'}
 				/>
 				<Label for="requires-evaluation" class="font-normal"
@@ -370,7 +370,7 @@
 					type="checkbox"
 					checked={shuffleQuestions}
 					onchange={(e) => onShuffleQuestionsChange(e.currentTarget.checked)}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 					disabled={!canEdit}
 				/>
 				<Label for="shuffle-questions" class="font-normal"
@@ -383,7 +383,7 @@
 					type="checkbox"
 					checked={shuffleSections}
 					onchange={(e) => onShuffleSectionsChange(e.currentTarget.checked)}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 					disabled={!canEdit}
 				/>
 				<Label for="shuffle-sections" class="font-normal"
@@ -400,7 +400,7 @@
 					type="checkbox"
 					checked={membersExempt}
 					onchange={(e) => onMembersExemptChange(e.currentTarget.checked)}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 					disabled={!canEdit}
 				/>
 				<Label for="members-exempt" class="font-normal"
@@ -421,7 +421,7 @@
 						type="checkbox"
 						checked={perEvent}
 						onchange={(e) => onPerEventChange(e.currentTarget.checked)}
-						class="h-4 w-4 rounded border-gray-300"
+						class="h-4 w-4 rounded border-input"
 						disabled={!canEdit}
 					/>
 					<Label for="per-event" class="font-normal"

--- a/src/lib/components/questionnaires/QuestionnaireReadOnlyView.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireReadOnlyView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import QuestionTypeBadge from './QuestionTypeBadge.svelte';
 	import type {
 		QuestionnaireQuestion as Question,
 		QuestionnaireSection as Section
@@ -22,7 +23,7 @@
 		<div class="mt-2 space-y-1">
 			{#each question.options as option (option.id)}
 				<div class="flex items-center gap-2 text-sm">
-					<span class={option.isCorrect ? 'font-medium text-green-600' : 'text-muted-foreground'}>
+					<span class={option.isCorrect ? 'font-medium text-success' : 'text-muted-foreground'}>
 						{option.isCorrect ? '\u2713' : '\u25CB'}
 					</span>
 					<span class={option.isCorrect ? 'font-medium' : ''}>{option.text}</span>
@@ -36,13 +37,10 @@
 						{#each option.conditionalQuestions as condQ (condQ.id)}
 							<div class="rounded border bg-muted/50 p-3">
 								<div class="mb-1 flex items-center gap-2">
-									<span
-										class="rounded px-2 py-0.5 text-xs font-medium {condQ.type === 'multiple_choice'
-											? 'bg-blue-100 text-blue-700'
-											: 'bg-purple-100 text-purple-700'}"
-									>
-										{condQ.type === 'multiple_choice' ? 'MC' : 'FT'}
-									</span>
+									<QuestionTypeBadge
+										type={condQ.type === 'multiple_choice' ? 'multiple_choice' : 'free_text'}
+										label={condQ.type === 'multiple_choice' ? 'MC' : 'FT'}
+									/>
 									{#if condQ.required}
 										<span class="text-xs text-destructive"
 											>{m['questionnaireReadOnlyView.required']()}</span
@@ -66,12 +64,12 @@
 				{/if}
 				<!-- Display conditional sections for this option -->
 				{#if option.conditionalSections && option.conditionalSections.length > 0}
-					<div class="ml-6 mt-2 space-y-2 border-l-2 border-green-500/30 pl-4">
+					<div class="ml-6 mt-2 space-y-2 border-l-2 border-primary/30 pl-4">
 						<p class="text-xs font-medium text-muted-foreground">
 							&#8627; {m['questionnaireReadOnlyView.ifSelectedShowSection']()}
 						</p>
 						{#each option.conditionalSections as condSection (condSection.id)}
-							<div class="rounded border border-green-500/50 bg-green-50/50 p-3">
+							<div class="rounded border border-primary/20 bg-primary/5 p-3">
 								<p class="mb-2 text-sm font-medium">{condSection.name}</p>
 								{#if condSection.description}
 									<p class="mb-2 text-xs text-muted-foreground">
@@ -81,14 +79,10 @@
 								{#each condSection.questions as condQ (condQ.id)}
 									<div class="mt-2 rounded border bg-background p-2">
 										<div class="mb-1 flex items-center gap-2">
-											<span
-												class="rounded px-2 py-0.5 text-xs font-medium {condQ.type ===
-												'multiple_choice'
-													? 'bg-blue-100 text-blue-700'
-													: 'bg-purple-100 text-purple-700'}"
-											>
-												{condQ.type === 'multiple_choice' ? 'MC' : 'FT'}
-											</span>
+											<QuestionTypeBadge
+												type={condQ.type === 'multiple_choice' ? 'multiple_choice' : 'free_text'}
+												label={condQ.type === 'multiple_choice' ? 'MC' : 'FT'}
+											/>
 										</div>
 										<p class="text-sm">{condQ.text}</p>
 									</div>
@@ -104,19 +98,14 @@
 
 {#snippet questionBadge(question: Question)}
 	<div class="mb-2 flex items-center gap-2">
-		<span
-			class="rounded px-2 py-1 text-xs font-medium {question.type === 'multiple_choice'
-				? 'bg-blue-100 text-blue-700'
-				: question.type === 'file_upload'
-					? 'bg-green-100 text-green-700'
-					: 'bg-purple-100 text-purple-700'}"
-		>
-			{question.type === 'multiple_choice'
+		<QuestionTypeBadge
+			type={question.type}
+			label={question.type === 'multiple_choice'
 				? 'Multiple Choice'
 				: question.type === 'file_upload'
 					? 'File Upload'
 					: 'Free Text'}
-		</span>
+		/>
 		{#if question.required}
 			<span class="text-xs text-destructive">{m['questionnaireReadOnlyView.required']()}</span>
 		{/if}

--- a/src/lib/components/questionnaires/QuestionnaireStatusBadge.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireStatusBadge.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
+	import type { QuestionnaireStatus } from '$lib/api/generated/types.gen';
+
+	interface Props {
+		status: QuestionnaireStatus;
+		/**
+		 * Already-translated label — i18n stays at the call site. `QuestionnaireCard`
+		 * and `QuestionnaireStatusBar` each carry their own pre-existing i18n keys
+		 * for the same three states (different namespaces, same English text), so
+		 * this mapper stays label-agnostic rather than picking one and silently
+		 * changing the other caller's translated string.
+		 */
+		label: string;
+		size?: 'sm' | 'md' | 'lg';
+		class?: string;
+	}
+	const { status, label, size = 'sm', class: className }: Props = $props();
+
+	/**
+	 * Domain→tone mapper (rebrand): replaces two independent hand-picked
+	 * amber/blue `Badge` implementations (`QuestionnaireCard`, `QuestionnaireStatusBar`)
+	 * with one shared, audited `StatusBadge` token mapping. `published` earns
+	 * `success` (live), `ready` is `info` (staged, awaiting publish), `draft` is
+	 * `warning` (not yet usable).
+	 */
+	const TONE_MAP: Record<QuestionnaireStatus, Tone> = {
+		draft: 'warning',
+		ready: 'info',
+		published: 'success'
+	};
+	const tone = $derived(TONE_MAP[status]);
+</script>
+
+<StatusBadge {tone} {label} {size} class={className} aria-label={label} />

--- a/src/lib/components/questionnaires/QuestionnaireStatusBadge.test.ts
+++ b/src/lib/components/questionnaires/QuestionnaireStatusBadge.test.ts
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import type { QuestionnaireStatus } from '$lib/api/generated/types.gen';
+import QuestionnaireStatusBadge from './QuestionnaireStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD, same shape as `members/StatusBadge.test.ts` and
+ * `polls/PollStatusBadge`'s sibling `SubmissionStatusBadge.test.ts`: this
+ * pill's accessible NAME is not decoration, and `common/StatusBadge` does not
+ * default an `aria-label` from its text content. This guards every status,
+ * not just a sample, against that name silently vanishing.
+ */
+const STATUS_ORDER: QuestionnaireStatus[] = ['draft', 'ready', 'published'];
+const LABELS: Record<QuestionnaireStatus, string> = {
+	draft: 'Draft',
+	ready: 'Ready',
+	published: 'Published'
+};
+const EXPECTED_TONE_CLASS: Record<QuestionnaireStatus, string> = {
+	draft: 'bg-highlight',
+	ready: 'bg-info',
+	published: 'bg-success'
+};
+
+describe('questionnaires/QuestionnaireStatusBadge', () => {
+	it.each(STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+		const label = LABELS[status];
+		render(QuestionnaireStatusBadge, { props: { status, label } });
+		expect(screen.getByLabelText(label)).toBeInTheDocument();
+		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+	});
+
+	it.each(STATUS_ORDER)('maps %s to its tone class', (status) => {
+		const { container } = render(QuestionnaireStatusBadge, {
+			props: { status, label: LABELS[status] }
+		});
+		expect(container.querySelector('span')?.className).toContain(EXPECTED_TONE_CLASS[status]);
+	});
+
+	it('keeps the caller class alongside the tone classes', () => {
+		const { container } = render(QuestionnaireStatusBadge, {
+			props: { status: 'draft', label: 'Draft', class: 'shrink-0' }
+		});
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('shrink-0');
+	});
+});

--- a/src/lib/components/questionnaires/QuestionnaireStatusBar.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireStatusBar.svelte
@@ -9,7 +9,7 @@
 		CardTitle
 	} from '$lib/components/ui/card';
 	import { AlertTriangle, FileCheck, FileEdit, Send } from '@lucide/svelte';
-	import { Badge } from '$lib/components/ui/badge';
+	import QuestionnaireStatusBadge from './QuestionnaireStatusBadge.svelte';
 	import type { QuestionnaireStatus } from '$lib/api/generated/types.gen';
 
 	interface Props {
@@ -20,24 +20,18 @@
 
 	const { currentStatus, isChangingStatus, onChangeStatus }: Props = $props();
 
-	// Status labels, variants, and descriptions
-	const statusInfo: Record<
-		QuestionnaireStatus,
-		{ label: string; variant: 'outline' | 'secondary' | 'default'; description: string }
-	> = {
+	// Status labels and descriptions (tone now comes from `QuestionnaireStatusBadge`)
+	const statusInfo: Record<QuestionnaireStatus, { label: string; description: string }> = {
 		draft: {
 			label: m['questionnaireEditPage.status.draft_label'](),
-			variant: 'outline',
 			description: m['questionnaireEditPage.status.draft_description']()
 		},
 		ready: {
 			label: m['questionnaireEditPage.status.ready_label'](),
-			variant: 'secondary',
 			description: m['questionnaireEditPage.status.ready_description']()
 		},
 		published: {
 			label: m['questionnaireEditPage.status.published_label'](),
-			variant: 'default',
 			description: m['questionnaireEditPage.status.published_description']()
 		}
 	};
@@ -45,62 +39,43 @@
 	const currentStatusInfo = $derived(statusInfo[currentStatus]);
 </script>
 
+<!--
+	Card tint mirrors the badge tone (rebrand): `draft` = warning (no
+	`--warning` token, so `border-highlight bg-highlight/10`), `ready` = info
+	(`border-info/50 bg-info/10`), `published` keeps the plain card surface.
+	Only default `text-foreground`/`text-muted-foreground` sit on these tints
+	(never `text-highlight`), per the dark-mode `--highlight` text-contrast trap.
+-->
 <Card
 	class="mb-6 {currentStatus === 'draft'
-		? 'border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30'
+		? 'border-highlight bg-highlight/10'
 		: currentStatus === 'ready'
-			? 'border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-950/30'
+			? 'border-info/50 bg-info/10'
 			: ''}"
 >
 	<CardHeader>
 		<div class="flex items-center justify-between">
 			<div>
 				<CardTitle>{m['questionnaireEditPage.status.title']()}</CardTitle>
-				<CardDescription
-					class={currentStatus === 'draft'
-						? 'text-amber-700 dark:text-amber-300'
-						: currentStatus === 'ready'
-							? 'text-blue-700 dark:text-blue-300'
-							: ''}>{m['questionnaireEditPage.status.description']()}</CardDescription
-				>
+				<CardDescription>{m['questionnaireEditPage.status.description']()}</CardDescription>
 			</div>
-			{#if currentStatus === 'draft'}
-				<Badge class="bg-amber-500 text-sm text-white hover:bg-amber-600">
-					{currentStatusInfo.label}
-				</Badge>
-			{:else if currentStatus === 'ready'}
-				<Badge class="bg-blue-500 text-sm text-white hover:bg-blue-600">
-					{currentStatusInfo.label}
-				</Badge>
-			{:else}
-				<Badge variant={currentStatusInfo.variant} class="text-sm">
-					{currentStatusInfo.label}
-				</Badge>
-			{/if}
+			<QuestionnaireStatusBadge status={currentStatus} label={currentStatusInfo.label} size="md" />
 		</div>
 	</CardHeader>
 	<CardContent>
 		<div class="space-y-4">
-			<p
-				class="text-sm {currentStatus === 'draft'
-					? 'text-amber-700 dark:text-amber-300'
-					: currentStatus === 'ready'
-						? 'text-blue-700 dark:text-blue-300'
-						: 'text-muted-foreground'}"
-			>
+			<p class="text-sm text-foreground">
 				{currentStatusInfo.description}
 			</p>
 
 			{#if currentStatus === 'ready'}
 				<!-- Warning for "ready" but not published status -->
-				<div
-					class="flex items-start gap-3 rounded-lg border border-orange-300 bg-orange-50 p-4 dark:border-orange-700 dark:bg-orange-950/50"
-				>
+				<div class="flex items-start gap-3 rounded-lg border border-highlight bg-highlight/10 p-4">
 					<AlertTriangle
-						class="h-5 w-5 flex-shrink-0 text-orange-600 dark:text-orange-400"
+						class="h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
 						aria-hidden="true"
 					/>
-					<p class="text-sm font-medium text-orange-800 dark:text-orange-200">
+					<p class="text-sm font-medium text-foreground">
 						{m['questionnaireEditPage.status.ready_warning']()}
 					</p>
 				</div>

--- a/src/lib/components/questionnaires/SectionEditor.svelte
+++ b/src/lib/components/questionnaires/SectionEditor.svelte
@@ -107,7 +107,7 @@
 							value={section.name}
 							oninput={(e) => onUpdate({ name: e.currentTarget.value })}
 							placeholder={m['sectionEditor.sectionNamePlaceholder']()}
-							class="text-lg font-semibold"
+							class="text-lg font-bold"
 						/>
 					</div>
 

--- a/src/lib/components/questionnaires/SubmissionStats.svelte
+++ b/src/lib/components/questionnaires/SubmissionStats.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { Clock, Check, TrendingUp } from '@lucide/svelte';
 	import { Card } from '$lib/components/ui/card';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 
 	interface Props {
 		pendingCount: number;
@@ -39,9 +40,7 @@
 				<p class="text-3xl font-bold">{pendingCount}</p>
 				<p class="mt-1 text-xs text-muted-foreground">{m['submissionStats.needAttention']()}</p>
 			</div>
-			<div class="rounded-full bg-yellow-100 p-3 dark:bg-yellow-950">
-				<Clock class="h-6 w-6 text-yellow-900 dark:text-yellow-100" aria-hidden="true" />
-			</div>
+			<ToneTile tone="warning" icon={Clock} size="lg" class="rounded-full" />
 		</div>
 	</Card>
 
@@ -53,9 +52,7 @@
 				<p class="text-3xl font-bold">{approvedCount}</p>
 				<p class="mt-1 text-xs text-muted-foreground">{m['submissionStats.totalApproved']()}</p>
 			</div>
-			<div class="rounded-full bg-green-100 p-3 dark:bg-green-950">
-				<Check class="h-6 w-6 text-green-900 dark:text-green-100" aria-hidden="true" />
-			</div>
+			<ToneTile tone="success" icon={Check} size="lg" class="rounded-full" />
 		</div>
 	</Card>
 
@@ -71,9 +68,7 @@
 					{approvedCount}/{totalEvaluated} approved
 				</p>
 			</div>
-			<div class="rounded-full bg-blue-100 p-3 dark:bg-blue-950">
-				<TrendingUp class="h-6 w-6 text-blue-900 dark:text-blue-100" aria-hidden="true" />
-			</div>
+			<ToneTile tone="info" icon={TrendingUp} size="lg" class="rounded-full" />
 		</div>
 	</Card>
 </div>

--- a/src/lib/components/questionnaires/SubmissionStatusBadge.svelte
+++ b/src/lib/components/questionnaires/SubmissionStatusBadge.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { Clock, Check, X, CheckCheck } from '@lucide/svelte';
-	import { Badge } from '$lib/components/ui/badge';
-	import { cn } from '$lib/utils/cn';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import type { SubmissionBadgeStatus } from '$lib/utils/questionnaire-types';
 
 	interface Props {
@@ -12,63 +12,56 @@
 
 	const { status, class: className }: Props = $props();
 
-	// Map status to display config
-	const config = $derived.by(() => {
-		switch (status) {
-			case 'approved':
-				return {
-					icon: Check,
-					label: m['submissionStatusBadge.approved'](),
-					variant: 'success' as const,
-					className: 'bg-green-100 text-green-900 dark:bg-green-950 dark:text-green-100'
-				};
-			case 'rejected':
-				return {
-					icon: X,
-					label: m['submissionStatusBadge.rejected'](),
-					variant: 'destructive' as const,
-					className: 'bg-red-100 text-red-900 dark:bg-red-950 dark:text-red-100'
-				};
-			case 'pending review':
-				return {
-					icon: Clock,
-					label: m['submissionStatusBadge.pending'](),
-					variant: 'secondary' as const,
-					className: 'bg-yellow-100 text-yellow-900 dark:bg-yellow-950 dark:text-yellow-100'
-				};
-			case 'draft':
-				return {
-					icon: Clock,
-					label: m['submissionStatusBadge.draft'](),
-					variant: 'outline' as const,
-					className: 'bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100'
-				};
-			case 'auto_accepted':
-				return {
-					icon: CheckCheck,
-					label: m['submissionStatusBadge.autoAccepted'](),
-					variant: 'success' as const,
-					className: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-100'
-				};
-		}
-	});
+	/**
+	 * Thin mapper over the shared `StatusBadge` primitive (rebrand). `approved`
+	 * and `auto_accepted` share `success` — both are acceptances, just via a
+	 * different mechanism — because the tone budget is for lifecycle stage, not
+	 * for provenance; the label text ("Approved" vs "Auto-accepted") and the
+	 * icon (`Check` vs `CheckCheck`) carry that distinction instead. `pending
+	 * review` takes `warning` (needs a human), `rejected` is `danger`, `draft`
+	 * is `neutral` (not yet a real submission).
+	 */
+	const TONE_MAP: Record<SubmissionBadgeStatus, Tone> = {
+		draft: 'neutral',
+		'pending review': 'warning',
+		approved: 'success',
+		auto_accepted: 'success',
+		rejected: 'danger'
+	};
 
-	const IconComponent = $derived(config.icon);
+	const ICON_MAP: Record<SubmissionBadgeStatus, typeof Clock> = {
+		draft: Clock,
+		'pending review': Clock,
+		approved: Check,
+		auto_accepted: CheckCheck,
+		rejected: X
+	};
+
+	const LABEL_MAP: Record<SubmissionBadgeStatus, () => string> = {
+		draft: () => m['submissionStatusBadge.draft'](),
+		'pending review': () => m['submissionStatusBadge.pending'](),
+		approved: () => m['submissionStatusBadge.approved'](),
+		auto_accepted: () => m['submissionStatusBadge.autoAccepted'](),
+		rejected: () => m['submissionStatusBadge.rejected']()
+	};
+
+	const tone = $derived(TONE_MAP[status]);
+	const icon = $derived(ICON_MAP[status]);
+	const label = $derived(LABEL_MAP[status]());
 </script>
 
 <!--
-  Submission Status Badge Component
+	Submission Status Badge Component
 
-  Displays the evaluation status of a questionnaire submission with appropriate
-  icon and color coding.
+	Displays the evaluation status of a questionnaire submission with an
+	`aria-label`-carrying pill (thin mapper over `common/StatusBadge`). The
+	label is explicit because the primitive does not default one, and the
+	submissions table/detail page locate this pill by its status text.
 
-  @component
-  @example
-  <SubmissionStatusBadge status="approved" />
-  <SubmissionStatusBadge status="pending review" />
-  <SubmissionStatusBadge status="auto_accepted" />
+	@component
+	@example
+	<SubmissionStatusBadge status="approved" />
+	<SubmissionStatusBadge status="pending review" />
+	<SubmissionStatusBadge status="auto_accepted" />
 -->
-<Badge class={cn(config.className, 'gap-1.5', className)}>
-	<IconComponent class="h-3 w-3" aria-hidden="true" />
-	<span>{config.label}</span>
-</Badge>
+<CommonStatusBadge {tone} {label} {icon} size="sm" class={className} aria-label={label} />

--- a/src/lib/components/questionnaires/SubmissionStatusBadge.test.ts
+++ b/src/lib/components/questionnaires/SubmissionStatusBadge.test.ts
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import { SUBMISSION_BADGE_STATUS_ORDER } from '$lib/utils/questionnaire-types';
+import SubmissionStatusBadge from './SubmissionStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD, same shape as `members/StatusBadge.test.ts`: this pill's
+ * accessible NAME is a cross-surface contract (the submissions table and the
+ * submission detail page locate it by its status text), not decoration. The
+ * rebrand turned this into a thin mapper over `common/StatusBadge`, which does
+ * not default an `aria-label` from its content — so this guards every status,
+ * not just a sample, against that name silently vanishing again.
+ */
+const LABELS: Record<(typeof SUBMISSION_BADGE_STATUS_ORDER)[number], string> = {
+	draft: 'Draft',
+	'pending review': 'Pending',
+	approved: 'Approved',
+	auto_accepted: 'Auto-accepted',
+	rejected: 'Rejected'
+};
+
+describe('questionnaires/SubmissionStatusBadge', () => {
+	it.each(SUBMISSION_BADGE_STATUS_ORDER)(
+		'exposes the %s label as the pill accessible name',
+		(status) => {
+			render(SubmissionStatusBadge, { props: { status } });
+			const label = LABELS[status];
+			expect(screen.getByLabelText(label)).toBeInTheDocument();
+			expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		}
+	);
+
+	it('collapses approved and auto_accepted onto the same tone, distinguished by label', () => {
+		const approved = render(SubmissionStatusBadge, { props: { status: 'approved' } });
+		const approvedEl = approved.container.querySelector('span') as HTMLElement;
+		expect(approvedEl.className).toContain('bg-success');
+
+		const auto = render(SubmissionStatusBadge, { props: { status: 'auto_accepted' } });
+		const autoEl = auto.container.querySelector('span') as HTMLElement;
+		expect(autoEl.className).toContain('bg-success');
+
+		expect(screen.getByLabelText('Approved')).toBeInTheDocument();
+		expect(screen.getByLabelText('Auto-accepted')).toBeInTheDocument();
+	});
+
+	it('maps rejected to danger', () => {
+		const { container } = render(SubmissionStatusBadge, { props: { status: 'rejected' } });
+		expect(container.querySelector('span')?.className).toContain('bg-destructive');
+	});
+
+	it('keeps the caller class alongside the tone classes', () => {
+		const { container } = render(SubmissionStatusBadge, {
+			props: { status: 'draft', class: 'shrink-0' }
+		});
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('shrink-0');
+	});
+});

--- a/src/lib/components/resources/ResourceAssignment.svelte
+++ b/src/lib/components/resources/ResourceAssignment.svelte
@@ -8,6 +8,7 @@
 	import { cn } from '$lib/utils/cn';
 	import { formatDate } from '$lib/utils/date';
 	import { SvelteSet } from 'svelte/reactivity';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 
 	interface Props {
 		organizationId: string;
@@ -87,9 +88,7 @@
 <div class="space-y-4">
 	<!-- Header -->
 	<div>
-		<h3 class="text-sm font-medium text-gray-900 dark:text-gray-100">
-			{m['resourceAssignment.assignToEvents']()}
-		</h3>
+		<SectionHeader title={m['resourceAssignment.assignToEvents']()} level={3} />
 		<p class="mt-1 text-xs text-muted-foreground">
 			{m['resourceAssignment.assignDescription']()}
 		</p>

--- a/src/lib/components/resources/ResourceForm.svelte
+++ b/src/lib/components/resources/ResourceForm.svelte
@@ -147,10 +147,7 @@
 	<!-- Resource Type Selection (only for new resources) -->
 	{#if !resource}
 		<div class="space-y-2">
-			<span
-				id="resource-type-label"
-				class="block text-sm font-medium text-gray-900 dark:text-gray-100"
-			>
+			<span id="resource-type-label" class="block text-sm font-medium text-foreground">
 				{m['resourceForm.resourceType']()}
 				<span class="text-destructive" aria-label={m['resourceForm.required']()}>*</span>
 			</span>
@@ -205,7 +202,7 @@
 
 	<!-- Name -->
 	<div class="space-y-2">
-		<label for="name" class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+		<label for="name" class="block text-sm font-medium text-foreground">
 			{m['resourceForm.name']()}
 			<span class="text-destructive" aria-label={m['resourceForm.required']()}>*</span>
 		</label>
@@ -227,7 +224,7 @@
 
 	<!-- Description -->
 	<div class="space-y-2">
-		<label for="description" class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+		<label for="description" class="block text-sm font-medium text-foreground">
 			{m['resourceForm.description']()}
 		</label>
 		<MarkdownEditor
@@ -247,7 +244,7 @@
 	<!-- Type-specific fields -->
 	{#if resourceType === 'file'}
 		<div class="space-y-2">
-			<label for="file" class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+			<label for="file" class="block text-sm font-medium text-foreground">
 				{m['resourceForm.file']()}
 				{#if !resource}<span class="text-destructive" aria-label={m['resourceForm.required']()}
 						>*</span
@@ -271,7 +268,7 @@
 					type="file"
 					onchange={handleFileChange}
 					disabled={isSubmitting}
-					class="block w-full text-sm text-gray-900 file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-100"
+					class="block w-full text-sm text-foreground file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 					aria-invalid={!!allErrors.file}
 					aria-describedby={allErrors.file ? 'file-error' : undefined}
 				/>
@@ -294,7 +291,7 @@
 		</div>
 	{:else if resourceType === 'link'}
 		<div class="space-y-2">
-			<label for="link" class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+			<label for="link" class="block text-sm font-medium text-foreground">
 				{m['resourceForm.url']()}
 				<span class="text-destructive" aria-label={m['resourceForm.required']()}>*</span>
 			</label>
@@ -316,7 +313,7 @@
 		</div>
 	{:else if resourceType === 'text'}
 		<div class="space-y-2">
-			<label for="text" class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+			<label for="text" class="block text-sm font-medium text-foreground">
 				{m['resourceForm.content']()}
 				<span class="text-destructive" aria-label={m['resourceForm.required']()}>*</span>
 			</label>
@@ -337,7 +334,7 @@
 
 	<!-- Visibility -->
 	<div class="space-y-2">
-		<label for="visibility" class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+		<label for="visibility" class="block text-sm font-medium text-foreground">
 			{m['resourceForm.visibility']()}
 		</label>
 		<select
@@ -371,7 +368,7 @@
 			class="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 		/>
 		<div class="flex-1">
-			<label for="display-on-org" class="text-sm font-medium text-gray-900 dark:text-gray-100">
+			<label for="display-on-org" class="text-sm font-medium text-foreground">
 				{m['resourceForm.displayOnOrgPage']()}
 			</label>
 			<p class="text-xs text-muted-foreground">

--- a/src/lib/components/resources/ResourceModal.svelte
+++ b/src/lib/components/resources/ResourceModal.svelte
@@ -9,7 +9,7 @@
 	} from '$lib/api/generated/types.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { getApiUrl } from '$lib/config/api';
-	import { X } from '@lucide/svelte';
+	import { X, AlertTriangle } from '@lucide/svelte';
 	import ResourceForm from './ResourceForm.svelte';
 	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
@@ -277,12 +277,15 @@
 			<!-- Error Message -->
 			{#if errorMessage}
 				<div
-					class="mb-6 rounded-md bg-destructive/10 p-4 text-destructive"
+					class="mb-6 flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4"
 					role="alert"
 					aria-live="assertive"
 				>
-					<p class="font-semibold">{m['resourceModal.error']()}</p>
-					<p class="mt-1 text-sm">{errorMessage}</p>
+					<AlertTriangle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
+					<div>
+						<p class="font-semibold text-foreground">{m['resourceModal.error']()}</p>
+						<p class="mt-1 text-sm text-foreground">{errorMessage}</p>
+					</div>
 				</div>
 			{/if}
 

--- a/src/lib/components/resources/ResourceModal.svelte
+++ b/src/lib/components/resources/ResourceModal.svelte
@@ -276,12 +276,19 @@
 
 			<!-- Error Message -->
 			{#if errorMessage}
+				<!-- dark:bg-destructive/25 dark:text-destructive-foreground (AutoEvalRecommendation's
+				     pattern): plain text-destructive on this /10 tint measured 2.69-2.95:1 in
+				     dark mode, under the 3:1 non-text floor; the /25 tint + destructive-foreground
+				     (white) icon pairing measures ~14-15:1 instead. -->
 				<div
-					class="mb-6 flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4"
+					class="mb-6 flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4 dark:bg-destructive/25"
 					role="alert"
 					aria-live="assertive"
 				>
-					<AlertTriangle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
+					<AlertTriangle
+						class="h-5 w-5 shrink-0 text-destructive dark:text-destructive-foreground"
+						aria-hidden="true"
+					/>
 					<div>
 						<p class="font-semibold text-foreground">{m['resourceModal.error']()}</p>
 						<p class="mt-1 text-sm text-foreground">{errorMessage}</p>

--- a/src/lib/components/tokens/EventTokenCard.svelte
+++ b/src/lib/components/tokens/EventTokenCard.svelte
@@ -60,7 +60,7 @@
 			<!-- Name and Status -->
 			<div class="flex items-center gap-2">
 				<Ticket class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-				<h3 class="font-semibold">
+				<h3 class="font-bold">
 					{token.name || m['eventTokenCard.unnamedToken']()}
 				</h3>
 				<TokenStatusBadge {status} />

--- a/src/lib/components/tokens/EventTokenModal.svelte
+++ b/src/lib/components/tokens/EventTokenModal.svelte
@@ -212,7 +212,7 @@
 					type="checkbox"
 					id="grants-invitation"
 					bind:checked={grantsInvitation}
-					class="h-4 w-4 rounded border-gray-300"
+					class="h-4 w-4 rounded border-input"
 				/>
 				<Label for="grants-invitation" class="font-normal">
 					{m['eventTokenModal.grantInvitation']()}
@@ -269,7 +269,7 @@
 									type="checkbox"
 									id="waives-questionnaire"
 									bind:checked={waivesQuestionnaire}
-									class="mt-0.5 h-4 w-4 rounded border-gray-300"
+									class="mt-0.5 h-4 w-4 rounded border-input"
 								/>
 								<div class="flex-1">
 									<Label for="waives-questionnaire" class="font-normal">
@@ -287,7 +287,7 @@
 									type="checkbox"
 									id="waives-purchase"
 									bind:checked={waivesPurchase}
-									class="mt-0.5 h-4 w-4 rounded border-gray-300"
+									class="mt-0.5 h-4 w-4 rounded border-input"
 								/>
 								<div class="flex-1">
 									<Label for="waives-purchase" class="font-normal">
@@ -305,7 +305,7 @@
 									type="checkbox"
 									id="overrides-max-attendees"
 									bind:checked={overridesMaxAttendees}
-									class="mt-0.5 h-4 w-4 rounded border-gray-300"
+									class="mt-0.5 h-4 w-4 rounded border-input"
 								/>
 								<div class="flex-1">
 									<Label for="overrides-max-attendees" class="font-normal">
@@ -323,7 +323,7 @@
 									type="checkbox"
 									id="waives-membership"
 									bind:checked={waivesMembershipRequired}
-									class="mt-0.5 h-4 w-4 rounded border-gray-300"
+									class="mt-0.5 h-4 w-4 rounded border-input"
 								/>
 								<div class="flex-1">
 									<Label for="waives-membership" class="font-normal">
@@ -341,7 +341,7 @@
 									type="checkbox"
 									id="waives-deadline"
 									bind:checked={waivesRsvpDeadline}
-									class="mt-0.5 h-4 w-4 rounded border-gray-300"
+									class="mt-0.5 h-4 w-4 rounded border-input"
 								/>
 								<div class="flex-1">
 									<Label for="waives-deadline" class="font-normal"
@@ -359,7 +359,7 @@
 									type="checkbox"
 									id="waives-apply-deadline"
 									bind:checked={waivesApplyDeadline}
-									class="mt-0.5 h-4 w-4 rounded border-gray-300"
+									class="mt-0.5 h-4 w-4 rounded border-input"
 								/>
 								<div class="flex-1">
 									<Label for="waives-apply-deadline" class="font-normal"
@@ -377,7 +377,7 @@
 				<!-- Ticket tier selection -->
 				{#if ticketTiers.length > 0}
 					<div class="space-y-3 rounded-lg border border-border p-4">
-						<h4 class="text-sm font-semibold">{m['eventTokenModal.assignTiers']()}</h4>
+						<h4 class="text-sm font-bold">{m['eventTokenModal.assignTiers']()}</h4>
 						<p class="text-xs text-muted-foreground">
 							{m['eventTokenModal.assignTiersHint']()}
 						</p>
@@ -395,7 +395,7 @@
 												selectedTierIds = selectedTierIds.filter((id) => id !== tier.id);
 											}
 										}}
-										class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+										class="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary"
 									/>
 									<div class="flex-1">
 										<span class="text-sm font-medium">{tier.name}</span>

--- a/src/lib/components/tokens/OrganizationTokenCard.svelte
+++ b/src/lib/components/tokens/OrganizationTokenCard.svelte
@@ -63,7 +63,7 @@
 			<!-- Name and Status -->
 			<div class="flex items-center gap-2">
 				<Icon class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-				<h3 class="font-semibold">
+				<h3 class="font-bold">
 					{token.name || m['organizationTokenCard.unnamedToken']()}
 				</h3>
 				<TokenStatusBadge {status} />

--- a/src/lib/components/tokens/OrganizationTokenModal.svelte
+++ b/src/lib/components/tokens/OrganizationTokenModal.svelte
@@ -269,21 +269,27 @@
 				{/if}
 
 				{#if showStaffWarning}
-					<div class="rounded-md bg-yellow-50 p-3 text-sm text-yellow-800">
+					<div
+						class="rounded-md border border-highlight bg-highlight/10 p-3 text-sm text-foreground"
+					>
 						<strong>{m['organizationTokenModal.securityWarning']()}</strong>
 						{m['organizationTokenModal.staffWarningBody']()}
 					</div>
 				{/if}
 
 				{#if showBothUncheckedWarning}
-					<div class="rounded-md bg-red-50 p-3 text-sm text-red-800">
+					<div
+						class="rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-foreground"
+					>
 						<strong>{m['organizationTokenModal.error']()}</strong>
 						{m['organizationTokenModal.bothUncheckedBody']()}
 					</div>
 				{/if}
 
 				{#if showTierRequiredWarning}
-					<div class="rounded-md bg-red-50 p-3 text-sm text-red-800">
+					<div
+						class="rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-foreground"
+					>
 						<strong>{m['organizationTokenModal.error']()}</strong>
 						{m['organizationTokenModal.tierRequiredBody']()}
 					</div>

--- a/src/lib/components/tokens/TokenStatusBadge.svelte
+++ b/src/lib/components/tokens/TokenStatusBadge.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { cn } from '$lib/utils/cn';
+	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		status: 'active' | 'expired' | 'limit-reached' | 'staff';
@@ -9,34 +10,38 @@
 
 	const { status, class: className }: Props = $props();
 
-	const statusConfig = {
-		active: {
-			label: m['tokenStatusBadge.active'](),
-			classes: 'bg-green-100 text-green-800 border-green-200'
-		},
-		expired: {
-			label: m['tokenStatusBadge.expired'](),
-			classes: 'bg-red-100 text-red-800 border-red-200'
-		},
-		'limit-reached': {
-			label: m['tokenStatusBadge.limitReached'](),
-			classes: 'bg-yellow-100 text-yellow-800 border-yellow-200'
-		},
-		staff: {
-			label: m['tokenStatusBadge.staff'](),
-			classes: 'bg-purple-100 text-purple-800 border-purple-200'
-		}
+	/**
+	 * Thin mapper over the shared `StatusBadge` primitive (rebrand). `staff`
+	 * keeps its own identity as `brand` — it isn't a lifecycle state like the
+	 * other three, it is a distinct token *kind* (unlimited, staff-issued) — so
+	 * collapsing it onto `neutral` would erase the one distinction admins scan
+	 * this pill for. `expired` and `limit-reached` stay apart too: expired is
+	 * "the token itself lapsed" (`danger`, mirrors event-side
+	 * `WaitlistOfferStatusBadge`'s expired state), limit-reached is "the token
+	 * hit its use cap" (`warning`, still a live token, just capped).
+	 */
+	const TONE_MAP: Record<Props['status'], Tone> = {
+		active: 'success',
+		expired: 'danger',
+		'limit-reached': 'warning',
+		staff: 'brand'
 	};
 
-	const config = $derived(statusConfig[status]);
+	const LABEL_MAP: Record<Props['status'], () => string> = {
+		active: () => m['tokenStatusBadge.active'](),
+		expired: () => m['tokenStatusBadge.expired'](),
+		'limit-reached': () => m['tokenStatusBadge.limitReached'](),
+		staff: () => m['tokenStatusBadge.staff']()
+	};
+
+	const tone = $derived(TONE_MAP[status]);
+	const label = $derived(LABEL_MAP[status]());
 </script>
 
-<span
-	class={cn(
-		'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold',
-		config.classes,
-		className
-	)}
->
-	{config.label}
-</span>
+<!--
+	`aria-label` is explicit: `common/StatusBadge` does not default one, and
+	every token surface (event admin card, org admin card) is located by its
+	status pill through this text — dropping it here silently un-names them
+	the same way it did for `members/StatusBadge` (see that component's test).
+-->
+<CommonStatusBadge {tone} {label} size="sm" class={className} aria-label={label} />

--- a/src/lib/components/tokens/TokenStatusBadge.test.ts
+++ b/src/lib/components/tokens/TokenStatusBadge.test.ts
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import TokenStatusBadge from './TokenStatusBadge.svelte';
+
+/**
+ * REGRESSION GUARD, same shape as `members/StatusBadge.test.ts`: this pill's
+ * accessible NAME is a cross-surface contract (event admin + org admin token
+ * cards locate their status pill by it), not decoration. The rebrand turned
+ * this into a thin mapper over `common/StatusBadge`, which does not default
+ * an `aria-label` from its content — so this guards every status, not just a
+ * sample, against that name silently vanishing again.
+ */
+const STATUS_ORDER = ['active', 'expired', 'limit-reached', 'staff'] as const;
+
+const LABELS: Record<(typeof STATUS_ORDER)[number], string> = {
+	active: 'Active',
+	expired: 'Expired',
+	'limit-reached': 'Limit Reached',
+	staff: 'Staff'
+};
+
+describe('tokens/TokenStatusBadge', () => {
+	it.each(STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+		render(TokenStatusBadge, { props: { status } });
+		const label = LABELS[status];
+		expect(screen.getByLabelText(label)).toBeInTheDocument();
+		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+	});
+
+	it('maps status to the primitive tone (active → success, expired → danger)', () => {
+		const active = render(TokenStatusBadge, { props: { status: 'active' } });
+		expect(active.container.querySelector('span')?.className).toContain('bg-success');
+
+		const expired = render(TokenStatusBadge, { props: { status: 'expired' } });
+		expect(expired.container.querySelector('span')?.className).toContain('bg-destructive');
+	});
+
+	it('keeps the caller class alongside the tone classes', () => {
+		const { container } = render(TokenStatusBadge, {
+			props: { status: 'active', class: 'shrink-0' }
+		});
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('shrink-0');
+		expect(el.className).toContain('bg-success');
+	});
+});

--- a/src/lib/utils/member-status.ts
+++ b/src/lib/utils/member-status.ts
@@ -1,0 +1,46 @@
+/**
+ * Presentation of one `MembershipStatus` (active/paused/cancelled/banned): its
+ * `Tone` and its localized label. Single source for `members/MemberCard` (the
+ * roster pill) and `members/ManageMemberModal` (the status select), following
+ * the same split-out pattern as `subscription-status.ts` — one map, not a copy
+ * per surface that a fifth status could reach only one of.
+ */
+import * as m from '$lib/paraglide/messages.js';
+import type { MembershipStatus } from '$lib/api/generated/types.gen';
+import type { Tone } from '$lib/components/common/tones';
+
+/**
+ * `banned` is the only status with real consequences beyond this org (loses
+ * access, subscription cancelled), so it alone takes `danger`. `paused` still
+ * needs attention (`warning`); `cancelled` is terminal-but-not-punitive, so it
+ * gets `neutral` rather than escalating alongside `banned`.
+ */
+const TONE_MAP: Record<MembershipStatus, Tone> = {
+	active: 'success',
+	paused: 'warning',
+	cancelled: 'neutral',
+	banned: 'danger'
+};
+
+export function getMemberStatusTone(status: MembershipStatus): Tone {
+	return TONE_MAP[status];
+}
+
+const STATUS_LABELS: Record<MembershipStatus, () => string> = {
+	active: () => m['memberStatus.active'](),
+	paused: () => m['memberStatus.paused'](),
+	cancelled: () => m['memberStatus.cancelled'](),
+	banned: () => m['memberStatus.banned']()
+};
+
+export function getMemberStatusLabel(status: MembershipStatus): string {
+	return STATUS_LABELS[status]();
+}
+
+/** Every `MembershipStatus`, exhaustive by construction (mirrors STATUS_ORDER). */
+export const MEMBER_STATUS_ORDER: readonly MembershipStatus[] = [
+	'active',
+	'paused',
+	'cancelled',
+	'banned'
+];

--- a/src/lib/utils/membership-request-status.ts
+++ b/src/lib/utils/membership-request-status.ts
@@ -1,0 +1,53 @@
+/**
+ * Presentation of one `MembershipRequestStatus`: its `Tone` and its localized
+ * label. Single source for `members/MembershipRequestCard`'s status pill —
+ * split out following `subscription-status.ts`'s pattern so the tone/label
+ * pair lives in exactly one place.
+ */
+import * as m from '$lib/paraglide/messages.js';
+import type { MembershipRequestStatus } from '$lib/api/generated/types.gen';
+import type { Tone } from '$lib/components/common/tones';
+
+/**
+ * `pending` needs attention (`warning`); `approved`/`completed` both read as
+ * "this went through" and share `success` — the label text, not the tone,
+ * carries which of the two it was. `rejected` is the one outcome with a real
+ * consequence for the applicant, so it alone escalates to `danger`.
+ * `cancelled` is neutral: withdrawn, not refused.
+ */
+const TONE_MAP: Record<MembershipRequestStatus, Tone> = {
+	pending: 'warning',
+	approved: 'success',
+	completed: 'success',
+	rejected: 'danger',
+	cancelled: 'neutral'
+};
+
+export function getMembershipRequestStatusTone(status: MembershipRequestStatus): Tone {
+	// `??` guards a BE-ahead version skew: the wire can carry a status this
+	// build has never heard of, and an unguarded lookup would hand `undefined`
+	// to the badge rather than degrading to a reasonable default.
+	return TONE_MAP[status] ?? TONE_MAP.pending;
+}
+
+const STATUS_LABELS: Record<MembershipRequestStatus, () => string> = {
+	pending: () => m['membershipRequestCard.statusPending'](),
+	approved: () => m['membershipRequestCard.approved'](),
+	completed: () => m['membershipRequestCard.statusCompleted'](),
+	rejected: () => m['membershipRequestCard.rejected'](),
+	cancelled: () => m['membershipRequestCard.statusCancelled']()
+};
+
+export function getMembershipRequestStatusLabel(status: MembershipRequestStatus): string {
+	// Same BE-ahead-skew guard as the tone lookup above.
+	return (STATUS_LABELS[status] ?? STATUS_LABELS.pending)();
+}
+
+/** Every `MembershipRequestStatus`, exhaustive by construction. */
+export const MEMBERSHIP_REQUEST_STATUS_ORDER: readonly MembershipRequestStatus[] = [
+	'pending',
+	'approved',
+	'completed',
+	'rejected',
+	'cancelled'
+];

--- a/src/lib/utils/questionnaire-types.ts
+++ b/src/lib/utils/questionnaire-types.ts
@@ -42,6 +42,20 @@ export type SubmissionBadgeStatus =
 	'approved' | 'rejected' | 'pending review' | 'draft' | 'auto_accepted';
 
 /**
+ * Every `SubmissionBadgeStatus`, in display order. Not a backend enum (see
+ * above), so there is no generated iteration order to reuse — this is the one
+ * source `SubmissionStatusBadge`'s mapper and its regression-guard test both
+ * drive off, so a sixth status can't reach one and be missed by the other.
+ */
+export const SUBMISSION_BADGE_STATUS_ORDER: readonly SubmissionBadgeStatus[] = [
+	'draft',
+	'pending review',
+	'approved',
+	'auto_accepted',
+	'rejected'
+];
+
+/**
  * Type guards for questionnaire evaluation status
  */
 export function isApproved(status: QuestionnaireEvaluationStatus | null | undefined): boolean {

--- a/src/lib/utils/subscription-status.ts
+++ b/src/lib/utils/subscription-status.ts
@@ -11,40 +11,59 @@
  */
 import * as m from '$lib/paraglide/messages.js';
 import type { SubscriptionStatus } from '$lib/api/generated/types.gen';
+import type { Tone } from '$lib/components/common/tones';
 
 export type StatusTone = 'green' | 'blue' | 'amber' | 'gray' | 'red' | 'muted';
 
 export interface StatusConfig {
 	tone: StatusTone;
-	className: string;
 }
 
+// `tone` here is the pre-rebrand descriptive axis (kept: `subscriptions.test.ts`
+// pins these six values and nothing about them changed). `className` is GONE —
+// it was the last raw `bg-green-100`/`bg-gray-200` map in this codebase (the
+// rebrand's raw-hue sweep target). Every renderer now goes through
+// `getStatusTone` below, which maps onto the shared `common/StatusBadge` token
+// vocabulary instead.
 const STATUS_CONFIG: Record<SubscriptionStatus, StatusConfig> = {
-	active: {
-		tone: 'green',
-		className: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-100'
-	},
-	pending: {
-		tone: 'blue',
-		className: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-100'
-	},
-	past_due: {
-		tone: 'amber',
-		className: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-100'
-	},
-	paused: {
-		tone: 'gray',
-		className: 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
-	},
-	cancelled: { tone: 'muted', className: 'bg-muted text-muted-foreground' },
-	expired: {
-		tone: 'red',
-		className: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-100'
-	}
+	active: { tone: 'green' },
+	pending: { tone: 'blue' },
+	past_due: { tone: 'amber' },
+	paused: { tone: 'gray' },
+	cancelled: { tone: 'muted' },
+	expired: { tone: 'red' }
 };
 
 export function getStatusConfig(status: SubscriptionStatus): StatusConfig {
 	return STATUS_CONFIG[status];
+}
+
+/**
+ * Semantic `Tone` (rebrand vocabulary) for one `SubscriptionStatus`. The
+ * single source both `members/StatusBadge` (single-status pill, `aria-label`
+ * carries the name) and `members/SubscriptionMetrics` (label+count chip strip,
+ * deliberately unlabelled — see `StatusBadge.test.ts`) render from, so the two
+ * surfaces can't drift onto different tones for the same status again.
+ *
+ * `paused` does not share `active`'s `success` — it needs attention, so it
+ * takes `warning` — and it stays visually louder than the two terminal states.
+ * `past_due` is a harder problem than "pending payment" (it risks losing
+ * access), so it escalates to `danger`. `cancelled` and `expired` collapse
+ * onto the same `neutral` tone deliberately: both are terminal/over, and the
+ * label text ("Cancelled" vs "Expired") — not the tone — carries the
+ * distinction.
+ */
+const TONE_MAP: Record<SubscriptionStatus, Tone> = {
+	active: 'success',
+	pending: 'info',
+	past_due: 'danger',
+	paused: 'warning',
+	cancelled: 'neutral',
+	expired: 'neutral'
+};
+
+export function getStatusTone(status: SubscriptionStatus): Tone {
+	return TONE_MAP[status];
 }
 
 /**

--- a/src/lib/utils/subscriptions.ts
+++ b/src/lib/utils/subscriptions.ts
@@ -252,6 +252,7 @@ export function formatPlanPrice(plan: PricedPlan): string {
 export {
 	getStatusConfig,
 	getStatusLabel,
+	getStatusTone,
 	STATUS_ORDER,
 	type StatusConfig,
 	type StatusTone

--- a/src/routes/(auth)/org/[slug]/admin/announcements/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/announcements/+page.svelte
@@ -33,6 +33,8 @@
 	import AnnouncementCard from '$lib/components/announcements/AnnouncementCard.svelte';
 	import AnnouncementModal from '$lib/components/announcements/AnnouncementModal.svelte';
 	import MarkdownContent from '$lib/components/common/MarkdownContent.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		data: PageData;
@@ -274,17 +276,18 @@
 </script>
 
 <div class="space-y-6">
-	<!-- Header -->
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div>
-			<h1 class="text-2xl font-bold">{m['announcements.title']()}</h1>
-			<p class="text-muted-foreground">{m['announcements.pageDescription']()}</p>
-		</div>
+	{#snippet announcementsHeaderActions()}
 		<Button onclick={openCreateModal}>
 			<Plus class="mr-2 h-4 w-4" aria-hidden="true" />
 			{m['announcements.new']()}
 		</Button>
-	</div>
+	{/snippet}
+
+	<PageHeader
+		title={m['announcements.title']()}
+		subtitle={m['announcements.pageDescription']()}
+		actions={announcementsHeaderActions}
+	/>
 
 	<!-- Tabs -->
 	<Tabs.Root bind:value={activeTab}>
@@ -314,19 +317,12 @@
 					<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
 				</div>
 			{:else if announcements.length === 0}
-				<div
-					class="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center"
-				>
-					<Megaphone class="mb-4 h-12 w-12 text-muted-foreground/50" />
-					<h3 class="font-medium">{m['announcements.empty.drafts']()}</h3>
-					<p class="text-sm text-muted-foreground">
-						{m['announcements.empty.draftsDescription']()}
-					</p>
-					<Button onclick={openCreateModal} class="mt-4">
-						<Plus class="mr-2 h-4 w-4" />
-						{m['announcements.new']()}
-					</Button>
-				</div>
+				<EmptyState
+					icon={Megaphone}
+					title={m['announcements.empty.drafts']()}
+					body={m['announcements.empty.draftsDescription']()}
+					action={announcementsHeaderActions}
+				/>
 			{:else}
 				<div class="space-y-3">
 					{#each announcements as announcement (announcement.id)}
@@ -349,15 +345,11 @@
 					<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
 				</div>
 			{:else if announcements.length === 0}
-				<div
-					class="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center"
-				>
-					<Megaphone class="mb-4 h-12 w-12 text-muted-foreground/50" />
-					<h3 class="font-medium">{m['announcements.empty.scheduled']()}</h3>
-					<p class="text-sm text-muted-foreground">
-						{m['announcements.empty.scheduledDescription']()}
-					</p>
-				</div>
+				<EmptyState
+					icon={Megaphone}
+					title={m['announcements.empty.scheduled']()}
+					body={m['announcements.empty.scheduledDescription']()}
+				/>
 			{:else}
 				<div class="space-y-3">
 					{#each announcements as announcement (announcement.id)}
@@ -379,13 +371,11 @@
 					<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
 				</div>
 			{:else if announcements.length === 0}
-				<div
-					class="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center"
-				>
-					<Megaphone class="mb-4 h-12 w-12 text-muted-foreground/50" />
-					<h3 class="font-medium">{m['announcements.empty.sent']()}</h3>
-					<p class="text-sm text-muted-foreground">{m['announcements.empty.sentDescription']()}</p>
-				</div>
+				<EmptyState
+					icon={Megaphone}
+					title={m['announcements.empty.sent']()}
+					body={m['announcements.empty.sentDescription']()}
+				/>
 			{:else}
 				<div class="space-y-3">
 					{#each announcements as announcement (announcement.id)}
@@ -437,7 +427,7 @@
 						<AlertTriangle class="h-5 w-5 text-destructive" aria-hidden="true" />
 					</div>
 					<div class="flex-1 space-y-2">
-						<p class="text-sm font-medium text-destructive">
+						<p class="text-sm font-medium text-foreground">
 							{announcementToDelete.title}
 						</p>
 					</div>

--- a/src/routes/(auth)/org/[slug]/admin/blacklist/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/blacklist/+page.svelte
@@ -42,6 +42,8 @@
 		WhitelistRequestsTab
 	} from '$lib/components/blacklist';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { toast } from 'svelte-sonner';
 
 	const organization = $derived($page.data.organization);
@@ -408,20 +410,17 @@
 
 <div class="space-y-6 px-4 md:px-0">
 	<!-- Header -->
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div class="min-w-0">
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['blacklistAdminPage.title']()}
-			</h1>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['blacklistAdminPage.pageDescription']()}
-			</p>
-		</div>
+	{#snippet headerActions()}
 		<Button onclick={() => (createModalOpen = true)} class="w-full sm:w-auto">
 			<Plus class="mr-2 h-4 w-4" aria-hidden="true" />
 			{m['blacklistAdminPage.addToBlacklist']()}
 		</Button>
-	</div>
+	{/snippet}
+	<PageHeader
+		title={m['blacklistAdminPage.title']()}
+		subtitle={m['blacklistAdminPage.pageDescription']()}
+		actions={headerActions}
+	/>
 
 	<!-- Tabs -->
 	<Tabs bind:value={activeTab} class="w-full">
@@ -482,8 +481,8 @@
 			</div>
 
 			<!-- Info Box -->
-			<div class="rounded-lg border border-amber-500/30 bg-amber-50 p-3 dark:bg-amber-950/30">
-				<p class="text-sm text-amber-900 dark:text-amber-100">
+			<div class="rounded-lg border border-highlight bg-highlight/10 p-3">
+				<p class="text-sm text-foreground">
 					{m['blacklistAdminPage.blacklistInfo']()}
 				</p>
 			</div>
@@ -498,15 +497,13 @@
 					<p class="text-sm text-destructive">{m['blacklistAdminPage.loadBlacklistError']()}</p>
 				</div>
 			{:else if blacklistEntries.length === 0}
-				<div class="rounded-lg border border-dashed p-12 text-center">
-					<Ban class="mx-auto h-12 w-12 text-muted-foreground" />
-					<h3 class="mt-4 font-semibold">{m['blacklistAdminPage.noEntries']()}</h3>
-					<p class="mt-2 text-sm text-muted-foreground">
-						{blacklistSearch
-							? m['blacklistAdminPage.noEntriesMatchSearch']()
-							: m['blacklistAdminPage.noEntriesHint']()}
-					</p>
-				</div>
+				<EmptyState
+					icon={Ban}
+					title={m['blacklistAdminPage.noEntries']()}
+					body={blacklistSearch
+						? m['blacklistAdminPage.noEntriesMatchSearch']()
+						: m['blacklistAdminPage.noEntriesHint']()}
+				/>
 			{:else}
 				<div class="grid gap-4 md:grid-cols-2">
 					{#each blacklistEntries as entry (entry.id)}
@@ -564,8 +561,8 @@
 		<!-- Verified Users Tab -->
 		<TabsContent value="verified" class="space-y-4">
 			<!-- Info Box -->
-			<div class="rounded-lg border border-green-500/30 bg-green-50 p-3 dark:bg-green-950/30">
-				<p class="text-sm text-green-900 dark:text-green-100">
+			<div class="rounded-lg border border-success bg-success/10 p-3">
+				<p class="text-sm text-foreground">
 					{m['blacklistAdminPage.verifiedInfo']()}
 				</p>
 			</div>
@@ -580,13 +577,12 @@
 					<p class="text-sm text-destructive">{m['blacklistAdminPage.loadVerifiedError']()}</p>
 				</div>
 			{:else if whitelistEntries.length === 0}
-				<div class="rounded-lg border border-dashed p-12 text-center">
-					<ShieldCheck class="mx-auto h-12 w-12 text-muted-foreground" />
-					<h3 class="mt-4 font-semibold">{m['blacklistAdminPage.noVerifiedUsers']()}</h3>
-					<p class="mt-2 text-sm text-muted-foreground">
-						{m['blacklistAdminPage.noVerifiedUsersHint']()}
-					</p>
-				</div>
+				<EmptyState
+					icon={ShieldCheck}
+					title={m['blacklistAdminPage.noVerifiedUsers']()}
+					body={m['blacklistAdminPage.noVerifiedUsersHint']()}
+					tone="success"
+				/>
 			{:else}
 				<div class="grid gap-4 md:grid-cols-2">
 					{#each whitelistEntries as entry (entry.id)}

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
@@ -365,11 +365,17 @@
 									</span>
 								</td>
 								<td class="px-4 py-3">
+									<!-- The info pill's text is fine as `text-info` (info@10% composited
+									     over --background is 9.5:1+ in both modes). The success one is
+									     NOT: text-success@10%-success-tint over --background measures
+									     4.39:1 in LIGHT mode — under the 4.5:1 text-xs floor (dark is
+									     8.73:1, fine) — so it keeps `text-foreground` and only the tint
+									     carries the success identity. -->
 									<span
 										class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {code.discount_type ===
 										'percentage'
 											? 'bg-info/10 text-info'
-											: 'bg-success/10 text-success'}"
+											: 'bg-success/10 text-foreground'}"
 									>
 										{formatValue(code)}
 									</span>
@@ -467,11 +473,15 @@
 									{/if}
 								</button>
 							</p>
+							<!-- Same fix as the desktop table cell: text-success@10%-success-tint
+							     over --background is 4.39:1 in light mode, under the text-xs
+							     floor — text-foreground carries the label, the tint carries the
+							     identity. Info pill (9.5:1+ both modes) is unaffected. -->
 							<span
 								class="mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium {code.discount_type ===
 								'percentage'
 									? 'bg-info/10 text-info'
-									: 'bg-success/10 text-success'}"
+									: 'bg-success/10 text-foreground'}"
 							>
 								{formatValue(code)}
 							</span>

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
@@ -30,6 +30,9 @@
 	import { toast } from 'svelte-sonner';
 	import { formatDateTime } from '$lib/utils/date';
 	import * as m from '$lib/paraglide/messages.js';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import DiscountCodeStatusBadge from '$lib/components/discount-codes/DiscountCodeStatusBadge.svelte';
 
 	const organization = $derived($page.data.organization);
 	const accessToken = $derived(authStore.accessToken);
@@ -216,14 +219,7 @@
 
 <div class="space-y-6">
 	<!-- Header -->
-	<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['discountCodesAdmin.heading']()}
-			</h1>
-			<p class="text-muted-foreground">{m['discountCodesAdmin.description']()}</p>
-		</div>
-
+	{#snippet headerActions()}
 		<Button
 			onclick={() =>
 				goto(resolve('/(auth)/org/[slug]/admin/discount-codes/new', { slug: organization.slug }))}
@@ -231,7 +227,12 @@
 			<Plus class="mr-2 h-4 w-4" aria-hidden="true" />
 			{m['discountCodesAdmin.newCode']()}
 		</Button>
-	</div>
+	{/snippet}
+	<PageHeader
+		title={m['discountCodesAdmin.heading']()}
+		subtitle={m['discountCodesAdmin.description']()}
+		actions={headerActions}
+	/>
 
 	<!-- Filters -->
 	<div class="flex flex-col gap-3 md:flex-row md:items-center">
@@ -287,29 +288,25 @@
 			></div>
 		</div>
 	{:else if codes.length === 0}
-		<div
-			class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600"
-		>
-			<Tag class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-4 text-lg font-semibold">{m['discountCodesAdmin.empty.title']()}</h3>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{searchQuery || activeFilter !== 'all' || typeFilter !== 'all'
-					? m['discountCodesAdmin.empty.adjustFilters']()
-					: m['discountCodesAdmin.empty.getStarted']()}
-			</p>
-			{#if !searchQuery && activeFilter === 'all' && typeFilter === 'all'}
-				<Button
-					class="mt-4"
-					onclick={() =>
-						goto(
-							resolve('/(auth)/org/[slug]/admin/discount-codes/new', { slug: organization.slug })
-						)}
-				>
-					<Plus class="mr-2 h-4 w-4" aria-hidden="true" />
-					{m['discountCodesAdmin.newCode']()}
-				</Button>
-			{/if}
-		</div>
+		{#snippet newCodeAction()}
+			<Button
+				onclick={() =>
+					goto(resolve('/(auth)/org/[slug]/admin/discount-codes/new', { slug: organization.slug }))}
+			>
+				<Plus class="mr-2 h-4 w-4" aria-hidden="true" />
+				{m['discountCodesAdmin.newCode']()}
+			</Button>
+		{/snippet}
+		<EmptyState
+			icon={Tag}
+			title={m['discountCodesAdmin.empty.title']()}
+			body={searchQuery || activeFilter !== 'all' || typeFilter !== 'all'
+				? m['discountCodesAdmin.empty.adjustFilters']()
+				: m['discountCodesAdmin.empty.getStarted']()}
+			action={searchQuery || activeFilter !== 'all' || typeFilter !== 'all'
+				? undefined
+				: newCodeAction}
+		/>
 	{:else}
 		<!-- Table (desktop) / Cards (mobile) -->
 		<div class="hidden md:block">
@@ -317,24 +314,32 @@
 				<table class="w-full text-sm">
 					<thead class="bg-muted/50">
 						<tr>
-							<th class="px-4 py-3 text-left font-medium">{m['discountCodesAdmin.table.code']()}</th
+							<th
+								class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+								>{m['discountCodesAdmin.table.code']()}</th
 							>
-							<th class="px-4 py-3 text-left font-medium"
+							<th
+								class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['discountCodesAdmin.table.discount']()}</th
 							>
-							<th class="px-4 py-3 text-left font-medium"
+							<th
+								class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['discountCodesAdmin.table.status']()}</th
 							>
-							<th class="px-4 py-3 text-left font-medium"
+							<th
+								class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['discountCodesAdmin.table.usage']()}</th
 							>
-							<th class="px-4 py-3 text-left font-medium"
+							<th
+								class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['discountCodesAdmin.table.validPeriod']()}</th
 							>
-							<th class="px-4 py-3 text-left font-medium"
+							<th
+								class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['discountCodesAdmin.table.scope']()}</th
 							>
-							<th class="px-4 py-3 text-right font-medium"
+							<th
+								class="px-4 py-3 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['discountCodesAdmin.table.actions']()}</th
 							>
 						</tr>
@@ -352,7 +357,7 @@
 											aria-label={m['discountCodesAdmin.actions.copyAria']({ code: code.code })}
 										>
 											{#if copiedCodeId === code.id}
-												<Check class="h-3.5 w-3.5 text-emerald-600" aria-hidden="true" />
+												<Check class="h-3.5 w-3.5 text-success" aria-hidden="true" />
 											{:else}
 												<Copy class="h-3.5 w-3.5" aria-hidden="true" />
 											{/if}
@@ -363,22 +368,14 @@
 									<span
 										class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {code.discount_type ===
 										'percentage'
-											? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
-											: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'}"
+											? 'bg-info/10 text-info'
+											: 'bg-success/10 text-success'}"
 									>
 										{formatValue(code)}
 									</span>
 								</td>
 								<td class="px-4 py-3">
-									<span
-										class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {code.is_active
-											? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
-											: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'}"
-									>
-										{code.is_active
-											? m['discountCodesAdmin.status.active']()
-											: m['discountCodesAdmin.status.inactive']()}
-									</span>
+									<DiscountCodeStatusBadge isActive={!!code.is_active} />
 								</td>
 								<td class="px-4 py-3 text-muted-foreground">
 									{formatUsage(code)}
@@ -403,9 +400,9 @@
 												: m['discountCodesAdmin.actions.activateAria']()}
 										>
 											{#if code.is_active}
-												<ToggleRight class="h-4 w-4 text-emerald-600" />
+												<ToggleRight class="h-4 w-4 text-success" aria-hidden="true" />
 											{:else}
-												<ToggleLeft class="h-4 w-4" />
+												<ToggleLeft class="h-4 w-4" aria-hidden="true" />
 											{/if}
 										</button>
 										<button
@@ -421,7 +418,7 @@
 											title={m['discountCodesAdmin.actions.edit']()}
 											aria-label={m['discountCodesAdmin.actions.editAria']()}
 										>
-											<Pencil class="h-4 w-4" />
+											<Pencil class="h-4 w-4" aria-hidden="true" />
 										</button>
 										<button
 											type="button"
@@ -455,7 +452,7 @@
 				<div class="rounded-lg border p-4">
 					<div class="flex items-start justify-between">
 						<div>
-							<p class="flex items-center gap-2 font-mono text-lg font-semibold">
+							<p class="flex items-center gap-2 font-mono text-lg font-bold">
 								{code.code}
 								<button
 									type="button"
@@ -464,7 +461,7 @@
 									aria-label={m['discountCodesAdmin.actions.copyAria']({ code: code.code })}
 								>
 									{#if copiedCodeId === code.id}
-										<Check class="h-4 w-4 text-emerald-600" aria-hidden="true" />
+										<Check class="h-4 w-4 text-success" aria-hidden="true" />
 									{:else}
 										<Copy class="h-4 w-4" aria-hidden="true" />
 									{/if}
@@ -473,21 +470,13 @@
 							<span
 								class="mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium {code.discount_type ===
 								'percentage'
-									? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
-									: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'}"
+									? 'bg-info/10 text-info'
+									: 'bg-success/10 text-success'}"
 							>
 								{formatValue(code)}
 							</span>
 						</div>
-						<span
-							class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {code.is_active
-								? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
-								: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'}"
-						>
-							{code.is_active
-								? m['discountCodesAdmin.status.active']()
-								: m['discountCodesAdmin.status.inactive']()}
-						</span>
+						<DiscountCodeStatusBadge isActive={!!code.is_active} />
 					</div>
 
 					<div class="mt-3 grid grid-cols-2 gap-2 text-sm text-muted-foreground">
@@ -519,10 +508,10 @@
 							class="flex-1"
 						>
 							{#if code.is_active}
-								<ToggleRight class="mr-1 h-4 w-4 text-emerald-600" />
+								<ToggleRight class="mr-1 h-4 w-4 text-success" aria-hidden="true" />
 								{m['discountCodesAdmin.actions.deactivate']()}
 							{:else}
-								<ToggleLeft class="mr-1 h-4 w-4" />
+								<ToggleLeft class="mr-1 h-4 w-4" aria-hidden="true" />
 								{m['discountCodesAdmin.actions.activate']()}
 							{/if}
 						</Button>

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/[code_id]/edit/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/[code_id]/edit/+page.svelte
@@ -138,11 +138,13 @@
 			<ArrowLeft class="h-5 w-5" />
 		</Button>
 		<div>
-			<h1 class="text-2xl font-bold tracking-tight">{m['discountCodeEditPage.title']()}</h1>
+			<h1 class="text-2xl font-extrabold tracking-tight sm:text-3xl">
+				{m['discountCodeEditPage.title']()}
+			</h1>
 			{#if existingCode}
-				<p class="text-muted-foreground">
+				<p class="mt-2 text-muted-foreground">
 					{m['discountCodeEditPage.editing']()}
-					<span class="font-mono font-semibold">{existingCode.code}</span>
+					<span class="font-mono font-bold">{existingCode.code}</span>
 				</p>
 			{/if}
 		</div>

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/new/+page.svelte
@@ -112,8 +112,10 @@
 			<ArrowLeft class="h-5 w-5" />
 		</Button>
 		<div>
-			<h1 class="text-2xl font-bold tracking-tight">{m['discountCodeNewPage.title']()}</h1>
-			<p class="text-muted-foreground">{m['discountCodeNewPage.subtitle']()}</p>
+			<h1 class="text-2xl font-extrabold tracking-tight sm:text-3xl">
+				{m['discountCodeNewPage.title']()}
+			</h1>
+			<p class="mt-2 text-muted-foreground">{m['discountCodeNewPage.subtitle']()}</p>
 		</div>
 	</div>
 

--- a/src/routes/(auth)/org/[slug]/admin/members/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/members/+page.svelte
@@ -24,6 +24,7 @@
 		Info,
 		ChevronDown
 	} from '@lucide/svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import MembersTab from '$lib/components/members/MembersTab.svelte';
 	import StaffTab from '$lib/components/members/StaffTab.svelte';
 	import MembershipRequestsTab from '$lib/components/members/MembershipRequestsTab.svelte';
@@ -170,15 +171,7 @@
 
 <div class="space-y-6 px-4 md:px-0">
 	<!-- Header -->
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div class="min-w-0">
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['orgAdmin.members.pageTitle']()}
-			</h1>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['orgAdmin.members.pageDescription']()}
-			</p>
-		</div>
+	{#snippet headerActions()}
 		{#if canManageMembers}
 			<Button
 				onclick={() => {
@@ -191,7 +184,12 @@
 				{m['orgAdmin.members.inviteMembers']()}
 			</Button>
 		{/if}
-	</div>
+	{/snippet}
+	<PageHeader
+		title={m['orgAdmin.members.pageTitle']()}
+		subtitle={m['orgAdmin.members.pageDescription']()}
+		actions={headerActions}
+	/>
 
 	<!-- What membership grants (discreet inline disclosure, collapsed by default) -->
 	<details class="group">

--- a/src/routes/(auth)/org/[slug]/admin/polls/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/polls/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import { Plus, Search } from '@lucide/svelte';
+	import { Plus, Search, Vote } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import PollCard from '$lib/components/polls/PollCard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -24,17 +26,19 @@
 	<title>{m['orgAdmin.polls.pageTitle']()} - {data.organization.name} Admin</title>
 </svelte:head>
 
-<!-- Page Header -->
-<div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-	<div>
-		<h1 class="text-3xl font-bold tracking-tight">{m['orgAdmin.polls.pageTitle']()}</h1>
-		<p class="mt-2 text-sm text-muted-foreground">{m['orgAdmin.polls.pageDescription']()}</p>
-	</div>
-	<Button href="polls/new" class="gap-2">
-		<Plus class="h-4 w-4" />
-		{m['orgAdmin.polls.createPollButton']()}
-	</Button>
-</div>
+<PageHeader
+	title={m['orgAdmin.polls.pageTitle']()}
+	subtitle={m['orgAdmin.polls.pageDescription']()}
+	kicker={data.organization.name}
+	class="mb-6"
+>
+	{#snippet actions()}
+		<Button href="polls/new" class="gap-2">
+			<Plus class="h-4 w-4" />
+			{m['orgAdmin.polls.createPollButton']()}
+		</Button>
+	{/snippet}
+</PageHeader>
 
 <!-- Search Bar -->
 <div class="mb-6">
@@ -53,30 +57,32 @@
 {#if filtered.length === 0}
 	{#if searchQuery}
 		<!-- No search results -->
-		<div class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12">
-			<div class="mb-4 rounded-full bg-muted p-3">
-				<Search class="h-6 w-6 text-muted-foreground" />
-			</div>
-			<h3 class="mb-2 text-lg font-semibold">{m['orgAdmin.polls.noResults.title']()}</h3>
-			<p class="mb-4 text-center text-sm text-muted-foreground">
-				{m['orgAdmin.polls.noResults.description']({ query: searchQuery })}
-			</p>
-			<Button variant="outline" onclick={() => (searchQuery = '')}>
-				{m['orgAdmin.polls.noResults.clearButton']()}
-			</Button>
-		</div>
+		<EmptyState
+			icon={Search}
+			tone="neutral"
+			title={m['orgAdmin.polls.noResults.title']()}
+			body={m['orgAdmin.polls.noResults.description']({ query: searchQuery })}
+		>
+			{#snippet action()}
+				<Button variant="outline" onclick={() => (searchQuery = '')}>
+					{m['orgAdmin.polls.noResults.clearButton']()}
+				</Button>
+			{/snippet}
+		</EmptyState>
 	{:else}
 		<!-- Empty state -->
-		<div class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12">
-			<h3 class="mb-2 text-lg font-semibold">{m['orgAdmin.polls.empty.title']()}</h3>
-			<p class="mb-4 text-center text-sm text-muted-foreground">
-				{m['orgAdmin.polls.empty.description']()}
-			</p>
-			<Button href="polls/new" class="gap-2">
-				<Plus class="h-4 w-4" />
-				{m['orgAdmin.polls.createPollButton']()}
-			</Button>
-		</div>
+		<EmptyState
+			icon={Vote}
+			title={m['orgAdmin.polls.empty.title']()}
+			body={m['orgAdmin.polls.empty.description']()}
+		>
+			{#snippet action()}
+				<Button href="polls/new" class="gap-2">
+					<Plus class="h-4 w-4" />
+					{m['orgAdmin.polls.createPollButton']()}
+				</Button>
+			{/snippet}
+		</EmptyState>
 	{/if}
 {:else}
 	<!-- Polls Grid -->

--- a/src/routes/(auth)/org/[slug]/admin/polls/[id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/polls/[id]/+page.svelte
@@ -20,6 +20,8 @@
 	import PollStatusBar from '$lib/components/polls/PollStatusBar.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import DuplicatePollModal from '$lib/components/polls/DuplicatePollModal.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import QuestionTypeBadge from '$lib/components/questionnaires/QuestionTypeBadge.svelte';
 	import PollAudienceCard from '$lib/components/polls/PollAudienceCard.svelte';
 	import PollAnonymityCard from '$lib/components/polls/PollAnonymityCard.svelte';
 	import PollScheduleCard from '$lib/components/polls/PollScheduleCard.svelte';
@@ -279,15 +281,22 @@
 		<ArrowLeft class="h-4 w-4" />
 		{m['pollEditPage.backToList']()}
 	</Button>
-	<div class="flex items-center justify-between gap-2">
-		<h1 class="text-3xl font-bold tracking-tight">
-			{name || poll.questionnaire?.name || m['pollEditPage.pageTitle']()}
-		</h1>
-		<Button variant="outline" size="sm" class="gap-2" onclick={() => (isDuplicateModalOpen = true)}>
-			<Copy class="h-4 w-4" />
-			{m['pollEditPage.duplicate']()}
-		</Button>
-	</div>
+	<PageHeader
+		title={name || poll.questionnaire?.name || m['pollEditPage.pageTitle']()}
+		kicker={data.organization.name}
+	>
+		{#snippet actions()}
+			<Button
+				variant="outline"
+				size="sm"
+				class="gap-2"
+				onclick={() => (isDuplicateModalOpen = true)}
+			>
+				<Copy class="h-4 w-4" />
+				{m['pollEditPage.duplicate']()}
+			</Button>
+		{/snippet}
+	</PageHeader>
 </div>
 
 <div class="mx-auto max-w-4xl space-y-6">
@@ -346,7 +355,7 @@
 					<CardTitle>{m['pollNewPage.questionsTitle']()} ({totalQuestionCount})</CardTitle>
 					{#if !isDraft}
 						<CardDescription
-							class="mt-2 rounded-md bg-amber-50 p-2 text-amber-900 dark:bg-amber-950/30 dark:text-amber-200"
+							class="mt-2 rounded-md border border-highlight bg-highlight/10 p-2 text-foreground"
 						>
 							{m['pollEditPage.questionsLockedBanner']()}
 						</CardDescription>
@@ -438,10 +447,11 @@
 					<div class="space-y-3">
 						{#each allMc as question (question.id)}
 							<div class="rounded-lg border p-4">
-								<span
-									class="mb-2 inline-block rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700"
-									>{m['questionAnswerDisplay.multipleChoice']()}</span
-								>
+								<QuestionTypeBadge
+									type="multiple_choice"
+									label={m['questionAnswerDisplay.multipleChoice']()}
+									class="mb-2"
+								/>
 								<p class="font-medium">{question.question}</p>
 								{#if question.options}
 									<div class="mt-2 space-y-1">
@@ -457,19 +467,21 @@
 						{/each}
 						{#each allFt as question (question.id)}
 							<div class="rounded-lg border p-4">
-								<span
-									class="mb-2 inline-block rounded bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700"
-									>{m['questionAnswerDisplay.freeText']()}</span
-								>
+								<QuestionTypeBadge
+									type="free_text"
+									label={m['questionAnswerDisplay.freeText']()}
+									class="mb-2"
+								/>
 								<p class="font-medium">{question.question}</p>
 							</div>
 						{/each}
 						{#each allFu as question (question.id)}
 							<div class="rounded-lg border p-4">
-								<span
-									class="mb-2 inline-block rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700"
-									>{m['questionAnswerDisplay.fileUpload']()}</span
-								>
+								<QuestionTypeBadge
+									type="file_upload"
+									label={m['questionAnswerDisplay.fileUpload']()}
+									class="mb-2"
+								/>
 								<p class="font-medium">{question.question}</p>
 							</div>
 						{/each}

--- a/src/routes/(auth)/org/[slug]/admin/polls/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/polls/new/+page.svelte
@@ -15,6 +15,7 @@
 		CardTitle
 	} from '$lib/components/ui/card';
 	import MarkdownEditor from '$lib/components/forms/MarkdownEditor.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import QuestionEditor from '$lib/components/questionnaires/QuestionEditor.svelte';
 	import SectionEditor from '$lib/components/questionnaires/SectionEditor.svelte';
 	import PollAudienceCard from '$lib/components/polls/PollAudienceCard.svelte';
@@ -249,7 +250,7 @@
 		<ArrowLeft class="h-4 w-4" />
 		{m['pollNewPage.backToList']()}
 	</Button>
-	<h1 class="text-3xl font-bold tracking-tight">{m['pollNewPage.pageTitle']()}</h1>
+	<PageHeader title={m['pollNewPage.pageTitle']()} kicker={data.organization.name} />
 </div>
 
 <div class="mx-auto max-w-4xl space-y-6">

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import { Plus, Search } from '@lucide/svelte';
+	import { Plus, Search, FileText } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import QuestionnaireCard from '$lib/components/questionnaires/QuestionnaireCard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { useQueryClient } from '@tanstack/svelte-query';
 	import { invalidateOrgQuestionnaires } from '$lib/queries/org-questionnaires';
 	import type { PageData } from './$types';
@@ -47,19 +49,19 @@
 	<title>{m['orgAdmin.questionnaires.pageTitle']()} - {data.organization.name} Admin</title>
 </svelte:head>
 
-<!-- Page Header -->
-<div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-	<div>
-		<h1 class="text-3xl font-bold tracking-tight">{m['orgAdmin.questionnaires.pageTitle']()}</h1>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{m['orgAdmin.questionnaires.pageDescription']()}
-		</p>
-	</div>
-	<Button href="questionnaires/new" class="gap-2">
-		<Plus class="h-4 w-4" />
-		{m['orgAdmin.questionnaires.createQuestionnaireButton']()}
-	</Button>
-</div>
+<PageHeader
+	title={m['orgAdmin.questionnaires.pageTitle']()}
+	subtitle={m['orgAdmin.questionnaires.pageDescription']()}
+	kicker={data.organization.name}
+	class="mb-6"
+>
+	{#snippet actions()}
+		<Button href="questionnaires/new" class="gap-2">
+			<Plus class="h-4 w-4" />
+			{m['orgAdmin.questionnaires.createQuestionnaireButton']()}
+		</Button>
+	{/snippet}
+</PageHeader>
 
 <!-- Search Bar -->
 <div class="mb-6">
@@ -78,46 +80,32 @@
 {#if filteredQuestionnaires.length === 0}
 	{#if searchQuery}
 		<!-- No search results -->
-		<div class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12">
-			<div class="mb-4 rounded-full bg-muted p-3">
-				<Search class="h-6 w-6 text-muted-foreground" />
-			</div>
-			<h3 class="mb-2 text-lg font-semibold">{m['orgAdmin.questionnaires.noResults.title']()}</h3>
-			<p class="mb-4 text-center text-sm text-muted-foreground">
-				{m['orgAdmin.questionnaires.noResults.description']({ query: searchQuery })}
-			</p>
-			<Button variant="outline" onclick={() => (searchQuery = '')}
-				>{m['orgAdmin.questionnaires.noResults.clearButton']()}</Button
-			>
-		</div>
+		<EmptyState
+			icon={Search}
+			tone="neutral"
+			title={m['orgAdmin.questionnaires.noResults.title']()}
+			body={m['orgAdmin.questionnaires.noResults.description']({ query: searchQuery })}
+		>
+			{#snippet action()}
+				<Button variant="outline" onclick={() => (searchQuery = '')}>
+					{m['orgAdmin.questionnaires.noResults.clearButton']()}
+				</Button>
+			{/snippet}
+		</EmptyState>
 	{:else}
 		<!-- Empty state -->
-		<div class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12">
-			<div class="mb-4 rounded-full bg-muted p-3">
-				<svg
-					class="h-6 w-6 text-muted-foreground"
-					fill="none"
-					stroke="currentColor"
-					viewBox="0 0 24 24"
-					aria-hidden="true"
-				>
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width="2"
-						d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-					/>
-				</svg>
-			</div>
-			<h3 class="mb-2 text-lg font-semibold">{m['orgAdmin.questionnaires.empty.title']()}</h3>
-			<p class="mb-4 text-center text-sm text-muted-foreground">
-				{m['orgAdmin.questionnaires.empty.description']()}
-			</p>
-			<Button href="questionnaires/new" class="gap-2">
-				<Plus class="h-4 w-4" />
-				{m['orgAdmin.questionnaires.createQuestionnaireButton']()}
-			</Button>
-		</div>
+		<EmptyState
+			icon={FileText}
+			title={m['orgAdmin.questionnaires.empty.title']()}
+			body={m['orgAdmin.questionnaires.empty.description']()}
+		>
+			{#snippet action()}
+				<Button href="questionnaires/new" class="gap-2">
+					<Plus class="h-4 w-4" />
+					{m['orgAdmin.questionnaires.createQuestionnaireButton']()}
+				</Button>
+			{/snippet}
+		</EmptyState>
 	{/if}
 {:else}
 	<!-- Questionnaires Grid -->

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/+page.svelte
@@ -10,6 +10,7 @@
 	import QuestionnaireFormFields from '$lib/components/questionnaires/QuestionnaireFormFields.svelte';
 	import QuestionnaireEditAssignments from '$lib/components/questionnaires/QuestionnaireEditAssignments.svelte';
 	import QuestionnaireEditQuestionsCard from '$lib/components/questionnaires/QuestionnaireEditQuestionsCard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { questionnaireUpdateQuestionnaireStatus } from '$lib/api/generated/sdk.gen';
 	import { useQueryClient } from '@tanstack/svelte-query';
 	import { invalidateOrgQuestionnaires } from '$lib/queries/org-questionnaires';
@@ -287,12 +288,12 @@
 			{m['questionnaireEditPage.backButton']()}
 		</Button>
 
-		<div class="flex items-center justify-between">
-			<div>
-				<h1 class="text-3xl font-bold tracking-tight">{m['questionnaireEditPage.title']()}</h1>
-				<p class="mt-2 text-sm text-muted-foreground">{m['questionnaireEditPage.subtitle']()}</p>
-			</div>
-			<div class="flex gap-2">
+		<PageHeader
+			title={m['questionnaireEditPage.title']()}
+			subtitle={m['questionnaireEditPage.subtitle']()}
+			kicker={data.organization.name}
+		>
+			{#snippet actions()}
 				<Button variant="outline" size="sm" onclick={() => (isDuplicateModalOpen = true)}>
 					{m['questionnaireEditPage.duplicate']()}
 				</Button>
@@ -303,8 +304,8 @@
 				>
 					{m['questionnaireEditPage.viewSummary']()}
 				</Button>
-			</div>
-		</div>
+			{/snippet}
+		</PageHeader>
 	</div>
 
 	<!-- Status Management -->
@@ -312,17 +313,15 @@
 
 	<!-- Info Banner -->
 	{#if isEditMode}
-		<div
-			class="mb-6 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950"
-		>
+		<div class="mb-6 rounded-lg border border-success/50 bg-success/10 p-4">
 			<div class="flex items-start justify-between gap-3">
 				<div class="flex gap-3">
-					<Pencil class="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-500" />
+					<Pencil class="h-5 w-5 flex-shrink-0 text-success" />
 					<div class="text-sm">
-						<p class="font-medium text-green-800 dark:text-green-200">
+						<p class="font-medium text-foreground">
 							{m['questionnaireEditPage.editModeEnabled']()}
 						</p>
-						<p class="mt-1 text-green-700 dark:text-green-300">
+						<p class="mt-1 text-foreground">
 							{m['questionnaireEditPage.editModeDescription']()}
 						</p>
 					</div>
@@ -340,17 +339,15 @@
 			</div>
 		</div>
 	{:else}
-		<div
-			class="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950"
-		>
+		<div class="mb-6 rounded-lg border border-info/50 bg-info/10 p-4">
 			<div class="flex items-start justify-between gap-3">
 				<div class="flex gap-3">
-					<FileEdit class="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-500" />
+					<FileEdit class="h-5 w-5 flex-shrink-0 text-info" />
 					<div class="text-sm">
-						<p class="font-medium text-blue-800 dark:text-blue-200">
+						<p class="font-medium text-foreground">
 							{m['questionnaireEditPage.viewMode']()}
 						</p>
-						<p class="mt-1 text-blue-700 dark:text-blue-300">
+						<p class="mt-1 text-foreground">
 							{m['questionnaireEditPage.viewModeDescription']()}
 						</p>
 					</div>

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/+page.svelte
@@ -99,7 +99,7 @@
 		<PageHeader
 			title={m['questionnaireSubmissionsPage.title']()}
 			subtitle={m['questionnaireSubmissionsPage.subtitle']()}
-			kicker={data.organizationSlug}
+			kicker={data.organization.name}
 		>
 			{#snippet actions()}
 				<Button

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/+page.svelte
@@ -8,13 +8,16 @@
 	import { Card } from '$lib/components/ui/card';
 	import SubmissionStats from '$lib/components/questionnaires/SubmissionStats.svelte';
 	import SubmissionStatusBadge from '$lib/components/questionnaires/SubmissionStatusBadge.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import {
 		ArrowLeft,
 		ChevronLeft,
 		ChevronRight,
 		ChevronsLeft,
 		ChevronsRight,
-		ArrowUpDown
+		ArrowUpDown,
+		FileText
 	} from '@lucide/svelte';
 	import { resolveSubmissionBadgeStatus } from '$lib/utils/resolve-submission-badge-status';
 	import { formatDateTime } from '$lib/utils/date';
@@ -93,19 +96,21 @@
 			<ArrowLeft class="h-4 w-4" />
 			{m['questionnaireSubmissionsPage.backToQuestionnaires']()}
 		</a>
-		<div class="flex items-center justify-between">
-			<div>
-				<h1 class="text-3xl font-bold">{m['questionnaireSubmissionsPage.title']()}</h1>
-				<p class="mt-2 text-muted-foreground">{m['questionnaireSubmissionsPage.subtitle']()}</p>
-			</div>
-			<Button
-				href="/org/{data.organizationSlug}/admin/questionnaires/{data.questionnaireId}/summary"
-				variant="outline"
-				size="sm"
-			>
-				{m['questionnaireSubmissionsPage.viewSummary']()}
-			</Button>
-		</div>
+		<PageHeader
+			title={m['questionnaireSubmissionsPage.title']()}
+			subtitle={m['questionnaireSubmissionsPage.subtitle']()}
+			kicker={data.organizationSlug}
+		>
+			{#snippet actions()}
+				<Button
+					href="/org/{data.organizationSlug}/admin/questionnaires/{data.questionnaireId}/summary"
+					variant="outline"
+					size="sm"
+				>
+					{m['questionnaireSubmissionsPage.viewSummary']()}
+				</Button>
+			{/snippet}
+		</PageHeader>
 	</div>
 
 	<!-- Stats -->
@@ -197,18 +202,14 @@
 
 	<!-- Submissions List -->
 	{#if data.submissions.length === 0}
-		<Card class="p-12 text-center">
-			<p class="text-lg text-muted-foreground">
-				{m['questionnaireSubmissionsPage.noSubmissionsFound']()}
-			</p>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{#if data.filters.search || data.filters.evaluationStatus}
-					{m['questionnaireSubmissionsPage.adjustFilters']()}
-				{:else}
-					{m['questionnaireSubmissionsPage.noSubmissionsYet']()}
-				{/if}
-			</p>
-		</Card>
+		<EmptyState
+			icon={FileText}
+			tone="neutral"
+			title={m['questionnaireSubmissionsPage.noSubmissionsFound']()}
+			body={data.filters.search || data.filters.evaluationStatus
+				? m['questionnaireSubmissionsPage.adjustFilters']()
+				: m['questionnaireSubmissionsPage.noSubmissionsYet']()}
+		/>
 	{:else}
 		<!-- Desktop Table View -->
 		<div class="hidden overflow-x-auto md:block">
@@ -216,21 +217,26 @@
 				<table class="w-full">
 					<thead class="border-b bg-muted/50">
 						<tr>
-							<th class="px-6 py-4 text-left text-sm font-medium"
+							<th
+								class="px-6 py-4 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['questionnaireSubmissionsPage.header_respondent']()}</th
 							>
-							<th class="px-6 py-4 text-left text-sm font-medium"
+							<th
+								class="px-6 py-4 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['questionnaireSubmissionsPage.header_submitted']()}</th
 							>
-							<th class="px-6 py-4 text-left text-sm font-medium"
+							<th
+								class="px-6 py-4 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['questionnaireSubmissionsPage.header_evaluationStatus']()}</th
 							>
 							{#if data.requiresEvaluation}
-								<th class="px-6 py-4 text-left text-sm font-medium"
+								<th
+									class="px-6 py-4 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 									>{m['questionnaireSubmissionsPage.header_score']()}</th
 								>
 							{/if}
-							<th class="px-6 py-4 text-right text-sm font-medium"
+							<th
+								class="px-6 py-4 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 								>{m['questionnaireSubmissionsPage.header_actions']()}</th
 							>
 						</tr>

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
@@ -8,6 +8,7 @@
 	import AutoEvalRecommendation from '$lib/components/questionnaires/AutoEvalRecommendation.svelte';
 	import EvaluationForm from '$lib/components/questionnaires/EvaluationForm.svelte';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import {
 		ArrowLeft,
 		ChevronLeft,
@@ -179,21 +180,21 @@
 
 			{@render submissionNav()}
 		</div>
-		<div class="flex items-start justify-between gap-4">
-			<div class="flex-1">
-				<h1 class="text-3xl font-bold">{m['questionnaireSubmissionDetailPage.title']()}</h1>
-				<p class="mt-2 text-muted-foreground">
-					{m['questionnaireSubmissionDetailPage.subtitle']()}
-				</p>
-			</div>
-			<SubmissionStatusBadge
-				status={resolveSubmissionBadgeStatus(
-					data.requiresEvaluation,
-					data.submission.evaluation?.status
-				)}
-				class="shrink-0"
-			/>
-		</div>
+		<PageHeader
+			title={m['questionnaireSubmissionDetailPage.title']()}
+			subtitle={m['questionnaireSubmissionDetailPage.subtitle']()}
+			kicker={data.organizationSlug}
+		>
+			{#snippet actions()}
+				<SubmissionStatusBadge
+					status={resolveSubmissionBadgeStatus(
+						data.requiresEvaluation,
+						data.submission.evaluation?.status
+					)}
+					class="shrink-0"
+				/>
+			{/snippet}
+		</PageHeader>
 	</div>
 
 	<div class="grid gap-8 lg:grid-cols-3">
@@ -201,11 +202,9 @@
 		<div class="space-y-8 lg:col-span-2">
 			{#if !data.requiresEvaluation}
 				<!-- No evaluation required banner -->
-				<div
-					class="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950"
-				>
-					<Info class="mt-0.5 h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400" />
-					<p class="text-sm text-blue-800 dark:text-blue-200">
+				<div class="flex items-start gap-3 rounded-lg border border-info/50 bg-info/10 p-4">
+					<Info class="mt-0.5 h-5 w-5 shrink-0 text-info" />
+					<p class="text-sm text-info">
 						{m['questionnaireSubmissionDetailPage.noEvaluationRequired']()}
 					</p>
 				</div>
@@ -218,7 +217,7 @@
 
 			<!-- Questionnaire Answers -->
 			<div>
-				<h2 class="mb-4 text-2xl font-semibold">
+				<h2 class="mb-4 text-2xl font-bold">
 					{m['questionnaireSubmissionDetailPage.responsesTitle']()}
 				</h2>
 				<QuestionAnswerDisplay answers={data.submission.answers} />
@@ -227,7 +226,7 @@
 			{#if data.requiresEvaluation}
 				<!-- Evaluation Form -->
 				<div>
-					<h2 class="mb-4 text-2xl font-semibold">
+					<h2 class="mb-4 text-2xl font-bold">
 						{isEvaluated
 							? m['questionnaireSubmissionDetailPage.changeEvaluationTitle']()
 							: m['questionnaireSubmissionDetailPage.evaluateTitle']()}
@@ -255,7 +254,7 @@
 		<div class="space-y-6 lg:col-span-1">
 			<!-- Submitter Information -->
 			<Card class="p-6">
-				<h3 class="mb-4 text-lg font-semibold">
+				<h3 class="mb-4 text-lg font-bold">
 					{m['questionnaireSubmissionDetailPage.submitterInfoTitle']()}
 				</h3>
 
@@ -348,7 +347,7 @@
 			<!-- Event Context (if submission was for a specific event) -->
 			{#if eventMetadata}
 				<Card class="p-6">
-					<h3 class="mb-4 text-lg font-semibold">
+					<h3 class="mb-4 text-lg font-bold">
 						{m['questionnaireSubmissionDetailPage.eventContextTitle']()}
 					</h3>
 					<div class="space-y-4">
@@ -386,7 +385,7 @@
 
 			<!-- Questionnaire Information -->
 			<Card class="p-6">
-				<h3 class="mb-4 text-lg font-semibold">
+				<h3 class="mb-4 text-lg font-bold">
 					{m['questionnaireSubmissionDetailPage.questionnaireTitle']()}
 				</h3>
 				<div class="space-y-2">

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
@@ -183,7 +183,7 @@
 		<PageHeader
 			title={m['questionnaireSubmissionDetailPage.title']()}
 			subtitle={m['questionnaireSubmissionDetailPage.subtitle']()}
-			kicker={data.organizationSlug}
+			kicker={data.organization.name}
 		>
 			{#snippet actions()}
 				<SubmissionStatusBadge

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/summary/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/summary/+page.svelte
@@ -147,7 +147,7 @@
 		<PageHeader
 			title={m['questionnaireSummaryPage.title']()}
 			subtitle={questionnaire?.questionnaire.name}
-			kicker={data.organizationSlug}
+			kicker={data.organization.name}
 		>
 			{#snippet actions()}
 				<ExportButton

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/summary/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/summary/+page.svelte
@@ -17,6 +17,9 @@
 	import ScoreStatsCard from '$lib/components/questionnaires/ScoreStatsCard.svelte';
 	import PronounDistributionChart from '$lib/components/common/PronounDistributionChart.svelte';
 	import ExportButton from '$lib/components/common/ExportButton.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import { questionnaireExportSubmissions } from '$lib/api';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import type { PageData } from './$types';
@@ -141,17 +144,19 @@
 			<ArrowLeft class="h-4 w-4" />
 			{m['questionnaireSummaryPage.backToQuestionnaire']()}
 		</a>
-		<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-			<div>
-				<h1 class="text-3xl font-bold">{m['questionnaireSummaryPage.title']()}</h1>
-				<p class="mt-1 text-muted-foreground">{questionnaire?.questionnaire.name}</p>
-			</div>
-			<ExportButton
-				label={m['exportButton.exportSubmissions']()}
-				onExport={handleExportSubmissions}
-				accessToken={authStore.accessToken}
-			/>
-		</div>
+		<PageHeader
+			title={m['questionnaireSummaryPage.title']()}
+			subtitle={questionnaire?.questionnaire.name}
+			kicker={data.organizationSlug}
+		>
+			{#snippet actions()}
+				<ExportButton
+					label={m['exportButton.exportSubmissions']()}
+					onExport={handleExportSubmissions}
+					accessToken={authStore.accessToken}
+				/>
+			{/snippet}
+		</PageHeader>
 	</div>
 
 	<!-- Filters -->
@@ -216,13 +221,12 @@
 
 	{#if summary.total_submissions === 0}
 		<!-- Empty state -->
-		<Card class="p-12 text-center">
-			<FileText class="mx-auto mb-4 h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<p class="text-lg font-medium">{m['questionnaireSummaryPage.noSubmissions']()}</p>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{m['questionnaireSummaryPage.noSubmissionsDescription']()}
-			</p>
-		</Card>
+		<EmptyState
+			icon={FileText}
+			tone="neutral"
+			title={m['questionnaireSummaryPage.noSubmissions']()}
+			body={m['questionnaireSummaryPage.noSubmissionsDescription']()}
+		/>
 	{:else}
 		<!-- Summary Cards -->
 		<div class="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -235,9 +239,7 @@
 						</p>
 						<p class="text-3xl font-bold">{summary.total_submissions}</p>
 					</div>
-					<div class="rounded-full bg-blue-100 p-3 dark:bg-blue-950">
-						<FileText class="h-6 w-6 text-blue-900 dark:text-blue-100" aria-hidden="true" />
-					</div>
+					<ToneTile tone="info" icon={FileText} size="lg" class="rounded-full" />
 				</div>
 			</Card>
 
@@ -250,9 +252,7 @@
 						</p>
 						<p class="text-3xl font-bold">{summary.unique_users}</p>
 					</div>
-					<div class="rounded-full bg-purple-100 p-3 dark:bg-purple-950">
-						<Users class="h-6 w-6 text-purple-900 dark:text-purple-100" aria-hidden="true" />
-					</div>
+					<ToneTile tone="brand" icon={Users} size="lg" class="rounded-full" />
 				</div>
 			</Card>
 
@@ -268,9 +268,7 @@
 							{summary.by_status_per_user.approved ?? 0}/{totalEvaluated}
 						</p>
 					</div>
-					<div class="rounded-full bg-green-100 p-3 dark:bg-green-950">
-						<TrendingUp class="h-6 w-6 text-green-900 dark:text-green-100" aria-hidden="true" />
-					</div>
+					<ToneTile tone="success" icon={TrendingUp} size="lg" class="rounded-full" />
 				</div>
 			</Card>
 
@@ -283,9 +281,7 @@
 						</p>
 						<p class="text-3xl font-bold">{summary.by_status_per_user.pending_review ?? 0}</p>
 					</div>
-					<div class="rounded-full bg-yellow-100 p-3 dark:bg-yellow-950">
-						<Clock class="h-6 w-6 text-yellow-900 dark:text-yellow-100" aria-hidden="true" />
-					</div>
+					<ToneTile tone="warning" icon={Clock} size="lg" class="rounded-full" />
 				</div>
 			</Card>
 		</div>

--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/new/+page.svelte
@@ -15,6 +15,7 @@
 	import SectionEditor from '$lib/components/questionnaires/SectionEditor.svelte';
 	import QuestionnaireCreateBasicInfo from '$lib/components/questionnaires/QuestionnaireCreateBasicInfo.svelte';
 	import QuestionnaireCreateAdvancedSettings from '$lib/components/questionnaires/QuestionnaireCreateAdvancedSettings.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { questionnaireCreateOrgQuestionnaire } from '$lib/api/generated/sdk.gen';
 	import { useQueryClient } from '@tanstack/svelte-query';
 	import { invalidateOrgQuestionnaires } from '$lib/queries/org-questionnaires';
@@ -225,10 +226,11 @@
 		{m['questionnaireNewPage.backToQuestionnaires']()}
 	</Button>
 
-	<h1 class="text-3xl font-bold tracking-tight">{m['questionnaireNewPage.title']()}</h1>
-	<p class="mt-2 text-sm text-muted-foreground">
-		{m['questionnaireNewPage.subtitle']()}
-	</p>
+	<PageHeader
+		title={m['questionnaireNewPage.title']()}
+		subtitle={m['questionnaireNewPage.subtitle']()}
+		kicker={data.organization.name}
+	/>
 </div>
 
 <!-- Form -->

--- a/src/routes/(auth)/org/[slug]/admin/resources/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/resources/+page.svelte
@@ -8,9 +8,11 @@
 	} from '$lib/api/generated/sdk.gen';
 	import type { AdditionalResourceSchema } from '$lib/api/generated/types.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import { Plus, Search, Filter } from '@lucide/svelte';
+	import { Plus, Search, Filter, AlertTriangle } from '@lucide/svelte';
 	import ResourceList from '$lib/components/resources/ResourceList.svelte';
 	import ResourceModal from '$lib/components/resources/ResourceModal.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	const organization = $derived($page.data.organization);
 	const accessToken = $derived(authStore.accessToken);
@@ -113,15 +115,7 @@
 </script>
 
 <div class="space-y-6">
-	<!-- Header -->
-	<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['orgAdmin.resources.pageTitle']()}
-			</h1>
-			<p class="text-muted-foreground">{m['orgAdmin.resources.pageDescription']()}</p>
-		</div>
-
+	{#snippet resourcesHeaderActions()}
 		<button
 			type="button"
 			onclick={handleCreate}
@@ -130,7 +124,13 @@
 			<Plus class="h-5 w-5" aria-hidden="true" />
 			{m['orgAdmin.resources.addResourceButton']()}
 		</button>
-	</div>
+	{/snippet}
+
+	<PageHeader
+		title={m['orgAdmin.resources.pageTitle']()}
+		subtitle={m['orgAdmin.resources.pageDescription']()}
+		actions={resourcesHeaderActions}
+	/>
 
 	<!-- Filters -->
 	<div class="flex flex-col gap-3 md:flex-row md:items-center">
@@ -182,9 +182,15 @@
 
 	<!-- Content -->
 	{#if error}
-		<div class="rounded-md bg-destructive/10 p-4 text-destructive" role="alert">
-			<p class="font-semibold">{m['orgAdmin.resources.error.title']()}</p>
-			<p class="mt-1 text-sm">{m['orgAdmin.resources.error.description']()}</p>
+		<div
+			class="flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4"
+			role="alert"
+		>
+			<AlertTriangle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
+			<div>
+				<p class="font-semibold text-foreground">{m['orgAdmin.resources.error.title']()}</p>
+				<p class="mt-1 text-sm text-foreground">{m['orgAdmin.resources.error.description']()}</p>
+			</div>
 		</div>
 	{:else if isLoading}
 		<div class="flex items-center justify-center py-12">
@@ -194,27 +200,16 @@
 			></div>
 		</div>
 	{:else if resources.length === 0}
-		<div
-			class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600"
-		>
-			<Filter class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-4 text-lg font-semibold">{m['orgAdmin.resources.empty.title']()}</h3>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{searchQuery || typeFilter !== 'all' || visibilityFilter !== 'all'
-					? m['orgAdmin.resources.empty.withFilters']()
-					: m['orgAdmin.resources.empty.noFilters']()}
-			</p>
-			{#if !searchQuery && typeFilter === 'all' && visibilityFilter === 'all'}
-				<button
-					type="button"
-					onclick={handleCreate}
-					class="mt-4 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				>
-					<Plus class="h-5 w-5" aria-hidden="true" />
-					{m['orgAdmin.resources.addResourceButton']()}
-				</button>
-			{/if}
-		</div>
+		<EmptyState
+			icon={Filter}
+			title={m['orgAdmin.resources.empty.title']()}
+			body={searchQuery || typeFilter !== 'all' || visibilityFilter !== 'all'
+				? m['orgAdmin.resources.empty.withFilters']()
+				: m['orgAdmin.resources.empty.noFilters']()}
+			action={!searchQuery && typeFilter === 'all' && visibilityFilter === 'all'
+				? resourcesHeaderActions
+				: undefined}
+		/>
 	{:else}
 		<ResourceList
 			{resources}

--- a/src/routes/(auth)/org/[slug]/admin/resources/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/resources/+page.svelte
@@ -182,11 +182,18 @@
 
 	<!-- Content -->
 	{#if error}
+		<!-- dark:bg-destructive/25 dark:text-destructive-foreground (AutoEvalRecommendation's
+		     pattern): plain text-destructive on this /10 tint measured 2.69-2.95:1 in dark
+		     mode, under the 3:1 non-text floor; the /25 tint + destructive-foreground (white)
+		     icon pairing measures ~14-15:1 instead. -->
 		<div
-			class="flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4"
+			class="flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4 dark:bg-destructive/25"
 			role="alert"
 		>
-			<AlertTriangle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
+			<AlertTriangle
+				class="h-5 w-5 shrink-0 text-destructive dark:text-destructive-foreground"
+				aria-hidden="true"
+			/>
 			<div>
 				<p class="font-semibold text-foreground">{m['orgAdmin.resources.error.title']()}</p>
 				<p class="mt-1 text-sm text-foreground">{m['orgAdmin.resources.error.description']()}</p>

--- a/src/routes/(auth)/org/[slug]/admin/tokens/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/tokens/+page.svelte
@@ -16,7 +16,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import { Plus, Search, Loader2 } from '@lucide/svelte';
+	import { Plus, Search, Loader2, Link } from '@lucide/svelte';
 	import OrganizationTokenCard from '$lib/components/tokens/OrganizationTokenCard.svelte';
 	import OrganizationTokenModal from '$lib/components/tokens/OrganizationTokenModal.svelte';
 	import TokenShareDialog from '$lib/components/tokens/TokenShareDialog.svelte';
@@ -31,6 +31,8 @@
 	import { getOrganizationTokenUrl } from '$lib/utils/tokens';
 	import { toast } from 'svelte-sonner';
 	import * as m from '$lib/paraglide/messages.js';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	const organization = $derived($page.data.organization);
 	const isOwner = $derived(!!$page.data.isOwner);
@@ -197,18 +199,17 @@
 
 <div class="space-y-6">
 	<!-- Header -->
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div class="min-w-0">
-			<h1 class="text-3xl font-bold">{m['orgAdminTokensPage.title']()}</h1>
-			<p class="text-muted-foreground">
-				{m['orgAdminTokensPage.subtitle']()}
-			</p>
-		</div>
+	{#snippet headerActions()}
 		<Button onclick={() => (isCreateModalOpen = true)} class="w-full sm:w-auto">
 			<Plus class="mr-2 h-4 w-4" aria-hidden="true" />
 			{m['orgAdminTokensPage.createButton']()}
 		</Button>
-	</div>
+	{/snippet}
+	<PageHeader
+		title={m['orgAdminTokensPage.title']()}
+		subtitle={m['orgAdminTokensPage.subtitle']()}
+		actions={headerActions}
+	/>
 
 	<!-- Search -->
 	<div class="relative">
@@ -231,16 +232,13 @@
 				<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
 			</div>
 		{:else if tokens.length === 0}
-			<div class="rounded-lg border border-dashed p-12 text-center">
-				<h3 class="text-lg font-semibold">{m['orgAdminTokensPage.empty_noLinks_title']()}</h3>
-				<p class="mt-2 text-sm text-muted-foreground">
-					{#if searchQuery}
-						{m['orgAdminTokensPage.empty_noLinks_search']()}
-					{:else}
-						{m['orgAdminTokensPage.empty_noLinks_initial']()}
-					{/if}
-				</p>
-			</div>
+			<EmptyState
+				icon={Link}
+				title={m['orgAdminTokensPage.empty_noLinks_title']()}
+				body={searchQuery
+					? m['orgAdminTokensPage.empty_noLinks_search']()
+					: m['orgAdminTokensPage.empty_noLinks_initial']()}
+			/>
 		{:else}
 			{#each tokens as token (token.id)}
 				<OrganizationTokenCard


### PR DESCRIPTION
## Platform rebrand, PR 9 of 10 — Admin: engagement + people

Studio pass over polls, questionnaires (list/builder/summary/submissions), announcements, resources, members, blacklist, tokens, and discount codes — 96 files.

### What's in it
- **QuestionnaireFillForm aligned with the landing's questionnaire-mock language** (byte-identical option-row pattern to the proven public PollVoteForm): 44px full-row hit targets, `role="group"` + error `aria-describedby` — a11y strictly improved; SSR intact on both public questionnaire routes. Closes the deferred cross-PR handoff.
- **12 badge mappers** over `common/StatusBadge`, every one with explicit `aria-label` + an enum-driven test guard — including closing the latent `PollStatusBadge` aria hole shipped by an earlier wave
- Ledger handoffs: `SubscriptionMetrics` aligned to the shared tone map, last `StatusConfig.className` consumer deleted
- Full raw-hue sweep; dark-destructive discipline applied consistently (review caught three icons and one outline button that had walked into the documented trap — fixed with measured ratios)

### Review process
Opus whole-branch review + one fix round + scoped re-review, clean. Rebased onto the merged PR 10; the `SubscriptionPayments*` collision resolved by taking the merged versions wholesale (verified byte-identical post-rebase). Conscious sign-off: expired/cancelled share the neutral tone in the metrics breakdown strip (labels+counts carry the distinction).

### Verification
`make check` 0 errors · full suite 216 files / 2520 green · brand audit 0 failures · every container-derivation and getByLabel locator in the admin journeys traced against the new markup · orchestrator screenshots (questionnaires light, members dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)