### PR TITLE
feat(rebrand): admin events, series & venues — studio pass across the largest admin cluster (PR 8/10)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -9,6 +9,7 @@
 		"title": "Programm",
 		"description": "Füge eine Zeitleiste mit Programmpunkten für diese Veranstaltung hinzu. Die Zeiten sind relativ zum Veranstaltungsbeginn, sodass das Programm auch beim Duplizieren der Veranstaltung korrekt bleibt.",
 		"empty": "Noch keine Programmpunkte. Füge den ersten hinzu, um deine Zeitleiste zu erstellen.",
+		"emptyTitle": "Noch keine Programmpunkte",
 		"sessionNumber": "Programmpunkt {number}",
 		"removeSession": "Programmpunkt entfernen",
 		"sessionTitle": "Titel des Programmpunkts",

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,6 +9,7 @@
 		"title": "Schedule",
 		"description": "Add a timeline of sessions for this event. Times are relative to the event start, so the schedule stays correct if you duplicate the event.",
 		"empty": "No sessions yet. Add the first one to build your event timeline.",
+		"emptyTitle": "No sessions yet",
 		"sessionNumber": "Session {number}",
 		"removeSession": "Remove session",
 		"sessionTitle": "Session title",

--- a/messages/es.json
+++ b/messages/es.json
@@ -9,6 +9,7 @@
 		"title": "Programa",
 		"description": "Añade una línea temporal de sesiones para este evento. Los horarios son relativos al inicio del evento, así el programa se mantiene correcto si duplicas el evento.",
 		"empty": "Todavía no hay sesiones. Añade la primera para crear la línea temporal de tu evento.",
+		"emptyTitle": "Todavía no hay sesiones",
 		"sessionNumber": "Sesión {number}",
 		"removeSession": "Eliminar sesión",
 		"sessionTitle": "Título de la sesión",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -8845,6 +8845,7 @@
 		"title": "Programme",
 		"description": "Ajoute une chronologie des sessions pour cet événement. Les horaires sont relatifs au début de l'événement, ainsi le programme reste correct si tu dupliques l'événement.",
 		"empty": "Aucune session pour l'instant. Ajoute la première pour construire la chronologie de ton événement.",
+		"emptyTitle": "Aucune session pour l'instant",
 		"sessionNumber": "Session {number}",
 		"removeSession": "Supprimer la session",
 		"sessionTitle": "Titre de la session",

--- a/messages/it.json
+++ b/messages/it.json
@@ -9,6 +9,7 @@
 		"title": "Programma",
 		"description": "Aggiungi una scaletta di sessioni per questo evento. Gli orari sono relativi all'inizio dell'evento, così il programma resta corretto se duplichi l'evento.",
 		"empty": "Ancora nessuna sessione. Aggiungi la prima per creare la scaletta dell'evento.",
+		"emptyTitle": "Ancora nessuna sessione",
 		"sessionNumber": "Sessione {number}",
 		"removeSession": "Rimuovi sessione",
 		"sessionTitle": "Titolo della sessione",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -9,6 +9,7 @@
 		"title": "Programa",
 		"description": "Adiciona uma linha temporal de sessões para este evento. Os horários são relativos ao início do evento, para que o programa se mantenha correto se duplicares o evento.",
 		"empty": "Ainda não há sessões. Adiciona a primeira para criares a linha temporal do teu evento.",
+		"emptyTitle": "Ainda não há sessões",
 		"sessionNumber": "Sessão {number}",
 		"removeSession": "Remover sessão",
 		"sessionTitle": "Título da sessão",

--- a/src/lib/components/attendees/AttendeeCardList.svelte
+++ b/src/lib/components/attendees/AttendeeCardList.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { cn } from '$lib/utils/cn';
 	import { getUserDisplayName } from '$lib/utils/user-display';
-	import { getRsvpStatusColor, getRsvpStatusLabel } from '$lib/utils/status-colors';
+	import { getRsvpStatusTone, getRsvpStatusLabel } from '$lib/utils/status-colors';
 	import { formatDateTime } from '$lib/utils/date';
 	import { Edit, Trash2, UserPlus, MoreVertical, Ban } from '@lucide/svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { Badge } from '$lib/components/ui/badge';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
 	import RsvpNoteCell from './RsvpNoteCell.svelte';
 	import type { RsvpDetailSchema } from '$lib/api/generated/types.gen';
@@ -66,14 +66,11 @@
 							<p class="text-sm text-muted-foreground">{rsvp.user.email || 'N/A'}</p>
 						</div>
 					</div>
-					<span
-						class={cn(
-							'shrink-0 rounded-full px-2 py-1 text-xs font-semibold',
-							getRsvpStatusColor(rsvp.status)
-						)}
-					>
-						{getRsvpStatusLabel(rsvp.status)}
-					</span>
+					<StatusBadge
+						tone={getRsvpStatusTone(rsvp.status)}
+						label={getRsvpStatusLabel(rsvp.status)}
+						class="shrink-0"
+					/>
 				</div>
 
 				<p class="text-xs text-muted-foreground">

--- a/src/lib/components/attendees/AttendeeFilters.svelte
+++ b/src/lib/components/attendees/AttendeeFilters.svelte
@@ -44,10 +44,10 @@
 			onclick={() => onStatusFilter('yes')}
 			aria-pressed={activeStatusFilters.includes('yes')}
 			class={cn(
-				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+				'rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
 				activeStatusFilters.includes('yes')
-					? 'bg-green-600 text-white'
-					: 'border border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-green-950'
+					? 'border-success bg-success text-success-foreground'
+					: 'border-success/50 bg-card text-foreground hover:bg-success/10'
 			)}
 		>
 			{m['attendeesAdmin.statsYes']()}
@@ -57,10 +57,10 @@
 			onclick={() => onStatusFilter('maybe')}
 			aria-pressed={activeStatusFilters.includes('maybe')}
 			class={cn(
-				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+				'rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
 				activeStatusFilters.includes('maybe')
-					? 'bg-yellow-600 text-white'
-					: 'border border-yellow-600 text-yellow-600 hover:bg-yellow-50 dark:hover:bg-yellow-950'
+					? 'border-highlight bg-highlight text-highlight-foreground'
+					: 'border-highlight/50 bg-card text-foreground hover:bg-highlight/10'
 			)}
 		>
 			{m['attendeesAdmin.statsMaybe']()}
@@ -70,10 +70,10 @@
 			onclick={() => onStatusFilter('no')}
 			aria-pressed={activeStatusFilters.includes('no')}
 			class={cn(
-				'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+				'rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
 				activeStatusFilters.includes('no')
-					? 'bg-red-600 text-white'
-					: 'border border-red-600 text-red-600 hover:bg-red-50 dark:hover:bg-red-950'
+					? 'border-destructive bg-destructive text-destructive-foreground'
+					: 'border-destructive/50 bg-card text-foreground hover:bg-destructive/10'
 			)}
 		>
 			{m['attendeesAdmin.statsNo']()}

--- a/src/lib/components/attendees/AttendeeStats.svelte
+++ b/src/lib/components/attendees/AttendeeStats.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import { AlertTriangle } from '@lucide/svelte';
 
 	interface Stats {
 		yesCount: number;
@@ -21,52 +22,55 @@
 	<!-- Warning for incomplete data -->
 	{#if hasMultiplePages}
 		<div
-			class="flex items-start gap-2 rounded-lg border border-yellow-200 bg-yellow-50 p-3 text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-100"
+			class="flex items-start gap-2 rounded-lg border border-highlight bg-highlight/10 p-3 text-sm"
 			role="alert"
 		>
-			<svg class="h-5 w-5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-				<path
-					fill-rule="evenodd"
-					d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
-					clip-rule="evenodd"
-				/>
-			</svg>
-			<div class="text-sm">
+			<AlertTriangle
+				class="mt-0.5 h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
+				aria-hidden="true"
+			/>
+			<div>
 				<p class="font-medium">{m['attendeesAdmin.warningIncompleteData']()}</p>
-				<p>{m['attendeesAdmin.warningTotalRsvps']({ total: totalCount })}</p>
+				<p class="text-muted-foreground">
+					{m['attendeesAdmin.warningTotalRsvps']({ total: totalCount })}
+				</p>
 			</div>
 		</div>
 	{/if}
 
-	<!-- Stats grid -->
+	<!-- Stats grid. Tint recipes mirror common/ToneTile's audited pairs:
+	     success is dark-enough-as-text in both modes (bg-success/10 text-success);
+	     highlight needs the foreground/dark split (amber itself is ~1.9:1 on a
+	     light tint); destructive needs the light/dark split the other way
+	     (dark destructive is too bright a red as text on its own dark tint). -->
 	<div class="grid gap-4 sm:grid-cols-4">
 		<div class="rounded-lg border border-border bg-card p-4">
 			<p class="text-sm font-medium text-muted-foreground">{m['attendeesAdmin.statsTotal']()}</p>
 			<p class="mt-1 text-2xl font-bold">{stats.total}</p>
 		</div>
-		<div
-			class="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950"
-		>
-			<p class="text-sm font-medium text-green-700 dark:text-green-300">
+		<div class="rounded-lg border border-success/30 bg-success/10 p-4">
+			<p class="text-sm font-medium text-success">
 				{m['attendeesAdmin.statsYes']()}
 			</p>
-			<p class="mt-1 text-2xl font-bold text-green-900 dark:text-green-100">{stats.yesCount}</p>
+			<p class="mt-1 text-2xl font-bold text-success">{stats.yesCount}</p>
 		</div>
-		<div
-			class="rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-950"
-		>
-			<p class="text-sm font-medium text-yellow-700 dark:text-yellow-300">
+		<div class="rounded-lg border border-highlight/50 bg-highlight/10 p-4">
+			<p class="text-sm font-medium text-highlight-foreground dark:text-highlight">
 				{m['attendeesAdmin.statsMaybe']()}
 			</p>
-			<p class="mt-1 text-2xl font-bold text-yellow-900 dark:text-yellow-100">
+			<p class="mt-1 text-2xl font-bold text-highlight-foreground dark:text-highlight">
 				{stats.maybeCount}
 			</p>
 		</div>
-		<div class="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950">
-			<p class="text-sm font-medium text-red-700 dark:text-red-300">
+		<div
+			class="rounded-lg border border-destructive/30 bg-destructive/10 p-4 dark:bg-destructive/25"
+		>
+			<p class="text-sm font-medium text-destructive dark:text-destructive-foreground">
 				{m['attendeesAdmin.statsNo']()}
 			</p>
-			<p class="mt-1 text-2xl font-bold text-red-900 dark:text-red-100">{stats.noCount}</p>
+			<p class="mt-1 text-2xl font-bold text-destructive dark:text-destructive-foreground">
+				{stats.noCount}
+			</p>
 		</div>
 	</div>
 </div>

--- a/src/lib/components/attendees/AttendeeStats.svelte
+++ b/src/lib/components/attendees/AttendeeStats.svelte
@@ -38,21 +38,29 @@
 		</div>
 	{/if}
 
-	<!-- Stats grid. Tint recipes mirror common/ToneTile's audited pairs:
-	     success is dark-enough-as-text in both modes (bg-success/10 text-success);
-	     highlight needs the foreground/dark split (amber itself is ~1.9:1 on a
-	     light tint); destructive needs the light/dark split the other way
-	     (dark destructive is too bright a red as text on its own dark tint). -->
+	<!-- Stats grid. Tint recipes mirror common/ToneTile's audited pairs, hand-
+	     verified (composited alpha is invisible to audit-brand-themes.py).
+	     Ratios below are text-vs-composited-tint, light / dark:
+	       success  4.39 (FAILS 4.5, bare bg-success/10 over --background) /
+	                8.73 — light needs an opaque bg-card layer under the tint
+	                to reach 4.94; dark already clears the bar unaided.
+	       highlight (text-highlight-foreground light / text-highlight dark)
+	                13.28 / 8.41 — clears both, no split needed beyond the
+	                existing foreground/dark swap.
+	       destructive (text-destructive light / text-destructive-foreground
+	                dark on the dark-only bg-destructive/25) 7.19 / 15.26 —
+	                clears both. -->
 	<div class="grid gap-4 sm:grid-cols-4">
 		<div class="rounded-lg border border-border bg-card p-4">
 			<p class="text-sm font-medium text-muted-foreground">{m['attendeesAdmin.statsTotal']()}</p>
 			<p class="mt-1 text-2xl font-bold">{stats.total}</p>
 		</div>
-		<div class="rounded-lg border border-success/30 bg-success/10 p-4">
-			<p class="text-sm font-medium text-success">
+		<div class="relative overflow-hidden rounded-lg border border-success/30 bg-card p-4">
+			<div class="absolute inset-0 bg-success/10" aria-hidden="true"></div>
+			<p class="relative text-sm font-medium text-success">
 				{m['attendeesAdmin.statsYes']()}
 			</p>
-			<p class="mt-1 text-2xl font-bold text-success">{stats.yesCount}</p>
+			<p class="relative mt-1 text-2xl font-bold text-success">{stats.yesCount}</p>
 		</div>
 		<div class="rounded-lg border border-highlight/50 bg-highlight/10 p-4">
 			<p class="text-sm font-medium text-highlight-foreground dark:text-highlight">

--- a/src/lib/components/attendees/AttendeeTable.svelte
+++ b/src/lib/components/attendees/AttendeeTable.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { cn } from '$lib/utils/cn';
 	import { getUserDisplayName } from '$lib/utils/user-display';
-	import { getRsvpStatusColor, getRsvpStatusLabel } from '$lib/utils/status-colors';
+	import { getRsvpStatusTone, getRsvpStatusLabel } from '$lib/utils/status-colors';
 	import { formatDateTime } from '$lib/utils/date';
 	import { Edit, Trash2, UserPlus, MoreVertical, Ban } from '@lucide/svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { Badge } from '$lib/components/ui/badge';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
 	import RsvpNoteCell from './RsvpNoteCell.svelte';
 	import type { RsvpDetailSchema } from '$lib/api/generated/types.gen';
@@ -38,32 +38,32 @@
 		<thead class="bg-muted/50">
 			<tr>
 				<th
-					class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+					class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 				>
 					{m['attendeesAdmin.tableHeaderName']()}
 				</th>
 				<th
-					class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+					class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 				>
 					{m['attendeesAdmin.tableHeaderEmail']()}
 				</th>
 				<th
-					class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+					class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 				>
 					{m['attendeesAdmin.tableHeaderStatus']()}
 				</th>
 				<th
-					class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+					class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 				>
 					{m['attendeesAdmin.tableHeaderNote']()}
 				</th>
 				<th
-					class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+					class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 				>
 					{m['attendeesAdmin.tableHeaderRsvpDate']()}
 				</th>
 				<th
-					class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground"
+					class="px-6 py-3 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 				>
 					{m['attendeesAdmin.tableHeaderActions']()}
 				</th>
@@ -105,14 +105,7 @@
 						{rsvp.user.email || 'N/A'}
 					</td>
 					<td class="whitespace-nowrap px-6 py-4 text-sm">
-						<span
-							class={cn(
-								'inline-flex rounded-full px-2 py-1 text-xs font-semibold',
-								getRsvpStatusColor(rsvp.status)
-							)}
-						>
-							{getRsvpStatusLabel(rsvp.status)}
-						</span>
+						<StatusBadge tone={getRsvpStatusTone(rsvp.status)} label={getRsvpStatusLabel(rsvp.status)} />
 					</td>
 					<td class="max-w-xs px-6 py-4 text-sm">
 						{#if rsvp.note}

--- a/src/lib/components/attendees/AttendeeTable.svelte
+++ b/src/lib/components/attendees/AttendeeTable.svelte
@@ -105,7 +105,10 @@
 						{rsvp.user.email || 'N/A'}
 					</td>
 					<td class="whitespace-nowrap px-6 py-4 text-sm">
-						<StatusBadge tone={getRsvpStatusTone(rsvp.status)} label={getRsvpStatusLabel(rsvp.status)} />
+						<StatusBadge
+							tone={getRsvpStatusTone(rsvp.status)}
+							label={getRsvpStatusLabel(rsvp.status)}
+						/>
 					</td>
 					<td class="max-w-xs px-6 py-4 text-sm">
 						{#if rsvp.note}

--- a/src/lib/components/attendees/CreateRsvpDialog.svelte
+++ b/src/lib/components/attendees/CreateRsvpDialog.svelte
@@ -117,7 +117,7 @@
 							name="create-status"
 							value="yes"
 							bind:group={selectedStatus}
-							class="h-4 w-4 text-green-600 focus:ring-green-600"
+							class="h-4 w-4 text-success focus:ring-success"
 						/>
 						<span class="text-sm font-medium">{m['attendeesAdmin.editModalYesLabel']()}</span>
 					</label>
@@ -129,7 +129,7 @@
 							name="create-status"
 							value="maybe"
 							bind:group={selectedStatus}
-							class="h-4 w-4 text-yellow-600 focus:ring-yellow-600"
+							class="h-4 w-4 text-highlight-foreground focus:ring-highlight dark:text-highlight"
 						/>
 						<span class="text-sm font-medium">{m['attendeesAdmin.editModalMaybeLabel']()}</span>
 					</label>
@@ -141,7 +141,7 @@
 							name="create-status"
 							value="no"
 							bind:group={selectedStatus}
-							class="h-4 w-4 text-red-600 focus:ring-red-600"
+							class="h-4 w-4 text-destructive focus:ring-destructive"
 						/>
 						<span class="text-sm font-medium">{m['attendeesAdmin.editModalNoLabel']()}</span>
 					</label>

--- a/src/lib/components/attendees/EditRsvpDialog.svelte
+++ b/src/lib/components/attendees/EditRsvpDialog.svelte
@@ -51,7 +51,10 @@
 				<div class="rounded-lg bg-muted p-3">
 					<p class="text-sm font-medium">{m['attendeesAdmin.editModalCurrentStatus']()}</p>
 					<p class="mt-1">
-						<StatusBadge tone={getRsvpStatusTone(rsvp.status)} label={getRsvpStatusLabel(rsvp.status)} />
+						<StatusBadge
+							tone={getRsvpStatusTone(rsvp.status)}
+							label={getRsvpStatusLabel(rsvp.status)}
+						/>
 					</p>
 				</div>
 

--- a/src/lib/components/attendees/EditRsvpDialog.svelte
+++ b/src/lib/components/attendees/EditRsvpDialog.svelte
@@ -76,7 +76,7 @@
 								name="status"
 								value="yes"
 								bind:group={selectedStatus}
-								class="h-4 w-4 text-green-600 focus:ring-green-600"
+								class="h-4 w-4 text-success focus:ring-success"
 							/>
 							<span class="text-sm font-medium">{m['attendeesAdmin.editModalYesLabel']()}</span>
 						</label>
@@ -88,7 +88,7 @@
 								name="status"
 								value="maybe"
 								bind:group={selectedStatus}
-								class="h-4 w-4 text-yellow-600 focus:ring-yellow-600"
+								class="h-4 w-4 text-highlight-foreground focus:ring-highlight dark:text-highlight"
 							/>
 							<span class="text-sm font-medium">{m['attendeesAdmin.editModalMaybeLabel']()}</span>
 						</label>
@@ -100,7 +100,7 @@
 								name="status"
 								value="no"
 								bind:group={selectedStatus}
-								class="h-4 w-4 text-red-600 focus:ring-red-600"
+								class="h-4 w-4 text-destructive focus:ring-destructive"
 							/>
 							<span class="text-sm font-medium">{m['attendeesAdmin.editModalNoLabel']()}</span>
 						</label>

--- a/src/lib/components/attendees/EditRsvpDialog.svelte
+++ b/src/lib/components/attendees/EditRsvpDialog.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { cn } from '$lib/utils/cn';
 	import { getUserDisplayName } from '$lib/utils/user-display';
-	import { getRsvpStatusColor, getRsvpStatusLabel } from '$lib/utils/status-colors';
+	import { getRsvpStatusTone, getRsvpStatusLabel } from '$lib/utils/status-colors';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { RsvpDetailSchema } from '$lib/api/generated/types.gen';
 
 	interface Props {
@@ -51,14 +51,7 @@
 				<div class="rounded-lg bg-muted p-3">
 					<p class="text-sm font-medium">{m['attendeesAdmin.editModalCurrentStatus']()}</p>
 					<p class="mt-1">
-						<span
-							class={cn(
-								'inline-flex rounded-full px-2 py-1 text-xs font-semibold',
-								getRsvpStatusColor(rsvp.status)
-							)}
-						>
-							{getRsvpStatusLabel(rsvp.status)}
-						</span>
+						<StatusBadge tone={getRsvpStatusTone(rsvp.status)} label={getRsvpStatusLabel(rsvp.status)} />
 					</p>
 				</div>
 

--- a/src/lib/components/event-series/admin/CancelDriftedOccurrencesDialog.svelte
+++ b/src/lib/components/event-series/admin/CancelDriftedOccurrencesDialog.svelte
@@ -198,7 +198,7 @@
 
 		{#if exceedsSafetyThreshold}
 			<p
-				class="border-warning/50 bg-warning/10 mt-3 rounded-md border p-3 text-xs text-muted-foreground"
+				class="mt-3 rounded-md border border-highlight bg-highlight/10 p-3 text-xs text-muted-foreground"
 				data-testid="drift-bulk-threshold"
 			>
 				{m['recurringEvents.drift.bulkDialog.thresholdWarning']({ n: total })}

--- a/src/lib/components/event-series/admin/CancelDriftedOccurrencesDialog.svelte
+++ b/src/lib/components/event-series/admin/CancelDriftedOccurrencesDialog.svelte
@@ -175,6 +175,22 @@
 				return m['recurringEvents.drift.bulkDialog.rowStatus.error']();
 		}
 	}
+
+	// Soft-tint chip classes mirror common/ToneTile's audited "icon/accent on
+	// surface" recipe (success/brand are legible as text in both modes; see
+	// CLAUDE.md trap list for why destructive/highlight would need a split).
+	function rowStatusChipClass(status: RowStatus): string {
+		switch (status) {
+			case 'done':
+				return 'bg-success/10 text-success';
+			case 'error':
+				return 'bg-destructive/10 text-destructive';
+			case 'inFlight':
+				return 'bg-primary/10 text-primary';
+			case 'pending':
+				return 'bg-muted text-muted-foreground';
+		}
+	}
 </script>
 
 <Dialog bind:open onOpenChange={(isOpen) => !isOpen && handleClose()}>
@@ -221,14 +237,9 @@
 						</p>
 					</div>
 					<span
-						class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium {status ===
-						'done'
-							? 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-200'
-							: status === 'error'
-								? 'bg-destructive/10 text-destructive'
-								: status === 'inFlight'
-									? 'bg-primary/10 text-primary'
-									: 'bg-muted text-muted-foreground'}"
+						class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium {rowStatusChipClass(
+							status
+						)}"
 					>
 						{#if status === 'inFlight'}
 							<Loader2 class="h-3 w-3 animate-spin" aria-hidden="true" />
@@ -250,7 +261,7 @@
 				type="checkbox"
 				bind:checked={armed}
 				disabled={running || allDone}
-				class="mt-1 h-4 w-4 rounded border-gray-300 text-destructive focus:ring-2 focus:ring-destructive"
+				class="mt-1 h-4 w-4 rounded border-input text-destructive focus:ring-2 focus:ring-destructive"
 				data-testid="drift-bulk-arm"
 			/>
 			<div class="flex-1 text-sm">

--- a/src/lib/components/event-series/admin/CancelOccurrenceDialog.svelte
+++ b/src/lib/components/event-series/admin/CancelOccurrenceDialog.svelte
@@ -190,11 +190,11 @@
 			{/if}
 
 			<div
-				class="border-warning/50 bg-warning/10 flex items-start gap-3 rounded-md border p-3 text-sm"
+				class="flex items-start gap-3 rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
 				data-testid="cancel-occurrence-body"
 			>
 				<AlertTriangle
-					class="text-warning-foreground mt-0.5 h-4 w-4 flex-shrink-0"
+					class="mt-0.5 h-4 w-4 flex-shrink-0 text-highlight-foreground dark:text-highlight"
 					aria-hidden="true"
 				/>
 				<p class="flex-1">

--- a/src/lib/components/event-series/admin/OccurrenceRow.svelte
+++ b/src/lib/components/event-series/admin/OccurrenceRow.svelte
@@ -175,11 +175,7 @@
 				{#if isDrifted}
 					<StatusBadge tone="danger" label={m['recurringEvents.row.driftedBadge']()} size="sm" />
 				{:else if showModifiedBadge}
-					<StatusBadge
-						tone="warning"
-						label={m['recurringEvents.row.modifiedBadge']()}
-						size="sm"
-					/>
+					<StatusBadge tone="warning" label={m['recurringEvents.row.modifiedBadge']()} size="sm" />
 				{/if}
 				{#if hasAttendees}
 					<span class="text-muted-foreground">

--- a/src/lib/components/event-series/admin/OccurrenceRow.svelte
+++ b/src/lib/components/event-series/admin/OccurrenceRow.svelte
@@ -167,7 +167,7 @@
 	     action cluster off-screen on intermediate viewports. -->
 	<div class="flex min-w-0 flex-1 flex-col gap-1.5">
 		<div class="flex flex-wrap items-center gap-2">
-			<h3 class="truncate text-sm font-semibold">{event.name}</h3>
+			<h3 class="truncate text-sm font-bold">{event.name}</h3>
 			<StatusBadge tone={statusTone} label={statusLabel} size="sm" class="flex-shrink-0" />
 		</div>
 		{#if isDrifted || showModifiedBadge || hasAttendees}

--- a/src/lib/components/event-series/admin/OccurrenceRow.svelte
+++ b/src/lib/components/event-series/admin/OccurrenceRow.svelte
@@ -14,6 +14,8 @@
 	} from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import { formatEventDate } from '$lib/utils/date';
 	import type { EventInListSchema, EventStatus } from '$lib/api/generated/types.gen';
 
@@ -86,16 +88,19 @@
 		}
 	});
 
-	const statusChipClass = $derived.by(() => {
+	// Administrative status only (not the temporal open/upcoming/past logic
+	// EventStatusBadge shows) — this row's "open" means "published", so it
+	// keeps its own label set and just borrows the shared StatusBadge shell.
+	const statusTone = $derived.by((): Tone => {
 		switch (variant) {
 			case 'draft':
-				return 'bg-muted text-muted-foreground';
+				return 'neutral';
 			case 'open':
-				return 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-200';
+				return 'success';
 			case 'closed':
-				return 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200';
+				return 'warning';
 			case 'cancelled':
-				return 'bg-destructive/10 text-destructive';
+				return 'danger';
 		}
 	});
 
@@ -139,7 +144,7 @@
 	class="flex flex-col gap-3 rounded-lg border border-l-4 border-border bg-card p-3 shadow-sm transition-colors hover:bg-accent/40 sm:flex-row sm:items-center sm:gap-4 {isDrifted
 		? 'border-l-destructive'
 		: showModifiedBadge
-			? 'border-l-amber-500'
+			? 'border-l-highlight'
 			: 'border-l-transparent'} {variant === 'cancelled' || variant === 'closed'
 		? 'opacity-70'
 		: ''}"
@@ -163,26 +168,18 @@
 	<div class="flex min-w-0 flex-1 flex-col gap-1.5">
 		<div class="flex flex-wrap items-center gap-2">
 			<h3 class="truncate text-sm font-semibold">{event.name}</h3>
-			<span
-				class="inline-flex flex-shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide {statusChipClass}"
-			>
-				{statusLabel}
-			</span>
+			<StatusBadge tone={statusTone} label={statusLabel} size="sm" class="flex-shrink-0" />
 		</div>
 		{#if isDrifted || showModifiedBadge || hasAttendees}
 			<div class="flex flex-wrap items-center gap-2 text-xs">
 				{#if isDrifted}
-					<span
-						class="inline-flex items-center rounded-full bg-destructive/10 px-2 py-0.5 font-medium text-destructive"
-					>
-						{m['recurringEvents.row.driftedBadge']()}
-					</span>
+					<StatusBadge tone="danger" label={m['recurringEvents.row.driftedBadge']()} size="sm" />
 				{:else if showModifiedBadge}
-					<span
-						class="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-900 dark:bg-amber-900/30 dark:text-amber-200"
-					>
-						{m['recurringEvents.row.modifiedBadge']()}
-					</span>
+					<StatusBadge
+						tone="warning"
+						label={m['recurringEvents.row.modifiedBadge']()}
+						size="sm"
+					/>
 				{/if}
 				{#if hasAttendees}
 					<span class="text-muted-foreground">
@@ -206,7 +203,7 @@
 			<Button
 				size="sm"
 				onclick={() => onPublish(event.id)}
-				class="h-8 gap-1 bg-green-600 px-2 text-white hover:bg-green-700 focus-visible:ring-green-700 dark:bg-green-600 dark:hover:bg-green-500"
+				class="h-8 gap-1 bg-success px-2 text-success-foreground hover:bg-success/90 focus-visible:ring-success"
 				data-testid="row-publish-occurrence"
 			>
 				<Megaphone class="h-4 w-4" aria-hidden="true" />
@@ -263,7 +260,7 @@
 					{#if variant === 'open' && onClose}
 						<DropdownMenu.Item
 							onclick={() => onClose(event.id)}
-							class="text-amber-700 focus:text-amber-700 dark:text-amber-400 dark:focus:text-amber-400"
+							class="text-highlight-foreground focus:text-highlight-foreground dark:text-highlight dark:focus:text-highlight"
 						>
 							<XCircle class="mr-2 h-4 w-4" aria-hidden="true" />
 							{m['orgAdmin.events.actions.close']()}

--- a/src/lib/components/event-series/admin/OccurrenceRow.svelte
+++ b/src/lib/components/event-series/admin/OccurrenceRow.svelte
@@ -91,6 +91,9 @@
 	// Administrative status only (not the temporal open/upcoming/past logic
 	// EventStatusBadge shows) — this row's "open" means "published", so it
 	// keeps its own label set and just borrows the shared StatusBadge shell.
+	// Tones align with EventStatusBadge's documented mapping: closed -> danger
+	// (no longer joinable), cancelled -> warning (the organizer called it off,
+	// but the label carries the distinction on its own either way).
 	const statusTone = $derived.by((): Tone => {
 		switch (variant) {
 			case 'draft':
@@ -98,9 +101,9 @@
 			case 'open':
 				return 'success';
 			case 'closed':
-				return 'warning';
-			case 'cancelled':
 				return 'danger';
+			case 'cancelled':
+				return 'warning';
 		}
 	});
 

--- a/src/lib/components/event-series/admin/PublishOccurrenceDialog.svelte
+++ b/src/lib/components/event-series/admin/PublishOccurrenceDialog.svelte
@@ -121,13 +121,10 @@
 			</div>
 
 			<div
-				class="flex items-start gap-3 rounded-md border border-green-500/40 bg-green-500/10 p-3 text-sm dark:border-green-700/50"
+				class="flex items-start gap-3 rounded-md border border-success/40 bg-success/10 p-3 text-sm"
 				data-testid="publish-occurrence-body"
 			>
-				<CheckCircle
-					class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-700 dark:text-green-400"
-					aria-hidden="true"
-				/>
+				<CheckCircle class="mt-0.5 h-4 w-4 flex-shrink-0 text-success" aria-hidden="true" />
 				<p class="flex-1">
 					{m['recurringEvents.publishOccurrenceDialog.body']()}
 				</p>

--- a/src/lib/components/event-series/admin/RecurrenceEditDialog.svelte
+++ b/src/lib/components/event-series/admin/RecurrenceEditDialog.svelte
@@ -323,7 +323,7 @@
 							type="checkbox"
 							bind:checked={autoPublish}
 							disabled={updateMutation.isPending}
-							class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+							class="mt-1 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 							data-testid="recurrence-edit-auto-publish"
 						/>
 						<div class="flex-1 space-y-1">

--- a/src/lib/components/event-series/admin/RecurrenceEditDialog.svelte
+++ b/src/lib/components/event-series/admin/RecurrenceEditDialog.svelte
@@ -400,11 +400,11 @@
 			</div>
 		{:else}
 			<div
-				class="border-warning/50 bg-warning/10 mt-4 flex items-start gap-3 rounded-md border p-4 text-sm"
+				class="mt-4 flex items-start gap-3 rounded-md border border-highlight bg-highlight/10 p-4 text-sm"
 				data-testid="recurrence-edit-confirm-banner"
 			>
 				<AlertTriangle
-					class="text-warning-foreground mt-0.5 h-5 w-5 flex-shrink-0"
+					class="mt-0.5 h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
 					aria-hidden="true"
 				/>
 				<p class="flex-1">

--- a/src/lib/components/event-series/admin/RecurringEventWizard.svelte
+++ b/src/lib/components/event-series/admin/RecurringEventWizard.svelte
@@ -443,7 +443,7 @@
 				'flex h-10 w-10 items-center justify-center rounded-full border-2 font-semibold transition-colors',
 				currentStep === 'event'
 					? 'border-primary bg-primary text-primary-foreground'
-					: 'border-green-600 bg-green-600 text-white'
+					: 'border-success bg-success text-success-foreground'
 			)}
 			aria-current={currentStep === 'event' ? 'step' : undefined}
 		>

--- a/src/lib/components/event-series/admin/SeriesHeaderCard.svelte
+++ b/src/lib/components/event-series/admin/SeriesHeaderCard.svelte
@@ -12,6 +12,7 @@
 		MoreHorizontal
 	} from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { EventSeriesRecurrenceDetailSchema } from '$lib/api/generated/types.gen';
 	import RecurrenceSummary from './RecurrenceSummary.svelte';
 	import SeriesActionSheet from './SeriesActionSheet.svelte';
@@ -71,25 +72,23 @@
 
 <header class="rounded-lg border border-border bg-card p-4 shadow-sm md:p-6">
 	<div class="flex flex-wrap items-center gap-2">
-		<h1 class="flex-1 text-2xl font-bold tracking-tight md:text-3xl">
+		<h1 class="flex-1 text-2xl font-extrabold tracking-tight sm:text-3xl">
 			{series.name}
 		</h1>
 		{#if isPaused}
-			<span
-				class="inline-flex items-center gap-1 rounded-full bg-muted px-3 py-0.5 text-xs font-medium text-muted-foreground"
+			<StatusBadge
+				tone="neutral"
+				icon={Pause}
+				label={m['recurringEvents.dashboard.statusPaused']()}
 				aria-label={m['recurringEvents.dashboard.statusPaused']()}
-			>
-				<Pause class="h-3 w-3" aria-hidden="true" />
-				{m['recurringEvents.dashboard.statusPaused']()}
-			</span>
+			/>
 		{:else}
-			<span
-				class="inline-flex items-center gap-1 rounded-full bg-green-100 px-3 py-0.5 text-xs font-medium text-green-900 dark:bg-green-900/30 dark:text-green-200"
+			<StatusBadge
+				tone="success"
+				icon={Play}
+				label={m['recurringEvents.dashboard.statusActive']()}
 				aria-label={m['recurringEvents.dashboard.statusActive']()}
-			>
-				<Play class="h-3 w-3" aria-hidden="true" />
-				{m['recurringEvents.dashboard.statusActive']()}
-			</span>
+			/>
 		{/if}
 		<span
 			class="inline-flex items-center rounded-full bg-secondary px-3 py-0.5 text-xs font-medium text-secondary-foreground"

--- a/src/lib/components/event-series/admin/SeriesQuestionnaireAssignmentModal.svelte
+++ b/src/lib/components/event-series/admin/SeriesQuestionnaireAssignmentModal.svelte
@@ -196,7 +196,9 @@
 		</DialogHeader>
 
 		<!-- Warning Banner -->
-		<div class="mx-6 mt-4 flex gap-2 rounded-md border border-highlight bg-highlight/10 p-3 text-sm">
+		<div
+			class="mx-6 mt-4 flex gap-2 rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
+		>
 			<AlertCircle
 				class="h-4 w-4 shrink-0 text-highlight-foreground dark:text-highlight"
 				aria-hidden="true"

--- a/src/lib/components/event-series/admin/SeriesQuestionnaireAssignmentModal.svelte
+++ b/src/lib/components/event-series/admin/SeriesQuestionnaireAssignmentModal.svelte
@@ -196,12 +196,12 @@
 		</DialogHeader>
 
 		<!-- Warning Banner -->
-		<div class="mx-6 mt-4 flex gap-2 rounded-md bg-orange-50 p-3 text-sm dark:bg-orange-950">
+		<div class="mx-6 mt-4 flex gap-2 rounded-md border border-highlight bg-highlight/10 p-3 text-sm">
 			<AlertCircle
-				class="h-4 w-4 shrink-0 text-orange-600 dark:text-orange-400"
+				class="h-4 w-4 shrink-0 text-highlight-foreground dark:text-highlight"
 				aria-hidden="true"
 			/>
-			<p class="text-orange-900 dark:text-orange-100">
+			<p class="text-foreground">
 				<strong>{m['seriesQuestionnaireAssignmentModal.appliesToAllEvents']()}</strong>
 				{m['seriesQuestionnaireAssignmentModal.allEventsSuffix']()}
 			</p>

--- a/src/lib/components/event-series/admin/SeriesResourceAssignmentModal.svelte
+++ b/src/lib/components/event-series/admin/SeriesResourceAssignmentModal.svelte
@@ -232,12 +232,12 @@
 		</DialogHeader>
 
 		<!-- Warning Banner -->
-		<div class="mx-6 mt-4 flex gap-2 rounded-md bg-orange-50 p-3 text-sm dark:bg-orange-950">
+		<div class="mx-6 mt-4 flex gap-2 rounded-md border border-highlight bg-highlight/10 p-3 text-sm">
 			<AlertCircle
-				class="h-4 w-4 shrink-0 text-orange-600 dark:text-orange-400"
+				class="h-4 w-4 shrink-0 text-highlight-foreground dark:text-highlight"
 				aria-hidden="true"
 			/>
-			<p class="text-orange-900 dark:text-orange-100">
+			<p class="text-foreground">
 				<strong>{m['seriesResourceAssignmentModal.appliesToAllEvents']()}</strong>
 				{m['seriesResourceAssignmentModal.allEventsSuffix']()}
 			</p>

--- a/src/lib/components/event-series/admin/SeriesResourceAssignmentModal.svelte
+++ b/src/lib/components/event-series/admin/SeriesResourceAssignmentModal.svelte
@@ -232,7 +232,9 @@
 		</DialogHeader>
 
 		<!-- Warning Banner -->
-		<div class="mx-6 mt-4 flex gap-2 rounded-md border border-highlight bg-highlight/10 p-3 text-sm">
+		<div
+			class="mx-6 mt-4 flex gap-2 rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
+		>
 			<AlertCircle
 				class="h-4 w-4 shrink-0 text-highlight-foreground dark:text-highlight"
 				aria-hidden="true"

--- a/src/lib/components/event-series/admin/TemplateEditDialog.svelte
+++ b/src/lib/components/event-series/admin/TemplateEditDialog.svelte
@@ -331,7 +331,7 @@
 			type="checkbox"
 			bind:checked={flags[t.key]}
 			disabled={updateMutation.isPending}
-			class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+			class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 			data-testid={t.testid}
 		/>
 		<div class="flex-1 text-sm font-medium">{t.label}</div>
@@ -630,7 +630,7 @@
 								type="checkbox"
 								bind:checked={visibilitySettings.show_pronoun_distribution}
 								disabled={updateMutation.isPending}
-								class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+								class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 								data-testid="template-edit-public-pronoun-distribution"
 							/>
 							<div class="flex-1 text-sm font-medium">

--- a/src/lib/components/events/admin/AdminEventCard.svelte
+++ b/src/lib/components/events/admin/AdminEventCard.svelte
@@ -225,9 +225,15 @@
 							</DropdownMenu.Item>
 						{/if}
 						{#if variant !== 'cancelled' && onCancel}
+							<!-- text-highlight-foreground alone passes AA (it's a dark ink,
+							     not amber) but reads as plain text next to the destructive
+							     red items below — no warning signal in light mode. The
+							     persistent bg-highlight/10 wash restores it; data-[highlighted]
+							     is a higher-specificity compound selector so the shared
+							     hover/focus bg-accent treatment still wins on interaction. -->
 							<DropdownMenu.Item
 								onclick={() => onCancel(event.id)}
-								class="text-highlight-foreground focus:text-highlight-foreground dark:text-highlight dark:focus:text-highlight"
+								class="bg-highlight/10 text-highlight-foreground focus:text-highlight-foreground dark:text-highlight dark:focus:text-highlight"
 							>
 								<Ban class="mr-2 h-4 w-4" />
 								{m['orgAdmin.events.actions.cancel']()}

--- a/src/lib/components/events/admin/AdminEventCard.svelte
+++ b/src/lib/components/events/admin/AdminEventCard.svelte
@@ -224,7 +224,7 @@
 						{#if variant === 'open' && onClose}
 							<DropdownMenu.Item
 								onclick={() => onClose(event.id)}
-								class="text-red-600 focus:text-red-600"
+								class="text-destructive focus:text-destructive"
 							>
 								<XCircle class="mr-2 h-4 w-4" />
 								{m['orgAdmin.events.actions.close']()}
@@ -233,7 +233,7 @@
 						{#if variant !== 'cancelled' && onCancel}
 							<DropdownMenu.Item
 								onclick={() => onCancel(event.id)}
-								class="text-orange-600 focus:text-orange-600"
+								class="text-highlight-foreground focus:text-highlight-foreground dark:text-highlight dark:focus:text-highlight"
 							>
 								<Ban class="mr-2 h-4 w-4" />
 								{m['orgAdmin.events.actions.cancel']()}
@@ -302,7 +302,7 @@
 				<button
 					type="button"
 					onclick={() => onPublish(event.id)}
-					class="inline-flex items-center gap-1 rounded-md bg-green-700 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-green-800"
+					class="inline-flex items-center gap-1 rounded-md bg-success px-3 py-1 text-sm font-medium text-success-foreground transition-colors hover:bg-success/90"
 				>
 					<CheckCircle class="h-4 w-4" aria-hidden="true" />
 					{m['orgAdmin.events.actions.publish']()}
@@ -313,7 +313,7 @@
 					<button
 						type="button"
 						onclick={manageTickets}
-						class="inline-flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+						class="inline-flex items-center gap-1 rounded-md bg-poster-periwinkle px-3 py-1 text-sm font-medium text-poster-ink ring-1 ring-inset ring-border transition-colors hover:bg-poster-periwinkle/90"
 					>
 						<UserCheck class="h-4 w-4" aria-hidden="true" />
 						{m['orgAdmin.events.actions.tickets']()}
@@ -322,7 +322,7 @@
 					<button
 						type="button"
 						onclick={manageAttendees}
-						class="inline-flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+						class="inline-flex items-center gap-1 rounded-md bg-poster-periwinkle px-3 py-1 text-sm font-medium text-poster-ink ring-1 ring-inset ring-border transition-colors hover:bg-poster-periwinkle/90"
 					>
 						<UserCheck class="h-4 w-4" aria-hidden="true" />
 						{m['orgAdmin.events.actions.attendees']()}
@@ -331,7 +331,7 @@
 				<button
 					type="button"
 					onclick={manageInvitations}
-					class="inline-flex items-center gap-1 rounded-md bg-purple-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-purple-700"
+					class="inline-flex items-center gap-1 rounded-md bg-poster-purple px-3 py-1 text-sm font-medium text-poster-white ring-1 ring-inset ring-border transition-colors hover:bg-poster-purple/90"
 				>
 					<Mail class="h-4 w-4" aria-hidden="true" />
 					{m['orgAdmin.events.actions.invitations']()}
@@ -339,7 +339,7 @@
 				<button
 					type="button"
 					onclick={manageWaitlist}
-					class="inline-flex items-center gap-1 rounded-md bg-amber-700 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-amber-800"
+					class="inline-flex items-center gap-1 rounded-md bg-poster-amber px-3 py-1 text-sm font-medium text-poster-ink ring-1 ring-inset ring-border transition-colors hover:bg-poster-amber/90"
 				>
 					<ListPlus class="h-4 w-4" aria-hidden="true" />
 					{m['orgAdmin.events.actions.waitlist']()}
@@ -349,7 +349,7 @@
 				<button
 					type="button"
 					onclick={() => onReopen(event.id)}
-					class="inline-flex items-center gap-1 rounded-md bg-green-700 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-green-800"
+					class="inline-flex items-center gap-1 rounded-md bg-success px-3 py-1 text-sm font-medium text-success-foreground transition-colors hover:bg-success/90"
 				>
 					<CheckCircle class="h-4 w-4" aria-hidden="true" />
 					{m['orgAdmin.events.actions.reopen']()}

--- a/src/lib/components/events/admin/AdminEventCard.svelte
+++ b/src/lib/components/events/admin/AdminEventCard.svelte
@@ -5,8 +5,9 @@
 	import type { EventInListSchema } from '$lib/api/generated/types.gen';
 	import { cn } from '$lib/utils/cn';
 	import { formatDateTime } from '$lib/utils/date';
-	import { getEventStatusColor } from '$lib/utils/status-colors';
+	import { getEventStatusTone } from '$lib/utils/status-colors';
 	import EventCoverImage from '$lib/components/events/EventCoverImage.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import {
 		Calendar,
@@ -181,14 +182,7 @@
 						{m['eventBadges.unlisted']()}
 					</span>
 				{/if}
-				<span
-					class={cn(
-						'rounded-full px-2 py-1 text-xs font-medium',
-						getEventStatusColor(event.status)
-					)}
-				>
-					{statusLabel}
-				</span>
+				<StatusBadge tone={getEventStatusTone(event.status)} label={statusLabel} />
 				<!-- More Actions Dropdown -->
 				<DropdownMenu.Root>
 					<DropdownMenu.Trigger>

--- a/src/lib/components/events/admin/AdminEventCard.svelte
+++ b/src/lib/components/events/admin/AdminEventCard.svelte
@@ -171,7 +171,7 @@
 	<div class="flex flex-1 flex-col gap-3 p-4">
 		<!-- Header -->
 		<div class="flex items-start justify-between gap-2">
-			<h3 class="flex-1 font-semibold">{event.name}</h3>
+			<h3 class="flex-1 font-bold">{event.name}</h3>
 			<div class="flex items-center gap-2">
 				{#if event.visibility === 'unlisted'}
 					<span

--- a/src/lib/components/events/admin/AdmissionScreeningSection.svelte
+++ b/src/lib/components/events/admin/AdmissionScreeningSection.svelte
@@ -68,7 +68,7 @@
 					type="checkbox"
 					checked={formData.requires_full_profile || false}
 					onchange={(e) => onUpdate({ requires_full_profile: e.currentTarget.checked })}
-					class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium">
@@ -88,7 +88,7 @@
 					type="checkbox"
 					checked={formData.accept_invitation_requests || false}
 					onchange={(e) => onUpdate({ accept_invitation_requests: e.currentTarget.checked })}
-					class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium">{m['detailsStep.acceptInvitationRequests']()}</div>

--- a/src/lib/components/events/admin/DetailsStep.svelte
+++ b/src/lib/components/events/admin/DetailsStep.svelte
@@ -299,7 +299,7 @@
 								type="checkbox"
 								checked={formData.accept_rsvp_notes || false}
 								onchange={(e) => onUpdate({ accept_rsvp_notes: e.currentTarget.checked })}
-								class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+								class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 							/>
 							<div class="flex-1">
 								<div class="font-medium">{m['detailsStep.acceptRsvpNotes']()}</div>
@@ -391,7 +391,7 @@
 							type="checkbox"
 							checked={formData.waitlist_open || false}
 							onchange={handleWaitlistOpenChange}
-							class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 						/>
 						<div class="flex-1">
 							<div class="font-medium">{m['detailsStep.waitlistOpen']()}</div>
@@ -545,7 +545,7 @@
 						type="checkbox"
 						checked={formData.potluck_open || false}
 						onchange={(e) => onUpdate({ potluck_open: e.currentTarget.checked })}
-						class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+						class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 					/>
 					<div class="flex-1">
 						<div class="font-medium">{m['detailsStep.enablePotluck']()}</div>
@@ -569,7 +569,7 @@
 									show_pronoun_distribution: e.currentTarget.checked
 								}
 							})}
-						class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+						class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 					/>
 					<div class="flex-1">
 						<div class="font-medium">
@@ -589,7 +589,7 @@
 						type="checkbox"
 						checked={formData.can_attend_without_login || false}
 						onchange={(e) => onUpdate({ can_attend_without_login: e.currentTarget.checked })}
-						class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+						class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 					/>
 					<div class="flex-1">
 						<div class="font-medium">{m['detailsStep.canAttendWithoutLogin']()}</div>
@@ -624,7 +624,7 @@
 							type="checkbox"
 							checked={formData.require_ticket_names ?? true}
 							onchange={(e) => onUpdate({ require_ticket_names: e.currentTarget.checked })}
-							class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 						/>
 						<div class="flex-1">
 							<div class="font-medium">{m['detailsStep.requireTicketNames']()}</div>

--- a/src/lib/components/events/admin/DetailsStep.svelte
+++ b/src/lib/components/events/admin/DetailsStep.svelte
@@ -364,7 +364,7 @@
 								{m['eventWizard.effectiveCapacity.label']()}: {effectiveCapacity}
 							</div>
 							{#if maxAttendees && maxAttendees > venueCapacity}
-								<p class="mt-1.5 text-amber-600 dark:text-amber-400">
+								<p class="mt-1.5 text-highlight-foreground dark:text-highlight">
 									⚠️ {m['eventWizard.effectiveCapacity.warning']({
 										maxAttendees: maxAttendees.toString(),
 										venueCapacity: venueCapacity.toString(),

--- a/src/lib/components/events/admin/EssentialsStep.svelte
+++ b/src/lib/components/events/admin/EssentialsStep.svelte
@@ -438,11 +438,7 @@
 		</div>
 
 		<!-- Dynamic explanation based on selected combination -->
-		<div
-			class="rounded-md border border-info/40 bg-info/10 p-4"
-			role="status"
-			aria-live="polite"
-		>
+		<div class="rounded-md border border-info/40 bg-info/10 p-4" role="status" aria-live="polite">
 			<div class="flex items-start gap-3">
 				<div class="flex-shrink-0">
 					<svg
@@ -506,8 +502,7 @@
 					role="alert"
 				>
 					<div class="flex items-start gap-2">
-						<span class="text-highlight-foreground dark:text-highlight" aria-hidden="true">⚠️</span
-						>
+						<span class="text-highlight-foreground dark:text-highlight" aria-hidden="true">⚠️</span>
 						<div class="flex-1 text-foreground">
 							<p class="font-medium">{m['essentialsStep.ticketingImmutableWarning']()}</p>
 							<p class="mt-1 text-xs text-muted-foreground">

--- a/src/lib/components/events/admin/EssentialsStep.svelte
+++ b/src/lib/components/events/admin/EssentialsStep.svelte
@@ -241,7 +241,7 @@
 					value="public"
 					checked={formData.visibility === 'public'}
 					onchange={(e) => onUpdate({ visibility: e.currentTarget.value as 'public' })}
-					class="h-4 w-4 border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium group-hover:text-accent-foreground">
@@ -262,7 +262,7 @@
 					value="unlisted"
 					checked={formData.visibility === 'unlisted'}
 					onchange={(e) => onUpdate({ visibility: e.currentTarget.value as 'unlisted' })}
-					class="h-4 w-4 border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium group-hover:text-accent-foreground">
@@ -283,7 +283,7 @@
 					value="private"
 					checked={formData.visibility === 'private'}
 					onchange={(e) => onUpdate({ visibility: e.currentTarget.value as 'private' })}
-					class="h-4 w-4 border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium group-hover:text-accent-foreground">
@@ -304,7 +304,7 @@
 					value="members-only"
 					checked={formData.visibility === 'members-only'}
 					onchange={(e) => onUpdate({ visibility: e.currentTarget.value as 'members-only' })}
-					class="h-4 w-4 border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium group-hover:text-accent-foreground">
@@ -325,7 +325,7 @@
 					value="staff-only"
 					checked={formData.visibility === 'staff-only'}
 					onchange={(e) => onUpdate({ visibility: e.currentTarget.value as 'staff-only' })}
-					class="h-4 w-4 border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium group-hover:text-accent-foreground">
@@ -382,7 +382,7 @@
 					value="public"
 					checked={formData.event_type === 'public'}
 					onchange={() => onUpdate({ event_type: 'public' })}
-					class="h-4 w-4 border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium group-hover:text-accent-foreground">
@@ -403,7 +403,7 @@
 					value="private"
 					checked={formData.event_type === 'private'}
 					onchange={() => onUpdate({ event_type: 'private' })}
-					class="h-4 w-4 border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium group-hover:text-accent-foreground">
@@ -424,7 +424,7 @@
 					value="members-only"
 					checked={formData.event_type === 'members-only'}
 					onchange={() => onUpdate({ event_type: 'members-only' })}
-					class="h-4 w-4 border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+					class="h-4 w-4 border-input text-primary focus:ring-2 focus:ring-ring"
 				/>
 				<div class="flex-1">
 					<div class="font-medium group-hover:text-accent-foreground">
@@ -439,14 +439,14 @@
 
 		<!-- Dynamic explanation based on selected combination -->
 		<div
-			class="rounded-md border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950"
+			class="rounded-md border border-info/40 bg-info/10 p-4"
 			role="status"
 			aria-live="polite"
 		>
 			<div class="flex items-start gap-3">
 				<div class="flex-shrink-0">
 					<svg
-						class="h-5 w-5 text-blue-600 dark:text-blue-400"
+						class="h-5 w-5 text-info"
 						fill="none"
 						stroke="currentColor"
 						viewBox="0 0 24 24"
@@ -461,10 +461,10 @@
 					</svg>
 				</div>
 				<div class="flex-1">
-					<h4 class="text-sm font-medium text-blue-900 dark:text-blue-100">
+					<h4 class="text-sm font-medium text-info">
 						{m['essentialsStep.withTheseSettings']()}
 					</h4>
-					<div class="mt-2 space-y-1 text-sm text-blue-800 dark:text-blue-200">
+					<div class="mt-2 space-y-1 text-sm text-foreground">
 						<p>
 							<strong>{m['essentialsStep.whoCanView']()}</strong>
 							{combinationExplanation.viewDescription}
@@ -478,7 +478,7 @@
 							})}
 						</p>
 						{#if combinationExplanation.showJoinOrgHint}
-							<p class="mt-2 rounded-md bg-blue-100 px-2 py-1.5 text-xs dark:bg-blue-900">
+							<p class="mt-2 rounded-md bg-info/15 px-2 py-1.5 text-xs">
 								💡 <strong>{m['essentialsStep.tip']()}</strong>
 								{m['essentialsStep.joinOrgHint']()}
 							</p>
@@ -502,14 +502,15 @@
 			<!-- Immutability warning - Always visible in create mode -->
 			{#if !isEditMode}
 				<div
-					class="rounded-md border border-orange-200 bg-orange-50 px-3 py-2.5 text-sm dark:border-orange-800 dark:bg-orange-950"
+					class="rounded-md border border-highlight bg-highlight/10 px-3 py-2.5 text-sm"
 					role="alert"
 				>
 					<div class="flex items-start gap-2">
-						<span class="text-orange-600 dark:text-orange-400" aria-hidden="true">⚠️</span>
-						<div class="flex-1 text-orange-800 dark:text-orange-100">
+						<span class="text-highlight-foreground dark:text-highlight" aria-hidden="true">⚠️</span
+						>
+						<div class="flex-1 text-foreground">
 							<p class="font-medium">{m['essentialsStep.ticketingImmutableWarning']()}</p>
-							<p class="mt-1 text-xs text-orange-700 dark:text-orange-200">
+							<p class="mt-1 text-xs text-muted-foreground">
 								{m['essentialsStep.ticketingImmutableHint']()}
 							</p>
 						</div>
@@ -528,7 +529,7 @@
 					checked={formData.requires_ticket || false}
 					onchange={(e) => onUpdate({ requires_ticket: e.currentTarget.checked })}
 					disabled={isEditMode}
-					class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+					class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
 				/>
 				<div class="flex-1">
 					<div class="font-medium">{m['essentialsStep.requiresTicket']()}</div>
@@ -541,7 +542,7 @@
 			<!-- Edit mode warning -->
 			{#if isEditMode}
 				<div
-					class="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-100"
+					class="rounded-md border border-highlight bg-highlight/10 px-3 py-2 text-xs text-highlight-foreground dark:text-highlight"
 					role="alert"
 				>
 					⚠️ {m['essentialsStep.ticketingImmutableEditWarning']()}

--- a/src/lib/components/events/admin/EventQuestionnaires.svelte
+++ b/src/lib/components/events/admin/EventQuestionnaires.svelte
@@ -68,21 +68,23 @@
 		generic: () => m['eventQuestionnaires.type_generic']()
 	};
 
-	// Status styling
+	// Status styling — token-backed tone classes (bg-{tone}/10 text-{tone}
+	// pairs mirror common/ToneTile's audited recipe; info/success are legible
+	// as text in both modes, so no foreground/dark split needed there).
 	const statusStyles: Record<string, { bg: string; text: string; label: () => string }> = {
 		draft: {
-			bg: 'bg-amber-100 dark:bg-amber-900/30',
-			text: 'text-amber-700 dark:text-amber-300',
+			bg: 'bg-muted',
+			text: 'text-muted-foreground',
 			label: () => m['eventQuestionnaires.status_draft']()
 		},
 		ready: {
-			bg: 'bg-blue-100 dark:bg-blue-900/30',
-			text: 'text-blue-700 dark:text-blue-300',
+			bg: 'bg-info/10',
+			text: 'text-info',
 			label: () => m['eventQuestionnaires.status_ready']()
 		},
 		published: {
-			bg: 'bg-green-100 dark:bg-green-900/30',
-			text: 'text-green-700 dark:text-green-300',
+			bg: 'bg-success/10',
+			text: 'text-success',
 			label: () => m['eventQuestionnaires.status_published']()
 		}
 	};
@@ -110,14 +112,12 @@
 
 	<!-- Warning if any questionnaire is not published -->
 	{#if hasUnpublishedQuestionnaires}
-		<div
-			class="flex items-start gap-3 rounded-lg border border-orange-300 bg-orange-50 p-3 dark:border-orange-700 dark:bg-orange-950/50"
-		>
+		<div class="flex items-start gap-3 rounded-lg border border-highlight bg-highlight/10 p-3">
 			<AlertTriangle
-				class="h-5 w-5 flex-shrink-0 text-orange-600 dark:text-orange-400"
+				class="h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
 				aria-hidden="true"
 			/>
-			<p class="text-sm text-orange-800 dark:text-orange-200">
+			<p class="text-sm text-foreground">
 				{m['eventQuestionnaires.unpublishedWarning']()}
 			</p>
 		</div>
@@ -140,7 +140,7 @@
 				{@const isNotPublished = status !== 'published'}
 				<div
 					class="flex items-center justify-between rounded-lg border p-3 {isNotPublished
-						? 'border-orange-200 dark:border-orange-800'
+						? 'border-highlight/50'
 						: ''}"
 				>
 					<div class="min-w-0 flex-1">
@@ -150,7 +150,7 @@
 									<Tooltip.Root>
 										<Tooltip.Trigger>
 											<AlertTriangle
-												class="h-4 w-4 text-orange-500"
+												class="h-4 w-4 text-highlight-foreground dark:text-highlight"
 												aria-label={m['eventQuestionnaires.notEnforcedTooltip']()}
 											/>
 										</Tooltip.Trigger>

--- a/src/lib/components/events/admin/EventResources.svelte
+++ b/src/lib/components/events/admin/EventResources.svelte
@@ -7,6 +7,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { FileText, Link as LinkIcon, AlignLeft, ExternalLink, Plus } from '@lucide/svelte';
 	import { cn } from '$lib/utils/cn';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 
 	interface Props {
@@ -108,7 +109,7 @@
 	<!-- Header -->
 	<div class="flex items-center justify-between">
 		<div>
-			<h3 class="text-sm font-medium text-gray-900 dark:text-gray-100">
+			<h3 class="text-sm font-medium text-foreground">
 				{m['eventResourcesAdmin.attachResources']()}
 			</h3>
 			<p class="mt-1 text-xs text-muted-foreground">
@@ -141,23 +142,19 @@
 			></div>
 		</div>
 	{:else if resources.length === 0}
-		<div
-			class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center dark:border-gray-600"
-		>
-			<FileText class="mx-auto h-8 w-8 text-muted-foreground" aria-hidden="true" />
-			<p class="mt-2 text-sm text-muted-foreground">
-				{m['eventResourcesAdmin.noResourcesAvailable']()}
-			</p>
-			<a
-				href={resolve('/(auth)/org/[slug]/admin/resources', { slug: organizationSlug })}
-				class="mt-2 inline-flex items-center gap-1 text-sm text-primary hover:underline"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				{m['eventResources.createFirstResource']()}
-				<ExternalLink class="h-3 w-3" aria-hidden="true" />
-			</a>
-		</div>
+		<EmptyState icon={FileText} title={m['eventResourcesAdmin.noResourcesAvailable']()}>
+			{#snippet action()}
+				<a
+					href={resolve('/(auth)/org/[slug]/admin/resources', { slug: organizationSlug })}
+					class="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{m['eventResources.createFirstResource']()}
+					<ExternalLink class="h-3 w-3" aria-hidden="true" />
+				</a>
+			{/snippet}
+		</EmptyState>
 	{:else}
 		<div class="space-y-2">
 			{#each resources as resource (resource.id)}

--- a/src/lib/components/events/admin/EventVisibilityFields.svelte
+++ b/src/lib/components/events/admin/EventVisibilityFields.svelte
@@ -148,7 +148,7 @@
 				checked={resolved[toggle.key]}
 				{disabled}
 				onchange={(e) => setToggle(toggle.key, e.currentTarget.checked)}
-				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-ring"
+				class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring"
 				data-testid={toggle.testid}
 			/>
 			<div class="flex-1">

--- a/src/lib/components/events/admin/EventWizard.svelte
+++ b/src/lib/components/events/admin/EventWizard.svelte
@@ -539,14 +539,20 @@
 		{/if}
 	</div>
 
-	<!-- Success message -->
+	<!-- Success message. `bg-success/10` alone composites against whatever
+	     sits behind it — over the page background that measures 4.39:1 for
+	     `text-success` (below 4.5 for this normal-size text); the opaque
+	     `bg-card` layer underneath fixes the backdrop so the tint composites
+	     to 4.94:1 instead (hand-verified; no destructive/success-on-background
+	     pair covers this composited case in scripts/audit-brand-themes.py). -->
 	{#if successMessage}
 		<div
-			class="rounded-md border border-success/40 bg-success/10 p-4 text-success"
+			class="relative overflow-hidden rounded-md border border-success/40 bg-card"
 			role="status"
 			aria-live="polite"
 		>
-			<p class="font-semibold">{successMessage}</p>
+			<div class="absolute inset-0 bg-success/10" aria-hidden="true"></div>
+			<p class="relative p-4 font-semibold text-success">{successMessage}</p>
 		</div>
 	{/if}
 

--- a/src/lib/components/events/admin/EventWizard.svelte
+++ b/src/lib/components/events/admin/EventWizard.svelte
@@ -502,7 +502,7 @@
 				'flex h-10 w-10 items-center justify-center rounded-full border-2 font-semibold transition-colors',
 				currentStep === 1
 					? 'border-primary bg-primary text-primary-foreground'
-					: 'border-green-600 bg-green-600 text-white'
+					: 'border-success bg-success text-success-foreground'
 			)}
 			aria-current={currentStep === 1 ? 'step' : undefined}
 		>
@@ -515,7 +515,7 @@
 				currentStep === 2
 					? 'border-primary bg-primary text-primary-foreground'
 					: currentStep > 2
-						? 'border-green-600 bg-green-600 text-white'
+						? 'border-success bg-success text-success-foreground'
 						: 'border-border bg-background text-muted-foreground'
 			)}
 			aria-current={currentStep === 2 ? 'step' : undefined}
@@ -542,7 +542,7 @@
 	<!-- Success message -->
 	{#if successMessage}
 		<div
-			class="rounded-md bg-green-50 p-4 text-green-900 dark:bg-green-950/50 dark:text-green-100"
+			class="rounded-md border border-success/40 bg-success/10 p-4 text-success"
 			role="status"
 			aria-live="polite"
 		>

--- a/src/lib/components/events/admin/LocationSection.svelte
+++ b/src/lib/components/events/admin/LocationSection.svelte
@@ -314,7 +314,7 @@
 					<div class="space-y-4 border-t p-3">
 						<!-- Info Box -->
 						<div
-							class="flex items-start gap-3 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950/50 dark:text-blue-100"
+							class="flex items-start gap-3 rounded-md border border-info/40 bg-info/10 p-3 text-sm text-info"
 						>
 							<HelpCircle class="mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" />
 							<div class="space-y-2">

--- a/src/lib/components/events/admin/ScheduleEditor.svelte
+++ b/src/lib/components/events/admin/ScheduleEditor.svelte
@@ -44,7 +44,11 @@
 	</div>
 
 	{#if rows.length === 0}
-		<EmptyState icon={CalendarClock} title={m['eventScheduleAdmin.empty']()} />
+		<EmptyState
+			icon={CalendarClock}
+			title={m['eventScheduleAdmin.emptyTitle']()}
+			body={m['eventScheduleAdmin.empty']()}
+		/>
 	{:else}
 		<ul class="space-y-4">
 			{#each rows as row, index (row.id)}

--- a/src/lib/components/events/admin/ScheduleEditor.svelte
+++ b/src/lib/components/events/admin/ScheduleEditor.svelte
@@ -6,6 +6,7 @@
 	import { DurationInput } from '$lib/components/forms';
 	import MarkdownEditor from '$lib/components/forms/MarkdownEditor.svelte';
 	import { CalendarClock, Plus, Trash2, AlertTriangle } from '@lucide/svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { emptyRow, rowCompleteness, startsBeforeAnchor, type ScheduleRow } from './schedule-rows';
 	import { formatDateTimeReadback } from '$lib/utils/date';
 
@@ -33,7 +34,7 @@
 	<div class="flex items-start gap-2">
 		<CalendarClock class="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
 		<div>
-			<h3 class="text-sm font-medium text-gray-900 dark:text-gray-100">
+			<h3 class="text-sm font-medium text-foreground">
 				{m['eventScheduleAdmin.title']()}
 			</h3>
 			<p class="mt-1 text-xs text-muted-foreground">
@@ -43,12 +44,7 @@
 	</div>
 
 	{#if rows.length === 0}
-		<div
-			class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center dark:border-gray-600"
-		>
-			<CalendarClock class="mx-auto h-8 w-8 text-muted-foreground" aria-hidden="true" />
-			<p class="mt-2 text-sm text-muted-foreground">{m['eventScheduleAdmin.empty']()}</p>
-		</div>
+		<EmptyState icon={CalendarClock} title={m['eventScheduleAdmin.empty']()} />
 	{:else}
 		<ul class="space-y-4">
 			{#each rows as row, index (row.id)}
@@ -183,7 +179,7 @@
 							type="checkbox"
 							bind:checked={row.isRequired}
 							{disabled}
-							class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+							class="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary"
 						/>
 						<div>
 							<span class="text-sm font-medium">{m['eventScheduleAdmin.required']()}</span>

--- a/src/lib/components/events/admin/ScheduleEditor.svelte
+++ b/src/lib/components/events/admin/ScheduleEditor.svelte
@@ -129,7 +129,7 @@
 							{:else if startBefore}
 								<p
 									id="schedule-start-warning-{row.id}"
-									class="mt-1 flex items-start gap-1 text-xs text-amber-600 dark:text-amber-500"
+									class="mt-1 flex items-start gap-1 text-xs text-highlight-foreground dark:text-highlight"
 								>
 									<AlertTriangle class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
 									{m['eventScheduleAdmin.beforeStartWarning']()}

--- a/src/lib/components/events/admin/TierForm.svelte
+++ b/src/lib/components/events/admin/TierForm.svelte
@@ -562,7 +562,7 @@
 							type="checkbox"
 							bind:checked={allowUserCancellation}
 							disabled={isPending}
-							class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+							class="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary"
 						/>
 						<div>
 							<span class="text-sm font-medium">

--- a/src/lib/components/events/admin/TierFormAvailabilitySection.svelte
+++ b/src/lib/components/events/admin/TierFormAvailabilitySection.svelte
@@ -92,7 +92,7 @@
 				type="checkbox"
 				bind:checked={restrictVisibilityToLinkedInvitations}
 				disabled={isPending}
-				class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+				class="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary"
 			/>
 			<div>
 				<span class="text-sm font-medium">{m['tierForm.onlyShowLinkedInvitees']()}</span>
@@ -125,7 +125,7 @@
 				type="checkbox"
 				bind:checked={restrictPurchaseToLinkedInvitations}
 				disabled={isPending}
-				class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+				class="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary"
 			/>
 			<div>
 				<span class="text-sm font-medium">{m['tierForm.onlyAllowPurchaseLinkedInvitees']()}</span>
@@ -162,7 +162,7 @@
 								}
 							}}
 							disabled={isPending}
-							class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+							class="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary"
 						/>
 						<div class="flex-1">
 							<span class="text-sm font-medium">{tier.name}</span>

--- a/src/lib/components/events/admin/TierFormSeatingSection.svelte
+++ b/src/lib/components/events/admin/TierFormSeatingSection.svelte
@@ -175,9 +175,7 @@
 			{#if sectorId}
 				{@const selectedStandingSector = standingSectors.find((s) => s.id === sectorId)}
 				{#if selectedStandingSector?.capacity}
-					<div
-						class="mt-3 rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
-					>
+					<div class="mt-3 rounded-md border border-highlight bg-highlight/10 p-3 text-sm">
 						<p class="font-medium text-highlight-foreground dark:text-highlight">
 							{m['tierForm.sectorHardLimit.title']()}
 						</p>
@@ -291,9 +289,7 @@
 						{#if sectorId}
 							{@const selectedSector = selectedVenueSectors.find((s) => s.id === sectorId)}
 							{#if selectedSector?.capacity}
-								<div
-									class="mt-3 rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
-								>
+								<div class="mt-3 rounded-md border border-highlight bg-highlight/10 p-3 text-sm">
 									<p class="font-medium text-highlight-foreground dark:text-highlight">
 										{m['tierForm.sectorHardLimit.title']()}
 									</p>
@@ -369,7 +365,9 @@
 								class="rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
 								role="alert"
 							>
-								<p class="flex items-center gap-1.5 font-medium text-highlight-foreground dark:text-highlight">
+								<p
+									class="flex items-center gap-1.5 font-medium text-highlight-foreground dark:text-highlight"
+								>
 									<TriangleAlert class="h-4 w-4 shrink-0" aria-hidden="true" />
 									{m['tierForm.categoryPrices.unsellableTitle']()}
 								</p>
@@ -384,7 +382,9 @@
 								class="rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
 								role="alert"
 							>
-								<p class="flex items-center gap-1.5 font-medium text-highlight-foreground dark:text-highlight">
+								<p
+									class="flex items-center gap-1.5 font-medium text-highlight-foreground dark:text-highlight"
+								>
 									<TriangleAlert class="h-4 w-4 shrink-0" aria-hidden="true" />
 									{m['tierForm.categoryPrices.gapsTitle']()}
 								</p>

--- a/src/lib/components/events/admin/TierFormSeatingSection.svelte
+++ b/src/lib/components/events/admin/TierFormSeatingSection.svelte
@@ -176,12 +176,12 @@
 				{@const selectedStandingSector = standingSectors.find((s) => s.id === sectorId)}
 				{#if selectedStandingSector?.capacity}
 					<div
-						class="mt-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950"
+						class="mt-3 rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
 					>
-						<p class="font-medium text-amber-800 dark:text-amber-200">
+						<p class="font-medium text-highlight-foreground dark:text-highlight">
 							{m['tierForm.sectorHardLimit.title']()}
 						</p>
-						<p class="mt-1 text-amber-700 dark:text-amber-300">
+						<p class="mt-1 text-foreground">
 							{m['tierForm.sectorHardLimit.description']({
 								capacity: selectedStandingSector.capacity.toString()
 							})}
@@ -292,12 +292,12 @@
 							{@const selectedSector = selectedVenueSectors.find((s) => s.id === sectorId)}
 							{#if selectedSector?.capacity}
 								<div
-									class="mt-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950"
+									class="mt-3 rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
 								>
-									<p class="font-medium text-amber-800 dark:text-amber-200">
+									<p class="font-medium text-highlight-foreground dark:text-highlight">
 										{m['tierForm.sectorHardLimit.title']()}
 									</p>
-									<p class="mt-1 text-amber-700 dark:text-amber-300">
+									<p class="mt-1 text-foreground">
 										{m['tierForm.sectorHardLimit.description']({
 											capacity: selectedSector.capacity.toString()
 										})}
@@ -366,14 +366,14 @@
 							     resolve_requested_zone accepts them, the picker finds no
 							     seats, every buyer gets a 409. Never intentional. -->
 							<div
-								class="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950"
+								class="rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
 								role="alert"
 							>
-								<p class="flex items-center gap-1.5 font-medium text-amber-800 dark:text-amber-200">
+								<p class="flex items-center gap-1.5 font-medium text-highlight-foreground dark:text-highlight">
 									<TriangleAlert class="h-4 w-4 shrink-0" aria-hidden="true" />
 									{m['tierForm.categoryPrices.unsellableTitle']()}
 								</p>
-								<p class="mt-1 text-amber-700 dark:text-amber-300">
+								<p class="mt-1 text-foreground">
 									{m['tierForm.categoryPrices.unsellableDescription']({ zones: unsellableNames })}
 								</p>
 							</div>
@@ -381,14 +381,14 @@
 
 						{#if pricingGaps.length > 0 && !isBestAvailable}
 							<div
-								class="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950"
+								class="rounded-md border border-highlight bg-highlight/10 p-3 text-sm"
 								role="alert"
 							>
-								<p class="flex items-center gap-1.5 font-medium text-amber-800 dark:text-amber-200">
+								<p class="flex items-center gap-1.5 font-medium text-highlight-foreground dark:text-highlight">
 									<TriangleAlert class="h-4 w-4 shrink-0" aria-hidden="true" />
 									{m['tierForm.categoryPrices.gapsTitle']()}
 								</p>
-								<p class="mt-1 text-amber-700 dark:text-amber-300">
+								<p class="mt-1 text-foreground">
 									{m['tierForm.categoryPrices.gapsDescription']({ categories: gapNames })}
 								</p>
 							</div>

--- a/src/lib/components/events/admin/seating/BoxOfficeSeatPicker.svelte
+++ b/src/lib/components/events/admin/seating/BoxOfficeSeatPicker.svelte
@@ -30,7 +30,7 @@
 	function seatChipClasses(seat: SeatView, selected: boolean, selectable: boolean): string {
 		if (selected) return 'border-primary bg-primary/10';
 		if (!selectable) return 'border-border/40 bg-muted/40 opacity-60';
-		if (seat.status === 'blocked') return 'border-amber-500/60 bg-amber-50 dark:bg-amber-950/30';
+		if (seat.status === 'blocked') return 'border-highlight/60 bg-highlight/10';
 		return 'border-border bg-background';
 	}
 </script>
@@ -85,11 +85,11 @@
 											<span class="text-muted-foreground">({status})</span>
 										{/if}
 										{#if seat.isAccessible}
-											<Accessibility class="h-3 w-3 text-blue-500" aria-hidden="true" />
+											<Accessibility class="h-3 w-3 text-info" aria-hidden="true" />
 										{/if}
 										{#if seat.isObstructedView}
 											<EyeOff
-												class="h-3 w-3 text-amber-600 dark:text-amber-400"
+												class="h-3 w-3 text-highlight-foreground dark:text-highlight"
 												aria-hidden="true"
 											/>
 										{/if}

--- a/src/lib/components/events/admin/seating/BoxOfficeSellPanel.svelte
+++ b/src/lib/components/events/admin/seating/BoxOfficeSellPanel.svelte
@@ -233,7 +233,7 @@
 			<div
 				bind:this={resultEl}
 				tabindex="-1"
-				class="rounded-lg border border-emerald-500/40 bg-emerald-50 p-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:bg-emerald-950/20"
+				class="rounded-lg border border-success/40 bg-success/10 p-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 				role="status"
 			>
 				<h3 class="text-sm font-semibold">

--- a/src/lib/components/events/admin/seating/SeatOverrideSectorList.svelte
+++ b/src/lib/components/events/admin/seating/SeatOverrideSectorList.svelte
@@ -30,7 +30,7 @@
 		}
 		switch (seat.status) {
 			case 'blocked':
-				return 'border-amber-500/60 bg-amber-50 dark:bg-amber-950/30';
+				return 'border-highlight/60 bg-highlight/10';
 			case 'sold':
 			case 'held':
 				return 'border-border/50 bg-muted/40';
@@ -115,11 +115,11 @@
 											<span class="text-muted-foreground">({status})</span>
 										{/if}
 										{#if seat.isAccessible}
-											<Accessibility class="h-3 w-3 text-blue-500" aria-hidden="true" />
+											<Accessibility class="h-3 w-3 text-info" aria-hidden="true" />
 										{/if}
 										{#if seat.isObstructedView}
 											<EyeOff
-												class="h-3 w-3 text-amber-600 dark:text-amber-400"
+												class="h-3 w-3 text-highlight-foreground dark:text-highlight"
 												aria-hidden="true"
 											/>
 										{/if}

--- a/src/lib/components/events/admin/seating/SeatOverridesPanel.svelte
+++ b/src/lib/components/events/admin/seating/SeatOverridesPanel.svelte
@@ -230,9 +230,7 @@
 			{#if blockedSeats.length > 0}
 				<ul class="mt-3 flex flex-wrap gap-1.5" role="list">
 					{#each blockedSeats as seat (seat.id)}
-						<li
-							class="rounded-md border border-highlight/60 bg-highlight/10 px-2 py-0.5 text-xs"
-						>
+						<li class="rounded-md border border-highlight/60 bg-highlight/10 px-2 py-0.5 text-xs">
 							{seat.label}
 						</li>
 					{/each}

--- a/src/lib/components/events/admin/seating/SeatOverridesPanel.svelte
+++ b/src/lib/components/events/admin/seating/SeatOverridesPanel.svelte
@@ -231,7 +231,7 @@
 				<ul class="mt-3 flex flex-wrap gap-1.5" role="list">
 					{#each blockedSeats as seat (seat.id)}
 						<li
-							class="rounded-md border border-amber-500/60 bg-amber-50 px-2 py-0.5 text-xs dark:bg-amber-950/30"
+							class="rounded-md border border-highlight/60 bg-highlight/10 px-2 py-0.5 text-xs"
 						>
 							{seat.label}
 						</li>

--- a/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte
+++ b/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte
@@ -2,7 +2,8 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { WaitlistOfferStatus } from '$lib/api/generated/types.gen';
 	import { Ban, Check, Clock, X } from '@lucide/svelte';
-	import { cn } from '$lib/utils/cn';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Props {
 		status: WaitlistOfferStatus;
@@ -11,44 +12,33 @@
 
 	const { status, class: className }: Props = $props();
 
-	const config = $derived.by(() => {
+	// Thin mapper over the shared StatusBadge primitive (rebrand PR 8):
+	// dense waitlist admin tables, so size stays 'sm'.
+	const config = $derived.by((): { label: string; icon: typeof Clock; tone: Tone } => {
 		switch (status) {
 			case 'pending':
-				return {
-					label: m['offerStatus.pending'](),
-					icon: Clock,
-					classes: 'bg-highlight text-highlight-foreground'
-				};
+				return { label: m['offerStatus.pending'](), icon: Clock, tone: 'warning' };
 			case 'claimed':
-				return {
-					label: m['offerStatus.claimed'](),
-					icon: Check,
-					classes: 'bg-success text-success-foreground'
-				};
+				return { label: m['offerStatus.claimed'](), icon: Check, tone: 'success' };
 			case 'expired':
-				return {
-					label: m['offerStatus.expired'](),
-					icon: X,
-					classes: 'bg-muted text-muted-foreground ring-1 ring-border'
-				};
+				return { label: m['offerStatus.expired'](), icon: X, tone: 'neutral' };
 			case 'revoked':
-				return {
-					label: m['offerStatus.revoked'](),
-					icon: Ban,
-					classes: 'bg-destructive text-destructive-foreground'
-				};
+				return { label: m['offerStatus.revoked'](), icon: Ban, tone: 'danger' };
 		}
 	});
 </script>
 
-<span
-	class={cn(
-		'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
-		config.classes,
-		className
-	)}
+<!--
+	aria-label is deliberate, not redundant with the visible text: this badge
+	is a `common/StatusBadge` consumer (see CLAUDE.md primitive contract) and
+	every domain mapper attaches its own aria-label explicitly — the primitive
+	does not default it.
+-->
+<StatusBadge
+	tone={config.tone}
+	label={config.label}
+	icon={config.icon}
+	size="sm"
+	class={className}
 	aria-label={config.label}
->
-	<config.icon class="h-3 w-3" aria-hidden="true" />
-	<span>{config.label}</span>
-</span>
+/>

--- a/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte
+++ b/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte
@@ -1,3 +1,8 @@
+<script module lang="ts">
+	/** Every status this mapper understands, in the order the regression test walks them. */
+	export const WAITLIST_OFFER_STATUS_ORDER = ['pending', 'claimed', 'expired', 'revoked'] as const;
+</script>
+
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import type { WaitlistOfferStatus } from '$lib/api/generated/types.gen';
@@ -12,20 +17,32 @@
 
 	const { status, class: className }: Props = $props();
 
+	const TONE_MAP: Record<WaitlistOfferStatus, Tone> = {
+		pending: 'warning',
+		claimed: 'success',
+		expired: 'neutral',
+		revoked: 'danger'
+	};
+
+	const ICON_MAP: Record<WaitlistOfferStatus, typeof Clock> = {
+		pending: Clock,
+		claimed: Check,
+		expired: X,
+		revoked: Ban
+	};
+
+	const LABEL_MAP: Record<WaitlistOfferStatus, () => string> = {
+		pending: () => m['offerStatus.pending'](),
+		claimed: () => m['offerStatus.claimed'](),
+		expired: () => m['offerStatus.expired'](),
+		revoked: () => m['offerStatus.revoked']()
+	};
+
 	// Thin mapper over the shared StatusBadge primitive (rebrand PR 8):
 	// dense waitlist admin tables, so size stays 'sm'.
-	const config = $derived.by((): { label: string; icon: typeof Clock; tone: Tone } => {
-		switch (status) {
-			case 'pending':
-				return { label: m['offerStatus.pending'](), icon: Clock, tone: 'warning' };
-			case 'claimed':
-				return { label: m['offerStatus.claimed'](), icon: Check, tone: 'success' };
-			case 'expired':
-				return { label: m['offerStatus.expired'](), icon: X, tone: 'neutral' };
-			case 'revoked':
-				return { label: m['offerStatus.revoked'](), icon: Ban, tone: 'danger' };
-		}
-	});
+	const tone = $derived(TONE_MAP[status]);
+	const icon = $derived(ICON_MAP[status]);
+	const label = $derived(LABEL_MAP[status]());
 </script>
 
 <!--
@@ -34,11 +51,4 @@
 	every domain mapper attaches its own aria-label explicitly — the primitive
 	does not default it.
 -->
-<StatusBadge
-	tone={config.tone}
-	label={config.label}
-	icon={config.icon}
-	size="sm"
-	class={className}
-	aria-label={config.label}
-/>
+<StatusBadge {tone} {label} {icon} size="sm" class={className} aria-label={label} />

--- a/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.test.ts
+++ b/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.test.ts
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 import * as m from '$lib/paraglide/messages.js';
 import type { WaitlistOfferStatus } from '$lib/api/generated/types.gen';
-import WaitlistOfferStatusBadge from './WaitlistOfferStatusBadge.svelte';
-
-const STATUS_ORDER: WaitlistOfferStatus[] = ['pending', 'claimed', 'expired', 'revoked'];
+import WaitlistOfferStatusBadge, {
+	WAITLIST_OFFER_STATUS_ORDER
+} from './WaitlistOfferStatusBadge.svelte';
 
 const LABELS: Record<WaitlistOfferStatus, string> = {
 	pending: m['offerStatus.pending'](),
@@ -21,7 +21,7 @@ const LABELS: Record<WaitlistOfferStatus, string> = {
  * stop resolving. Pin every enum value, not a sample.
  */
 describe('events/waitlist/WaitlistOfferStatusBadge', () => {
-	it.each(STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+	it.each(WAITLIST_OFFER_STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
 		render(WaitlistOfferStatusBadge, { props: { status } });
 		const label = LABELS[status];
 		expect(screen.getByLabelText(label)).toBeInTheDocument();

--- a/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.test.ts
+++ b/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.test.ts
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import * as m from '$lib/paraglide/messages.js';
+import type { WaitlistOfferStatus } from '$lib/api/generated/types.gen';
+import WaitlistOfferStatusBadge from './WaitlistOfferStatusBadge.svelte';
+
+const STATUS_ORDER: WaitlistOfferStatus[] = ['pending', 'claimed', 'expired', 'revoked'];
+
+const LABELS: Record<WaitlistOfferStatus, string> = {
+	pending: m['offerStatus.pending'](),
+	claimed: m['offerStatus.claimed'](),
+	expired: m['offerStatus.expired'](),
+	revoked: m['offerStatus.revoked']()
+};
+
+/**
+ * REGRESSION GUARD (see members/StatusBadge.test.ts for the incident this
+ * pattern guards against). `common/StatusBadge` names itself from its text
+ * content only — it never defaults `aria-label` — so every domain mapper
+ * must pass it explicitly or `getByLabel` lookups against the badge silently
+ * stop resolving. Pin every enum value, not a sample.
+ */
+describe('events/waitlist/WaitlistOfferStatusBadge', () => {
+	it.each(STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+		render(WaitlistOfferStatusBadge, { props: { status } });
+		const label = LABELS[status];
+		expect(screen.getByLabelText(label)).toBeInTheDocument();
+		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+	});
+
+	it('maps status to the primitive tone (claimed → success, revoked → danger)', () => {
+		const claimed = render(WaitlistOfferStatusBadge, { props: { status: 'claimed' } });
+		expect(claimed.container.querySelector('span')?.className).toContain('bg-success');
+
+		const revoked = render(WaitlistOfferStatusBadge, { props: { status: 'revoked' } });
+		expect(revoked.container.querySelector('span')?.className).toContain('bg-destructive');
+	});
+
+	it('keeps the caller class alongside the tone classes', () => {
+		const { container } = render(WaitlistOfferStatusBadge, {
+			props: { status: 'pending', class: 'shrink-0' }
+		});
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.className).toContain('shrink-0');
+		expect(el.className).toContain('bg-highlight');
+	});
+});

--- a/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.test.ts
+++ b/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.test.ts
@@ -21,12 +21,15 @@ const LABELS: Record<WaitlistOfferStatus, string> = {
  * stop resolving. Pin every enum value, not a sample.
  */
 describe('events/waitlist/WaitlistOfferStatusBadge', () => {
-	it.each(WAITLIST_OFFER_STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
-		render(WaitlistOfferStatusBadge, { props: { status } });
-		const label = LABELS[status];
-		expect(screen.getByLabelText(label)).toBeInTheDocument();
-		expect(screen.getByLabelText(label)).toHaveTextContent(label);
-	});
+	it.each(WAITLIST_OFFER_STATUS_ORDER)(
+		'exposes the %s label as the pill accessible name',
+		(status) => {
+			render(WaitlistOfferStatusBadge, { props: { status } });
+			const label = LABELS[status];
+			expect(screen.getByLabelText(label)).toBeInTheDocument();
+			expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		}
+	);
 
 	it('maps status to the primitive tone (claimed → success, revoked → danger)', () => {
 		const claimed = render(WaitlistOfferStatusBadge, { props: { status: 'claimed' } });

--- a/src/lib/components/events/waitlist/admin/WaitlistEntriesTable.svelte
+++ b/src/lib/components/events/waitlist/admin/WaitlistEntriesTable.svelte
@@ -103,6 +103,7 @@
 		icon={Users}
 		title={m['orgAdmin.waitlist.empty.title']()}
 		body={m['orgAdmin.waitlist.empty.description']()}
+		level={2}
 	/>
 {:else if data}
 	<div class="rounded-lg border bg-card p-4">

--- a/src/lib/components/events/waitlist/admin/WaitlistEntriesTable.svelte
+++ b/src/lib/components/events/waitlist/admin/WaitlistEntriesTable.svelte
@@ -11,6 +11,7 @@
 		Users
 	} from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import WaitlistOfferStatusBadge from '$lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte';
 	import OfferExpiryCountdown from '$lib/components/events/waitlist/OfferExpiryCountdown.svelte';
 	import type {
@@ -98,13 +99,11 @@
 		</p>
 	</div>
 {:else if data && data.results.length === 0}
-	<div class="rounded-lg border border-border bg-card p-12 text-center">
-		<Users class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-		<h3 class="mt-4 text-lg font-semibold">{m['orgAdmin.waitlist.empty.title']()}</h3>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{m['orgAdmin.waitlist.empty.description']()}
-		</p>
-	</div>
+	<EmptyState
+		icon={Users}
+		title={m['orgAdmin.waitlist.empty.title']()}
+		body={m['orgAdmin.waitlist.empty.description']()}
+	/>
 {:else if data}
 	<div class="rounded-lg border bg-card p-4">
 		<div class="flex items-center gap-2">
@@ -121,19 +120,29 @@
 		<table class="w-full border-collapse">
 			<thead class="bg-muted/50">
 				<tr>
-					<th class="px-4 py-3 text-left text-sm font-medium">
+					<th
+						class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+					>
 						{m['orgAdmin.waitlist.table.user']()}
 					</th>
-					<th class="px-4 py-3 text-left text-sm font-medium">
+					<th
+						class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+					>
 						{m['orgAdmin.waitlist.table.email']()}
 					</th>
-					<th class="px-4 py-3 text-left text-sm font-medium">
+					<th
+						class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+					>
 						{m['orgAdmin.waitlist.table.joinedAt']()}
 					</th>
-					<th class="px-4 py-3 text-left text-sm font-medium">
+					<th
+						class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+					>
 						{m['orgAdmin.waitlist.offer.statusColumn']()}
 					</th>
-					<th class="px-4 py-3 text-right text-sm font-medium">
+					<th
+						class="px-4 py-3 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+					>
 						{m['orgAdmin.waitlist.table.actions']()}
 					</th>
 				</tr>

--- a/src/lib/components/events/waitlist/admin/WaitlistSettingsCard.svelte
+++ b/src/lib/components/events/waitlist/admin/WaitlistSettingsCard.svelte
@@ -25,7 +25,7 @@
 		<div class="flex items-start gap-3">
 			<Settings class="mt-0.5 h-5 w-5 text-muted-foreground" aria-hidden="true" />
 			<div>
-				<h2 class="text-lg font-semibold">{m['orgAdmin.waitlist.settings.title']()}</h2>
+				<h2 class="text-lg font-bold">{m['orgAdmin.waitlist.settings.title']()}</h2>
 				{#if isLoading}
 					<p class="mt-1 text-sm text-muted-foreground">
 						<Loader2 class="inline h-3.5 w-3.5 animate-spin" aria-hidden="true" />

--- a/src/lib/components/invitations/InvitationFormDialogs.svelte
+++ b/src/lib/components/invitations/InvitationFormDialogs.svelte
@@ -194,7 +194,7 @@
 						placeholder={m['eventInvitationsAdmin.customMessagePlaceholder']()}
 						rows="3"
 						maxlength="500"
-						class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+						class="mt-1 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 					></textarea>
 					<p class="mt-1 text-xs text-muted-foreground">
 						{m['eventInvitationsAdmin.charactersCount']({ count: invitationMessage.length })}
@@ -285,7 +285,7 @@
 							placeholder={m['eventInvitationsAdmin.customMessagePlaceholder']()}
 							rows="3"
 							maxlength="500"
-							class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+							class="mt-1 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						></textarea>
 						<p class="mt-1 text-xs text-muted-foreground">
 							{m['eventInvitationsAdmin.charactersCount']({
@@ -304,7 +304,7 @@
 								name="waives_questionnaire"
 								value="true"
 								bind:checked={editFormData.waives_questionnaire}
-								class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+								class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 							/>
 							<span class="text-sm">{m['eventInvitationsAdmin.waiveQuestionnaire']()}</span>
 						</label>
@@ -315,7 +315,7 @@
 								name="waives_purchase"
 								value="true"
 								bind:checked={editFormData.waives_purchase}
-								class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+								class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 							/>
 							<span class="text-sm">{m['eventInvitationsAdmin.waivePurchase']()}</span>
 						</label>
@@ -326,7 +326,7 @@
 								name="waives_membership_required"
 								value="true"
 								bind:checked={editFormData.waives_membership_required}
-								class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+								class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 							/>
 							<span class="text-sm">{m['eventInvitationsAdmin.waiveMembership']()}</span>
 						</label>
@@ -337,7 +337,7 @@
 								name="waives_rsvp_deadline"
 								value="true"
 								bind:checked={editFormData.waives_rsvp_deadline}
-								class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+								class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 							/>
 							<span class="text-sm">{m['eventInvitationsAdmin.waiveDeadline']()}</span>
 						</label>
@@ -348,7 +348,7 @@
 								name="overrides_max_attendees"
 								value="true"
 								bind:checked={editFormData.overrides_max_attendees}
-								class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+								class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 							/>
 							<span class="text-sm">{m['eventInvitationsAdmin.overrideMaxAttendees']()}</span>
 						</label>
@@ -431,7 +431,7 @@
 						placeholder={m['eventInvitationsAdmin.customMessagePlaceholder']()}
 						rows="3"
 						maxlength="500"
-						class="mt-1 w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+						class="mt-1 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
 					></textarea>
 					<p class="mt-1 text-xs text-muted-foreground">
 						{m['eventInvitationsAdmin.charactersCount']({
@@ -450,7 +450,7 @@
 							name="waives_questionnaire"
 							value="true"
 							bind:checked={bulkEditFormData.waives_questionnaire}
-							class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						/>
 						<span class="text-sm">{m['eventInvitationsAdmin.waiveQuestionnaire']()}</span>
 					</label>
@@ -461,7 +461,7 @@
 							name="waives_purchase"
 							value="true"
 							bind:checked={bulkEditFormData.waives_purchase}
-							class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						/>
 						<span class="text-sm">{m['eventInvitationsAdmin.waivePurchase']()}</span>
 					</label>
@@ -472,7 +472,7 @@
 							name="waives_membership_required"
 							value="true"
 							bind:checked={bulkEditFormData.waives_membership_required}
-							class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						/>
 						<span class="text-sm">{m['eventInvitationsAdmin.waiveMembership']()}</span>
 					</label>
@@ -483,7 +483,7 @@
 							name="waives_rsvp_deadline"
 							value="true"
 							bind:checked={bulkEditFormData.waives_rsvp_deadline}
-							class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						/>
 						<span class="text-sm">{m['eventInvitationsAdmin.waiveDeadline']()}</span>
 					</label>
@@ -494,7 +494,7 @@
 							name="overrides_max_attendees"
 							value="true"
 							bind:checked={bulkEditFormData.overrides_max_attendees}
-							class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 						/>
 						<span class="text-sm">{m['eventInvitationsAdmin.overrideMaxAttendees']()}</span>
 					</label>
@@ -531,7 +531,7 @@
 				type="checkbox"
 				name="waives_questionnaire"
 				value="true"
-				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+				class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 			/>
 			<span class="text-sm">{m['eventInvitationsAdmin.waiveQuestionnaire']()}</span>
 		</label>
@@ -541,7 +541,7 @@
 				type="checkbox"
 				name="waives_purchase"
 				value="true"
-				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+				class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 			/>
 			<span class="text-sm">{m['eventInvitationsAdmin.waivePurchase']()}</span>
 		</label>
@@ -551,7 +551,7 @@
 				type="checkbox"
 				name="waives_membership_required"
 				value="true"
-				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+				class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 			/>
 			<span class="text-sm">{m['eventInvitationsAdmin.waiveMembership']()}</span>
 		</label>
@@ -561,7 +561,7 @@
 				type="checkbox"
 				name="waives_rsvp_deadline"
 				value="true"
-				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+				class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 			/>
 			<span class="text-sm">{m['eventInvitationsAdmin.waiveDeadline']()}</span>
 		</label>
@@ -571,7 +571,7 @@
 				type="checkbox"
 				name="overrides_max_attendees"
 				value="true"
-				class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+				class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
 			/>
 			<span class="text-sm">{m['eventInvitationsAdmin.overrideMaxAttendees']()}</span>
 		</label>
@@ -599,7 +599,7 @@
 									onUpdate(selectedIds.filter((id) => id !== tier.id));
 								}
 							}}
-							class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
+							class="mt-0.5 h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary"
 						/>
 						<div class="flex-1">
 							<span class="text-sm font-medium">{tier.name}</span>

--- a/src/lib/components/invitations/InvitationLinksTab.svelte
+++ b/src/lib/components/invitations/InvitationLinksTab.svelte
@@ -8,6 +8,7 @@
 	import { Search, Plus, Link, Loader2 } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { createQuery, createMutation, useQueryClient } from '@tanstack/svelte-query';
 	import {
 		eventadmintokensListEventTokens,
@@ -232,17 +233,13 @@
 				<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
 			</div>
 		{:else if tokens.length === 0}
-			<div class="rounded-lg border border-dashed p-12 text-center">
-				<Link class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-				<h3 class="mt-4 text-lg font-semibold">{m['eventInvitationsAdmin.noLinksFound']()}</h3>
-				<p class="mt-2 text-sm text-muted-foreground">
-					{#if tokenSearchQuery}
-						{m['eventInvitationsAdmin.noLinksSearch']()}
-					{:else}
-						{m['eventInvitationsAdmin.noLinksEmpty']()}
-					{/if}
-				</p>
-			</div>
+			<EmptyState
+				icon={Link}
+				title={m['eventInvitationsAdmin.noLinksFound']()}
+				body={tokenSearchQuery
+					? m['eventInvitationsAdmin.noLinksSearch']()
+					: m['eventInvitationsAdmin.noLinksEmpty']()}
+			/>
 		{:else}
 			{#each tokens as token (token.id)}
 				<EventTokenCard

--- a/src/lib/components/invitations/InvitationLinksTab.svelte
+++ b/src/lib/components/invitations/InvitationLinksTab.svelte
@@ -239,6 +239,7 @@
 				body={tokenSearchQuery
 					? m['eventInvitationsAdmin.noLinksSearch']()
 					: m['eventInvitationsAdmin.noLinksEmpty']()}
+				level={2}
 			/>
 		{:else}
 			{#each tokens as token (token.id)}

--- a/src/lib/components/invitations/InvitationListTab.svelte
+++ b/src/lib/components/invitations/InvitationListTab.svelte
@@ -148,12 +148,12 @@
 
 {#snippet registeredHeaders()}
 	<th
-		class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+		class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 	>
 		{m['eventInvitationsAdmin.headerUser']()}
 	</th>
 	<th
-		class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+		class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 	>
 		{m['eventInvitationsAdmin.headerEmail']()}
 	</th>
@@ -194,7 +194,7 @@
 
 {#snippet pendingHeaders()}
 	<th
-		class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+		class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 	>
 		{m['eventInvitationsAdmin.headerEmail']()}
 	</th>

--- a/src/lib/components/invitations/InvitationRequestsTab.svelte
+++ b/src/lib/components/invitations/InvitationRequestsTab.svelte
@@ -144,6 +144,7 @@
 			body={activeStatusFilter || searchQuery
 				? m['eventInvitationsAdmin.noRequestsFiltered']()
 				: m['eventInvitationsAdmin.noRequestsEmpty']()}
+			level={2}
 		/>
 	{:else}
 		<!-- Requests Table -->
@@ -153,27 +154,27 @@
 					<thead class="border-b bg-muted/50">
 						<tr>
 							<th
-								class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+								class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>
 								{m['eventInvitationsAdmin.headerUser']()}
 							</th>
 							<th
-								class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+								class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>
 								{m['eventInvitationsAdmin.headerMessage']()}
 							</th>
 							<th
-								class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+								class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>
 								{m['eventInvitationsAdmin.headerStatus']()}
 							</th>
 							<th
-								class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+								class="px-6 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>
 								{m['eventInvitationsAdmin.headerRequested']()}
 							</th>
 							<th
-								class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground"
+								class="px-6 py-3 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>
 								{m['eventInvitationsAdmin.headerActions']()}
 							</th>

--- a/src/lib/components/invitations/InvitationRequestsTab.svelte
+++ b/src/lib/components/invitations/InvitationRequestsTab.svelte
@@ -7,6 +7,9 @@
 	import { cn } from '$lib/utils/cn';
 	import { getUserDisplayName } from '$lib/utils/user-display';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	interface Pagination {
 		page: number;
@@ -48,16 +51,16 @@
 		}
 	}
 
-	function getStatusBadge(status: string) {
+	function getStatusTone(status: string): Tone {
 		switch (status) {
 			case 'pending':
-				return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
+				return 'warning';
 			case 'approved':
-				return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+				return 'success';
 			case 'rejected':
-				return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+				return 'danger';
 			default:
-				return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
+				return 'neutral';
 		}
 	}
 </script>
@@ -98,10 +101,10 @@
 				type="button"
 				onclick={() => onFilterByStatus('pending')}
 				class={cn(
-					'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+					'rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
 					activeStatusFilter === 'pending'
-						? 'bg-yellow-600 text-white'
-						: 'border border-yellow-600 text-yellow-600 hover:bg-yellow-50 dark:hover:bg-yellow-950'
+						? 'border-highlight bg-highlight text-highlight-foreground'
+						: 'border-highlight/50 bg-card text-foreground hover:bg-highlight/10'
 				)}
 			>
 				{m['eventInvitationsAdmin.filterPending']()}
@@ -110,10 +113,10 @@
 				type="button"
 				onclick={() => onFilterByStatus('approved')}
 				class={cn(
-					'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+					'rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
 					activeStatusFilter === 'approved'
-						? 'bg-green-600 text-white'
-						: 'border border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-green-950'
+						? 'border-success bg-success text-success-foreground'
+						: 'border-success/50 bg-card text-foreground hover:bg-success/10'
 				)}
 			>
 				{m['eventInvitationsAdmin.filterApproved']()}
@@ -122,10 +125,10 @@
 				type="button"
 				onclick={() => onFilterByStatus('rejected')}
 				class={cn(
-					'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+					'rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
 					activeStatusFilter === 'rejected'
-						? 'bg-red-600 text-white'
-						: 'border border-red-600 text-red-600 hover:bg-red-50 dark:hover:bg-red-950'
+						? 'border-destructive bg-destructive text-destructive-foreground'
+						: 'border-destructive/50 bg-card text-foreground hover:bg-destructive/10'
 				)}
 			>
 				{m['eventInvitationsAdmin.filterRejected']()}
@@ -135,17 +138,13 @@
 
 	<!-- Requests List -->
 	{#if invitationRequests.length === 0}
-		<div class="rounded-lg border bg-card p-12 text-center">
-			<Users class="mx-auto mb-4 h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mb-2 text-lg font-semibold">{m['eventInvitationsAdmin.noRequests']()}</h3>
-			<p class="text-sm text-muted-foreground">
-				{#if activeStatusFilter || searchQuery}
-					{m['eventInvitationsAdmin.noRequestsFiltered']()}
-				{:else}
-					{m['eventInvitationsAdmin.noRequestsEmpty']()}
-				{/if}
-			</p>
-		</div>
+		<EmptyState
+			icon={Users}
+			title={m['eventInvitationsAdmin.noRequests']()}
+			body={activeStatusFilter || searchQuery
+				? m['eventInvitationsAdmin.noRequestsFiltered']()
+				: m['eventInvitationsAdmin.noRequestsEmpty']()}
+		/>
 	{:else}
 		<!-- Requests Table -->
 		<div class="overflow-hidden rounded-lg border bg-card">
@@ -223,14 +222,11 @@
 
 								<!-- Status -->
 								<td class="px-6 py-4">
-									<span
-										class="inline-flex rounded-full px-2 py-1 text-xs font-semibold {getStatusBadge(
-											request.status ?? ''
-										)}"
-									>
-										{(request.status ?? '').charAt(0).toUpperCase() +
+									<StatusBadge
+										tone={getStatusTone(request.status ?? '')}
+										label={(request.status ?? '').charAt(0).toUpperCase() +
 											(request.status ?? '').slice(1)}
-									</span>
+									/>
 								</td>
 
 								<!-- Requested -->
@@ -260,7 +256,7 @@
 												<button
 													type="submit"
 													disabled={processingId === request.id}
-													class="inline-flex items-center gap-1 rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+													class="inline-flex items-center gap-1 rounded-md bg-success px-3 py-1.5 text-xs font-medium text-success-foreground transition-colors hover:bg-success/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 												>
 													<Check class="h-3.5 w-3.5" aria-hidden="true" />
 													{m['eventInvitationsAdmin.approve']()}
@@ -282,7 +278,7 @@
 												<button
 													type="submit"
 													disabled={processingId === request.id}
-													class="inline-flex items-center gap-1 rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+													class="inline-flex items-center gap-1 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground transition-colors hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 												>
 													<X class="h-3.5 w-3.5" aria-hidden="true" />
 													{m['eventInvitationsAdmin.reject']()}

--- a/src/lib/components/invitations/InvitationTable.svelte
+++ b/src/lib/components/invitations/InvitationTable.svelte
@@ -12,6 +12,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { getUserDisplayName } from '$lib/utils/user-display';
 	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 
 	interface Props {
 		title: string;
@@ -72,21 +73,17 @@
 </script>
 
 <div class="space-y-3">
-	<div class="flex items-center justify-between">
-		<h3 class="text-lg font-semibold">
-			{title}
-		</h3>
+	{#snippet tableActions()}
 		{#if selectedIds.size > 0}
-			<div class="flex items-center gap-2">
-				<span class="text-sm text-muted-foreground">
-					{m['eventInvitationsAdmin.selected']({ count: selectedIds.size })}
-				</span>
-				<Button size="sm" variant="outline" onclick={onClear}
-					>{m['eventInvitationsAdmin.clear']()}</Button
-				>
-			</div>
+			<span class="text-sm text-muted-foreground">
+				{m['eventInvitationsAdmin.selected']({ count: selectedIds.size })}
+			</span>
+			<Button size="sm" variant="outline" onclick={onClear}
+				>{m['eventInvitationsAdmin.clear']()}</Button
+			>
 		{/if}
-	</div>
+	{/snippet}
+	<SectionHeader {title} level={3} actions={tableActions} />
 
 	{#if invitations.length === 0}
 		<div class="rounded-lg border bg-card p-8 text-center">

--- a/src/lib/components/invitations/InvitationTable.svelte
+++ b/src/lib/components/invitations/InvitationTable.svelte
@@ -11,6 +11,7 @@
 	import { formatDistanceToNow } from 'date-fns';
 	import { Button } from '$lib/components/ui/button';
 	import { getUserDisplayName } from '$lib/utils/user-display';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 
 	interface Props {
 		title: string;
@@ -114,17 +115,17 @@
 							</th>
 							{@render identityHeaders()}
 							<th
-								class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+								class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>
 								{m['eventInvitationsAdmin.headerProperties']()}
 							</th>
 							<th
-								class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground"
+								class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>
 								{m['eventInvitationsAdmin.headerCreated']()}
 							</th>
 							<th
-								class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground"
+								class="px-4 py-3 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 							>
 								{m['eventInvitationsAdmin.headerActions']()}
 							</th>
@@ -213,62 +214,62 @@
 {#snippet invitationProperties(invitation: T)}
 	<div class="flex flex-wrap gap-1">
 		{#if invitation.waives_questionnaire}
-			<span
-				class="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+			<StatusBadge
+				tone="info"
+				label={m['eventInvitationsAdmin.noQuestionnaire']()}
+				size="sm"
 				title={m['invitationListTab.waivesQuestionnaireTitle']()}
-			>
-				{m['eventInvitationsAdmin.noQuestionnaire']()}
-			</span>
+			/>
 		{/if}
 		{#if invitation.waives_purchase}
-			<span
-				class="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200"
+			<StatusBadge
+				tone="success"
+				label={m['eventInvitationsAdmin.free']()}
+				size="sm"
 				title={m['invitationListTab.waivesPurchaseTitle']()}
-			>
-				{m['eventInvitationsAdmin.free']()}
-			</span>
+			/>
 		{/if}
 		{#if invitation.waives_membership_required}
-			<span
-				class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+			<StatusBadge
+				tone="brand"
+				label={m['eventInvitationsAdmin.noMembership']()}
+				size="sm"
 				title={m['invitationListTab.waivesMembershipTitle']()}
-			>
-				{m['eventInvitationsAdmin.noMembership']()}
-			</span>
+			/>
 		{/if}
 		{#if invitation.waives_rsvp_deadline}
-			<span
-				class="inline-flex items-center rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-800 dark:bg-orange-900 dark:text-orange-200"
+			<StatusBadge
+				tone="warning"
+				label={m['eventInvitationsAdmin.noDeadline']()}
+				size="sm"
 				title={m['invitationListTab.waivesRsvpDeadlineTitle']()}
-			>
-				{m['eventInvitationsAdmin.noDeadline']()}
-			</span>
+			/>
 		{/if}
 		{#if invitation.overrides_max_attendees}
-			<span
-				class="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900 dark:text-red-200"
+			<StatusBadge
+				tone="danger"
+				label={m['eventInvitationsAdmin.overrideCap']()}
+				size="sm"
 				title={m['invitationListTab.overridesMaxAttendeesTitle']()}
-			>
-				{m['eventInvitationsAdmin.overrideCap']()}
-			</span>
+			/>
 		{/if}
 		{#if invitation.tiers?.length}
 			{#each invitation.tiers as tier (tier.id)}
-				<span
-					class="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200"
+				<StatusBadge
+					tone="neutral"
+					label={tier.name}
+					size="sm"
 					title={m['invitationListTab.assignedTierTitle']({ name: tier.name })}
-				>
-					{tier.name}
-				</span>
+				/>
 			{/each}
 		{/if}
 		{#if invitation.custom_message}
-			<span
-				class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-900 dark:text-gray-200"
+			<StatusBadge
+				tone="neutral"
+				label={`Has ${m['eventInvitationsAdmin.headerMessage']()}`}
+				size="sm"
 				title={invitation.custom_message}
-			>
-				Has {m['eventInvitationsAdmin.headerMessage']()}
-			</span>
+			/>
 		{/if}
 	</div>
 {/snippet}

--- a/src/lib/components/tickets/TicketCardList.svelte
+++ b/src/lib/components/tickets/TicketCardList.svelte
@@ -227,9 +227,7 @@
 							{#if ticket.payment.platform_fee_reverse_charge}
 								<div class="flex items-center justify-between text-xs">
 									<span class="text-muted-foreground">{m['tickets.reverseCharge']()}:</span>
-									<span class="font-medium text-info"
-										>{m['tickets.reverseChargeYes']()}</span
-									>
+									<span class="font-medium text-info">{m['tickets.reverseChargeYes']()}</span>
 								</div>
 							{/if}
 						{/if}

--- a/src/lib/components/tickets/TicketCardList.svelte
+++ b/src/lib/components/tickets/TicketCardList.svelte
@@ -231,7 +231,7 @@
 							{#if ticket.payment.platform_fee_reverse_charge}
 								<div class="flex items-center justify-between text-xs">
 									<span class="text-muted-foreground">{m['tickets.reverseCharge']()}:</span>
-									<span class="font-medium text-blue-600 dark:text-blue-400"
+									<span class="font-medium text-info"
 										>{m['tickets.reverseChargeYes']()}</span
 									>
 								</div>

--- a/src/lib/components/tickets/TicketCardList.svelte
+++ b/src/lib/components/tickets/TicketCardList.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { cn } from '$lib/utils/cn';
 	import { getUserDisplayName } from '$lib/utils/user-display';
-	import { getTicketStatusColor, getTicketStatusLabel } from '$lib/utils/status-colors';
+	import { getTicketStatusTone, getTicketStatusLabel } from '$lib/utils/status-colors';
 	import { formatPrice } from '$lib/utils/format';
 	import { formatDate } from '$lib/utils/date';
 	import {
@@ -34,6 +33,7 @@
 	} from '@lucide/svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import RefundStatusBadge from './RefundStatusBadge.svelte';
 	import TicketDiscountBadge from './TicketDiscountBadge.svelte';
 	import SeriesPassBadge from './SeriesPassBadge.svelte';
@@ -139,14 +139,10 @@
 					</div>
 				</div>
 				<div class="flex shrink-0 flex-col items-end gap-1">
-					<span
-						class={cn(
-							'rounded-full px-2 py-1 text-xs font-semibold',
-							getTicketStatusColor(ticket.status ?? '')
-						)}
-					>
-						{getTicketStatusLabel(ticket.status ?? '')}
-					</span>
+					<StatusBadge
+						tone={getTicketStatusTone(ticket.status ?? '')}
+						label={getTicketStatusLabel(ticket.status ?? '')}
+					/>
 					{#if ticket.status === 'cancelled'}
 						<RefundStatusBadge
 							status={ticket.payment?.refund_status}

--- a/src/lib/components/tickets/TicketStats.svelte
+++ b/src/lib/components/tickets/TicketStats.svelte
@@ -51,13 +51,16 @@
 	<!-- Warning for incomplete (page-local) counts -->
 	{#if hasMultiplePages}
 		<div
-			class="flex items-start gap-2 rounded-lg border border-yellow-200 bg-yellow-50 p-3 text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-100"
+			class="flex items-start gap-2 rounded-lg border border-highlight bg-highlight/10 p-3"
 			role="alert"
 		>
-			<AlertTriangle class="h-5 w-5 shrink-0" aria-hidden="true" />
+			<AlertTriangle
+				class="h-5 w-5 shrink-0 text-highlight-foreground dark:text-highlight"
+				aria-hidden="true"
+			/>
 			<div>
 				<p class="font-medium">{m['eventTicketsAdmin.pageWarningTitle']()}</p>
-				<p class="text-sm">
+				<p class="text-sm text-muted-foreground">
 					{m['eventTicketsAdmin.pageWarningDescription']({ total: totalCount })}
 				</p>
 			</div>
@@ -71,19 +74,27 @@
 			<div class="text-sm text-muted-foreground">{m['eventTicketsAdmin.statsTotalPage']()}</div>
 		</div>
 		<div class="rounded-lg border bg-card p-4">
-			<div class="text-2xl font-bold text-yellow-600">{stats.pending}</div>
+			<div class="text-2xl font-bold text-highlight-foreground dark:text-highlight">
+				{stats.pending}
+			</div>
 			<div class="text-sm text-muted-foreground">{m['eventTicketsAdmin.statsPending']()}</div>
 		</div>
 		<div class="rounded-lg border bg-card p-4">
-			<div class="text-2xl font-bold text-green-600">{stats.active}</div>
+			<div class="text-2xl font-bold text-success">{stats.active}</div>
 			<div class="text-sm text-muted-foreground">{m['eventTicketsAdmin.statsActive']()}</div>
 		</div>
 		<div class="rounded-lg border bg-card p-4">
-			<div class="text-2xl font-bold text-blue-600">{stats.checkedIn}</div>
+			<div class="text-2xl font-bold text-info">{stats.checkedIn}</div>
 			<div class="text-sm text-muted-foreground">{m['eventTicketsAdmin.statsCheckedIn']()}</div>
 		</div>
 		<div class="rounded-lg border bg-card p-4">
-			<div class="text-2xl font-bold text-red-600">{stats.cancelled}</div>
+			<!-- dark --destructive on dark --card measures 2.86:1 (hand-verified,
+			     scripts/audit-brand-themes.py has no destructive/card pair — see
+			     CLAUDE.md trap list) — falls back to text-foreground in dark mode;
+			     the "Cancelled" label below still carries the meaning. -->
+			<div class="text-2xl font-bold text-destructive dark:text-foreground">
+				{stats.cancelled}
+			</div>
 			<div class="text-sm text-muted-foreground">{m['eventTicketsAdmin.statsCancelled']()}</div>
 		</div>
 	</div>

--- a/src/lib/components/tickets/TicketTable.svelte
+++ b/src/lib/components/tickets/TicketTable.svelte
@@ -133,7 +133,8 @@
 	<table class="w-full">
 		<thead class="border-b bg-muted/50">
 			<tr>
-				<th class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+				<th
+					class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 					>{m['eventTicketsAdmin.headerAttendee']()}</th
 				>
 				{@render sortableHeader(m['eventTicketsAdmin.headerTier'](), 'tier__name')}
@@ -144,7 +145,8 @@
 				)}
 				{@render sortableHeader(m['eventTicketsAdmin.headerStatus'](), 'status')}
 				{@render sortableHeader(m['eventTicketsAdmin.headerPurchased'](), 'created_at')}
-				<th class="px-4 py-3 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+				<th
+					class="px-4 py-3 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 					>{m['eventTicketsAdmin.headerActions']()}</th
 				>
 			</tr>

--- a/src/lib/components/tickets/TicketTable.svelte
+++ b/src/lib/components/tickets/TicketTable.svelte
@@ -105,7 +105,7 @@
 {#snippet sortableHeader(label: string, field: TicketSortField)}
 	{@const dir = sortDirection(orderBy, field)}
 	<th
-		class="px-4 py-3 text-left text-sm font-semibold"
+		class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 		aria-sort={dir === 'asc' ? 'ascending' : dir === 'desc' ? 'descending' : 'none'}
 	>
 		{#if onSort}
@@ -133,7 +133,7 @@
 	<table class="w-full">
 		<thead class="border-b bg-muted/50">
 			<tr>
-				<th class="px-4 py-3 text-left text-sm font-semibold"
+				<th class="px-4 py-3 text-left text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 					>{m['eventTicketsAdmin.headerAttendee']()}</th
 				>
 				{@render sortableHeader(m['eventTicketsAdmin.headerTier'](), 'tier__name')}
@@ -144,7 +144,7 @@
 				)}
 				{@render sortableHeader(m['eventTicketsAdmin.headerStatus'](), 'status')}
 				{@render sortableHeader(m['eventTicketsAdmin.headerPurchased'](), 'created_at')}
-				<th class="px-4 py-3 text-right text-sm font-semibold"
+				<th class="px-4 py-3 text-right text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
 					>{m['eventTicketsAdmin.headerActions']()}</th
 				>
 			</tr>

--- a/src/lib/components/tickets/TicketTable.svelte
+++ b/src/lib/components/tickets/TicketTable.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { cn } from '$lib/utils/cn';
 	import { getUserDisplayName } from '$lib/utils/user-display';
-	import { getTicketStatusColor, getTicketStatusLabel } from '$lib/utils/status-colors';
+	import { getTicketStatusTone, getTicketStatusLabel } from '$lib/utils/status-colors';
 	import { formatPrice } from '$lib/utils/format';
 	import { formatDate } from '$lib/utils/date';
 	import {
@@ -37,6 +36,7 @@
 	} from '@lucide/svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import UserAvatar from '$lib/components/common/UserAvatar.svelte';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import RefundStatusBadge from './RefundStatusBadge.svelte';
 	import TicketDiscountBadge from './TicketDiscountBadge.svelte';
 	import SeriesPassBadge from './SeriesPassBadge.svelte';
@@ -233,14 +233,11 @@
 					</td>
 					<td class="px-4 py-3">
 						<div class="flex flex-col gap-1">
-							<span
-								class={cn(
-									'inline-flex w-fit rounded-full px-2 py-1 text-xs font-semibold',
-									getTicketStatusColor(ticket.status ?? '')
-								)}
-							>
-								{getTicketStatusLabel(ticket.status ?? '')}
-							</span>
+							<StatusBadge
+								tone={getTicketStatusTone(ticket.status ?? '')}
+								label={getTicketStatusLabel(ticket.status ?? '')}
+								class="w-fit"
+							/>
 							{#if ticket.status === 'cancelled'}
 								<RefundStatusBadge
 									status={ticket.payment?.refund_status}

--- a/src/lib/components/venues/PriceCategorySection.svelte
+++ b/src/lib/components/venues/PriceCategorySection.svelte
@@ -9,6 +9,8 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 	import { Plus, Edit, Trash2, Tag } from '@lucide/svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import PriceCategoryModal from './PriceCategoryModal.svelte';
 	import { toast } from 'svelte-sonner';
 
@@ -122,16 +124,7 @@
 	aria-labelledby="price-categories-heading"
 >
 	<!-- Section header -->
-	<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-		<div>
-			<h2 id="price-categories-heading" class="text-xl font-bold tracking-tight">
-				{m['orgAdmin.priceCategories.sectionTitle']()}
-			</h2>
-			<p class="text-sm text-muted-foreground">
-				{m['orgAdmin.priceCategories.sectionDescription']()}
-			</p>
-		</div>
-
+	{#snippet sectionActions()}
 		<button
 			type="button"
 			onclick={handleCreate}
@@ -140,7 +133,15 @@
 			<Plus class="h-5 w-5" aria-hidden="true" />
 			{m['orgAdmin.priceCategories.createButton']()}
 		</button>
-	</div>
+	{/snippet}
+	<SectionHeader
+		id="price-categories-heading"
+		title={m['orgAdmin.priceCategories.sectionTitle']()}
+		actions={sectionActions}
+	/>
+	<p class="-mt-2 text-sm text-muted-foreground">
+		{m['orgAdmin.priceCategories.sectionDescription']()}
+	</p>
 
 	{#if categoriesQuery.error}
 		<div class="rounded-md bg-destructive/10 p-4 text-destructive" role="alert">
@@ -162,25 +163,22 @@
 			</span>
 		</div>
 	{:else if categories.length === 0}
-		<div
-			class="rounded-lg border-2 border-dashed border-gray-300 p-8 text-center dark:border-gray-600"
+		<EmptyState
+			icon={Tag}
+			title={m['orgAdmin.priceCategories.empty.title']()}
+			body={m['orgAdmin.priceCategories.empty.description']()}
 		>
-			<Tag class="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-3 text-lg font-semibold">
-				{m['orgAdmin.priceCategories.empty.title']()}
-			</h3>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{m['orgAdmin.priceCategories.empty.description']()}
-			</p>
-			<button
-				type="button"
-				onclick={handleCreate}
-				class="mt-4 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			>
-				<Plus class="h-5 w-5" aria-hidden="true" />
-				{m['orgAdmin.priceCategories.createButton']()}
-			</button>
-		</div>
+			{#snippet action()}
+				<button
+					type="button"
+					onclick={handleCreate}
+					class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				>
+					<Plus class="h-5 w-5" aria-hidden="true" />
+					{m['orgAdmin.priceCategories.createButton']()}
+				</button>
+			{/snippet}
+		</EmptyState>
 	{:else}
 		<ul class="divide-y rounded-lg border bg-card shadow-sm">
 			{#each categories as category (category.id)}

--- a/src/lib/components/venues/SeatGrid.svelte
+++ b/src/lib/components/venues/SeatGrid.svelte
@@ -334,7 +334,7 @@
 							<button
 								type="button"
 								onclick={() => removeHorizontalAisle(aisleAfterRow)}
-								class="flex h-5 w-full items-center justify-center text-xs text-amber-600 hover:text-destructive dark:text-amber-400"
+								class="flex h-5 w-full items-center justify-center text-xs text-highlight-foreground hover:text-destructive dark:text-highlight"
 								title={m['seatGridEditor.removeAisleAfterRow']({
 									row: getRowLabel(aisleAfterRow)
 								})}
@@ -425,7 +425,7 @@
 							<!-- Indicator icons -->
 							{#if seatData.is_accessible || seatData.is_obstructed_view}
 								<div
-									class="absolute -bottom-1 -right-1 flex gap-0.5 rounded bg-white/90 p-0.5 shadow-sm dark:bg-gray-900/90"
+									class="absolute -bottom-1 -right-1 flex gap-0.5 rounded bg-card/90 p-0.5 shadow-sm"
 								>
 									{#if seatData.is_accessible}
 										<Accessibility class="h-3 w-3 text-blue-600" />

--- a/src/lib/components/venues/SeatGridEditor.svelte
+++ b/src/lib/components/venues/SeatGridEditor.svelte
@@ -377,7 +377,7 @@
 		<!-- Blast radius BEFORE the paint commits (#674): the editor is opened in
 		     the context of one event, which is exactly what makes the venue-wide,
 		     immediate effect of repainting surprising. -->
-		<p class="mb-3 flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400">
+		<p class="mb-3 flex items-start gap-1.5 text-xs text-highlight-foreground dark:text-highlight">
 			<TriangleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
 			{m['seatGridEditor.paint.venueWideCaution']()}
 		</p>
@@ -453,7 +453,7 @@
 				<button
 					type="button"
 					onclick={markSelectedAccessible}
-					class="inline-flex items-center gap-1.5 rounded-md border border-blue-300 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
+					class="inline-flex items-center gap-1.5 rounded-md border border-info/40 bg-info/10 px-3 py-1.5 text-sm font-medium text-info hover:bg-info/20"
 				>
 					<Accessibility class="h-4 w-4" />
 					{m['seatGridEditor.toggleAccessible']()}
@@ -461,7 +461,7 @@
 				<button
 					type="button"
 					onclick={markSelectedObstructed}
-					class="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300 dark:hover:bg-amber-900"
+					class="inline-flex items-center gap-1.5 rounded-md border border-highlight/60 bg-highlight/10 px-3 py-1.5 text-sm font-medium text-highlight-foreground hover:bg-highlight/20 dark:text-highlight"
 				>
 					<EyeOff class="h-4 w-4" />
 					{m['seatGridEditor.toggleObstructed']()}

--- a/src/lib/components/venues/SectorCard.svelte
+++ b/src/lib/components/venues/SectorCard.svelte
@@ -21,7 +21,7 @@
 	<div class="flex items-start justify-between gap-4">
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2">
-				<h3 class="truncate text-lg font-semibold">{sector.name}</h3>
+				<h3 class="truncate text-lg font-bold">{sector.name}</h3>
 				{#if sector.code}
 					<span class="rounded bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
 						{sector.code}

--- a/src/lib/components/venues/VenueCard.svelte
+++ b/src/lib/components/venues/VenueCard.svelte
@@ -28,7 +28,7 @@
 >
 	<div class="flex items-start justify-between gap-4">
 		<div class="min-w-0 flex-1">
-			<h3 class="truncate text-lg font-semibold">{venue.name}</h3>
+			<h3 class="truncate text-lg font-bold">{venue.name}</h3>
 			{#if venue.description}
 				<div class="mt-1 line-clamp-2 text-sm text-muted-foreground">
 					<MarkdownContent content={venue.description} inline={true} class="!prose-sm" />

--- a/src/lib/utils/status-colors.ts
+++ b/src/lib/utils/status-colors.ts
@@ -1,41 +1,44 @@
 /**
- * Status color and label utilities for admin pages.
- * Centralizes status badge styling across events, tickets, and attendees.
+ * Status tone and label utilities for admin pages.
+ * Centralizes status -> tone mapping across events, tickets, and
+ * attendees — every call site renders through `common/StatusBadge`, so
+ * these return a semantic `Tone`, never a raw color class.
  */
 
 import * as m from '$lib/paraglide/messages.js';
+import type { Tone } from '$lib/components/common/tones';
 
 // -- Event status --
 
-export function getEventStatusColor(status: string): string {
+export function getEventStatusTone(status: string): Tone {
 	switch (status) {
 		case 'draft':
-			return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100';
+			return 'neutral';
 		case 'open':
-			return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100';
+			return 'success';
 		case 'closed':
-			return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100';
+			return 'danger';
 		case 'cancelled':
-			return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-100';
+			return 'warning';
 		default:
-			return 'bg-gray-100 text-gray-800';
+			return 'neutral';
 	}
 }
 
 // -- Ticket status --
 
-export function getTicketStatusColor(status: string): string {
+export function getTicketStatusTone(status: string): Tone {
 	switch (status) {
 		case 'pending':
-			return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100';
+			return 'warning';
 		case 'active':
-			return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100';
+			return 'success';
 		case 'checked_in':
-			return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100';
+			return 'info';
 		case 'cancelled':
-			return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100';
+			return 'danger';
 		default:
-			return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100';
+			return 'neutral';
 	}
 }
 
@@ -56,16 +59,16 @@ export function getTicketStatusLabel(status: string): string {
 
 // -- RSVP status --
 
-export function getRsvpStatusColor(status: string): string {
+export function getRsvpStatusTone(status: string): Tone {
 	switch (status) {
 		case 'yes':
-			return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100';
+			return 'success';
 		case 'maybe':
-			return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100';
+			return 'warning';
 		case 'no':
-			return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100';
+			return 'danger';
 		default:
-			return 'bg-gray-100 text-gray-800';
+			return 'neutral';
 	}
 }
 

--- a/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
@@ -148,7 +148,7 @@
 								<ToneTile tone="neutral" icon={Folder} size="lg" />
 							{/if}
 							<div class="min-w-0 flex-1">
-								<h3 class="line-clamp-1 font-semibold">{series.name}</h3>
+								<h3 class="line-clamp-1 font-bold">{series.name}</h3>
 								<p class="text-sm text-muted-foreground">{series.organization.name}</p>
 							</div>
 						</div>

--- a/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
@@ -8,6 +8,9 @@
 	import { Repeat, Calendar, Edit, Eye, Tag, Plus, Folder } from '@lucide/svelte';
 	import { getImageUrl } from '$lib/utils/url';
 	import NewSeriesPickerDialog from '$lib/components/event-series/admin/NewSeriesPickerDialog.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import ToneTile from '$lib/components/common/ToneTile.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -70,16 +73,7 @@
 
 <div class="space-y-6">
 	<!-- Header -->
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['orgAdmin.eventSeries.pageTitle']()}
-			</h1>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['orgAdmin.eventSeries.pageDescription']()}
-			</p>
-		</div>
-
+	{#snippet headerActions()}
 		<button
 			type="button"
 			onclick={openNewSeriesPicker}
@@ -89,25 +83,32 @@
 			<Plus class="h-5 w-5" aria-hidden="true" />
 			{m['recurringEvents.seriesList.primaryCta']()}
 		</button>
-	</div>
+	{/snippet}
+	<PageHeader
+		kicker={m['orgAdmin.nav.eventSeries']()}
+		title={m['orgAdmin.eventSeries.pageTitle']()}
+		subtitle={m['orgAdmin.eventSeries.pageDescription']()}
+		actions={headerActions}
+	/>
 
 	<!-- Empty state -->
 	{#if data.series.length === 0}
-		<div class="rounded-lg border border-border bg-card p-12 text-center">
-			<Repeat class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-4 text-lg font-semibold">{m['orgAdmin.eventSeries.empty.title']()}</h3>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{m['orgAdmin.eventSeries.empty.description']()}
-			</p>
-			<button
-				type="button"
-				onclick={openNewSeriesPicker}
-				class="mt-6 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			>
-				<Plus class="h-4 w-4" aria-hidden="true" />
-				{m['recurringEvents.seriesList.primaryCta']()}
-			</button>
-		</div>
+		<EmptyState
+			icon={Repeat}
+			title={m['orgAdmin.eventSeries.empty.title']()}
+			body={m['orgAdmin.eventSeries.empty.description']()}
+		>
+			{#snippet action()}
+				<button
+					type="button"
+					onclick={openNewSeriesPicker}
+					class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				>
+					<Plus class="h-4 w-4" aria-hidden="true" />
+					{m['recurringEvents.seriesList.primaryCta']()}
+				</button>
+			{/snippet}
+		</EmptyState>
 	{:else}
 		<!-- Series List -->
 		<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -142,17 +143,9 @@
 									class="h-12 w-12 flex-shrink-0 rounded-lg object-cover"
 								/>
 							{:else if isRecurring}
-								<div
-									class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-950"
-								>
-									<Repeat class="h-6 w-6 text-indigo-600 dark:text-indigo-400" aria-hidden="true" />
-								</div>
+								<ToneTile tone="brand" icon={Repeat} size="lg" />
 							{:else}
-								<div
-									class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg bg-muted"
-								>
-									<Folder class="h-6 w-6 text-muted-foreground" aria-hidden="true" />
-								</div>
+								<ToneTile tone="neutral" icon={Folder} size="lg" />
 							{/if}
 							<div class="min-w-0 flex-1">
 								<h3 class="line-clamp-1 font-semibold">{series.name}</h3>

--- a/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
@@ -84,8 +84,10 @@
 			{m['recurringEvents.seriesList.primaryCta']()}
 		</button>
 	{/snippet}
+	<!-- No kicker: orgAdmin.nav.eventSeries and orgAdmin.eventSeries.pageTitle
+	     are both literally "Event Series" — a kicker repeating the title
+	     verbatim is noise. -->
 	<PageHeader
-		kicker={m['orgAdmin.nav.eventSeries']()}
 		title={m['orgAdmin.eventSeries.pageTitle']()}
 		subtitle={m['orgAdmin.eventSeries.pageDescription']()}
 		actions={headerActions}
@@ -97,6 +99,7 @@
 			icon={Repeat}
 			title={m['orgAdmin.eventSeries.empty.title']()}
 			body={m['orgAdmin.eventSeries.empty.description']()}
+			level={2}
 		>
 			{#snippet action()}
 				<button

--- a/src/routes/(auth)/org/[slug]/admin/event-series/[series_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/[series_id]/+page.svelte
@@ -247,11 +247,11 @@
 	     recurring + paused (the existing pause banner). -->
 	{#if isBroken}
 		<div
-			class="border-warning/50 bg-warning/10 flex items-start gap-3 rounded-lg border p-4 text-sm"
+			class="flex items-start gap-3 rounded-lg border border-highlight bg-highlight/10 p-4 text-sm"
 			role="alert"
 		>
 			<AlertTriangle
-				class="text-warning-foreground mt-0.5 h-5 w-5 flex-shrink-0"
+				class="mt-0.5 h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
 				aria-hidden="true"
 			/>
 			<div class="flex-1 space-y-1">

--- a/src/routes/(auth)/org/[slug]/admin/event-series/new-recurring/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/new-recurring/+page.svelte
@@ -6,6 +6,7 @@
 	import { ArrowLeft } from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import RecurringEventWizard from '$lib/components/event-series/admin/RecurringEventWizard.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -36,12 +37,12 @@
 			<ArrowLeft class="h-5 w-5" aria-hidden="true" />
 		</button>
 		<div class="flex-1">
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['recurringEvents.wizard.title']()}
-			</h1>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['recurringEvents.wizard.pageDescription']({ organizationName: organization.name })}
-			</p>
+			<PageHeader
+				title={m['recurringEvents.wizard.title']()}
+				subtitle={m['recurringEvents.wizard.pageDescription']({
+					organizationName: organization.name
+				})}
+			/>
 		</div>
 	</div>
 

--- a/src/routes/(auth)/org/[slug]/admin/event-series/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/new/+page.svelte
@@ -9,6 +9,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { organizationadmincoreCreateEventSeries } from '$lib/api/generated';
 	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
@@ -104,12 +105,10 @@
 			<ArrowLeft class="h-5 w-5" aria-hidden="true" />
 		</button>
 		<div class="flex-1">
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['eventSeriesNewPage.title']()}
-			</h1>
-			<p class="mt-1 text-sm text-muted-foreground">
-				{m['eventSeriesNewPage.subtitle']({ organizationName: organization.name })}
-			</p>
+			<PageHeader
+				title={m['eventSeriesNewPage.title']()}
+				subtitle={m['eventSeriesNewPage.subtitle']({ organizationName: organization.name })}
+			/>
 		</div>
 	</div>
 

--- a/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
@@ -31,6 +31,9 @@
 		Edit
 	} from '@lucide/svelte';
 	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -215,14 +218,7 @@
 
 <div class="space-y-6">
 	<!-- Header -->
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['orgAdmin.events.pageTitle']()}
-			</h1>
-			<p class="mt-1 text-sm text-muted-foreground">{m['orgAdmin.events.pageDescription']()}</p>
-		</div>
-
+	{#snippet headerActions()}
 		{#if data.canCreateEvent}
 			<button
 				type="button"
@@ -233,34 +229,43 @@
 				{m['orgAdmin.events.createEventButton']()}
 			</button>
 		{/if}
-	</div>
+	{/snippet}
+	<PageHeader
+		kicker={m['orgAdmin.nav.events']()}
+		title={m['orgAdmin.events.pageTitle']()}
+		subtitle={m['orgAdmin.events.pageDescription']()}
+		actions={headerActions}
+	/>
 
 	<!-- Empty state -->
 	{#if data.events.length === 0}
-		<div class="rounded-lg border border-border bg-card p-12 text-center">
-			<Calendar class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-4 text-lg font-semibold">{m['orgAdmin.events.empty.title']()}</h3>
-			<p class="mt-2 text-sm text-muted-foreground">{m['orgAdmin.events.empty.description']()}</p>
-			{#if data.canCreateEvent}
-				<button
-					type="button"
-					onclick={createEvent}
-					class="mt-6 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-				>
-					<Plus class="h-5 w-5" aria-hidden="true" />
-					{m['orgAdmin.events.createEventButton']()}
-				</button>
-			{/if}
-		</div>
+		<EmptyState
+			icon={Calendar}
+			title={m['orgAdmin.events.empty.title']()}
+			body={m['orgAdmin.events.empty.description']()}
+		>
+			{#snippet action()}
+				{#if data.canCreateEvent}
+					<button
+						type="button"
+						onclick={createEvent}
+						class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+					>
+						<Plus class="h-5 w-5" aria-hidden="true" />
+						{m['orgAdmin.events.createEventButton']()}
+					</button>
+				{/if}
+			{/snippet}
+		</EmptyState>
 	{:else}
 		<!-- Draft Events -->
 		{#if draftEvents.length > 0}
 			<div class="space-y-4">
-				<h2 class="text-lg font-semibold">
-					{m['orgAdmin.events.sections.drafts']({
+				<SectionHeader
+					title={m['orgAdmin.events.sections.drafts']({
 						count: draftEvents.length
 					})}
-				</h2>
+				/>
 				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 					{#each draftEvents as event (event.id)}
 						<AdminEventCard
@@ -280,11 +285,11 @@
 		<!-- Open Events -->
 		{#if openEvents.length > 0}
 			<div class="space-y-4">
-				<h2 class="text-lg font-semibold">
-					{m['orgAdmin.events.sections.open']({
+				<SectionHeader
+					title={m['orgAdmin.events.sections.open']({
 						count: openEvents.length
 					})}
-				</h2>
+				/>
 				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 					{#each openEvents as event (event.id)}
 						<AdminEventCard
@@ -304,11 +309,11 @@
 		<!-- Closed Events -->
 		{#if closedEvents.length > 0}
 			<div class="space-y-4">
-				<h2 class="text-lg font-semibold">
-					{m['orgAdmin.events.sections.closed']({
+				<SectionHeader
+					title={m['orgAdmin.events.sections.closed']({
 						count: closedEvents.length
 					})}
-				</h2>
+				/>
 				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 					{#each closedEvents as event (event.id)}
 						<AdminEventCard
@@ -328,11 +333,11 @@
 		<!-- Cancelled Events -->
 		{#if cancelledEvents.length > 0}
 			<div class="space-y-4">
-				<h2 class="text-lg font-semibold">
-					{m['orgAdmin.events.sections.cancelled']({
+				<SectionHeader
+					title={m['orgAdmin.events.sections.cancelled']({
 						count: cancelledEvents.length
 					})}
-				</h2>
+				/>
 				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 					{#each cancelledEvents as event (event.id)}
 						<AdminEventCard
@@ -353,11 +358,11 @@
 			<!-- grayscale (not opacity): opacity-dimming blends buttons toward the page
 			     background and breaks WCAG contrast; grayscale preserves luminance (#595) -->
 			<div class="space-y-4 grayscale">
-				<h2 class="text-lg font-semibold">
-					{m['orgAdmin.events.sections.past']({
+				<SectionHeader
+					title={m['orgAdmin.events.sections.past']({
 						count: pastEvents.length
 					})}
-				</h2>
+				/>
 				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 					{#each pastEvents as event (event.id)}
 						<div

--- a/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
@@ -243,6 +243,7 @@
 			icon={Calendar}
 			title={m['orgAdmin.events.empty.title']()}
 			body={m['orgAdmin.events.empty.description']()}
+			level={2}
 		>
 			{#snippet action()}
 				{#if data.canCreateEvent}

--- a/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
@@ -373,7 +373,7 @@
 							<div class="flex flex-1 flex-col gap-4 p-4">
 								<div class="space-y-2">
 									<div class="flex items-start justify-between gap-2">
-										<h3 class="line-clamp-2 flex-1 text-lg font-semibold leading-tight">
+										<h3 class="line-clamp-2 flex-1 text-lg font-bold leading-tight">
 											{event.name}
 										</h3>
 										<div class="flex items-center gap-2">

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
@@ -21,6 +21,8 @@
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import ExportButton from '$lib/components/common/ExportButton.svelte';
 	import MakeMemberModal from '$lib/components/members/MakeMemberModal.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import AttendeeStats from '$lib/components/attendees/AttendeeStats.svelte';
 	import AttendeeFilters from '$lib/components/attendees/AttendeeFilters.svelte';
 	import AttendeeTable from '$lib/components/attendees/AttendeeTable.svelte';
@@ -454,54 +456,49 @@
 <div class="space-y-6">
 	<!-- Header -->
 	<div>
-		<div class="mb-4">
+		<a
+			href={resolve('/(auth)/org/[slug]/admin/events', { slug: organization.slug })}
+			class="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+		>
+			<ChevronLeft class="h-4 w-4" aria-hidden="true" />
+			{m['attendeesAdmin.backToEvents']()}
+		</a>
+		{#snippet headerActions()}
+			<Button variant="outline" size="sm" onclick={() => (showCreateRsvpModal = true)}>
+				<UserPlus class="h-4 w-4" aria-hidden="true" />
+				{m['attendeesAdmin.createButton']()}
+			</Button>
 			<a
-				href={resolve('/(auth)/org/[slug]/admin/events', { slug: organization.slug })}
-				class="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+				href={resolve('/(auth)/org/[slug]/admin/events/[event_id]/edit', {
+					slug: organization.slug,
+					event_id: data.event.id
+				})}
+				class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 			>
-				<ChevronLeft class="h-4 w-4" aria-hidden="true" />
-				{m['attendeesAdmin.backToEvents']()}
+				{m['eventEditor.editEvent']()}
 			</a>
-		</div>
-		<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-			<div>
-				<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-					{m['attendeesAdmin.pageTitle']()}
-				</h1>
-				<p class="mt-1 text-sm text-muted-foreground">{data.event.name}</p>
-			</div>
-			<div class="flex flex-wrap items-center gap-2">
-				<Button variant="outline" size="sm" onclick={() => (showCreateRsvpModal = true)}>
-					<UserPlus class="h-4 w-4" aria-hidden="true" />
-					{m['attendeesAdmin.createButton']()}
-				</Button>
+			{#if data.event.waitlist_open}
 				<a
-					href={resolve('/(auth)/org/[slug]/admin/events/[event_id]/edit', {
+					href={resolve('/(auth)/org/[slug]/admin/events/[event_id]/waitlist', {
 						slug: organization.slug,
 						event_id: data.event.id
 					})}
 					class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 				>
-					{m['eventEditor.editEvent']()}
+					{m['eventActionSidebar.manageWaitlist']()}
 				</a>
-				{#if data.event.waitlist_open}
-					<a
-						href={resolve('/(auth)/org/[slug]/admin/events/[event_id]/waitlist', {
-							slug: organization.slug,
-							event_id: data.event.id
-						})}
-						class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-					>
-						{m['eventActionSidebar.manageWaitlist']()}
-					</a>
-				{/if}
-				<ExportButton
-					label={m['exportButton.exportAttendees']()}
-					onExport={handleExportAttendees}
-					{accessToken}
-				/>
-			</div>
-		</div>
+			{/if}
+			<ExportButton
+				label={m['exportButton.exportAttendees']()}
+				onExport={handleExportAttendees}
+				{accessToken}
+			/>
+		{/snippet}
+		<PageHeader
+			title={m['attendeesAdmin.pageTitle']()}
+			subtitle={data.event.name}
+			actions={headerActions}
+		/>
 	</div>
 
 	<!-- Stats (always shown) -->
@@ -518,17 +515,13 @@
 
 	<!-- Attendees list -->
 	{#if data.rsvps.length === 0}
-		<div class="rounded-lg border border-border bg-card p-12 text-center">
-			<Users class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-4 text-lg font-semibold">{m['attendeesAdmin.noRsvpsHeading']()}</h3>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{#if activeStatusFilters.length || searchQuery}
-					{m['attendeesAdmin.noRsvpsFiltered']()}
-				{:else}
-					{m['attendeesAdmin.noRsvpsEmpty']()}
-				{/if}
-			</p>
-		</div>
+		<EmptyState
+			icon={Users}
+			title={m['attendeesAdmin.noRsvpsHeading']()}
+			body={activeStatusFilters.length || searchQuery
+				? m['attendeesAdmin.noRsvpsFiltered']()
+				: m['attendeesAdmin.noRsvpsEmpty']()}
+		/>
 	{:else}
 		<AttendeeTable
 			rsvps={data.rsvps}

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/attendees/+page.svelte
@@ -521,6 +521,7 @@
 			body={activeStatusFilters.length || searchQuery
 				? m['attendeesAdmin.noRsvpsFiltered']()
 				: m['attendeesAdmin.noRsvpsEmpty']()}
+			level={2}
 		/>
 	{:else}
 		<AttendeeTable

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
@@ -17,6 +17,8 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { CheckCircle, XCircle, FileEdit, Trash2, Ban, MoreVertical, Copy } from '@lucide/svelte';
 	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 
 	const { data }: { data: PageData } = $props();
 
@@ -27,6 +29,17 @@
 
 	// Current status
 	const currentStatus = $derived(event.status as string);
+	const statusTone = $derived.by((): Tone => {
+		switch (currentStatus) {
+			case 'open':
+				return 'success';
+			case 'closed':
+				return 'danger';
+			case 'draft':
+			default:
+				return 'neutral';
+		}
+	});
 
 	// Update event status mutation
 	const updateStatusMutation = createMutation(() => ({
@@ -190,27 +203,19 @@
 		<div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
 			<div>
 				<div class="flex items-center gap-3">
-					<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
+					<h1 class="text-2xl font-extrabold tracking-tight sm:text-3xl">
 						{m['eventEditPage.heading']()}
 					</h1>
-					<!-- Status Badge -->
-					<span
-						class="rounded-full px-3 py-1 text-xs font-medium {currentStatus === 'draft'
-							? 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100'
-							: currentStatus === 'open'
-								? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100'
-								: currentStatus === 'closed'
-									? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100'
-									: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'}"
-					>
-						{currentStatus === 'draft'
+					<StatusBadge
+						tone={statusTone}
+						label={currentStatus === 'draft'
 							? m['eventEditPage.statusDraft']()
 							: currentStatus === 'open'
 								? m['eventEditPage.statusPublished']()
 								: currentStatus === 'closed'
 									? m['eventEditPage.statusClosed']()
 									: currentStatus}
-					</span>
+					/>
 				</div>
 				<p class="mt-1 text-sm text-muted-foreground">
 					{m['eventEditPage.updateDetailsFor']()}
@@ -231,7 +236,7 @@
 										type="button"
 										onclick={publishEvent}
 										disabled={updateStatusMutation.isPending}
-										class="inline-flex items-center gap-2 rounded-md bg-green-700 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-green-800 disabled:cursor-not-allowed disabled:opacity-50"
+										class="inline-flex items-center gap-2 rounded-md bg-success px-3 py-2 text-sm font-medium text-success-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
 									>
 										<CheckCircle class="h-4 w-4" aria-hidden="true" />
 										{m['eventEditPage.publishButton']()}
@@ -250,7 +255,7 @@
 										type="button"
 										onclick={closeEvent}
 										disabled={updateStatusMutation.isPending}
-										class="inline-flex items-center gap-2 rounded-md bg-orange-700 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-800 disabled:cursor-not-allowed disabled:opacity-50"
+										class="inline-flex items-center gap-2 rounded-md bg-highlight px-3 py-2 text-sm font-medium text-highlight-foreground transition-colors hover:bg-highlight/90 disabled:cursor-not-allowed disabled:opacity-50"
 									>
 										<XCircle class="h-4 w-4" aria-hidden="true" />
 										{m['eventEditPage.closeButton']()}
@@ -287,7 +292,7 @@
 										type="button"
 										onclick={reopenEvent}
 										disabled={updateStatusMutation.isPending}
-										class="inline-flex items-center gap-2 rounded-md bg-green-700 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-green-800 disabled:cursor-not-allowed disabled:opacity-50"
+										class="inline-flex items-center gap-2 rounded-md bg-success px-3 py-2 text-sm font-medium text-success-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
 									>
 										<CheckCircle class="h-4 w-4" aria-hidden="true" />
 										{m['eventEditPage.reopenButton']()}

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.svelte
@@ -95,40 +95,48 @@
 		<PageHeader title={m['eventInvitationsAdmin.pageTitle']()} subtitle={data.event.name} />
 	</div>
 
-	<!-- Success/Error Messages -->
+	<!-- Success/Error Messages. Both tints composite against whatever sits
+	     behind them, so each gets an opaque `bg-card` layer underneath:
+	     `text-success` on a bare `bg-success/10` measures 4.39:1 over the page
+	     background (below 4.5 for this normal-size text) — the card backing
+	     brings it to 4.94:1 (hand-verified). The error banner's heading/body
+	     stay on `text-foreground` (always-audited body-text pair) with the
+	     icon alone carrying the destructive tone — `text-destructive` on
+	     `bg-destructive/10` measures ~2.95:1 in dark mode, well under AA, and
+	     neither half of that pair is covered by audit-brand-themes.py. -->
 	{#if form?.success}
-		<div
-			class="flex items-center gap-2 rounded-lg border border-success/40 bg-success/10 p-4 text-success"
-			role="alert"
-		>
-			<Check class="h-5 w-5 shrink-0" aria-hidden="true" />
-			<p class="text-sm font-medium">
-				{#if form.action === 'approved'}
-					{m['eventInvitationsAdmin.requestApproved']()}
-				{:else if form.action === 'rejected'}
-					{m['eventInvitationsAdmin.requestRejected']()}
-				{:else if form.action === 'created'}
-					{m['eventInvitationsAdmin.invitationsCreated']({
-						created: form.data?.created_invitations || 0,
-						pending: form.data?.pending_invitations || 0
-					})}
-				{:else if form.action === 'deleted'}
-					{m['eventInvitationsAdmin.invitationDeleted']()}
-				{:else if form.action === 'updated'}
-					{m['eventInvitationsAdmin.invitationUpdated']()}
-				{:else if form.action === 'bulk_updated'}
-					{m['eventInvitationsAdmin.bulkUpdated']({ count: form.count || 0 })}
-				{/if}
-			</p>
+		<div class="relative overflow-hidden rounded-lg border border-success/40 bg-card" role="alert">
+			<div class="absolute inset-0 bg-success/10" aria-hidden="true"></div>
+			<div class="relative flex items-center gap-2 p-4">
+				<Check class="h-5 w-5 shrink-0 text-success" aria-hidden="true" />
+				<p class="text-sm font-medium text-success">
+					{#if form.action === 'approved'}
+						{m['eventInvitationsAdmin.requestApproved']()}
+					{:else if form.action === 'rejected'}
+						{m['eventInvitationsAdmin.requestRejected']()}
+					{:else if form.action === 'created'}
+						{m['eventInvitationsAdmin.invitationsCreated']({
+							created: form.data?.created_invitations || 0,
+							pending: form.data?.pending_invitations || 0
+						})}
+					{:else if form.action === 'deleted'}
+						{m['eventInvitationsAdmin.invitationDeleted']()}
+					{:else if form.action === 'updated'}
+						{m['eventInvitationsAdmin.invitationUpdated']()}
+					{:else if form.action === 'bulk_updated'}
+						{m['eventInvitationsAdmin.bulkUpdated']({ count: form.count || 0 })}
+					{/if}
+				</p>
+			</div>
 		</div>
 	{/if}
 
 	{#if form?.errors?.form}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-destructive"
+			class="flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-foreground"
 			role="alert"
 		>
-			<AlertCircle class="h-5 w-5 shrink-0" aria-hidden="true" />
+			<AlertCircle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
 			<p class="text-sm font-medium">{form.errors.form}</p>
 		</div>
 	{/if}

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.svelte
@@ -9,6 +9,7 @@
 	import InvitationListTab from '$lib/components/invitations/InvitationListTab.svelte';
 	import InvitationLinksTab from '$lib/components/invitations/InvitationLinksTab.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 
 	interface Props {
 		data: PageData;
@@ -84,25 +85,20 @@
 <div class="space-y-6">
 	<!-- Header -->
 	<div>
-		<div class="mb-4">
-			<a
-				href={resolve('/(auth)/org/[slug]/admin/events', { slug: data.organization.slug })}
-				class="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-			>
-				<ChevronLeft class="h-4 w-4" aria-hidden="true" />
-				{m['eventInvitationsAdmin.backToEvents']()}
-			</a>
-		</div>
-		<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-			{m['eventInvitationsAdmin.pageTitle']()}
-		</h1>
-		<p class="mt-1 text-sm text-muted-foreground">{data.event.name}</p>
+		<a
+			href={resolve('/(auth)/org/[slug]/admin/events', { slug: data.organization.slug })}
+			class="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+		>
+			<ChevronLeft class="h-4 w-4" aria-hidden="true" />
+			{m['eventInvitationsAdmin.backToEvents']()}
+		</a>
+		<PageHeader title={m['eventInvitationsAdmin.pageTitle']()} subtitle={data.event.name} />
 	</div>
 
 	<!-- Success/Error Messages -->
 	{#if form?.success}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
+			class="flex items-center gap-2 rounded-lg border border-success/40 bg-success/10 p-4 text-success"
 			role="alert"
 		>
 			<Check class="h-5 w-5 shrink-0" aria-hidden="true" />
@@ -129,7 +125,7 @@
 
 	{#if form?.errors?.form}
 		<div
-			class="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+			class="flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-destructive"
 			role="alert"
 		>
 			<AlertCircle class="h-5 w-5 shrink-0" aria-hidden="true" />

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/seating/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/seating/+page.svelte
@@ -6,6 +6,7 @@
 	import SeatOverridesPanel from '$lib/components/events/admin/seating/SeatOverridesPanel.svelte';
 	import BoxOfficeSellPanel from '$lib/components/events/admin/seating/BoxOfficeSellPanel.svelte';
 	import { Tabs, TabsList, TabsTrigger, TabsContent } from '$lib/components/ui/tabs';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -24,12 +25,10 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div>
-		<h1 class="text-2xl font-bold tracking-tight md:text-3xl">{pageTitle}</h1>
-		<p class="mt-1 text-sm text-muted-foreground">
-			{m['orgAdmin.seating.pageDescription']({ eventName: data.event.name })}
-		</p>
-	</div>
+	<PageHeader
+		title={pageTitle}
+		subtitle={m['orgAdmin.seating.pageDescription']({ eventName: data.event.name })}
+	/>
 
 	<Tabs bind:value={activeTab} class="w-full">
 		<TabsList class="grid w-full grid-cols-2 sm:inline-grid sm:w-auto">

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/tickets/+page.svelte
@@ -42,6 +42,8 @@
 	import RenameTicketHolderDialog from '$lib/components/tickets/RenameTicketHolderDialog.svelte';
 	import MakeMemberModal from '$lib/components/members/MakeMemberModal.svelte';
 	import ExportButton from '$lib/components/common/ExportButton.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { isSeriesPassCode } from '$lib/utils/series-pass-qr';
 	import { extractApiErrorDetail } from '$lib/utils/api-error-detail';
 
@@ -466,47 +468,46 @@
 			<span>/</span>
 			<span>{data.event.name}</span>
 		</div>
-		<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-			<div>
-				<h1 class="text-3xl font-bold">{m['eventTicketsAdmin.pageTitle']()}</h1>
-				<p class="mt-2 text-muted-foreground">{m['eventTicketsAdmin.pageDescription']()}</p>
-			</div>
-			<div class="flex flex-wrap items-center gap-2">
+		{#snippet ticketsHeaderActions()}
+			<a
+				href={resolve('/(auth)/org/[slug]/admin/events/[event_id]/edit', {
+					slug: data.event.organization.slug,
+					event_id: data.event.id
+				})}
+				class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			>
+				{m['eventEditor.editEvent']()}
+			</a>
+			<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
+			<a
+				href={`${resolve('/(auth)/org/[slug]/admin/events/[event_id]/edit', { slug: data.event.organization.slug, event_id: data.event.id })}?tab=ticketing`}
+				class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			>
+				{m['eventEditor.ticketing']()}
+			</a>
+			<!-- eslint-enable svelte/no-navigation-without-resolve -->
+			{#if data.event.waitlist_open}
 				<a
-					href={resolve('/(auth)/org/[slug]/admin/events/[event_id]/edit', {
+					href={resolve('/(auth)/org/[slug]/admin/events/[event_id]/waitlist', {
 						slug: data.event.organization.slug,
 						event_id: data.event.id
 					})}
 					class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 				>
-					{m['eventEditor.editEvent']()}
+					{m['eventActionSidebar.manageWaitlist']()}
 				</a>
-				<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
-				<a
-					href={`${resolve('/(auth)/org/[slug]/admin/events/[event_id]/edit', { slug: data.event.organization.slug, event_id: data.event.id })}?tab=ticketing`}
-					class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-				>
-					{m['eventEditor.ticketing']()}
-				</a>
-				<!-- eslint-enable svelte/no-navigation-without-resolve -->
-				{#if data.event.waitlist_open}
-					<a
-						href={resolve('/(auth)/org/[slug]/admin/events/[event_id]/waitlist', {
-							slug: data.event.organization.slug,
-							event_id: data.event.id
-						})}
-						class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-					>
-						{m['eventActionSidebar.manageWaitlist']()}
-					</a>
-				{/if}
-				<ExportButton
-					label={m['exportButton.exportAttendees']()}
-					onExport={handleExportAttendees}
-					accessToken={authStore.accessToken}
-				/>
-			</div>
-		</div>
+			{/if}
+			<ExportButton
+				label={m['exportButton.exportAttendees']()}
+				onExport={handleExportAttendees}
+				accessToken={authStore.accessToken}
+			/>
+		{/snippet}
+		<PageHeader
+			title={m['eventTicketsAdmin.pageTitle']()}
+			subtitle={m['eventTicketsAdmin.pageDescription']()}
+			actions={ticketsHeaderActions}
+		/>
 	</div>
 
 	<!-- Check-in Button (QR Scanner) -->
@@ -544,19 +545,13 @@
 	<!-- Tickets List -->
 	<div class="mt-6">
 		{#if data.tickets.length === 0}
-			<div
-				class="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center"
-			>
-				<Ticket class="mb-4 h-12 w-12 text-muted-foreground" aria-hidden="true" />
-				<h3 class="mb-2 text-lg font-semibold">{m['eventTicketsAdmin.noTicketsFiltered']()}</h3>
-				<p class="text-sm text-muted-foreground">
-					{#if searchQuery || selectedStatus || selectedPaymentMethod || selectedSource}
-						{m['eventTicketsAdmin.noTicketsFiltered']()}
-					{:else}
-						{m['eventTicketsAdmin.noTicketsEmpty']()}
-					{/if}
-				</p>
-			</div>
+			<EmptyState
+				icon={Ticket}
+				title={m['eventTicketsAdmin.noTicketsFiltered']()}
+				body={searchQuery || selectedStatus || selectedPaymentMethod || selectedSource
+					? m['eventTicketsAdmin.noTicketsFiltered']()
+					: m['eventTicketsAdmin.noTicketsEmpty']()}
+			/>
 		{:else}
 			<!-- Desktop Table -->
 			<TicketTable

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/waitlist/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/waitlist/+page.svelte
@@ -7,6 +7,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { AlertCircle, X } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
 	import WaitlistSettingsCard from '$lib/components/events/waitlist/admin/WaitlistSettingsCard.svelte';
 	import WaitlistEntriesTable from '$lib/components/events/waitlist/admin/WaitlistEntriesTable.svelte';
@@ -344,18 +345,14 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['orgAdmin.waitlist.pageTitle']()}
-			</h1>
-			<p class="mt-1 text-sm text-muted-foreground">{m['orgAdmin.waitlist.pageDescription']()}</p>
-		</div>
-	</div>
+	<PageHeader
+		title={m['orgAdmin.waitlist.pageTitle']()}
+		subtitle={m['orgAdmin.waitlist.pageDescription']()}
+	/>
 
 	{#if capacityBannerOpen}
 		<div
-			class="flex flex-col gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-100 sm:flex-row sm:items-center sm:justify-between"
+			class="flex flex-col gap-3 rounded-lg border border-highlight bg-highlight/10 p-4 text-sm text-highlight-foreground dark:text-highlight sm:flex-row sm:items-center sm:justify-between"
 			role="alert"
 		>
 			<div class="flex items-start gap-2">
@@ -367,7 +364,7 @@
 					variant="outline"
 					size="sm"
 					onclick={jumpToPendingOffers}
-					class="border-amber-400 bg-white text-amber-900 hover:bg-amber-100 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/70"
+					class="border-highlight bg-transparent text-highlight-foreground hover:bg-highlight/20 dark:text-highlight"
 				>
 					{m['orgAdmin.waitlist.offer.viewPendingShortcut']()}
 				</Button>

--- a/src/routes/(auth)/org/[slug]/admin/events/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/new/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import type { PageData } from './$types';
 	import EventEditor from '$lib/components/events/admin/EventEditor.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -20,12 +21,11 @@
 
 <div class="space-y-6">
 	<!-- Header Section -->
-	<div>
-		<h1 class="text-2xl font-bold tracking-tight md:text-3xl">{m['eventNewPage.title']()}</h1>
-		<p class="mt-1 text-sm text-muted-foreground">
-			{m['eventNewPage.subtitle']({ organizationName: organization.name })}
-		</p>
-	</div>
+	<PageHeader
+		kicker={m['orgAdmin.nav.events']()}
+		title={m['eventNewPage.title']()}
+		subtitle={m['eventNewPage.subtitle']({ organizationName: organization.name })}
+	/>
 
 	<!-- Event Editor Component -->
 	<div class="rounded-lg border bg-card text-card-foreground shadow-sm">

--- a/src/routes/(auth)/org/[slug]/admin/venues/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/+page.svelte
@@ -13,6 +13,8 @@
 	import { Plus, Search, Building2 } from '@lucide/svelte';
 	import VenueCard from '$lib/components/venues/VenueCard.svelte';
 	import VenueModal from '$lib/components/venues/VenueModal.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { toast } from 'svelte-sonner';
 
 	const organization = $derived($page.data.organization);
@@ -124,14 +126,7 @@
 
 <div class="space-y-6">
 	<!-- Header -->
-	<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['orgAdmin.venues.pageTitle']()}
-			</h1>
-			<p class="text-muted-foreground">{m['orgAdmin.venues.pageDescription']()}</p>
-		</div>
-
+	{#snippet headerActions()}
 		<button
 			type="button"
 			onclick={handleCreate}
@@ -140,7 +135,13 @@
 			<Plus class="h-5 w-5" aria-hidden="true" />
 			{m['orgAdmin.venues.createButton']()}
 		</button>
-	</div>
+	{/snippet}
+	<PageHeader
+		kicker={m['orgAdmin.nav.venues']()}
+		title={m['orgAdmin.venues.pageTitle']()}
+		subtitle={m['orgAdmin.venues.pageDescription']()}
+		actions={headerActions}
+	/>
 
 	<!-- Search -->
 	<div class="relative max-w-md">
@@ -171,27 +172,26 @@
 			></div>
 		</div>
 	{:else if venues.length === 0}
-		<div
-			class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600"
+		<EmptyState
+			icon={Building2}
+			title={m['orgAdmin.venues.empty.title']()}
+			body={searchQuery
+				? m['orgAdmin.venues.empty.withSearch']()
+				: m['orgAdmin.venues.empty.description']()}
 		>
-			<Building2 class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-			<h3 class="mt-4 text-lg font-semibold">{m['orgAdmin.venues.empty.title']()}</h3>
-			<p class="mt-2 text-sm text-muted-foreground">
-				{searchQuery
-					? m['orgAdmin.venues.empty.withSearch']()
-					: m['orgAdmin.venues.empty.description']()}
-			</p>
-			{#if !searchQuery}
-				<button
-					type="button"
-					onclick={handleCreate}
-					class="mt-4 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				>
-					<Plus class="h-5 w-5" aria-hidden="true" />
-					{m['orgAdmin.venues.createButton']()}
-				</button>
-			{/if}
-		</div>
+			{#snippet action()}
+				{#if !searchQuery}
+					<button
+						type="button"
+						onclick={handleCreate}
+						class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					>
+						<Plus class="h-5 w-5" aria-hidden="true" />
+						{m['orgAdmin.venues.createButton']()}
+					</button>
+				{/if}
+			{/snippet}
+		</EmptyState>
 	{:else}
 		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 			{#each venues as venue (venue.id)}

--- a/src/routes/(auth)/org/[slug]/admin/venues/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/+page.svelte
@@ -136,8 +136,9 @@
 			{m['orgAdmin.venues.createButton']()}
 		</button>
 	{/snippet}
+	<!-- No kicker: orgAdmin.nav.venues and orgAdmin.venues.pageTitle are both
+	     literally "Venues" — a kicker repeating the title verbatim is noise. -->
 	<PageHeader
-		kicker={m['orgAdmin.nav.venues']()}
 		title={m['orgAdmin.venues.pageTitle']()}
 		subtitle={m['orgAdmin.venues.pageDescription']()}
 		actions={headerActions}
@@ -178,6 +179,7 @@
 			body={searchQuery
 				? m['orgAdmin.venues.empty.withSearch']()
 				: m['orgAdmin.venues.empty.description']()}
+			level={2}
 		>
 			{#snippet action()}
 				{#if !searchQuery}

--- a/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/+page.svelte
@@ -226,6 +226,7 @@
 				icon={LayoutGrid}
 				title={m['orgAdmin.sectors.empty.title']()}
 				body={m['orgAdmin.sectors.empty.description']()}
+				level={2}
 			>
 				{#snippet action()}
 					<button

--- a/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/+page.svelte
@@ -15,6 +15,8 @@
 	import SectorCard from '$lib/components/venues/SectorCard.svelte';
 	import SectorModal from '$lib/components/venues/SectorModal.svelte';
 	import PriceCategorySection from '$lib/components/venues/PriceCategorySection.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { toast } from 'svelte-sonner';
 
 	const organization = $derived(page.data.organization);
@@ -191,55 +193,51 @@
 		</div>
 	{:else if venue}
 		<!-- Header -->
-		<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-			<div>
-				<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-					{m['orgAdmin.sectors.pageTitle']({ venueName: venue.name })}
-				</h1>
-				<p class="text-muted-foreground">{m['orgAdmin.sectors.pageDescription']()}</p>
-			</div>
-
-			<div class="flex flex-wrap items-center gap-3">
-				<a
-					href={resolve('/(auth)/org/[slug]/admin/venues/[venue_id]/designer', {
-						slug: organization.slug,
-						venue_id: venueId
-					})}
-					class="inline-flex items-center gap-2 rounded-md border border-input px-4 py-2 font-semibold transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				>
-					<PenTool class="h-5 w-5" aria-hidden="true" />
-					{m['seatDesigner.open']()}
-				</a>
-				<button
-					type="button"
-					onclick={handleCreate}
-					class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				>
-					<Plus class="h-5 w-5" aria-hidden="true" />
-					{m['orgAdmin.sectors.createButton']()}
-				</button>
-			</div>
-		</div>
+		{#snippet headerActions()}
+			<a
+				href={resolve('/(auth)/org/[slug]/admin/venues/[venue_id]/designer', {
+					slug: organization.slug,
+					venue_id: venueId
+				})}
+				class="inline-flex items-center gap-2 rounded-md border border-input px-4 py-2 font-semibold transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+			>
+				<PenTool class="h-5 w-5" aria-hidden="true" />
+				{m['seatDesigner.open']()}
+			</a>
+			<button
+				type="button"
+				onclick={handleCreate}
+				class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+			>
+				<Plus class="h-5 w-5" aria-hidden="true" />
+				{m['orgAdmin.sectors.createButton']()}
+			</button>
+		{/snippet}
+		<PageHeader
+			kicker={m['orgAdmin.nav.venues']()}
+			title={m['orgAdmin.sectors.pageTitle']({ venueName: venue.name })}
+			subtitle={m['orgAdmin.sectors.pageDescription']()}
+			actions={headerActions}
+		/>
 
 		<!-- Content -->
 		{#if sectors.length === 0}
-			<div
-				class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600"
+			<EmptyState
+				icon={LayoutGrid}
+				title={m['orgAdmin.sectors.empty.title']()}
+				body={m['orgAdmin.sectors.empty.description']()}
 			>
-				<LayoutGrid class="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-				<h3 class="mt-4 text-lg font-semibold">{m['orgAdmin.sectors.empty.title']()}</h3>
-				<p class="mt-2 text-sm text-muted-foreground">
-					{m['orgAdmin.sectors.empty.description']()}
-				</p>
-				<button
-					type="button"
-					onclick={handleCreate}
-					class="mt-4 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				>
-					<Plus class="h-5 w-5" aria-hidden="true" />
-					{m['orgAdmin.sectors.createButton']()}
-				</button>
-			</div>
+				{#snippet action()}
+					<button
+						type="button"
+						onclick={handleCreate}
+						class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					>
+						<Plus class="h-5 w-5" aria-hidden="true" />
+						{m['orgAdmin.sectors.createButton']()}
+					</button>
+				{/snippet}
+			</EmptyState>
 		{:else}
 			<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 				{#each sectors as sector (sector.id)}

--- a/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/designer/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/designer/+page.svelte
@@ -226,7 +226,16 @@
 		/>
 
 		{#if model.blocks.length === 0}
-			<EmptyState icon={LayoutGrid} title={m['seatDesigner.empty']()} />
+			<!-- `orgAdmin.sectors.empty.title` is reused deliberately — this venue's
+			     "no sectors yet" is exactly what leaves the designer with nothing to
+			     lay out, so the existing short title fits verbatim. Full explanation
+			     stays in `body`. -->
+			<EmptyState
+				icon={LayoutGrid}
+				title={m['orgAdmin.sectors.empty.title']()}
+				body={m['seatDesigner.empty']()}
+				level={2}
+			/>
 		{:else}
 			<SeatMapDesigner
 				{model}

--- a/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/designer/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/designer/+page.svelte
@@ -26,8 +26,10 @@
 		VenueSectorWithSeatsSchema
 	} from '$lib/api/generated/types.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import { ArrowLeft } from '@lucide/svelte';
+	import { ArrowLeft, LayoutGrid } from '@lucide/svelte';
 	import SeatMapDesigner from '$lib/components/venues/designer/SeatMapDesigner.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import {
 		buildDesignerModel,
 		type DesignerModel
@@ -217,21 +219,14 @@
 			></div>
 		</div>
 	{:else}
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">{pageTitle}</h1>
-			<p class="text-muted-foreground">
-				{m['seatDesigner.pageDescription']()}
-			</p>
-		</div>
+		<PageHeader
+			kicker={m['orgAdmin.nav.venues']()}
+			title={pageTitle}
+			subtitle={m['seatDesigner.pageDescription']()}
+		/>
 
 		{#if model.blocks.length === 0}
-			<div
-				class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600"
-			>
-				<p class="text-sm text-muted-foreground">
-					{m['seatDesigner.empty']()}
-				</p>
-			</div>
+			<EmptyState icon={LayoutGrid} title={m['seatDesigner.empty']()} />
 		{:else}
 			<SeatMapDesigner
 				{model}

--- a/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/sectors/[sector_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/sectors/[sector_id]/+page.svelte
@@ -32,6 +32,8 @@
 	import { ArrowLeft, LayoutDashboard, Users } from '@lucide/svelte';
 	import SeatGridEditor, { type AisleMetadata } from '$lib/components/venues/SeatGridEditor.svelte';
 	import { toast } from 'svelte-sonner';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	const organization = $derived($page.data.organization);
 	const venueId = $derived($page.params.venue_id);
@@ -524,29 +526,27 @@
 		</div>
 	{:else if sector}
 		<!-- Header -->
-		<div>
-			<h1 class="text-2xl font-bold tracking-tight md:text-3xl">
-				{m['orgAdmin.seats.pageTitle']({ sectorName: sector.name })}
-			</h1>
-			<p class="text-muted-foreground">{m['orgAdmin.seats.pageDescription']()}</p>
-		</div>
+		<PageHeader
+			kicker={m['orgAdmin.nav.venues']()}
+			title={m['orgAdmin.seats.pageTitle']({ sectorName: sector.name })}
+			subtitle={m['orgAdmin.seats.pageDescription']()}
+		/>
 
 		{#if isStandingSector}
 			<!-- Standing sectors have no seat map: explain instead of the editor -->
-			<div class="rounded-lg border bg-card p-8 text-center">
-				<Users class="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
-				<h2 class="mt-3 text-lg font-semibold">
-					{m['orgAdmin.seats.standing.title']()}
-				</h2>
-				<p class="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
-					{m['orgAdmin.seats.standing.description']()}
-				</p>
-				{#if sector.capacity != null}
-					<p class="mt-3 text-sm">
-						{m['orgAdmin.sectors.form.capacityLabel']()}: <strong>{sector.capacity}</strong>
-					</p>
-				{/if}
-			</div>
+			<EmptyState
+				icon={Users}
+				title={m['orgAdmin.seats.standing.title']()}
+				body={m['orgAdmin.seats.standing.description']()}
+			>
+				{#snippet action()}
+					{#if sector.capacity != null}
+						<p class="text-sm">
+							{m['orgAdmin.sectors.form.capacityLabel']()}: <strong>{sector.capacity}</strong>
+						</p>
+					{/if}
+				{/snippet}
+			</EmptyState>
 		{:else}
 			<!-- Seat Grid Editor -->
 			<SeatGridEditor

--- a/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/sectors/[sector_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/venues/[venue_id]/sectors/[sector_id]/+page.svelte
@@ -538,6 +538,7 @@
 				icon={Users}
 				title={m['orgAdmin.seats.standing.title']()}
 				body={m['orgAdmin.seats.standing.description']()}
+				level={2}
 			>
 				{#snippet action()}
 					{#if sector.capacity != null}


### PR DESCRIPTION
## Platform rebrand, PR 8 of 10 — Admin: events, series, venues

The largest admin cluster: 71 files across events CRUD/attendees/tickets/waitlist/invitations/seating, event series, and venue management (canvas internals untouched — chrome only).

### What's in it
- Studio `PageHeader`/`SectionHeader` rhythm on all 16 routes; kicker table headers; `EmptyState` adoption with correct heading levels
- **Ledger handoffs closed**: the four files shipping dead `-warning` utilities (which rendered NOTHING — no such token exists) now use the highlight recipes; waitlist admin tables fully swept
- `WaitlistOfferStatusBadge` as a StatusBadge mapper with aria-label + exported STATUS_ORDER driving its test guard
- `OccurrenceRow`'s event-status tones aligned to the documented house mapping (they were inverted vs `EventStatusBadge` — visible only once both used the same palette)
- `status-colors.ts` renamed color→tone (all consumers in-branch, verified repo-wide)
- Approved exemption: seat-grid cell fills + legend swatches stay raw (data colors); the chrome around them (toggle button, badge backdrop) tokenized

### Review process
Opus whole-branch review + one fix round + scoped re-review, clean. The review enumerated every container-derivation and getByLabel locator in the e2e suite against the diff (zero breaks — including the aria-label that j18's recurring-admin spec depends on, preserved). Fixed on review: one dark-mode AA regression, three 4.39:1 success-tint composites (opaque-base fix), heading levels, duplicated kickers, and two paragraph-as-heading EmptyStates (one new `emptyTitle` key ×6 locales — the program's only new key in this PR). Rebased twice (over merged PRs 10 and 9); the superseded `RefundStatusBadge` duplicate dropped for the merged version (byte-identical verified).

### Verification
`make check` 0 errors · full suite 217 files / 2526 green · brand audit 0 failures · orchestrator screenshots (events light+dark, venues light).

🤖 Generated with [Claude Code](https://claude.com/claude-code)