### PR TITLE
feat(uplift): discovery, listings, org profile & series go poster-grade (U2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1086,6 +1086,13 @@ PR 7, mirrors `StatusBadge`) so routed adopters can attach `id`/`aria-label`/etc
 instead. `PageHeader`'s `decoration` slot is aria-hidden ornament only — status
 text goes through `actions` or `StatusBadge`, never `decoration`.
 
+**Band/wash pairing:** a mode-inert poster-solid ribbon pairs with a theme-aware
+tinted wash below it, and a theme `bg-secondary` band pairs with a plain
+`--background` body — never pair a band with a wash from the same token family.
+**Pull-up opacity rule:** whenever body content is pulled up to overlap a
+band's bottom edge, the first block it lands on must be an opaque surface
+(never `bg-card/NN`).
+
 **Typography scale** (encoded in the primitives; use the same classes when
 composing manually):
 

--- a/src/lib/components/common/EmptyState.svelte
+++ b/src/lib/components/common/EmptyState.svelte
@@ -42,7 +42,7 @@
 
 <div
 	class={cn(
-		'flex flex-col items-center rounded-lg border bg-card px-6 py-10 text-center',
+		'flex flex-col items-center rounded-lg border-2 bg-card px-6 py-10 text-center shadow-poster',
 		className
 	)}
 >

--- a/src/lib/components/common/PricingCard.svelte
+++ b/src/lib/components/common/PricingCard.svelte
@@ -72,7 +72,13 @@
 
 <div
 	class={cn(
-		'rounded-lg border bg-card p-4 text-card-foreground shadow-sm transition-shadow sm:p-5',
+		// Thick edge + poster float, matching what `ui/card` took globally in the
+		// uplift: a pricing card is the loudest decision surface on its page and
+		// was the only one still wearing shadcn's hairline silhouette.
+		// `bg-card` is spelled out as its own class ON THIS ELEMENT and must stay
+		// that way — `tests/e2e/support/membership-locators.ts` resolves a plan
+		// card by walking to the nearest `bg-card` ancestor of its heading.
+		'rounded-lg border-2 bg-card p-4 text-card-foreground shadow-poster transition-shadow sm:p-5',
 		layout === 'stack' && 'flex h-full flex-col',
 		muted && 'opacity-60',
 		className

--- a/src/lib/components/events/EventCard.svelte
+++ b/src/lib/components/events/EventCard.svelte
@@ -110,9 +110,14 @@
 	// Container classes based on variant
 	const containerClasses = $derived(
 		cn(
-			'group relative overflow-hidden rounded-lg border bg-card transition-all',
-			// Same lift on all three discovery cards (event / series / organization).
-			'hover:-translate-y-0.5 hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-all',
+			// Same silhouette and lift on all three discovery cards (event / series /
+			// organization): the thick edge + poster float that `ui/card` took
+			// globally in the uplift, applied by hand because these are bare
+			// `<article>`s rather than the Card primitive. The float is the point —
+			// discovery pages now sit on a tinted panel, so a card has to read as a
+			// white sticker ON it, not a rectangle cut out of it.
+			'hover:-translate-y-1 hover:shadow-poster-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',
 			isPast && 'opacity-75',

--- a/src/lib/components/events/EventSeriesCard.svelte
+++ b/src/lib/components/events/EventSeriesCard.svelte
@@ -82,9 +82,10 @@
 	// Container classes based on variant
 	const containerClasses = $derived(
 		cn(
-			'group relative overflow-hidden rounded-lg border bg-card transition-all',
-			// Same lift on all three discovery cards (event / series / organization).
-			'hover:-translate-y-0.5 hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-all',
+			// Same silhouette and lift on all three discovery cards (event / series /
+			// organization) — see EventCard for why it is spelled out by hand.
+			'hover:-translate-y-1 hover:shadow-poster-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',
 			className

--- a/src/lib/components/events/filters/EventFilters.svelte
+++ b/src/lib/components/events/filters/EventFilters.svelte
@@ -96,7 +96,7 @@
 </script>
 
 <aside
-	class={cn('flex w-full flex-col gap-6 rounded-lg border bg-card p-6', className)}
+	class={cn('flex w-full flex-col gap-6 rounded-lg border-2 bg-card p-6 shadow-poster', className)}
 	aria-label={m['eventFilters.eventFilters']()}
 >
 	<!-- Header -->

--- a/src/lib/components/organization/membership/MembershipSection.svelte
+++ b/src/lib/components/organization/membership/MembershipSection.svelte
@@ -161,12 +161,31 @@
 		/>
 	{/if}
 
-	<PageHeader
-		volume="celebration"
-		kicker={organization.name}
-		title={m['membershipTiers.heading']()}
-		subtitle={m['membershipTiers.subtitle']({ organizationName: organization.name })}
-	/>
+	<!--
+		Colour-block header (uplift, spec §9). CONTAINED rather than the full-bleed
+		ribbon the org profile and the two discovery listings wear: the h1 lives in
+		this component (a unit test pins it here), and the component is dropped
+		inside the route's container — so bleeding it to the viewport edge would
+		mean either moving the heading out or a negative-margin hack. A contained
+		block is also the right pitch for a sub-page: loud, but a step below the
+		profile that links to it.
+
+		`bg-secondary` at full strength is the same audit-enforced pair the
+		questionnaire routes' band uses, so it is a real poster panel in both
+		modes; `onBand` is what keeps the kicker off `text-primary`, which does NOT
+		clear AA on the light periwinkle (4.12:1 — see PageHeader).
+	-->
+	<div
+		class="rounded-lg bg-secondary px-6 py-8 text-secondary-foreground shadow-poster md:px-8 md:py-10"
+	>
+		<PageHeader
+			volume="poster"
+			onBand
+			kicker={organization.name}
+			title={m['membershipTiers.heading']()}
+			subtitle={m['membershipTiers.subtitle']({ organizationName: organization.name })}
+		/>
+	</div>
 
 	{#if hasStanding}
 		<!-- Summary mode (no tierId): the badge branches only, no eligibility

--- a/src/lib/components/organizations/OrganizationCard.svelte
+++ b/src/lib/components/organizations/OrganizationCard.svelte
@@ -61,9 +61,10 @@
 	// Container classes based on variant
 	const containerClasses = $derived(
 		cn(
-			'group relative overflow-hidden rounded-lg border bg-card transition-all',
-			// Same lift on all three discovery cards (event / series / organization).
-			'hover:-translate-y-0.5 hover:shadow-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-all',
+			// Same silhouette and lift on all three discovery cards (event / series /
+			// organization) — see EventCard for why it is spelled out by hand.
+			'hover:-translate-y-1 hover:shadow-poster-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',
 			className

--- a/src/lib/components/organizations/filters/OrganizationFilters.svelte
+++ b/src/lib/components/organizations/filters/OrganizationFilters.svelte
@@ -56,7 +56,7 @@
 </script>
 
 <aside
-	class={cn('flex w-full flex-col gap-6 rounded-lg border bg-card p-6', className)}
+	class={cn('flex w-full flex-col gap-6 rounded-lg border-2 bg-card p-6 shadow-poster', className)}
 	aria-label={m['organizationFilters.ariaLabel']()}
 >
 	<!-- Header -->

--- a/src/lib/components/polls/PollPrivacySummary.svelte
+++ b/src/lib/components/polls/PollPrivacySummary.svelte
@@ -61,7 +61,7 @@
 	const showVoterAnonymityRow = $derived(resultVisibility !== 'staff-only');
 </script>
 
-<section class="space-y-2 rounded-lg border bg-card/50 p-4">
+<section class="space-y-2 rounded-lg border bg-card p-4">
 	<!-- Who can vote -->
 	<div class="flex items-center gap-2 text-sm">
 		<Users class="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />

--- a/src/lib/components/resources/ResourceCard.svelte
+++ b/src/lib/components/resources/ResourceCard.svelte
@@ -167,7 +167,7 @@
 
 <article
 	class={cn(
-		'group relative flex flex-col gap-4 rounded-lg border bg-card p-4 transition-all hover:-translate-y-0.5 hover:shadow-lg',
+		'group relative flex flex-col gap-4 rounded-lg border-2 bg-card p-4 shadow-poster transition-all hover:-translate-y-1 hover:shadow-poster-lg',
 		isDeleting && 'opacity-50'
 	)}
 >

--- a/src/routes/(public)/events/+page.svelte
+++ b/src/routes/(public)/events/+page.svelte
@@ -239,20 +239,17 @@
 	</section>
 
 	<!--
-		Tinted content panel — same wash the event detail page introduced, so the
-		filter aside and every card read as white stickers FLOATING on a coloured
-		surface instead of rectangles on paper. Composited alphas are invisible to
-		scripts/audit-brand-themes.py, so the text layers that land DIRECTLY on
-		this panel (never inside a card) are hand-verified against the composite;
-		the numbers are the event page's, because the composite is identical
-		(`--secondary` over `--background` at the same alphas):
-		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
-		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
-		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
-		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
-		(`muted-foreground` is the pagination tally, `foreground` the page indicator.)
+		Body on plain `--background`, pulled up over the band's bottom edge — the
+		merged questionnaire page's arrangement, not the event page's tinted wash.
+		Both were tried: a `bg-secondary/55` wash under a `bg-secondary` band lands
+		within 5 points of lightness of it in light mode, so the band stops reading
+		as a colour BLOCK and the page becomes one flat field. The event page can
+		afford the wash because its band is the mode-inert poster-purple ribbon,
+		which is dark enough that the step is unmissable. Here the separation has
+		to come from the band itself, and the float comes from the cards:
+		`shadow-poster` over paper, overlapping the cut.
 	-->
-	<div class="bg-secondary/55 pb-16 dark:bg-secondary/[0.28]">
+	<div class="pb-16">
 		<div class="container mx-auto px-4">
 			<!-- Main Content: Sidebar + Event Grid -->
 			<div class="-mt-8 flex flex-col gap-8 lg:flex-row">

--- a/src/routes/(public)/events/+page.svelte
+++ b/src/routes/(public)/events/+page.svelte
@@ -182,202 +182,254 @@
 
 <SeoHead config={data.seo} />
 
-<div class="container mx-auto px-4 py-8">
-	<!-- Skip to content link for keyboard navigation -->
-	<a
-		href="#events-content"
-		class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
-	>
-		{m['browse.events_skipTo']()}
-	</a>
+<div class="bg-background">
+	<!--
+		Color-block header band (uplift, spec §9). The same full-strength
+		`bg-secondary` poster panel the questionnaire routes opened on — an
+		audit-enforced pair in both modes, so it is a real poster surface that
+		still respects the light/dark axis. Deliberately SHALLOWER than a detail
+		page's: a listing is a work surface, the band is only its entrance, and
+		the toolbar + grid below must stay above the fold on a phone.
 
-	<!-- Page Header. The result count rides `subtitle`, exactly as /organizations
-	     does, rather than a paragraph pulled back under the header with a
-	     negative margin that breaks the moment the header wraps. -->
-	<PageHeader
-		volume="celebration"
-		kicker={m['browse.events_kicker']()}
-		title={m['browse.events_title']()}
-		subtitle={countLabel}
-		class="mb-8"
-	>
-		{#snippet actions()}
-			<!-- View Toggle -->
-			<Button variant="outline" size="sm" onclick={toggleViewMode} class="flex items-center gap-2">
-				{#if viewMode === 'list'}
-					<Calendar class="h-4 w-4" aria-hidden="true" />
-					{m['calendar.calendar_view']()}
-				{:else}
-					<List class="h-4 w-4" aria-hidden="true" />
-					{m['calendar.list_view']()}
-				{/if}
-			</Button>
-		{/snippet}
-	</PageHeader>
+		No sticker chip here by the sticker-chip rule (spec §9): discovery has no
+		organization to speak for, and the Revel mark is never filler.
+	-->
+	<section class="bg-secondary text-secondary-foreground">
+		<div class="container mx-auto px-4 pb-16 pt-8">
+			<!-- Skip to content link for keyboard navigation -->
+			<a
+				href="#events-content"
+				class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
+			>
+				{m['browse.events_skipTo']()}
+			</a>
 
-	<!-- Main Content: Sidebar + Event Grid -->
-	<div class="flex flex-col gap-8 lg:flex-row">
-		<!-- Filter Sidebar (Desktop) -->
-		<div class="hidden lg:block lg:w-80 lg:shrink-0">
-			<div class="sticky top-8">
-				<EventFilters
-					filters={currentFilters}
-					onUpdateFilters={handleUpdateFilters}
-					onClearFilters={handleClearFilters}
-				/>
-			</div>
+			<!-- Page Header. The result count rides `subtitle`, exactly as /organizations
+			     does, rather than a paragraph pulled back under the header with a
+			     negative margin that breaks the moment the header wraps. -->
+			<PageHeader
+				volume="poster"
+				onBand
+				kicker={m['browse.events_kicker']()}
+				title={m['browse.events_title']()}
+				subtitle={countLabel}
+			>
+				{#snippet actions()}
+					<!-- View Toggle. Left on the stock `outline` chrome on purpose: its
+					     `bg-background` reads as a light control chip against the band
+					     and keeps the audited foreground pair, where a transparent
+					     override would have to re-derive contrast per mode. -->
+					<Button
+						variant="outline"
+						size="sm"
+						onclick={toggleViewMode}
+						class="flex items-center gap-2"
+					>
+						{#if viewMode === 'list'}
+							<Calendar class="h-4 w-4" aria-hidden="true" />
+							{m['calendar.calendar_view']()}
+						{:else}
+							<List class="h-4 w-4" aria-hidden="true" />
+							{m['calendar.list_view']()}
+						{/if}
+					</Button>
+				{/snippet}
+			</PageHeader>
 		</div>
+	</section>
 
-		<!-- Event Content -->
-		<div id="events-content" class="flex-1">
-			{#if viewMode === 'list'}
-				<!-- List View -->
-				{#if error}
-					<!-- Error State -->
-					<div
-						class="rounded-lg border border-destructive bg-destructive/10 p-8 text-center"
-						role="alert"
-						aria-live="polite"
-					>
-						<p class="font-semibold text-destructive">{error}</p>
-						<p class="mt-2 text-sm text-muted-foreground">
-							{m['common.errors_refreshPage']()}
-						</p>
+	<!--
+		Tinted content panel — same wash the event detail page introduced, so the
+		filter aside and every card read as white stickers FLOATING on a coloured
+		surface instead of rectangles on paper. Composited alphas are invisible to
+		scripts/audit-brand-themes.py, so the text layers that land DIRECTLY on
+		this panel (never inside a card) are hand-verified against the composite;
+		the numbers are the event page's, because the composite is identical
+		(`--secondary` over `--background` at the same alphas):
+		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
+		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
+		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		(`muted-foreground` is the pagination tally, `foreground` the page indicator.)
+	-->
+	<div class="bg-secondary/55 pb-16 dark:bg-secondary/[0.28]">
+		<div class="container mx-auto px-4">
+			<!-- Main Content: Sidebar + Event Grid -->
+			<div class="-mt-8 flex flex-col gap-8 lg:flex-row">
+				<!-- Filter Sidebar (Desktop) -->
+				<div class="hidden lg:block lg:w-80 lg:shrink-0">
+					<div class="sticky top-8">
+						<EventFilters
+							filters={currentFilters}
+							onUpdateFilters={handleUpdateFilters}
+							onClearFilters={handleClearFilters}
+						/>
 					</div>
-				{:else if events.length === 0}
-					<!-- level 2: the page's only other heading is the h1 above. -->
-					<EmptyState
-						level={2}
-						icon={Calendar}
-						title={m['browse.events_noEventsFound']()}
-						body={currentFilters.search || currentFilters.cityId || currentFilters.tags
-							? m['browse.events_tryAdjustingFilters']()
-							: m['browse.events_noUpcomingEvents']()}
-					>
-						{#snippet action()}
-							{#if currentFilters.search || currentFilters.cityId || currentFilters.tags}
-								<Button onclick={handleClearFilters}>
-									{m['browse.events_clearFilters']()}
-								</Button>
-							{/if}
-						{/snippet}
-					</EmptyState>
-				{:else}
-					<!-- Event Grid -->
-					<div
-						class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3"
-						role="list"
-						aria-label={m['browse.events_listingsLabel']()}
-					>
-						{#each events as event, index (`${event.id}-${index}`)}
-							<div role="listitem">
-								<EventCard {event} variant="standard" />
+				</div>
+
+				<!-- Event Content -->
+				<div id="events-content" class="flex-1">
+					{#if viewMode === 'list'}
+						<!-- List View -->
+						{#if error}
+							<!-- Error State. `bg-card` rather than the old `bg-destructive/10`
+						     wash: the panel underneath is itself tinted now, so a second
+						     alpha would stack two composites under `text-destructive`. On
+						     card it is the audited token pair, and the doubled destructive
+						     edge carries the alarm. -->
+							<div
+								class="rounded-lg border-2 border-destructive bg-card p-8 text-center shadow-poster"
+								role="alert"
+								aria-live="polite"
+							>
+								<p class="font-semibold text-destructive">{error}</p>
+								<p class="mt-2 text-sm text-muted-foreground">
+									{m['common.errors_refreshPage']()}
+								</p>
 							</div>
-						{/each}
-					</div>
+						{:else if events.length === 0}
+							<!-- level 2: the page's only other heading is the h1 above. -->
+							<EmptyState
+								level={2}
+								icon={Calendar}
+								title={m['browse.events_noEventsFound']()}
+								body={currentFilters.search || currentFilters.cityId || currentFilters.tags
+									? m['browse.events_tryAdjustingFilters']()
+									: m['browse.events_noUpcomingEvents']()}
+							>
+								{#snippet action()}
+									{#if currentFilters.search || currentFilters.cityId || currentFilters.tags}
+										<Button onclick={handleClearFilters}>
+											{m['browse.events_clearFilters']()}
+										</Button>
+									{/if}
+								{/snippet}
+							</EmptyState>
+						{:else}
+							<!-- Event Grid -->
+							<div
+								class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3"
+								role="list"
+								aria-label={m['browse.events_listingsLabel']()}
+							>
+								{#each events as event, index (`${event.id}-${index}`)}
+									<div role="listitem">
+										<EventCard {event} variant="standard" />
+									</div>
+								{/each}
+							</div>
 
-					<!-- Pagination -->
-					{#if totalPages > 1}
-						<nav
-							class="mt-12 flex flex-col items-center justify-between gap-4 sm:flex-row"
-							aria-label={m['eventsListPage.paginationLabel']()}
-						>
-							<!-- Results info -->
-							<p class="text-sm text-muted-foreground" aria-live="polite">
-								{m['common.pagination_showing']()}
-								{showingFrom}–{showingTo}
-								{m['common.pagination_of']()}
-								{totalCount}
-								{m['common.plurals_events']()}
-							</p>
-
-							<!-- Pagination controls -->
-							<div class="flex items-center gap-2">
-								{#if hasPrevPage}
-									<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
-									<a
-										href="?{filtersToParams({ ...currentFilters, page: currentPage - 1 })}"
-										class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-										aria-label={m['eventsListPage.goToPreviousPage']()}
-									>
-										{m['common.pagination_previous']()}
-									</a>
-									<!-- eslint-enable svelte/no-navigation-without-resolve -->
-								{:else}
-									<button
-										type="button"
-										disabled
-										class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
-										aria-label={m['common.pagination_previousUnavailable']()}
-									>
-										{m['common.pagination_previous']()}
-									</button>
-								{/if}
-
-								<!-- Page indicator -->
-								<span
-									class="inline-flex h-10 items-center justify-center px-4 text-sm font-medium"
-									aria-current="page"
+							<!-- Pagination -->
+							{#if totalPages > 1}
+								<nav
+									class="mt-12 flex flex-col items-center justify-between gap-4 sm:flex-row"
+									aria-label={m['eventsListPage.paginationLabel']()}
 								>
-									{m['common.pagination_page']()}
-									{currentPage}
-									{m['common.pagination_of']()}
-									{totalPages}
-								</span>
+									<!-- Results info -->
+									<p class="text-sm text-muted-foreground" aria-live="polite">
+										{m['common.pagination_showing']()}
+										{showingFrom}–{showingTo}
+										{m['common.pagination_of']()}
+										{totalCount}
+										{m['common.plurals_events']()}
+									</p>
 
-								{#if hasNextPage}
-									<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
-									<a
-										href="?{filtersToParams({ ...currentFilters, page: currentPage + 1 })}"
-										class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-										aria-label={m['eventsListPage.goToNextPage']()}
-									>
-										{m['common.pagination_next']()}
-									</a>
-									<!-- eslint-enable svelte/no-navigation-without-resolve -->
-								{:else}
-									<button
-										type="button"
-										disabled
-										class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
-										aria-label={m['common.pagination_nextUnavailable']()}
-									>
-										{m['common.pagination_next']()}
-									</button>
-								{/if}
-							</div>
-						</nav>
+									<!-- Pagination controls -->
+									<div class="flex items-center gap-2">
+										{#if hasPrevPage}
+											<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
+											<a
+												href="?{filtersToParams({ ...currentFilters, page: currentPage - 1 })}"
+												class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+												aria-label={m['eventsListPage.goToPreviousPage']()}
+											>
+												{m['common.pagination_previous']()}
+											</a>
+											<!-- eslint-enable svelte/no-navigation-without-resolve -->
+										{:else}
+											<button
+												type="button"
+												disabled
+												class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
+												aria-label={m['common.pagination_previousUnavailable']()}
+											>
+												{m['common.pagination_previous']()}
+											</button>
+										{/if}
+
+										<!-- Page indicator -->
+										<span
+											class="inline-flex h-10 items-center justify-center px-4 text-sm font-medium"
+											aria-current="page"
+										>
+											{m['common.pagination_page']()}
+											{currentPage}
+											{m['common.pagination_of']()}
+											{totalPages}
+										</span>
+
+										{#if hasNextPage}
+											<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
+											<a
+												href="?{filtersToParams({ ...currentFilters, page: currentPage + 1 })}"
+												class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+												aria-label={m['eventsListPage.goToNextPage']()}
+											>
+												{m['common.pagination_next']()}
+											</a>
+											<!-- eslint-enable svelte/no-navigation-without-resolve -->
+										{:else}
+											<button
+												type="button"
+												disabled
+												class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
+												aria-label={m['common.pagination_nextUnavailable']()}
+											>
+												{m['common.pagination_next']()}
+											</button>
+										{/if}
+									</div>
+								</nav>
+							{/if}
+						{/if}
+					{:else}
+						<!-- Calendar View. Wrapped in a card surface: the grid draws no
+					     background of its own, and its day cells tint with
+					     `bg-muted/30` / `bg-primary/5` — over the page's new tinted
+					     panel those would be a second stacked composite. On `bg-card`
+					     they composite exactly as they always did, and the calendar
+					     floats like every other block on this page. -->
+						<div class="rounded-lg border-2 bg-card p-4 shadow-poster md:p-6">
+							<CalendarControls
+								view={calendarParams.view}
+								year={calendarParams.year}
+								month={calendarParams.month}
+								week={calendarParams.week}
+								baseUrl="/events"
+								preserveParams={[
+									'viewMode',
+									'city_id',
+									'organization',
+									'event_type',
+									'visibility',
+									'tags',
+									'ticket_type'
+								]}
+							/>
+
+							<CalendarView
+								view={calendarParams.view}
+								year={calendarParams.year}
+								month={calendarParams.month}
+								week={calendarParams.week}
+								events={calendarEvents}
+								isLoading={isCalendarLoading}
+								onEventClick={handleEventClick}
+							/>
+						</div>
 					{/if}
-				{/if}
-			{:else}
-				<!-- Calendar View -->
-				<CalendarControls
-					view={calendarParams.view}
-					year={calendarParams.year}
-					month={calendarParams.month}
-					week={calendarParams.week}
-					baseUrl="/events"
-					preserveParams={[
-						'viewMode',
-						'city_id',
-						'organization',
-						'event_type',
-						'visibility',
-						'tags',
-						'ticket_type'
-					]}
-				/>
-
-				<CalendarView
-					view={calendarParams.view}
-					year={calendarParams.year}
-					month={calendarParams.month}
-					week={calendarParams.week}
-					events={calendarEvents}
-					isLoading={isCalendarLoading}
-					onEventClick={handleEventClick}
-				/>
-			{/if}
+				</div>
+			</div>
 		</div>
 	</div>
 

--- a/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
@@ -214,9 +214,9 @@
 						<div class="flex flex-1 gap-4">
 							<!-- Series/Organization Logo -->
 							<div class="flex-shrink-0">
-								{#if logoUrl || orgLogoUrl}
+								{#if logoUrl}
 									<img
-										src={logoUrl || orgLogoUrl}
+										src={logoUrl}
 										alt={m['eventSeriesDetailPage.coverImageAlt']({ seriesName: series.name })}
 										class="h-16 w-16 rounded-lg object-cover shadow-poster md:h-20 md:w-20"
 									/>
@@ -246,12 +246,18 @@
 								     separate visual context. The affordance is preserved, not
 								     removed. -->
 
-								<!-- Tags -->
+								<!-- Tags: primary on the card surface with a 2px primary edge —
+								     poster stickers, not washes (mirrors the event detail page's
+								     tags section). `bg-primary/10` on the `bg-secondary/55` wash
+								     below only reaches 4.29:1, under the 4.5:1 floor for 14px bold
+								     text. The card fill is opaque, so the audited primary-vs-card
+								     pair governs instead: 6.99:1 light / 6.27:1 dark (the same
+								     pair the questionnaire option rows rest on). -->
 								{#if series.tags && series.tags.length > 0}
 									<div class="mt-3 flex flex-wrap gap-2">
 										{#each series.tags as tag (tag)}
 											<span
-												class="inline-block rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary"
+												class="inline-block rounded-full border-2 border-primary/40 bg-card px-3 py-1 text-sm font-bold text-primary shadow-poster"
 											>
 												{tag}
 											</span>

--- a/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
@@ -238,15 +238,13 @@
 									class="mb-2"
 								/>
 
-								<!-- Organization Link -->
-								<a
-									href={resolve('/(public)/org/[slug]', { slug: series.organization.slug })}
-									class="mb-2 inline-block text-base font-bold text-primary hover:underline"
-								>
-									{m['eventSeriesDetailPage.byOrganization']({
-										organizationName: series.organization.name
-									})}
-								</a>
+								<!-- The "by {org}" link that used to sit here is gone: the ribbon
+								     directly above it is the same link to the same place, carrying
+								     the org's own mark and a richer accessible name, and the two
+								     ended up ~130px apart — visible duplication, unlike the event
+								     page's hero kicker, which is white-on-photo and reads as a
+								     separate visual context. The affordance is preserved, not
+								     removed. -->
 
 								<!-- Tags -->
 								{#if series.tags && series.tags.length > 0}

--- a/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
@@ -13,6 +13,7 @@
 	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
 	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import Sticker from '$lib/components/brand/Sticker.svelte';
+	import LogoChip from '$lib/components/brand/LogoChip.svelte';
 	import { getPosterFallbackGradient } from '$lib/utils/fallback-gradient';
 
 	const { data }: { data: PageData } = $props();
@@ -44,7 +45,10 @@
 
 <SeoHead config={data.seo} />
 
-<div class="min-h-screen bg-background">
+<!-- `flex-col` so the tinted panel below can take `flex-1`: without it a short
+     series (no passes, one event) leaves a bare `--background` strip under the
+     wash, which reads as an unfinished page. -->
+<div class="flex min-h-screen flex-col bg-background">
 	<!-- Hero Section with Cover Art -->
 	<section class="relative w-full overflow-hidden">
 		<!-- Cover Image or Gradient -->
@@ -76,298 +80,384 @@
 		</div>
 	</section>
 
-	<!-- Main Content -->
-	<div class="container mx-auto px-6 py-8 md:px-8 lg:py-12">
-		<!-- Back Button -->
-		<div class="mb-6">
+	<!--
+		Poster ribbon (uplift, spec §9) — the event detail page's move, mirrored
+		here because a series is the same kind of object: someone else's thing,
+		put on by an organization. A solid brand-purple colour block under the
+		cover carrying the org as a tilted white sticker, with `LogoChip` — the
+		landing hero's mark-and-hearts chip — pinned to the far end.
+
+		Ribbon, strip and chip are mode-INERT by the imagery rule (a poster panel
+		is not a surface), so every pair on them is hand-verified against the
+		fixed values; a poster-palette pair is invisible to
+		scripts/audit-brand-themes.py (numbers are the audit script's own):
+		  ink on white                   → 17.40:1
+		  Hearty Purple #8C3CDD on white →  5.52:1 (the text-xs kicker clears AA)
+		  white on crimson-DEEP          →  4.59:1 (the logo-less initial tile)
+		The initial tile's gradient ends on `crimson-deep`, not raw
+		`poster-crimson`: white on raw Light Crimson is 4.33:1, which fails AA
+		for the tile's bold letter — the trap app.css documents at the
+		`--poster-crimson-deep` declaration.
+		Note: always the ORGANIZATION's logo/initial, never the series' own — the
+		series keeps its mark in the header block below, and this ribbon answers
+		"who is putting this on".
+	-->
+	<div class="bg-poster-purple">
+		<!-- `container`, not the event header's `max-w-[1920px]`: that page's cover
+		     is capped at 1920 so its ribbon matches it, whereas this cover is
+		     edge-to-edge and the body below is a container — so the strip lines up
+		     with the h1 it introduces. -->
+		<div class="container relative mx-auto px-6 pb-6 md:px-8">
 			<a
 				href={resolve('/(public)/org/[slug]', { slug: series.organization.slug })}
-				class="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+				class="group -mt-8 inline-flex -rotate-1 items-center gap-3 rounded-[1.25rem] bg-poster-white p-3 shadow-poster-lg transition-transform hover:rotate-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-purple"
 			>
-				<ArrowLeft class="h-4 w-4" aria-hidden="true" />
-				{m['eventSeriesDetailPage.backToOrganization']({
-					organizationName: series.organization.name
-				})}
-			</a>
-		</div>
-
-		<!-- Admin Actions Card (Mobile) -->
-		{#if data.canEdit}
-			<div class="mb-8 lg:hidden">
-				<aside
-					class="rounded-lg border border-border bg-card p-4 shadow-sm"
-					aria-label={m['seriesPublicPage.adminActionsLabel']()}
-				>
-					<h3 class="mb-3 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
-						{m['eventSeriesDetailPage.admin_title']()}
-					</h3>
-					<div class="space-y-2">
-						<a
-							href={resolve('/(auth)/org/[slug]/admin/event-series/[series_id]/edit', {
-								slug: series.organization.slug,
-								series_id: series.id
-							})}
-							class="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-						>
-							<Settings class="h-4 w-4" aria-hidden="true" />
-							{m['eventSeriesDetailPage.admin_editButton']()}
-						</a>
+				{#if orgLogoUrl}
+					<img
+						src={orgLogoUrl}
+						alt={m['eventHeader.organizationLogoAlt']({ name: series.organization.name })}
+						class="h-12 w-12 rounded-md object-cover"
+					/>
+				{:else}
+					<div
+						class="flex h-12 w-12 items-center justify-center rounded-md bg-gradient-to-br from-poster-purple to-poster-crimson-deep text-lg font-black text-poster-white"
+					>
+						{series.organization.name.charAt(0).toUpperCase()}
 					</div>
-				</aside>
+				{/if}
+
+				<div class="flex flex-col pr-2">
+					<span class="text-xs font-extrabold uppercase tracking-[0.12em] text-poster-purple">
+						{m['eventHeader.organizedBy']()}
+					</span>
+					<span class="font-extrabold text-poster-ink">
+						{series.organization.name}
+					</span>
+				</div>
+			</a>
+			<!-- Positioning lives on the wrapper: LogoChip owns its own `transform`
+			     (the tilt), so a translate utility on the chip itself would be
+			     overwritten. Anchored to the ribbon's BOTTOM so the chip grows
+			     UPWARD over the cover — a sticker straddling the cut. Renders
+			     nothing for a logo-less org (sticker-chip rule): the strip's
+			     initial tile is the only identity mark then, which is the point. -->
+			<div class="absolute bottom-3 right-8 hidden md:block">
+				<LogoChip
+					rotate={-8}
+					logo={series.organization.logo}
+					logoThumbnail={series.organization.logo_thumbnail_url}
+				/>
 			</div>
-		{/if}
+		</div>
+	</div>
 
-		<div class="grid gap-8 lg:grid-cols-3">
-			<!-- Left Column: Main Content -->
-			<div class="space-y-8 lg:col-span-2">
-				<!-- Header with Logo, Name, and Organization -->
-				<div class="flex flex-col gap-6 sm:flex-row sm:items-start">
-					<div class="flex flex-1 gap-4">
-						<!-- Series/Organization Logo -->
-						<div class="flex-shrink-0">
-							{#if logoUrl || orgLogoUrl}
-								<img
-									src={logoUrl || orgLogoUrl}
-									alt={m['eventSeriesDetailPage.coverImageAlt']({ seriesName: series.name })}
-									class="h-16 w-16 rounded-lg object-cover shadow-sm md:h-20 md:w-20"
-								/>
-							{:else}
-								<div
-									class="flex h-16 w-16 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-primary/70 text-xl font-bold text-primary-foreground shadow-sm md:h-20 md:w-20 md:text-2xl"
-								>
-									{series.name.charAt(0).toUpperCase()}
-								</div>
-							{/if}
-						</div>
+	<!--
+		Tinted content panel — the event detail page's wash, so a series and the
+		events it contains read as the same surface. Composite and therefore
+		ratios are identical to that page's (a composited alpha is invisible to
+		scripts/audit-brand-themes.py):
+		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
+		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
+		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		Everything landing directly on it is covered: the h1 and section headings
+		(`foreground`), the back link, tallies and blurbs (`muted-foreground`),
+		and the SectionHeader kickers plus the org link (`primary`).
+	-->
+	<div class="flex-1 bg-secondary/55 dark:bg-secondary/[0.28]">
+		<!-- Main Content -->
+		<div class="container mx-auto px-6 py-8 md:px-8 lg:py-12">
+			<!-- Back Button -->
+			<div class="mb-6">
+				<a
+					href={resolve('/(public)/org/[slug]', { slug: series.organization.slug })}
+					class="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+				>
+					<ArrowLeft class="h-4 w-4" aria-hidden="true" />
+					{m['eventSeriesDetailPage.backToOrganization']({
+						organizationName: series.organization.name
+					})}
+				</a>
+			</div>
 
-						<!-- Series Info -->
-						<div class="min-w-0 flex-1">
-							<PageHeader
-								volume="celebration"
-								kicker={m['eventSeriesCard.eventSeries']()}
-								title={series.name}
-								class="mb-2"
-							/>
-
-							<!-- Organization Link -->
+			<!-- Admin Actions Card (Mobile) -->
+			{#if data.canEdit}
+				<div class="mb-8 lg:hidden">
+					<aside
+						class="rounded-lg border-2 border-border bg-card p-4 shadow-poster"
+						aria-label={m['seriesPublicPage.adminActionsLabel']()}
+					>
+						<h3 class="mb-3 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
+							{m['eventSeriesDetailPage.admin_title']()}
+						</h3>
+						<div class="space-y-2">
 							<a
-								href={resolve('/(public)/org/[slug]', { slug: series.organization.slug })}
-								class="mb-2 inline-block text-base font-bold text-primary hover:underline"
-							>
-								{m['eventSeriesDetailPage.byOrganization']({
-									organizationName: series.organization.name
+								href={resolve('/(auth)/org/[slug]/admin/event-series/[series_id]/edit', {
+									slug: series.organization.slug,
+									series_id: series.id
 								})}
+								class="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+							>
+								<Settings class="h-4 w-4" aria-hidden="true" />
+								{m['eventSeriesDetailPage.admin_editButton']()}
 							</a>
+						</div>
+					</aside>
+				</div>
+			{/if}
 
-							<!-- Tags -->
-							{#if series.tags && series.tags.length > 0}
-								<div class="mt-3 flex flex-wrap gap-2">
-									{#each series.tags as tag (tag)}
-										<span
-											class="inline-block rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary"
-										>
-											{tag}
-										</span>
-									{/each}
-								</div>
-							{/if}
+			<div class="grid gap-8 lg:grid-cols-3">
+				<!-- Left Column: Main Content -->
+				<div class="space-y-8 lg:col-span-2">
+					<!-- Header with Logo, Name, and Organization -->
+					<div class="flex flex-col gap-6 sm:flex-row sm:items-start">
+						<div class="flex flex-1 gap-4">
+							<!-- Series/Organization Logo -->
+							<div class="flex-shrink-0">
+								{#if logoUrl || orgLogoUrl}
+									<img
+										src={logoUrl || orgLogoUrl}
+										alt={m['eventSeriesDetailPage.coverImageAlt']({ seriesName: series.name })}
+										class="h-16 w-16 rounded-lg object-cover shadow-poster md:h-20 md:w-20"
+									/>
+								{:else}
+									<div
+										class="flex h-16 w-16 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-primary/70 text-xl font-black text-primary-foreground shadow-poster md:h-20 md:w-20 md:text-2xl"
+									>
+										{series.name.charAt(0).toUpperCase()}
+									</div>
+								{/if}
+							</div>
 
-							<!-- Follow Button -->
-							<div class="mt-4">
-								<FollowButton
-									entityType="event-series"
-									entityId={series.id}
-									entityName={series.name}
-									isAuthenticated={data.isAuthenticated}
-									variant="outline"
+							<!-- Series Info -->
+							<div class="min-w-0 flex-1">
+								<PageHeader
+									volume="poster"
+									kicker={m['eventSeriesCard.eventSeries']()}
+									title={series.name}
+									class="mb-2"
 								/>
+
+								<!-- Organization Link -->
+								<a
+									href={resolve('/(public)/org/[slug]', { slug: series.organization.slug })}
+									class="mb-2 inline-block text-base font-bold text-primary hover:underline"
+								>
+									{m['eventSeriesDetailPage.byOrganization']({
+										organizationName: series.organization.name
+									})}
+								</a>
+
+								<!-- Tags -->
+								{#if series.tags && series.tags.length > 0}
+									<div class="mt-3 flex flex-wrap gap-2">
+										{#each series.tags as tag (tag)}
+											<span
+												class="inline-block rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary"
+											>
+												{tag}
+											</span>
+										{/each}
+									</div>
+								{/if}
+
+								<!-- Follow Button -->
+								<div class="mt-4">
+									<FollowButton
+										entityType="event-series"
+										entityId={series.id}
+										entityName={series.name}
+										isAuthenticated={data.isAuthenticated}
+										variant="outline"
+									/>
+								</div>
 							</div>
 						</div>
 					</div>
+
+					<!-- Series Description -->
+					{#if series.description}
+						<section
+							aria-labelledby="description-heading"
+							class="rounded-lg border-2 bg-card p-6 shadow-poster md:p-8"
+						>
+							<h2 id="description-heading" class="sr-only">
+								{m['eventSeriesDetailPage.description_heading']({ seriesName: series.name })}
+							</h2>
+							<MarkdownContent content={series.description} class="prose-slate" />
+						</section>
+					{/if}
+
+					<!-- Season Passes Section -->
+					{#if seriesPasses.length > 0}
+						<section aria-labelledby="passes-heading">
+							<div class="mb-6">
+								<SectionHeader
+									volume="celebration"
+									id="passes-heading"
+									title={m['seriesPass.sectionHeading']()}
+								/>
+								<p class="mt-1 text-sm text-muted-foreground">
+									{m['seriesPass.sectionDescription']()}
+								</p>
+							</div>
+							<div class="grid gap-4 sm:grid-cols-2">
+								{#each seriesPasses as pass (pass.id)}
+									<SeriesPassCard
+										{pass}
+										seriesId={series.id}
+										isAuthenticated={data.isAuthenticated}
+									/>
+								{/each}
+							</div>
+						</section>
+					{/if}
+
+					<!-- Events Section -->
+					<section aria-labelledby="events-heading">
+						<div class="mb-6 flex flex-wrap items-end justify-between gap-4">
+							<div>
+								<SectionHeader
+									volume="celebration"
+									id="events-heading"
+									title={m['eventSeriesDetailPage.events_heading']()}
+								/>
+								{#if totalCount > 0}
+									<p class="mt-1 text-sm text-muted-foreground">
+										{m['eventSeriesDetailPage.events_count']({
+											count: totalCount
+										})}
+									</p>
+								{/if}
+							</div>
+
+							<!-- Sort Order Toggle -->
+							<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
+							<a
+								href="?order_by={orderBy === '-start' ? 'start' : '-start'}"
+								class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+								aria-label={orderBy === '-start'
+									? m['eventSeriesDetailPage.sort_ariaLabel_newest']()
+									: m['eventSeriesDetailPage.sort_ariaLabel_oldest']()}
+							>
+								<ArrowDownUp class="h-4 w-4" aria-hidden="true" />
+								{orderBy === '-start'
+									? m['eventSeriesDetailPage.sort_newestFirst']()
+									: m['eventSeriesDetailPage.sort_oldestFirst']()}
+							</a>
+							<!-- eslint-enable svelte/no-navigation-without-resolve -->
+						</div>
+
+						{#if events.length === 0}
+							<EmptyState
+								icon={Calendar}
+								title={m['eventSeriesDetailPage.empty_title']()}
+								body={m['eventSeriesDetailPage.empty_description']()}
+							/>
+						{:else}
+							<!-- Event Cards Grid -->
+							<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+								{#each events as event, index (`${event.id}-${index}`)}
+									<EventCard {event} />
+								{/each}
+							</div>
+
+							<!-- Pagination -->
+							{#if totalPages > 1}
+								<nav
+									class="mt-12 flex flex-col items-center justify-between gap-4 sm:flex-row"
+									aria-label={m['seriesPublicPage.paginationLabel']()}
+								>
+									<!-- Results info -->
+									<p class="text-sm text-muted-foreground">
+										{m['eventSeriesDetailPage.pagination_showingPage']({ currentPage, totalPages })}
+									</p>
+
+									<!-- Pagination controls -->
+									<div class="flex items-center gap-2">
+										{#if hasPrevPage}
+											<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
+											<a
+												href="?page={currentPage - 1}"
+												class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+												aria-label={m['seriesPublicPage.goToPreviousPage']()}
+											>
+												{m['eventSeriesDetailPage.pagination_previous']()}
+											</a>
+											<!-- eslint-enable svelte/no-navigation-without-resolve -->
+										{:else}
+											<button
+												type="button"
+												disabled
+												class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
+												aria-label={m['eventSeriesDetailPage.pagination_previousUnavailable']()}
+											>
+												{m['eventSeriesDetailPage.pagination_previous']()}
+											</button>
+										{/if}
+
+										<!-- Page indicator -->
+										<span
+											class="inline-flex h-10 items-center justify-center px-4 text-sm font-medium"
+										>
+											{m['eventSeriesDetailPage.pagination_pageIndicator']({
+												currentPage,
+												totalPages
+											})}
+										</span>
+
+										{#if hasNextPage}
+											<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
+											<a
+												href="?page={currentPage + 1}"
+												class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+												aria-label={m['seriesPublicPage.goToNextPage']()}
+											>
+												{m['eventSeriesDetailPage.pagination_next']()}
+											</a>
+											<!-- eslint-enable svelte/no-navigation-without-resolve -->
+										{:else}
+											<button
+												type="button"
+												disabled
+												class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
+												aria-label={m['eventSeriesDetailPage.pagination_nextUnavailable']()}
+											>
+												{m['eventSeriesDetailPage.pagination_next']()}
+											</button>
+										{/if}
+									</div>
+								</nav>
+							{/if}
+						{/if}
+					</section>
 				</div>
 
-				<!-- Series Description -->
-				{#if series.description}
-					<section
-						aria-labelledby="description-heading"
-						class="rounded-lg border bg-card p-6 md:p-8"
-					>
-						<h2 id="description-heading" class="sr-only">
-							{m['eventSeriesDetailPage.description_heading']({ seriesName: series.name })}
-						</h2>
-						<MarkdownContent content={series.description} class="prose-slate" />
-					</section>
-				{/if}
-
-				<!-- Season Passes Section -->
-				{#if seriesPasses.length > 0}
-					<section aria-labelledby="passes-heading">
-						<div class="mb-6">
-							<SectionHeader
-								volume="celebration"
-								id="passes-heading"
-								title={m['seriesPass.sectionHeading']()}
-							/>
-							<p class="mt-1 text-sm text-muted-foreground">
-								{m['seriesPass.sectionDescription']()}
-							</p>
-						</div>
-						<div class="grid gap-4 sm:grid-cols-2">
-							{#each seriesPasses as pass (pass.id)}
-								<SeriesPassCard
-									{pass}
-									seriesId={series.id}
-									isAuthenticated={data.isAuthenticated}
-								/>
-							{/each}
-						</div>
-					</section>
-				{/if}
-
-				<!-- Events Section -->
-				<section aria-labelledby="events-heading">
-					<div class="mb-6 flex flex-wrap items-end justify-between gap-4">
-						<div>
-							<SectionHeader
-								volume="celebration"
-								id="events-heading"
-								title={m['eventSeriesDetailPage.events_heading']()}
-							/>
-							{#if totalCount > 0}
-								<p class="mt-1 text-sm text-muted-foreground">
-									{m['eventSeriesDetailPage.events_count']({
-										count: totalCount
-									})}
-								</p>
-							{/if}
-						</div>
-
-						<!-- Sort Order Toggle -->
-						<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
-						<a
-							href="?order_by={orderBy === '-start' ? 'start' : '-start'}"
-							class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-							aria-label={orderBy === '-start'
-								? m['eventSeriesDetailPage.sort_ariaLabel_newest']()
-								: m['eventSeriesDetailPage.sort_ariaLabel_oldest']()}
-						>
-							<ArrowDownUp class="h-4 w-4" aria-hidden="true" />
-							{orderBy === '-start'
-								? m['eventSeriesDetailPage.sort_newestFirst']()
-								: m['eventSeriesDetailPage.sort_oldestFirst']()}
-						</a>
-						<!-- eslint-enable svelte/no-navigation-without-resolve -->
-					</div>
-
-					{#if events.length === 0}
-						<EmptyState
-							icon={Calendar}
-							title={m['eventSeriesDetailPage.empty_title']()}
-							body={m['eventSeriesDetailPage.empty_description']()}
-						/>
-					{:else}
-						<!-- Event Cards Grid -->
-						<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-							{#each events as event, index (`${event.id}-${index}`)}
-								<EventCard {event} />
-							{/each}
-						</div>
-
-						<!-- Pagination -->
-						{#if totalPages > 1}
-							<nav
-								class="mt-12 flex flex-col items-center justify-between gap-4 sm:flex-row"
-								aria-label={m['seriesPublicPage.paginationLabel']()}
-							>
-								<!-- Results info -->
-								<p class="text-sm text-muted-foreground">
-									{m['eventSeriesDetailPage.pagination_showingPage']({ currentPage, totalPages })}
-								</p>
-
-								<!-- Pagination controls -->
-								<div class="flex items-center gap-2">
-									{#if hasPrevPage}
-										<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
-										<a
-											href="?page={currentPage - 1}"
-											class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-											aria-label={m['seriesPublicPage.goToPreviousPage']()}
-										>
-											{m['eventSeriesDetailPage.pagination_previous']()}
-										</a>
-										<!-- eslint-enable svelte/no-navigation-without-resolve -->
-									{:else}
-										<button
-											type="button"
-											disabled
-											class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
-											aria-label={m['eventSeriesDetailPage.pagination_previousUnavailable']()}
-										>
-											{m['eventSeriesDetailPage.pagination_previous']()}
-										</button>
-									{/if}
-
-									<!-- Page indicator -->
-									<span
-										class="inline-flex h-10 items-center justify-center px-4 text-sm font-medium"
-									>
-										{m['eventSeriesDetailPage.pagination_pageIndicator']({
-											currentPage,
-											totalPages
+				<!-- Right Column: Admin Sidebar (Desktop only, sticky) -->
+				{#if data.canEdit}
+					<aside class="hidden lg:col-span-1 lg:block">
+						<div class="sticky top-4 space-y-6">
+							<div class="rounded-lg border-2 border-border bg-card p-4 shadow-poster">
+								<h3 class="mb-3 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
+									{m['eventSeriesDetailPage.admin_title']()}
+								</h3>
+								<div class="space-y-2">
+									<a
+										href={resolve('/(auth)/org/[slug]/admin/event-series/[series_id]/edit', {
+											slug: series.organization.slug,
+											series_id: series.id
 										})}
-									</span>
-
-									{#if hasNextPage}
-										<!-- eslint-disable svelte/no-navigation-without-resolve -- same-route query-only update; the relative "?"+params string preserves the current pathname (resolve() cannot express search params) -->
-										<a
-											href="?page={currentPage + 1}"
-											class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-											aria-label={m['seriesPublicPage.goToNextPage']()}
-										>
-											{m['eventSeriesDetailPage.pagination_next']()}
-										</a>
-										<!-- eslint-enable svelte/no-navigation-without-resolve -->
-									{:else}
-										<button
-											type="button"
-											disabled
-											class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
-											aria-label={m['eventSeriesDetailPage.pagination_nextUnavailable']()}
-										>
-											{m['eventSeriesDetailPage.pagination_next']()}
-										</button>
-									{/if}
+										class="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+									>
+										<Settings class="h-4 w-4" aria-hidden="true" />
+										{m['eventSeriesDetailPage.admin_editButton']()}
+									</a>
 								</div>
-							</nav>
-						{/if}
-					{/if}
-				</section>
-			</div>
-
-			<!-- Right Column: Admin Sidebar (Desktop only, sticky) -->
-			{#if data.canEdit}
-				<aside class="hidden lg:col-span-1 lg:block">
-					<div class="sticky top-4 space-y-6">
-						<div class="rounded-lg border border-border bg-card p-4 shadow-sm">
-							<h3 class="mb-3 text-xs font-extrabold uppercase tracking-[0.12em] text-primary">
-								{m['eventSeriesDetailPage.admin_title']()}
-							</h3>
-							<div class="space-y-2">
-								<a
-									href={resolve('/(auth)/org/[slug]/admin/event-series/[series_id]/edit', {
-										slug: series.organization.slug,
-										series_id: series.id
-									})}
-									class="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-								>
-									<Settings class="h-4 w-4" aria-hidden="true" />
-									{m['eventSeriesDetailPage.admin_editButton']()}
-								</a>
 							</div>
 						</div>
-					</div>
-				</aside>
-			{/if}
+					</aside>
+				{/if}
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -158,7 +158,10 @@
 
 <SeoHead config={data.seo} />
 
-<div class="min-h-screen bg-background">
+<!-- `flex-col` so the tinted panel below can take `flex-1`: without it a sparse
+     org (no series, no resources, few events) leaves a bare `--background`
+     strip under the wash, which reads as an unfinished page. -->
+<div class="flex min-h-screen flex-col bg-background">
 	<!-- Hero Section with Cover Art -->
 	<section class="relative w-full overflow-hidden">
 		<!-- Cover Image or Gradient -->
@@ -190,294 +193,507 @@
 		</div>
 	</section>
 
-	<!-- Main Content -->
-	<div class="container mx-auto px-6 py-8 md:px-8 lg:py-12">
-		<!-- Header with Logo, Name, and Actions -->
-		<div class="mb-8 flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
-			<div class="flex flex-1 gap-4">
-				<!-- Organization Logo -->
-				<div class="flex-shrink-0">
-					{#if logoUrl}
-						<img
-							src={logoUrl}
-							alt="{organization.name} logo"
-							class="h-16 w-16 rounded-lg object-cover shadow-sm md:h-20 md:w-20"
-						/>
-					{:else}
-						<div
-							class="flex h-16 w-16 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-primary/70 text-xl font-bold text-primary-foreground shadow-sm md:h-20 md:w-20 md:text-2xl"
-						>
-							{organization.name.charAt(0).toUpperCase()}
-						</div>
-					{/if}
-				</div>
+	<!--
+		Poster ribbon (uplift, spec §9) — the event page's move, applied to the
+		other public identity page. A solid brand-purple colour block under the
+		cover, with the organization's own logo promoted OUT of the header row
+		and onto it as a tilted white sticker straddling the cut. The logo used
+		to be a 64px thumbnail beside the title; here it is the page's identity
+		mark, which is what an org profile is for.
 
-				<!-- Organization Info -->
-				<div class="min-w-0 flex-1">
-					<PageHeader
-						volume="celebration"
-						kicker={m['organizationProfile.kicker']()}
-						title={organization.name}
-						class="mb-2"
+		Ribbon and sticker are mode-INERT by the imagery rule (a poster panel is
+		not a surface). No copy sits on the purple itself — the only text here is
+		the initial tile's letter, hand-verified against the fixed values because
+		a poster-palette pair is invisible to scripts/audit-brand-themes.py
+		(number is the audit script's own):
+		  white on crimson-DEEP →  4.59:1
+		The initial tile's gradient ends on `crimson-deep`, not raw
+		`poster-crimson`: white on raw Light Crimson is 4.33:1, which fails AA
+		for the tile's bold letter — the trap app.css documents at the
+		`--poster-crimson-deep` declaration. That tile is the DEFAULT for any org
+		without a logo, not an edge case, which is also why the sticker is kept
+		here rather than delegated to `brand/LogoChip`: LogoChip renders NOTHING
+		without a logo (it is pure ornament), and this mark is not ornament.
+	-->
+	<div class="bg-poster-purple">
+		<div class="container mx-auto px-6 pb-6 md:px-8">
+			<div
+				class="-mt-8 inline-block -rotate-1 rounded-[1.25rem] bg-poster-white p-3 shadow-poster-lg"
+			>
+				{#if logoUrl}
+					<img
+						src={logoUrl}
+						alt="{organization.name} logo"
+						class="h-16 w-16 rounded-lg object-cover md:h-20 md:w-20"
 					/>
+				{:else}
+					<div
+						class="flex h-16 w-16 items-center justify-center rounded-lg bg-gradient-to-br from-poster-purple to-poster-crimson-deep text-xl font-black text-poster-white md:h-20 md:w-20 md:text-2xl"
+					>
+						{organization.name.charAt(0).toUpperCase()}
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
 
-					<!-- Metadata Row -->
-					<div class="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
-						<!-- Location -->
-						{#if locationDisplay}
-							<div class="flex items-center gap-1.5">
-								<MapPin class="h-4 w-4" aria-hidden="true" />
-								<span>{locationDisplay}</span>
-							</div>
-						{/if}
+	<!--
+		Tinted content panel — the event detail page's wash, so an org profile and
+		the events it lists read as the same surface. Composite and therefore
+		ratios are identical to that page's (a composited alpha is invisible to
+		scripts/audit-brand-themes.py):
+		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
+		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
+		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		Everything that lands directly on it here is covered: the h1 and section
+		headings (`foreground`), the metadata/social row and section blurbs
+		(`muted-foreground`), and the SectionHeader kickers plus the inline
+		"browse all"/"calendar" links (`primary`).
+	-->
+	<div class="flex-1 bg-secondary/55 dark:bg-secondary/[0.28]">
+		<!-- Main Content -->
+		<div class="container mx-auto px-6 py-8 md:px-8 lg:py-12">
+			<!-- Header with Name and Actions -->
+			<div class="mb-8 flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+				<div class="flex flex-1 gap-4">
+					<!-- Organization Info -->
+					<div class="min-w-0 flex-1">
+						<PageHeader
+							volume="poster"
+							kicker={m['organizationProfile.kicker']()}
+							title={organization.name}
+							class="mb-2"
+						/>
 
-						<!-- Social Links -->
-						{#if hasSocialLinks}
-							<div class="flex items-center gap-3">
-								{#if organization.instagram_url}
-									<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
-									<a
-										href={organization.instagram_url}
-										target="_blank"
-										rel="noopener noreferrer"
-										class="text-muted-foreground transition-colors hover:text-primary"
-										aria-label={m['organizationProfile.social_instagram']()}
-									>
-										<Instagram class="h-5 w-5" aria-hidden="true" />
-									</a>
-									<!-- eslint-enable svelte/no-navigation-without-resolve -->
-								{/if}
-								{#if organization.facebook_url}
-									<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
-									<a
-										href={organization.facebook_url}
-										target="_blank"
-										rel="noopener noreferrer"
-										class="text-muted-foreground transition-colors hover:text-primary"
-										aria-label={m['organizationProfile.social_facebook']()}
-									>
-										<Facebook class="h-5 w-5" aria-hidden="true" />
-									</a>
-									<!-- eslint-enable svelte/no-navigation-without-resolve -->
-								{/if}
-								{#if organization.bluesky_url}
-									<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
-									<a
-										href={organization.bluesky_url}
-										target="_blank"
-										rel="noopener noreferrer"
-										class="text-muted-foreground transition-colors hover:text-primary"
-										aria-label={m['organizationProfile.social_bluesky']()}
-									>
-										<AtSign class="h-5 w-5" aria-hidden="true" />
-									</a>
-									<!-- eslint-enable svelte/no-navigation-without-resolve -->
-								{/if}
-								{#if organization.telegram_url}
-									<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
-									<a
-										href={organization.telegram_url}
-										target="_blank"
-										rel="noopener noreferrer"
-										class="text-muted-foreground transition-colors hover:text-primary"
-										aria-label={m['organizationProfile.social_telegram']()}
-									>
-										<Send class="h-5 w-5" aria-hidden="true" />
-									</a>
-									<!-- eslint-enable svelte/no-navigation-without-resolve -->
-								{/if}
-							</div>
-						{/if}
+						<!-- Metadata Row -->
+						<div class="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+							<!-- Location -->
+							{#if locationDisplay}
+								<div class="flex items-center gap-1.5">
+									<MapPin class="h-4 w-4" aria-hidden="true" />
+									<span>{locationDisplay}</span>
+								</div>
+							{/if}
+
+							<!-- Social Links -->
+							{#if hasSocialLinks}
+								<div class="flex items-center gap-3">
+									{#if organization.instagram_url}
+										<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
+										<a
+											href={organization.instagram_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="text-muted-foreground transition-colors hover:text-primary"
+											aria-label={m['organizationProfile.social_instagram']()}
+										>
+											<Instagram class="h-5 w-5" aria-hidden="true" />
+										</a>
+										<!-- eslint-enable svelte/no-navigation-without-resolve -->
+									{/if}
+									{#if organization.facebook_url}
+										<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
+										<a
+											href={organization.facebook_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="text-muted-foreground transition-colors hover:text-primary"
+											aria-label={m['organizationProfile.social_facebook']()}
+										>
+											<Facebook class="h-5 w-5" aria-hidden="true" />
+										</a>
+										<!-- eslint-enable svelte/no-navigation-without-resolve -->
+									{/if}
+									{#if organization.bluesky_url}
+										<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
+										<a
+											href={organization.bluesky_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="text-muted-foreground transition-colors hover:text-primary"
+											aria-label={m['organizationProfile.social_bluesky']()}
+										>
+											<AtSign class="h-5 w-5" aria-hidden="true" />
+										</a>
+										<!-- eslint-enable svelte/no-navigation-without-resolve -->
+									{/if}
+									{#if organization.telegram_url}
+										<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
+										<a
+											href={organization.telegram_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="text-muted-foreground transition-colors hover:text-primary"
+											aria-label={m['organizationProfile.social_telegram']()}
+										>
+											<Send class="h-5 w-5" aria-hidden="true" />
+										</a>
+										<!-- eslint-enable svelte/no-navigation-without-resolve -->
+									{/if}
+								</div>
+							{/if}
+						</div>
 					</div>
 				</div>
-			</div>
 
-			<!-- Action Buttons -->
-			<div class="flex flex-shrink-0 flex-wrap gap-2">
-				<!-- Edit Button (if user has permission) -->
-				{#if data.canEdit}
-					<a
-						href={resolve('/(auth)/org/[slug]/admin/settings', { slug: organization.slug })}
-						class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-					>
-						<Settings class="h-4 w-4" aria-hidden="true" />
-						{m['organizationProfile.editProfile']()}
-					</a>
-				{/if}
+				<!-- Action Buttons -->
+				<div class="flex flex-shrink-0 flex-wrap gap-2">
+					<!-- Edit Button (if user has permission) -->
+					{#if data.canEdit}
+						<a
+							href={resolve('/(auth)/org/[slug]/admin/settings', { slug: organization.slug })}
+							class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						>
+							<Settings class="h-4 w-4" aria-hidden="true" />
+							{m['organizationProfile.editProfile']()}
+						</a>
+					{/if}
 
-				<!-- Claim Membership Button (if token present and grants membership) -->
-				{#if data.organizationTokenDetails && data.organizationTokenDetails.grants_membership && !data.isMember && !data.isOwner && !data.isStaff}
-					<ClaimMembershipButton
-						tokenId={data.organizationTokenDetails.id || ''}
-						tokenDetails={data.organizationTokenDetails}
-						class="inline-flex items-center gap-2"
-					/>
-					<!-- Membership CTA (if org accepts members and user is not a member) -->
-				{:else if organization.accept_membership_requests}
-					<MembershipCta
-						organizationSlug={organization.slug}
-						organizationName={organization.name}
-						isAuthenticated={data.isAuthenticated}
-						isMember={data.isMember}
-						membershipTier={data.membershipTier}
-						membershipStatus={data.membershipStatus}
-						isOwner={data.isOwner}
-						isStaff={data.isStaff}
-					/>
-				{/if}
+					<!-- Claim Membership Button (if token present and grants membership) -->
+					{#if data.organizationTokenDetails && data.organizationTokenDetails.grants_membership && !data.isMember && !data.isOwner && !data.isStaff}
+						<ClaimMembershipButton
+							tokenId={data.organizationTokenDetails.id || ''}
+							tokenDetails={data.organizationTokenDetails}
+							class="inline-flex items-center gap-2"
+						/>
+						<!-- Membership CTA (if org accepts members and user is not a member) -->
+					{:else if organization.accept_membership_requests}
+						<MembershipCta
+							organizationSlug={organization.slug}
+							organizationName={organization.name}
+							isAuthenticated={data.isAuthenticated}
+							isMember={data.isMember}
+							membershipTier={data.membershipTier}
+							membershipStatus={data.membershipStatus}
+							isOwner={data.isOwner}
+							isStaff={data.isStaff}
+						/>
+					{/if}
 
-				<!-- Follow Button -->
-				<FollowButton
-					entityType="organization"
-					entityId={organization.slug}
-					entityName={organization.name}
-					isAuthenticated={data.isAuthenticated}
-					variant="outline"
-				/>
-
-				<!-- Contact Organizer Button -->
-				{#if organization.contact_method && organization.contact_method !== 'none'}
-					<OrgContactButton
-						organizationSlug={organization.slug}
-						organizationName={organization.name}
-						contactMethod={organization.contact_method}
-						contactEmail={organization.contact_email}
+					<!-- Follow Button -->
+					<FollowButton
+						entityType="organization"
+						entityId={organization.slug}
+						entityName={organization.name}
 						isAuthenticated={data.isAuthenticated}
 						variant="outline"
 					/>
-				{/if}
-			</div>
-		</div>
 
-		{#if data.isAuthenticated && organization.id}
-			<div class="mb-6">
-				<OrgMembershipInline
-					orgId={organization.id}
-					orgName={organization.name}
-					plans={data.membershipPlans}
+					<!-- Contact Organizer Button -->
+					{#if organization.contact_method && organization.contact_method !== 'none'}
+						<OrgContactButton
+							organizationSlug={organization.slug}
+							organizationName={organization.name}
+							contactMethod={organization.contact_method}
+							contactEmail={organization.contact_email}
+							isAuthenticated={data.isAuthenticated}
+							variant="outline"
+						/>
+					{/if}
+				</div>
+			</div>
+
+			{#if data.isAuthenticated && organization.id}
+				<div class="mb-6">
+					<OrgMembershipInline
+						orgId={organization.id}
+						orgName={organization.name}
+						plans={data.membershipPlans}
+					/>
+				</div>
+			{/if}
+
+			<!-- Organization Description -->
+			<div class="mb-12">
+				<OrganizationDescription
+					description={organization.description}
+					organizationName={organization.name}
 				/>
 			</div>
-		{/if}
 
-		<!-- Organization Description -->
-		<div class="mb-12">
-			<OrganizationDescription
-				description={organization.description}
-				organizationName={organization.name}
-			/>
-		</div>
-
-		<!-- Membership entry point.
+			<!-- Membership entry point.
 
 		     The plan grid used to live here, above the resources, series and
 		     events this page exists to show. It moved to /org/[slug]/membership
 		     (#720) — a tier can only be *chosen* there — and what is left is the
 		     pointer at it. The `id="membership"` stays so the deep links that
 		     predate the move still land on something that explains itself. -->
-		{#if organization.accept_membership_requests || data.membershipPlans.length > 0}
-			<section id="membership" aria-labelledby="membership-heading" class="mb-12">
-				<SectionHeader
-					volume="celebration"
-					id="membership-heading"
-					title={m['membershipPlans.heading']()}
-				/>
-				<p class="mt-1 text-sm text-muted-foreground">
-					{m['membershipTiers.landingBlurb']({ organizationName: organization.name })}
-				</p>
-				<a
-					href={resolve('/(public)/org/[slug]/membership', { slug: organization.slug })}
-					class="mt-3 inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				>
-					{m['membershipPlans.viewMembership']()}
-					<ArrowRight class="h-4 w-4" aria-hidden="true" />
-				</a>
-			</section>
-		{/if}
-
-		<!-- Resources Section -->
-		{#if displayedResources.length > 0}
-			<section aria-labelledby="resources-heading" class="mb-12">
-				<div class="mb-6 flex items-center justify-between">
-					<div>
-						<SectionHeader
-							volume="celebration"
-							id="resources-heading"
-							title={m['organizationProfile.resources_heading']()}
-						/>
-						<p class="mt-1 text-sm text-muted-foreground">
-							{m['organizationProfile.resources_description']({
-								organizationName: organization.name
-							})}
-						</p>
-					</div>
+			{#if organization.accept_membership_requests || data.membershipPlans.length > 0}
+				<section id="membership" aria-labelledby="membership-heading" class="mb-12">
+					<SectionHeader
+						volume="celebration"
+						id="membership-heading"
+						title={m['membershipPlans.heading']()}
+					/>
+					<p class="mt-1 text-sm text-muted-foreground">
+						{m['membershipTiers.landingBlurb']({ organizationName: organization.name })}
+					</p>
 					<a
-						href={resolve('/(public)/org/[slug]/resources', { slug: organization.slug })}
-						class="text-sm font-bold text-primary hover:underline"
+						href={resolve('/(public)/org/[slug]/membership', { slug: organization.slug })}
+						class="mt-3 inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
-						{m['organizationProfile.resources_viewAll']()}
+						{m['membershipPlans.viewMembership']()}
+						<ArrowRight class="h-4 w-4" aria-hidden="true" />
 					</a>
-				</div>
-				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{#each displayedResources as resource (resource.id)}
-						<ResourceCard {resource} />
-					{/each}
-				</div>
-			</section>
-		{/if}
+				</section>
+			{/if}
 
-		<!-- Event Series Section -->
-		{#if !seriesQuery.isError && (eventSeries.length > 0 || seriesQuery.isLoading)}
-			<section aria-labelledby="series-heading" class="mb-12">
-				<div class="mb-6 flex items-center justify-between">
+			<!-- Resources Section -->
+			{#if displayedResources.length > 0}
+				<section aria-labelledby="resources-heading" class="mb-12">
+					<div class="mb-6 flex items-center justify-between">
+						<div>
+							<SectionHeader
+								volume="celebration"
+								id="resources-heading"
+								title={m['organizationProfile.resources_heading']()}
+							/>
+							<p class="mt-1 text-sm text-muted-foreground">
+								{m['organizationProfile.resources_description']({
+									organizationName: organization.name
+								})}
+							</p>
+						</div>
+						<a
+							href={resolve('/(public)/org/[slug]/resources', { slug: organization.slug })}
+							class="text-sm font-bold text-primary hover:underline"
+						>
+							{m['organizationProfile.resources_viewAll']()}
+						</a>
+					</div>
+					<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{#each displayedResources as resource (resource.id)}
+							<ResourceCard {resource} />
+						{/each}
+					</div>
+				</section>
+			{/if}
+
+			<!-- Event Series Section -->
+			{#if !seriesQuery.isError && (eventSeries.length > 0 || seriesQuery.isLoading)}
+				<section aria-labelledby="series-heading" class="mb-12">
+					<div class="mb-6 flex items-center justify-between">
+						<div>
+							<SectionHeader
+								volume="celebration"
+								id="series-heading"
+								title={m['organizationProfile.eventSeries_heading']()}
+							/>
+							<p class="mt-1 text-sm text-muted-foreground">
+								{m['organizationProfile.eventSeries_description']({
+									organizationName: organization.name
+								})}
+							</p>
+						</div>
+					</div>
+
+					{#if seriesQuery.isLoading}
+						<!-- Loading State -->
+						<div class="rounded-lg border-2 bg-card p-8 text-center shadow-poster">
+							<Repeat class="mx-auto mb-4 h-12 w-12 animate-pulse text-muted-foreground" />
+							<p class="text-muted-foreground">{m['organizationProfile.eventSeries_loading']()}</p>
+						</div>
+					{:else if eventSeries.length > 0}
+						<!-- Series Cards Grid -->
+						<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+							{#each eventSeries as series (series.id)}
+								<EventSeriesCard {series} />
+							{/each}
+						</div>
+
+						<!-- Pagination -->
+						{#if seriesTotalPages > 1}
+							<div class="mt-6 flex items-center justify-center gap-2">
+								<button
+									type="button"
+									disabled={seriesPage === 1}
+									onclick={() => (seriesPage = seriesPage - 1)}
+									class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+								>
+									{m['common.pagination_previous']()}
+								</button>
+								<span class="text-sm text-muted-foreground">
+									{m['common.pagination_page']()}
+									{seriesPage}
+									{m['common.pagination_of']()}
+									{seriesTotalPages}
+								</span>
+								<button
+									type="button"
+									disabled={seriesPage >= seriesTotalPages}
+									onclick={() => (seriesPage = seriesPage + 1)}
+									class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+								>
+									{m['common.pagination_next']()}
+								</button>
+							</div>
+						{/if}
+					{/if}
+				</section>
+			{/if}
+
+			<!-- Events Section -->
+			<section aria-labelledby="events-heading" class="mb-12">
+				<div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 					<div>
 						<SectionHeader
 							volume="celebration"
-							id="series-heading"
-							title={m['organizationProfile.eventSeries_heading']()}
+							id="events-heading"
+							title={m['organizationProfile.events_heading']()}
 						/>
 						<p class="mt-1 text-sm text-muted-foreground">
-							{m['organizationProfile.eventSeries_description']({
-								organizationName: organization.name
-							})}
+							{m['organizationProfile.events_description']({ organizationName: organization.name })}
 						</p>
+					</div>
+
+					<div class="flex flex-wrap items-center gap-4">
+						<!-- Filter Toggle -->
+						<div class="flex items-center gap-2">
+							<label for="include-past" class="text-sm font-bold"
+								>{m['organizationProfile.events_includePast']()}</label
+							>
+							<input
+								id="include-past"
+								type="checkbox"
+								bind:checked={includePastEvents}
+								class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
+							/>
+						</div>
+
+						<!-- Ticket Type Filter -->
+						<div class="flex items-center gap-2">
+							<Ticket class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+							{#each [{ value: 'ticketed', label: m['filters.ticketType.ticketed']() }, { value: 'free', label: m['filters.ticketType.free']() }] as option (option.value)}
+								{@const isSelected = ticketType === option.value}
+								<button
+									type="button"
+									onclick={() =>
+										(ticketType = isSelected ? undefined : (option.value as 'ticketed' | 'free'))}
+									class="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {isSelected
+										? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
+										: 'border-input bg-background hover:bg-accent hover:text-accent-foreground'}"
+									aria-pressed={isSelected}
+								>
+									{option.label}
+								</button>
+							{/each}
+						</div>
+
+						<!-- Sort Order Toggle -->
+						<button
+							type="button"
+							onclick={toggleEventsOrder}
+							class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+							aria-label={eventsOrderBy === '-start'
+								? 'Showing newest first'
+								: 'Showing oldest first'}
+						>
+							<ArrowDownUp class="h-4 w-4" aria-hidden="true" />
+							{eventsOrderBy === '-start'
+								? m['organizationProfile.events_newestFirst']()
+								: m['organizationProfile.events_oldestFirst']()}
+						</button>
+
+						<!-- Calendar View Shortcut -->
+						<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
+						<a
+							href="/events?organization={organization.id}&organization_name={encodeURIComponent(
+								organization.name
+							)}&organization_slug={organization.slug}&viewMode=calendar"
+							class="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+						>
+							<CalendarDays class="h-4 w-4" aria-hidden="true" />
+							{m['organizationProfile.events_calendar']()}
+						</a>
+						<!-- eslint-enable svelte/no-navigation-without-resolve -->
+
+						<!-- Browse All Button -->
+						<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
+						<a
+							href="/events?organization={organization.id}&organization_name={encodeURIComponent(
+								organization.name
+							)}&organization_slug={organization.slug}"
+							class="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+						>
+							{m['organizationProfile.events_browseAll']()}
+							<ArrowRight class="h-4 w-4" aria-hidden="true" />
+						</a>
+						<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					</div>
 				</div>
 
-				{#if seriesQuery.isLoading}
+				{#if eventsQuery.isLoading}
 					<!-- Loading State -->
-					<div class="rounded-lg border bg-card p-8 text-center">
-						<Repeat class="mx-auto mb-4 h-12 w-12 animate-pulse text-muted-foreground" />
-						<p class="text-muted-foreground">{m['organizationProfile.eventSeries_loading']()}</p>
+					<div class="rounded-lg border-2 bg-card p-8 text-center shadow-poster">
+						<Calendar class="mx-auto mb-4 h-12 w-12 animate-pulse text-muted-foreground" />
+						<p class="text-muted-foreground">{m['organizationProfile.events_loading']()}</p>
 					</div>
-				{:else if eventSeries.length > 0}
-					<!-- Series Cards Grid -->
+				{:else if eventsQuery.isError}
+					<!-- Error State. `bg-card` rather than a `bg-destructive/5` wash: the
+				     panel underneath is itself tinted now, so a second alpha would
+				     stack two composites under `text-destructive`. On card it is the
+				     audited token pair, and the doubled destructive edge carries the
+				     alarm. -->
+					<div class="rounded-lg border-2 border-destructive bg-card p-8 text-center shadow-poster">
+						<p class="font-semibold text-destructive">{m['organizationProfile.events_failed']()}</p>
+						<p class="mt-2 text-sm text-muted-foreground">
+							{m['common.errors_refreshPage']()}
+						</p>
+					</div>
+				{:else if events.length === 0}
+					<EmptyState
+						icon={Calendar}
+						title={includePastEvents
+							? m['organizationProfile.events_noEvents']()
+							: m['organizationProfile.events_noUpcoming']()}
+						body={includePastEvents
+							? m['organizationProfile.events_noEventsYet']({ organizationName: organization.name })
+							: m['organizationProfile.events_noUpcomingScheduled']({
+									organizationName: organization.name
+								})}
+					>
+						{#snippet action()}
+							{#if !includePastEvents}
+								<button
+									type="button"
+									onclick={() => (includePastEvents = true)}
+									class="text-sm font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+								>
+									{m['organizationProfile.events_viewPast']()}
+								</button>
+							{/if}
+						{/snippet}
+					</EmptyState>
+				{:else}
+					<!-- Event Cards Grid -->
 					<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-						{#each eventSeries as series (series.id)}
-							<EventSeriesCard {series} />
+						{#each events as event (event.id)}
+							<EventCard {event} />
 						{/each}
 					</div>
 
 					<!-- Pagination -->
-					{#if seriesTotalPages > 1}
+					{#if eventsTotalPages > 1}
 						<div class="mt-6 flex items-center justify-center gap-2">
 							<button
 								type="button"
-								disabled={seriesPage === 1}
-								onclick={() => (seriesPage = seriesPage - 1)}
+								disabled={eventsPage === 1}
+								onclick={() => (eventsPage = eventsPage - 1)}
 								class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
 							>
 								{m['common.pagination_previous']()}
 							</button>
 							<span class="text-sm text-muted-foreground">
 								{m['common.pagination_page']()}
-								{seriesPage}
+								{eventsPage}
 								{m['common.pagination_of']()}
-								{seriesTotalPages}
+								{eventsTotalPages}
 							</span>
 							<button
 								type="button"
-								disabled={seriesPage >= seriesTotalPages}
-								onclick={() => (seriesPage = seriesPage + 1)}
+								disabled={eventsPage >= eventsTotalPages}
+								onclick={() => (eventsPage = eventsPage + 1)}
 								class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
 							>
 								{m['common.pagination_next']()}
@@ -486,198 +702,32 @@
 					{/if}
 				{/if}
 			</section>
-		{/if}
 
-		<!-- Events Section -->
-		<section aria-labelledby="events-heading" class="mb-12">
-			<div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div>
+			<!-- Tags Section -->
+			{#if organization.tags && organization.tags.length > 0}
+				<section aria-labelledby="tags-heading" class="border-t pt-8">
 					<SectionHeader
 						volume="celebration"
-						id="events-heading"
-						title={m['organizationProfile.events_heading']()}
+						id="tags-heading"
+						title={m['eventDetails.tags_heading']()}
+						class="mb-4"
 					/>
-					<p class="mt-1 text-sm text-muted-foreground">
-						{m['organizationProfile.events_description']({ organizationName: organization.name })}
-					</p>
-				</div>
-
-				<div class="flex flex-wrap items-center gap-4">
-					<!-- Filter Toggle -->
-					<div class="flex items-center gap-2">
-						<label for="include-past" class="text-sm font-bold"
-							>{m['organizationProfile.events_includePast']()}</label
-						>
-						<input
-							id="include-past"
-							type="checkbox"
-							bind:checked={includePastEvents}
-							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary focus:ring-offset-2"
-						/>
-					</div>
-
-					<!-- Ticket Type Filter -->
-					<div class="flex items-center gap-2">
-						<Ticket class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-						{#each [{ value: 'ticketed', label: m['filters.ticketType.ticketed']() }, { value: 'free', label: m['filters.ticketType.free']() }] as option (option.value)}
-							{@const isSelected = ticketType === option.value}
-							<button
-								type="button"
-								onclick={() =>
-									(ticketType = isSelected ? undefined : (option.value as 'ticketed' | 'free'))}
-								class="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {isSelected
-									? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
-									: 'border-input bg-background hover:bg-accent hover:text-accent-foreground'}"
-								aria-pressed={isSelected}
-							>
-								{option.label}
-							</button>
-						{/each}
-					</div>
-
-					<!-- Sort Order Toggle -->
-					<button
-						type="button"
-						onclick={toggleEventsOrder}
-						class="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-						aria-label={eventsOrderBy === '-start'
-							? 'Showing newest first'
-							: 'Showing oldest first'}
-					>
-						<ArrowDownUp class="h-4 w-4" aria-hidden="true" />
-						{eventsOrderBy === '-start'
-							? m['organizationProfile.events_newestFirst']()
-							: m['organizationProfile.events_oldestFirst']()}
-					</button>
-
-					<!-- Calendar View Shortcut -->
-					<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
-					<a
-						href="/events?organization={organization.id}&organization_name={encodeURIComponent(
-							organization.name
-						)}&organization_slug={organization.slug}&viewMode=calendar"
-						class="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
-					>
-						<CalendarDays class="h-4 w-4" aria-hidden="true" />
-						{m['organizationProfile.events_calendar']()}
-					</a>
-					<!-- eslint-enable svelte/no-navigation-without-resolve -->
-
-					<!-- Browse All Button -->
-					<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
-					<a
-						href="/events?organization={organization.id}&organization_name={encodeURIComponent(
-							organization.name
-						)}&organization_slug={organization.slug}"
-						class="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
-					>
-						{m['organizationProfile.events_browseAll']()}
-						<ArrowRight class="h-4 w-4" aria-hidden="true" />
-					</a>
-					<!-- eslint-enable svelte/no-navigation-without-resolve -->
-				</div>
-			</div>
-
-			{#if eventsQuery.isLoading}
-				<!-- Loading State -->
-				<div class="rounded-lg border bg-card p-8 text-center">
-					<Calendar class="mx-auto mb-4 h-12 w-12 animate-pulse text-muted-foreground" />
-					<p class="text-muted-foreground">{m['organizationProfile.events_loading']()}</p>
-				</div>
-			{:else if eventsQuery.isError}
-				<!-- Error State -->
-				<div class="rounded-lg border border-destructive/20 bg-destructive/5 p-8 text-center">
-					<p class="font-semibold text-destructive">{m['organizationProfile.events_failed']()}</p>
-					<p class="mt-2 text-sm text-muted-foreground">
-						{m['common.errors_refreshPage']()}
-					</p>
-				</div>
-			{:else if events.length === 0}
-				<EmptyState
-					icon={Calendar}
-					title={includePastEvents
-						? m['organizationProfile.events_noEvents']()
-						: m['organizationProfile.events_noUpcoming']()}
-					body={includePastEvents
-						? m['organizationProfile.events_noEventsYet']({ organizationName: organization.name })
-						: m['organizationProfile.events_noUpcomingScheduled']({
-								organizationName: organization.name
-							})}
-				>
-					{#snippet action()}
-						{#if !includePastEvents}
-							<button
-								type="button"
-								onclick={() => (includePastEvents = true)}
-								class="text-sm font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-							>
-								{m['organizationProfile.events_viewPast']()}
-							</button>
-						{/if}
-					{/snippet}
-				</EmptyState>
-			{:else}
-				<!-- Event Cards Grid -->
-				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{#each events as event (event.id)}
-						<EventCard {event} />
-					{/each}
-				</div>
-
-				<!-- Pagination -->
-				{#if eventsTotalPages > 1}
-					<div class="mt-6 flex items-center justify-center gap-2">
-						<button
-							type="button"
-							disabled={eventsPage === 1}
-							onclick={() => (eventsPage = eventsPage - 1)}
-							class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-						>
-							{m['common.pagination_previous']()}
-						</button>
-						<span class="text-sm text-muted-foreground">
-							{m['common.pagination_page']()}
-							{eventsPage}
-							{m['common.pagination_of']()}
-							{eventsTotalPages}
-						</span>
-						<button
-							type="button"
-							disabled={eventsPage >= eventsTotalPages}
-							onclick={() => (eventsPage = eventsPage + 1)}
-							class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-						>
-							{m['common.pagination_next']()}
-						</button>
-					</div>
-				{/if}
-			{/if}
-		</section>
-
-		<!-- Tags Section -->
-		{#if organization.tags && organization.tags.length > 0}
-			<section aria-labelledby="tags-heading" class="border-t pt-8">
-				<SectionHeader
-					volume="celebration"
-					id="tags-heading"
-					title={m['eventDetails.tags_heading']()}
-					class="mb-4"
-				/>
-				<!-- Tag chips: primary on a 10% primary tint. The tint composites to
+					<!-- Tag chips: primary on a 10% primary tint. The tint composites to
 				     ~the page colour, so primary-vs-background governs — 5.3:1 light /
 				     5.9:1 dark (hand-recomputed; a composited alpha is invisible to
 				     scripts/audit-brand-themes.py). -->
-				<div class="flex flex-wrap gap-2">
-					{#each organization.tags as tag (tag)}
-						<span class="rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary">
-							{tag}
-						</span>
-					{/each}
-				</div>
-			</section>
-		{/if}
+					<div class="flex flex-wrap gap-2">
+						{#each organization.tags as tag (tag)}
+							<span class="rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary">
+								{tag}
+							</span>
+						{/each}
+					</div>
+				</section>
+			{/if}
 
-		<!-- Announcements Section -->
-		<OrgAnnouncements organizationSlug={organization.slug} />
+			<!-- Announcements Section -->
+			<OrgAnnouncements organizationSlug={organization.slug} />
+		</div>
 	</div>
 </div>

--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -712,13 +712,18 @@
 						title={m['eventDetails.tags_heading']()}
 						class="mb-4"
 					/>
-					<!-- Tag chips: primary on a 10% primary tint. The tint composites to
-				     ~the page colour, so primary-vs-background governs — 5.3:1 light /
-				     5.9:1 dark (hand-recomputed; a composited alpha is invisible to
-				     scripts/audit-brand-themes.py). -->
+					<!-- Tag chips: primary on the card surface with a 2px primary edge —
+				     poster stickers, not washes (mirrors the event detail page's tags
+				     section). This comment used to claim 5.3:1 for `bg-primary/10` on
+				     the `bg-secondary/55` wash; the honest composite is 4.29:1, under
+				     the 4.5:1 floor for 14px bold text. The card fill is opaque, so the
+				     audited primary-vs-card pair governs instead: 6.99:1 light /
+				     6.27:1 dark (the same pair the questionnaire option rows rest on). -->
 					<div class="flex flex-wrap gap-2">
 						{#each organization.tags as tag (tag)}
-							<span class="rounded-full bg-primary/10 px-3 py-1 text-sm font-bold text-primary">
+							<span
+								class="rounded-full border-2 border-primary/40 bg-card px-3 py-1 text-sm font-bold text-primary shadow-poster"
+							>
 								{tag}
 							</span>
 						{/each}

--- a/src/routes/(public)/org/[slug]/membership/+page.svelte
+++ b/src/routes/(public)/org/[slug]/membership/+page.svelte
@@ -13,21 +13,13 @@
 
 <SeoHead config={data.seo} />
 
-<!--
-	Tinted page panel (uplift, spec §9) — the org profile's wash, so following
-	"View membership" from that page lands on the same surface rather than
-	dropping back onto bare paper. Full-bleed with `min-h-screen`, so a short
-	tier list cannot leave a `--background` strip underneath. Composite and
-	therefore ratios are identical to the profile's (a composited alpha is
-	invisible to scripts/audit-brand-themes.py):
-	  light — secondary@55 over background ⇒ hsl(231 88% 90%);
-	          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
-	  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
-	          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
-	The back link (`muted-foreground`) is the only copy that lands directly on
-	it; everything else is inside the header block or a tier card.
--->
-<div class="min-h-screen bg-secondary/55 dark:bg-secondary/[0.28]">
+<!-- Plain `--background` under `MembershipSection`'s own colour block: a
+     `bg-secondary` wash sits 5 points of lightness from a `bg-secondary` block
+     in light mode, which would flatten the block into the page. The tinted wash
+     is reserved for the pages whose header is the mode-inert poster-purple
+     ribbon (event, org profile, series). Tier cards float on their own
+     `shadow-poster`. -->
+<div class="min-h-screen">
 	<!-- The `(public)` layout does NOT wrap its children, so every page supplies its
 	     own container; without one the content runs edge to edge. Same values as the
 	     org landing page this is a sub-page of, so navigating between them does not

--- a/src/routes/(public)/org/[slug]/membership/+page.svelte
+++ b/src/routes/(public)/org/[slug]/membership/+page.svelte
@@ -13,27 +13,43 @@
 
 <SeoHead config={data.seo} />
 
-<!-- The `(public)` layout does NOT wrap its children, so every page supplies its
-     own container; without one the content runs edge to edge. Same values as the
-     org landing page this is a sub-page of, so navigating between them does not
-     shift the gutters. -->
-<div class="container mx-auto space-y-6 px-6 py-8 md:px-8 lg:py-12">
-	<a
-		href={resolve('/(public)/org/[slug]', { slug: organization.slug })}
-		class="inline-flex items-center gap-2 text-sm font-bold text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-	>
-		<ArrowLeft class="h-4 w-4" aria-hidden="true" />
-		{m['membershipTiers.backToOrg']({ organizationName: organization.name })}
-	</a>
+<!--
+	Tinted page panel (uplift, spec §9) — the org profile's wash, so following
+	"View membership" from that page lands on the same surface rather than
+	dropping back onto bare paper. Full-bleed with `min-h-screen`, so a short
+	tier list cannot leave a `--background` strip underneath. Composite and
+	therefore ratios are identical to the profile's (a composited alpha is
+	invisible to scripts/audit-brand-themes.py):
+	  light — secondary@55 over background ⇒ hsl(231 88% 90%);
+	          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+	  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
+	          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+	The back link (`muted-foreground`) is the only copy that lands directly on
+	it; everything else is inside the header block or a tier card.
+-->
+<div class="min-h-screen bg-secondary/55 dark:bg-secondary/[0.28]">
+	<!-- The `(public)` layout does NOT wrap its children, so every page supplies its
+	     own container; without one the content runs edge to edge. Same values as the
+	     org landing page this is a sub-page of, so navigating between them does not
+	     shift the gutters. -->
+	<div class="container mx-auto space-y-6 px-6 py-8 md:px-8 lg:py-12">
+		<a
+			href={resolve('/(public)/org/[slug]', { slug: organization.slug })}
+			class="inline-flex items-center gap-2 text-sm font-bold text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+		>
+			<ArrowLeft class="h-4 w-4" aria-hidden="true" />
+			{m['membershipTiers.backToOrg']({ organizationName: organization.name })}
+		</a>
 
-	<MembershipSection
-		{organization}
-		tiers={data.tiers}
-		isAuthenticated={data.isAuthenticated}
-		isMember={data.isMember}
-		membershipTier={data.membershipTier}
-		membershipStatus={data.membershipStatus}
-		isOwner={data.isOwner}
-		isStaff={data.isStaff}
-	/>
+		<MembershipSection
+			{organization}
+			tiers={data.tiers}
+			isAuthenticated={data.isAuthenticated}
+			isMember={data.isMember}
+			membershipTier={data.membershipTier}
+			membershipStatus={data.membershipStatus}
+			isOwner={data.isOwner}
+			isStaff={data.isStaff}
+		/>
+	</div>
 </div>

--- a/src/routes/(public)/org/[slug]/polls/[id]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/polls/[id]/+page.svelte
@@ -10,6 +10,7 @@
 	import PollStatusBadge from '$lib/components/polls/PollStatusBadge.svelte';
 	import PollVoteForm from '$lib/components/polls/PollVoteForm.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import { pollWithdrawVoteAction } from '$lib/api/generated/sdk.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import type { PageData } from './$types';
@@ -78,151 +79,183 @@
 	<title>{m['pollVoterPage.title']({ name: poll?.questionnaire?.name ?? 'Poll' })}</title>
 </svelte:head>
 
-<main class="container mx-auto max-w-3xl space-y-6 px-4 py-8">
-	{#if data.forbidden}
-		<!--
-			Backend returned 403: the poll exists but the caller is not in any
-			audience. We don't have poll data to render the privacy summary, so
-			show a self-contained no-access page rather than falling through to
-			the global 404.
-		-->
-		<Card class="border-highlight/60">
-			<CardHeader>
-				<CardTitle level={2}>{m['pollVoterPage.forbiddenTitle']()}</CardTitle>
-			</CardHeader>
-			<CardContent class="space-y-3 py-4 text-sm">
-				<p>{m['pollVoterPage.forbiddenBody']()}</p>
-				{#if !data.isAuthenticated}
-					<Button href={`/login?next=${encodeURIComponent($page.url.pathname)}`}>
-						{m['pollVoterPage.signIn']()}
-					</Button>
-				{/if}
-			</CardContent>
-		</Card>
-	{:else if poll}
-		<Card>
-			<CardHeader>
-				<CardTitle level={2} class="flex items-center justify-between gap-2">
-					<span>{poll.questionnaire?.name ?? 'Poll'}</span>
-					<PollStatusBadge status={poll.status} />
-				</CardTitle>
-			</CardHeader>
-			<CardContent>
-				{#if poll.questionnaire?.description}
-					<p class="text-sm text-muted-foreground">{poll.questionnaire.description}</p>
-				{/if}
-			</CardContent>
-		</Card>
+<!--
+	Colour-block header band (uplift, spec §9). It replaces the title Card, which
+	also closes a real gap: this page had NO h1 at all — the poll's name was a
+	level-2 CardTitle and the level-2s below it had nothing to sit under. The
+	band's `PageHeader` is that h1 now, in both branches.
 
-		<PollPrivacySummary
-			voteVisibility={poll.vote_visibility}
-			resultVisibility={poll.result_visibility}
-			resultTiming={poll.result_timing}
-			staffAnonymous={poll.staff_anonymous}
-			publicAnonymous={poll.public_anonymous}
-			allowVoteChanges={poll.allow_vote_changes}
-		/>
+	`bg-secondary` at full strength is the audit-enforced pair the questionnaire
+	routes' band uses; `onBand` keeps the kicker off `text-primary`, which does
+	not clear AA on the light periwinkle (4.12:1 — see PageHeader). The status
+	badge rides `actions`, never `decoration`: that slot is aria-hidden ornament
+	and a poll's open/closed state is not ornament.
+-->
+<div class="flex min-h-screen flex-col bg-background">
+	<section class="bg-secondary text-secondary-foreground">
+		<div class="container mx-auto max-w-3xl px-4 pb-16 pt-8">
+			{#if data.forbidden}
+				<PageHeader volume="poster" onBand title={m['pollVoterPage.forbiddenTitle']()} />
+			{:else if poll}
+				<PageHeader
+					volume="poster"
+					onBand
+					title={poll.questionnaire?.name ?? 'Poll'}
+					subtitle={poll.questionnaire?.description ?? undefined}
+				>
+					{#snippet actions()}
+						<PollStatusBadge status={poll.status} />
+					{/snippet}
+				</PageHeader>
+			{/if}
+		</div>
+	</section>
 
-		<!-- State banners — order matters; first match wins -->
-		{#if poll.status === 'draft'}
-			<Card class="border-highlight/60">
-				<CardContent class="py-4 text-sm">{m['pollVoterPage.draftBanner']()}</CardContent>
-			</Card>
-		{:else if requiresAuth}
-			<!--
-				Anonymous viewer on public/unlisted poll: they can see the poll,
-				but voting needs auth. Surface a sign-in CTA rather than the
-				generic "ineligible" banner (which implies they couldn't vote
-				even if signed in).
-			-->
-			<!-- Info tint: `bg-info/10` composites to ~the card colour, so the copy
-			     keeps `text-card-foreground` and the token contract's AA guarantee. -->
-			<Card class="border-info/60 bg-info/10">
-				<CardContent class="space-y-2 py-4 text-sm">
-					<p>{m['pollVoterPage.signInToVote']()}</p>
-					<Button href={`/login?next=${encodeURIComponent($page.url.pathname)}`}
-						>{m['pollVoterPage.signIn']()}</Button
-					>
-				</CardContent>
-			</Card>
-		{:else if poll.status === 'closed' && poll.user_has_voted}
-			<Card>
-				<CardContent class="py-4 text-sm">{m['pollVoterPage.closedVotedBanner']()}</CardContent>
-			</Card>
-		{:else if poll.status === 'closed'}
-			<Card>
-				<CardContent class="py-4 text-sm">{m['pollVoterPage.closedNotVotedBanner']()}</CardContent>
-			</Card>
-		{:else if poll.status === 'open' && !poll.user_can_vote && !poll.user_has_voted}
-			<!--
-				Authenticated viewer who passes the BE audience check
-				(otherwise we'd be in the data.forbidden branch above) but
-				can't vote — typically a tier mismatch. We deliberately KEEP
-				the PollPrivacySummary visible above this banner so the user
-				can see WHY they're ineligible ("members in tier X"), unlike
-				the forbidden card which strips all poll details from
-				non-audience callers.
-			-->
-			<Card class="border-highlight/60">
-				<CardContent class="py-4 text-sm">{m['pollVoterPage.ineligibleBanner']()}</CardContent>
-			</Card>
-		{:else if showVotedBanner}
-			<Card>
-				<CardContent class="space-y-2 py-4 text-sm">
-					<p>{m['pollVoterPage.votedBanner']()}</p>
-					{#if poll.status === 'open' && poll.allow_vote_changes}
-						<div class="flex flex-wrap gap-2">
-							<Button variant="outline" size="sm" onclick={() => (editing = true)}>
-								{m['pollVoterPage.changeVote']()}
+	<!--
+		Tinted content panel — the same wash the event page and the org surfaces
+		use, so every card below floats. Composite and ratios are identical to
+		those pages' (a composited alpha is invisible to
+		scripts/audit-brand-themes.py):
+		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
+		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
+		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		Nothing lands directly on it — every block here is a Card — so the panel
+		is pure depth.
+	-->
+	<div class="flex-1 bg-secondary/55 dark:bg-secondary/[0.28]">
+		<main class="container mx-auto -mt-8 max-w-3xl space-y-6 px-4 pb-8">
+			{#if data.forbidden}
+				<!--
+					Backend returned 403: the poll exists but the caller is not in any
+					audience. We don't have poll data to render the privacy summary, so
+					show a self-contained no-access page rather than falling through to
+					the global 404.
+				-->
+				<Card class="border-highlight/60">
+					<CardContent class="space-y-3 py-4 text-sm">
+						<p>{m['pollVoterPage.forbiddenBody']()}</p>
+						{#if !data.isAuthenticated}
+							<Button href={`/login?next=${encodeURIComponent($page.url.pathname)}`}>
+								{m['pollVoterPage.signIn']()}
 							</Button>
-							<Button
-								variant="outline"
-								size="sm"
-								onclick={() => (withdrawConfirmOpen = true)}
-								disabled={withdrawing}
+						{/if}
+					</CardContent>
+				</Card>
+			{:else if poll}
+				<PollPrivacySummary
+					voteVisibility={poll.vote_visibility}
+					resultVisibility={poll.result_visibility}
+					resultTiming={poll.result_timing}
+					staffAnonymous={poll.staff_anonymous}
+					publicAnonymous={poll.public_anonymous}
+					allowVoteChanges={poll.allow_vote_changes}
+				/>
+
+				<!-- State banners — order matters; first match wins -->
+				{#if poll.status === 'draft'}
+					<Card class="border-highlight/60">
+						<CardContent class="py-4 text-sm">{m['pollVoterPage.draftBanner']()}</CardContent>
+					</Card>
+				{:else if requiresAuth}
+					<!--
+						Anonymous viewer on public/unlisted poll: they can see the poll,
+						but voting needs auth. Surface a sign-in CTA rather than the
+						generic "ineligible" banner (which implies they couldn't vote
+						even if signed in).
+					-->
+					<!-- Info tint: `bg-info/10` composites to ~the card colour, so the copy
+					     keeps `text-card-foreground` and the token contract's AA guarantee. -->
+					<Card class="border-info/60 bg-info/10">
+						<CardContent class="space-y-2 py-4 text-sm">
+							<p>{m['pollVoterPage.signInToVote']()}</p>
+							<Button href={`/login?next=${encodeURIComponent($page.url.pathname)}`}
+								>{m['pollVoterPage.signIn']()}</Button
 							>
-								{m['pollVoterPage.withdrawVote']()}
-							</Button>
-						</div>
-					{/if}
-				</CardContent>
-			</Card>
-		{/if}
+						</CardContent>
+					</Card>
+				{:else if poll.status === 'closed' && poll.user_has_voted}
+					<Card>
+						<CardContent class="py-4 text-sm">{m['pollVoterPage.closedVotedBanner']()}</CardContent>
+					</Card>
+				{:else if poll.status === 'closed'}
+					<Card>
+						<CardContent class="py-4 text-sm"
+							>{m['pollVoterPage.closedNotVotedBanner']()}</CardContent
+						>
+					</Card>
+				{:else if poll.status === 'open' && !poll.user_can_vote && !poll.user_has_voted}
+					<!--
+						Authenticated viewer who passes the BE audience check
+						(otherwise we'd be in the data.forbidden branch above) but
+						can't vote — typically a tier mismatch. We deliberately KEEP
+						the PollPrivacySummary visible above this banner so the user
+						can see WHY they're ineligible ("members in tier X"), unlike
+						the forbidden card which strips all poll details from
+						non-audience callers.
+					-->
+					<Card class="border-highlight/60">
+						<CardContent class="py-4 text-sm">{m['pollVoterPage.ineligibleBanner']()}</CardContent>
+					</Card>
+				{:else if showVotedBanner}
+					<Card>
+						<CardContent class="space-y-2 py-4 text-sm">
+							<p>{m['pollVoterPage.votedBanner']()}</p>
+							{#if poll.status === 'open' && poll.allow_vote_changes}
+								<div class="flex flex-wrap gap-2">
+									<Button variant="outline" size="sm" onclick={() => (editing = true)}>
+										{m['pollVoterPage.changeVote']()}
+									</Button>
+									<Button
+										variant="outline"
+										size="sm"
+										onclick={() => (withdrawConfirmOpen = true)}
+										disabled={withdrawing}
+									>
+										{m['pollVoterPage.withdrawVote']()}
+									</Button>
+								</div>
+							{/if}
+						</CardContent>
+					</Card>
+				{/if}
 
-		<!-- Vote form -->
-		{#if showForm && poll.questionnaire}
-			<Card>
-				<CardHeader>
-					<CardTitle level={2}>{m['pollVoterPage.castVoteTitle']()}</CardTitle>
-				</CardHeader>
-				<CardContent>
-					<PollVoteForm
-						questionnaire={poll.questionnaire}
-						pollId={poll.id}
-						initialVote={poll.user_vote}
-						onSuccess={handleVoteSuccess}
-					/>
-				</CardContent>
-			</Card>
-		{/if}
+				<!-- Vote form -->
+				{#if showForm && poll.questionnaire}
+					<Card>
+						<CardHeader>
+							<CardTitle level={2}>{m['pollVoterPage.castVoteTitle']()}</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<PollVoteForm
+								questionnaire={poll.questionnaire}
+								pollId={poll.id}
+								initialVote={poll.user_vote}
+								onSuccess={handleVoteSuccess}
+							/>
+						</CardContent>
+					</Card>
+				{/if}
 
-		<!-- Results -->
-		{#if poll.user_can_see_results && poll.results}
-			<Card>
-				<CardHeader>
-					<CardTitle level={2}>{m['pollVoterPage.resultsTitle']()}</CardTitle>
-				</CardHeader>
-				<CardContent>
-					{#if poll.results.total_voters > 0}
-						<PollResultsView results={poll.results} staffAnonymous={poll.staff_anonymous} />
-					{:else}
-						<p class="text-sm text-muted-foreground">{m['pollVoterPage.resultsEmpty']()}</p>
-					{/if}
-				</CardContent>
-			</Card>
-		{/if}
-	{/if}
-</main>
+				<!-- Results -->
+				{#if poll.user_can_see_results && poll.results}
+					<Card>
+						<CardHeader>
+							<CardTitle level={2}>{m['pollVoterPage.resultsTitle']()}</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{#if poll.results.total_voters > 0}
+								<PollResultsView results={poll.results} staffAnonymous={poll.staff_anonymous} />
+							{:else}
+								<p class="text-sm text-muted-foreground">{m['pollVoterPage.resultsEmpty']()}</p>
+							{/if}
+						</CardContent>
+					</Card>
+				{/if}
+			{/if}
+		</main>
+	</div>
+</div>
 
 <ConfirmDialog
 	isOpen={withdrawConfirmOpen}

--- a/src/routes/(public)/org/[slug]/polls/[id]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/polls/[id]/+page.svelte
@@ -111,19 +111,11 @@
 		</div>
 	</section>
 
-	<!--
-		Tinted content panel — the same wash the event page and the org surfaces
-		use, so every card below floats. Composite and ratios are identical to
-		those pages' (a composited alpha is invisible to
-		scripts/audit-brand-themes.py):
-		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
-		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
-		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
-		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
-		Nothing lands directly on it — every block here is a Card — so the panel
-		is pure depth.
-	-->
-	<div class="flex-1 bg-secondary/55 dark:bg-secondary/[0.28]">
+	<!-- Body on plain `--background`, pulled up over the band's bottom edge — the
+	     merged questionnaire page's arrangement (see /events for why a
+	     `bg-secondary` band does not get a `bg-secondary` wash under it). Every
+	     block here is a Card, so the float is already theirs. -->
+	<div class="flex-1">
 		<main class="container mx-auto -mt-8 max-w-3xl space-y-6 px-4 pb-8">
 			{#if data.forbidden}
 				<!--

--- a/src/routes/(public)/org/[slug]/polls/[id]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/polls/[id]/+page.svelte
@@ -113,8 +113,13 @@
 
 	<!-- Body on plain `--background`, pulled up over the band's bottom edge — the
 	     merged questionnaire page's arrangement (see /events for why a
-	     `bg-secondary` band does not get a `bg-secondary` wash under it). Every
-	     block here is a Card, so the float is already theirs. -->
+	     `bg-secondary` band does not get a `bg-secondary` wash under it). Rule:
+	     when body content pulls up over a band this way, its first block must be
+	     an opaque surface — the pull-up straddles the band's own bottom edge, and
+	     a translucent block there shows a visible seam. `PollPrivacySummary` is
+	     that first block and is opaque `bg-card` for exactly this reason (it used
+	     to be `bg-card/50`, a 1.21:1 seam against the band); the Cards below it
+	     are opaque by default. -->
 	<div class="flex-1">
 		<main class="container mx-auto -mt-8 max-w-3xl space-y-6 px-4 pb-8">
 			{#if data.forbidden}

--- a/src/routes/(public)/org/[slug]/resources/+page.svelte
+++ b/src/routes/(public)/org/[slug]/resources/+page.svelte
@@ -80,18 +80,13 @@
 		</div>
 	</section>
 
-	<!--
-		Tinted content panel — the org profile's wash, so a resource list reads as
-		part of the same org. Composite and ratios identical to that page's (a
-		composited alpha is invisible to scripts/audit-brand-themes.py):
-		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
-		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
-		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
-		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
-		Nothing lands directly on it here — the toolbar controls and every card
-		carry their own surface — so the panel is pure depth.
-	-->
-	<div class="flex-1 bg-secondary/55 dark:bg-secondary/[0.28]">
+	<!-- Body on plain `--background`, pulled up over the band's bottom edge — the
+	     merged questionnaire page's arrangement. A `bg-secondary` wash under a
+	     `bg-secondary` band sits 5 points of lightness from it and the block stops
+	     reading as a block; the tinted wash is reserved for pages whose header is
+	     the mode-inert poster-purple ribbon (event, org profile, series). The
+	     float is the resource cards' `shadow-poster`. -->
+	<div class="flex-1">
 		<div class="container mx-auto -mt-8 space-y-6 px-6 pb-8 md:px-8 lg:pb-12">
 			<!-- Filters -->
 			<div class="flex flex-col gap-3 md:flex-row md:items-center">

--- a/src/routes/(public)/org/[slug]/resources/+page.svelte
+++ b/src/routes/(public)/org/[slug]/resources/+page.svelte
@@ -133,7 +133,8 @@
 					{#each filteredResources as resource (resource.id)}
 						<!-- Same silhouette and lift as the three discovery cards: `border-2`
 						     + `shadow-poster`, so a resource reads as a white sticker
-						     floating on the tinted panel. -->
+						     floating on the page — this route's body sits on plain
+						     `--background` (see the comment above), not a tinted panel. -->
 						<article
 							class="flex flex-col gap-3 rounded-lg border-2 bg-card p-4 shadow-poster transition-all hover:-translate-y-1 hover:shadow-poster-lg"
 						>

--- a/src/routes/(public)/org/[slug]/resources/+page.svelte
+++ b/src/routes/(public)/org/[slug]/resources/+page.svelte
@@ -54,103 +54,136 @@
 	/>
 </svelte:head>
 
-<!-- Same omission as the membership page had: the `(public)` layout does not wrap
-     its children, so a page without a container renders edge to edge. -->
-<div class="container mx-auto space-y-6 px-6 py-8 md:px-8 lg:py-12">
-	<!-- Header -->
-	<PageHeader
-		volume="celebration"
-		kicker={organization.name}
-		title={m['orgResourcesPage.title']()}
-		subtitle={m['orgResourcesPage.subtitle']({ organizationName: organization.name })}
-	/>
+<!-- `flex-col` so the tinted panel can take `flex-1`: an org with two resources
+     would otherwise leave a bare `--background` strip under the wash. -->
+<div class="flex min-h-screen flex-col bg-background">
+	<!--
+		Colour-block header band (uplift, spec §9), full-bleed: this route owns its
+		own h1, so unlike the membership sub-page it can bleed to the viewport
+		edge. Same full-strength `bg-secondary` poster panel as the discovery
+		listings — audit-enforced in both modes — and shallow, because what follows
+		is a search box and a grid.
 
-	<!-- Filters -->
-	<div class="flex flex-col gap-3 md:flex-row md:items-center">
-		<!-- Search -->
-		<div class="relative flex-1">
-			<Search
-				class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-				aria-hidden="true"
-			/>
-			<input
-				type="search"
-				bind:value={searchQuery}
-				placeholder={m['orgResourcesPage.searchPlaceholder']()}
-				class="w-full rounded-md border border-input bg-background py-2 pl-10 pr-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-				aria-label={m['orgResourcesPage.searchAriaLabel']()}
+		No sticker chip: the org's logo is not in this route's payload, and the
+		sticker-chip rule forbids the Revel mark as a stand-in.
+	-->
+	<section class="bg-secondary text-secondary-foreground">
+		<div class="container mx-auto px-6 pb-16 pt-8 md:px-8">
+			<!-- Header -->
+			<PageHeader
+				volume="poster"
+				onBand
+				kicker={organization.name}
+				title={m['orgResourcesPage.title']()}
+				subtitle={m['orgResourcesPage.subtitle']({ organizationName: organization.name })}
 			/>
 		</div>
+	</section>
 
-		<!-- Type Filter -->
-		<select
-			bind:value={typeFilter}
-			class="rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			aria-label={m['orgResourcesPage.filterAriaLabel']()}
-		>
-			<option value="all">{m['orgResourcesPage.filter_allTypes']()}</option>
-			<option value="file">{m['orgResourcesPage.filter_files']()}</option>
-			<option value="link">{m['orgResourcesPage.filter_links']()}</option>
-			<option value="text">{m['orgResourcesPage.filter_text']()}</option>
-		</select>
-	</div>
+	<!--
+		Tinted content panel — the org profile's wash, so a resource list reads as
+		part of the same org. Composite and ratios identical to that page's (a
+		composited alpha is invisible to scripts/audit-brand-themes.py):
+		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
+		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
+		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		Nothing lands directly on it here — the toolbar controls and every card
+		carry their own surface — so the panel is pure depth.
+	-->
+	<div class="flex-1 bg-secondary/55 dark:bg-secondary/[0.28]">
+		<div class="container mx-auto -mt-8 space-y-6 px-6 pb-8 md:px-8 lg:pb-12">
+			<!-- Filters -->
+			<div class="flex flex-col gap-3 md:flex-row md:items-center">
+				<!-- Search -->
+				<div class="relative flex-1">
+					<Search
+						class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+						aria-hidden="true"
+					/>
+					<input
+						type="search"
+						bind:value={searchQuery}
+						placeholder={m['orgResourcesPage.searchPlaceholder']()}
+						class="w-full rounded-md border border-input bg-background py-2 pl-10 pr-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+						aria-label={m['orgResourcesPage.searchAriaLabel']()}
+					/>
+				</div>
 
-	<!-- Resources Grid -->
-	{#if filteredResources.length === 0}
-		<EmptyState
-			level={2}
-			icon={Filter}
-			title={m['orgResourcesPage.empty_title']()}
-			body={searchQuery || typeFilter !== 'all'
-				? m['orgResourcesPage.empty_withFilters']()
-				: m['orgResourcesPage.empty_initial']()}
-		/>
-	{:else}
-		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-			{#each filteredResources as resource (resource.id)}
-				<article
-					class="flex flex-col gap-3 rounded-lg border bg-card p-4 transition-all hover:-translate-y-0.5 hover:shadow-lg"
+				<!-- Type Filter -->
+				<select
+					bind:value={typeFilter}
+					class="rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+					aria-label={m['orgResourcesPage.filterAriaLabel']()}
 				>
-					<!-- Header -->
-					<div class="flex items-start gap-3">
-						<ToneTile tone="brand" icon={FileText} />
-						<div class="min-w-0 flex-1">
-							<h3 class="truncate font-bold leading-tight">
-								{resource.name || m['orgResourcesPage.resource_untitled']()}
-							</h3>
-							<p class="text-xs capitalize text-muted-foreground">
-								{resource.resource_type}
-							</p>
-						</div>
-					</div>
+					<option value="all">{m['orgResourcesPage.filter_allTypes']()}</option>
+					<option value="file">{m['orgResourcesPage.filter_files']()}</option>
+					<option value="link">{m['orgResourcesPage.filter_links']()}</option>
+					<option value="text">{m['orgResourcesPage.filter_text']()}</option>
+				</select>
+			</div>
 
-					<!-- Description -->
-					{#if resource.description}
-						<p class="line-clamp-2 text-sm text-muted-foreground">
-							{resource.description}
-						</p>
-					{/if}
-
-					<!-- Action Button -->
-					{#if resource.resource_type !== 'text'}
-						<button
-							type="button"
-							onclick={() => openResource(resource)}
-							class="mt-auto rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+			<!-- Resources Grid -->
+			{#if filteredResources.length === 0}
+				<EmptyState
+					level={2}
+					icon={Filter}
+					title={m['orgResourcesPage.empty_title']()}
+					body={searchQuery || typeFilter !== 'all'
+						? m['orgResourcesPage.empty_withFilters']()
+						: m['orgResourcesPage.empty_initial']()}
+				/>
+			{:else}
+				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{#each filteredResources as resource (resource.id)}
+						<!-- Same silhouette and lift as the three discovery cards: `border-2`
+						     + `shadow-poster`, so a resource reads as a white sticker
+						     floating on the tinted panel. -->
+						<article
+							class="flex flex-col gap-3 rounded-lg border-2 bg-card p-4 shadow-poster transition-all hover:-translate-y-1 hover:shadow-poster-lg"
 						>
-							{resource.resource_type === 'file'
-								? m['orgResourcesPage.button_viewFile']()
-								: m['orgResourcesPage.button_openLink']()}
-						</button>
-					{:else if resource.text}
-						<div class="mt-auto rounded-md bg-muted/50 p-3 text-sm">
-							<p class="line-clamp-3 text-muted-foreground">
-								{resource.text}
-							</p>
-						</div>
-					{/if}
-				</article>
-			{/each}
+							<!-- Header -->
+							<div class="flex items-start gap-3">
+								<ToneTile tone="brand" icon={FileText} />
+								<div class="min-w-0 flex-1">
+									<h3 class="truncate font-bold leading-tight">
+										{resource.name || m['orgResourcesPage.resource_untitled']()}
+									</h3>
+									<p class="text-xs capitalize text-muted-foreground">
+										{resource.resource_type}
+									</p>
+								</div>
+							</div>
+
+							<!-- Description -->
+							{#if resource.description}
+								<p class="line-clamp-2 text-sm text-muted-foreground">
+									{resource.description}
+								</p>
+							{/if}
+
+							<!-- Action Button -->
+							{#if resource.resource_type !== 'text'}
+								<button
+									type="button"
+									onclick={() => openResource(resource)}
+									class="mt-auto rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+								>
+									{resource.resource_type === 'file'
+										? m['orgResourcesPage.button_viewFile']()
+										: m['orgResourcesPage.button_openLink']()}
+								</button>
+							{:else if resource.text}
+								<div class="mt-auto rounded-md bg-muted/50 p-3 text-sm">
+									<p class="line-clamp-3 text-muted-foreground">
+										{resource.text}
+									</p>
+								</div>
+							{/if}
+						</article>
+					{/each}
+				</div>
+			{/if}
 		</div>
-	{/if}
+	</div>
 </div>

--- a/src/routes/(public)/organizations/+page.svelte
+++ b/src/routes/(public)/organizations/+page.svelte
@@ -126,17 +126,11 @@
 		</div>
 	</section>
 
-	<!--
-		Tinted content panel — identical composite to /events and the event detail
-		page, so the same hand-verified ratios govern (a composited alpha is
-		invisible to scripts/audit-brand-themes.py):
-		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
-		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
-		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
-		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
-		(`muted-foreground` is the pagination tally, `foreground` the page indicator.)
-	-->
-	<div class="bg-secondary/55 pb-16 dark:bg-secondary/[0.28]">
+	<!-- Body on plain `--background`, pulled up over the band's bottom edge — see
+	     /events for why a `bg-secondary` band does NOT get a `bg-secondary` wash
+	     under it (they land 5 points of lightness apart and the block stops
+	     reading as a block). The float is the cards' `shadow-poster`. -->
+	<div class="pb-16">
 		<div class="container mx-auto px-4">
 			<!-- Main Content: Sidebar + Organization Grid -->
 			<div class="-mt-8 flex flex-col gap-8 lg:flex-row">

--- a/src/routes/(public)/organizations/+page.svelte
+++ b/src/routes/(public)/organizations/+page.svelte
@@ -87,170 +87,201 @@
 
 <SeoHead config={data.seo} />
 
-<div class="container mx-auto px-4 py-8">
-	<!-- Skip to content link for keyboard navigation -->
-	<a
-		href="#organizations-content"
-		class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
-	>
-		{m['browse.organizations_skipTo']()}
-	</a>
+<div class="bg-background">
+	<!--
+		Color-block header band (uplift, spec §9) — the twin of /events, so the two
+		discovery entrances read as one system rather than two designs. Same
+		full-strength `bg-secondary` poster panel (audit-enforced pair in both
+		modes), same shallow depth: a listing is a work surface.
 
-	<!-- Page Header -->
-	<PageHeader
-		volume="celebration"
-		kicker={m['browse.organizations_kicker']()}
-		title={m['browse.organizations_title']()}
-		subtitle={!error && totalCount > 0
-			? m['browse.organizations_count']({
-					count: totalCount,
-					organizationPlural:
-						totalCount === 1
-							? m['common.plurals_organization']()
-							: m['common.plurals_organizations']()
-				})
-			: undefined}
-		class="mb-8"
-	/>
+		No sticker chip: discovery speaks for no single organization, and the
+		sticker-chip rule forbids the Revel mark as filler.
+	-->
+	<section class="bg-secondary text-secondary-foreground">
+		<div class="container mx-auto px-4 pb-16 pt-8">
+			<!-- Skip to content link for keyboard navigation -->
+			<a
+				href="#organizations-content"
+				class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
+			>
+				{m['browse.organizations_skipTo']()}
+			</a>
 
-	<!-- Main Content: Sidebar + Organization Grid -->
-	<div class="flex flex-col gap-8 lg:flex-row">
-		<!-- Filter Sidebar (Desktop) -->
-		<div class="hidden lg:block lg:w-80 lg:shrink-0">
-			<div class="sticky top-8">
-				<OrganizationFilters
-					filters={currentFilters}
-					onUpdateFilters={handleUpdateFilters}
-					onClearFilters={handleClearFilters}
-				/>
-			</div>
+			<!-- Page Header -->
+			<PageHeader
+				volume="poster"
+				onBand
+				kicker={m['browse.organizations_kicker']()}
+				title={m['browse.organizations_title']()}
+				subtitle={!error && totalCount > 0
+					? m['browse.organizations_count']({
+							count: totalCount,
+							organizationPlural:
+								totalCount === 1
+									? m['common.plurals_organization']()
+									: m['common.plurals_organizations']()
+						})
+					: undefined}
+			/>
 		</div>
+	</section>
 
-		<!-- Organization Content -->
-		<div id="organizations-content" class="flex-1">
-			{#if error}
-				<!-- Error State -->
-				<div
-					class="rounded-lg border border-destructive bg-destructive/10 p-8 text-center"
-					role="alert"
-					aria-live="polite"
-				>
-					<p class="font-semibold text-destructive">{error}</p>
-					<p class="mt-2 text-sm text-muted-foreground">
-						{m['common.errors_refreshPage']()}
-					</p>
+	<!--
+		Tinted content panel — identical composite to /events and the event detail
+		page, so the same hand-verified ratios govern (a composited alpha is
+		invisible to scripts/audit-brand-themes.py):
+		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
+		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
+		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		(`muted-foreground` is the pagination tally, `foreground` the page indicator.)
+	-->
+	<div class="bg-secondary/55 pb-16 dark:bg-secondary/[0.28]">
+		<div class="container mx-auto px-4">
+			<!-- Main Content: Sidebar + Organization Grid -->
+			<div class="-mt-8 flex flex-col gap-8 lg:flex-row">
+				<!-- Filter Sidebar (Desktop) -->
+				<div class="hidden lg:block lg:w-80 lg:shrink-0">
+					<div class="sticky top-8">
+						<OrganizationFilters
+							filters={currentFilters}
+							onUpdateFilters={handleUpdateFilters}
+							onClearFilters={handleClearFilters}
+						/>
+					</div>
 				</div>
-			{:else if organizations.length === 0}
-				<!-- level 2: the page's only other heading is the h1 above. -->
-				<EmptyState
-					level={2}
-					icon={Users}
-					title={m['browse.organizations_noOrganizationsFound']()}
-					body={currentFilters.search || currentFilters.cityId || currentFilters.tags
-						? m['browse.organizations_tryAdjustingFilters']()
-						: m['browse.organizations_noOrganizations']()}
-				>
-					{#snippet action()}
-						{#if currentFilters.search || currentFilters.cityId || currentFilters.tags}
-							<Button onclick={handleClearFilters}>
-								{m['browse.organizations_clearFilters']()}
-							</Button>
-						{/if}
-					{/snippet}
-				</EmptyState>
-			{:else}
-				<!-- Organization Grid -->
-				<div
-					class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3"
-					role="list"
-					aria-label={m['browse.organizations_listingsLabel']()}
-				>
-					{#each organizations as org, index (`${org.id}-${index}`)}
-						<div role="listitem">
-							<OrganizationCard organization={org} variant="standard" />
+
+				<!-- Organization Content -->
+				<div id="organizations-content" class="flex-1">
+					{#if error}
+						<!-- Error State. `bg-card` rather than the old `bg-destructive/10`
+						     wash: the panel underneath is itself tinted now, so a second
+						     alpha would stack two composites under `text-destructive`. On
+						     card it is the audited token pair, and the doubled destructive
+						     edge carries the alarm. -->
+						<div
+							class="rounded-lg border-2 border-destructive bg-card p-8 text-center shadow-poster"
+							role="alert"
+							aria-live="polite"
+						>
+							<p class="font-semibold text-destructive">{error}</p>
+							<p class="mt-2 text-sm text-muted-foreground">
+								{m['common.errors_refreshPage']()}
+							</p>
 						</div>
-					{/each}
-				</div>
+					{:else if organizations.length === 0}
+						<!-- level 2: the page's only other heading is the h1 above. -->
+						<EmptyState
+							level={2}
+							icon={Users}
+							title={m['browse.organizations_noOrganizationsFound']()}
+							body={currentFilters.search || currentFilters.cityId || currentFilters.tags
+								? m['browse.organizations_tryAdjustingFilters']()
+								: m['browse.organizations_noOrganizations']()}
+						>
+							{#snippet action()}
+								{#if currentFilters.search || currentFilters.cityId || currentFilters.tags}
+									<Button onclick={handleClearFilters}>
+										{m['browse.organizations_clearFilters']()}
+									</Button>
+								{/if}
+							{/snippet}
+						</EmptyState>
+					{:else}
+						<!-- Organization Grid -->
+						<div
+							class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3"
+							role="list"
+							aria-label={m['browse.organizations_listingsLabel']()}
+						>
+							{#each organizations as org, index (`${org.id}-${index}`)}
+								<div role="listitem">
+									<OrganizationCard organization={org} variant="standard" />
+								</div>
+							{/each}
+						</div>
 
-				<!-- Pagination -->
-				{#if totalPages > 1}
-					<nav
-						class="mt-12 flex flex-col items-center justify-between gap-4 sm:flex-row"
-						aria-label={m['organizationsListPage.paginationLabel']()}
-					>
-						<!-- Results info -->
-						<p class="text-sm text-muted-foreground" aria-live="polite">
-							{m['common.pagination_showing']()}
-							{showingFrom}–{showingTo}
-							{m['common.pagination_of']()}
-							{totalCount}
-							{m['common.plurals_organizations']()}
-						</p>
-
-						<!-- Pagination controls -->
-						<div class="flex items-center gap-2">
-							{#if hasPrevPage}
-								<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
-								<a
-									href="?{organizationFiltersToParams({
-										...currentFilters,
-										page: currentPage - 1
-									})}"
-									class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-									aria-label={m['organizationsListPage.goToPreviousPage']()}
-								>
-									{m['common.pagination_previous']()}
-								</a>
-								<!-- eslint-enable svelte/no-navigation-without-resolve -->
-							{:else}
-								<button
-									type="button"
-									disabled
-									class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
-									aria-label={m['organizationsListPage.previousPageUnavailable']()}
-								>
-									{m['common.pagination_previous']()}
-								</button>
-							{/if}
-
-							<!-- Page indicator -->
-							<span
-								class="inline-flex h-10 items-center justify-center px-4 text-sm font-medium"
-								aria-current="page"
+						<!-- Pagination -->
+						{#if totalPages > 1}
+							<nav
+								class="mt-12 flex flex-col items-center justify-between gap-4 sm:flex-row"
+								aria-label={m['organizationsListPage.paginationLabel']()}
 							>
-								{m['common.pagination_page']()}
-								{currentPage}
-								{m['common.pagination_of']()}
-								{totalPages}
-							</span>
+								<!-- Results info -->
+								<p class="text-sm text-muted-foreground" aria-live="polite">
+									{m['common.pagination_showing']()}
+									{showingFrom}–{showingTo}
+									{m['common.pagination_of']()}
+									{totalCount}
+									{m['common.plurals_organizations']()}
+								</p>
 
-							{#if hasNextPage}
-								<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
-								<a
-									href="?{organizationFiltersToParams({
-										...currentFilters,
-										page: currentPage + 1
-									})}"
-									class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-									aria-label={m['organizationsListPage.goToNextPage']()}
-								>
-									{m['common.pagination_next']()}
-								</a>
-								<!-- eslint-enable svelte/no-navigation-without-resolve -->
-							{:else}
-								<button
-									type="button"
-									disabled
-									class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
-									aria-label={m['organizationsListPage.nextPageUnavailable']()}
-								>
-									{m['common.pagination_next']()}
-								</button>
-							{/if}
-						</div>
-					</nav>
-				{/if}
-			{/if}
+								<!-- Pagination controls -->
+								<div class="flex items-center gap-2">
+									{#if hasPrevPage}
+										<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
+										<a
+											href="?{organizationFiltersToParams({
+												...currentFilters,
+												page: currentPage - 1
+											})}"
+											class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+											aria-label={m['organizationsListPage.goToPreviousPage']()}
+										>
+											{m['common.pagination_previous']()}
+										</a>
+										<!-- eslint-enable svelte/no-navigation-without-resolve -->
+									{:else}
+										<button
+											type="button"
+											disabled
+											class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
+											aria-label={m['organizationsListPage.previousPageUnavailable']()}
+										>
+											{m['common.pagination_previous']()}
+										</button>
+									{/if}
+
+									<!-- Page indicator -->
+									<span
+										class="inline-flex h-10 items-center justify-center px-4 text-sm font-medium"
+										aria-current="page"
+									>
+										{m['common.pagination_page']()}
+										{currentPage}
+										{m['common.pagination_of']()}
+										{totalPages}
+									</span>
+
+									{#if hasNextPage}
+										<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
+										<a
+											href="?{organizationFiltersToParams({
+												...currentFilters,
+												page: currentPage + 1
+											})}"
+											class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+											aria-label={m['organizationsListPage.goToNextPage']()}
+										>
+											{m['common.pagination_next']()}
+										</a>
+										<!-- eslint-enable svelte/no-navigation-without-resolve -->
+									{:else}
+										<button
+											type="button"
+											disabled
+											class="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium opacity-50"
+											aria-label={m['organizationsListPage.nextPageUnavailable']()}
+										>
+											{m['common.pagination_next']()}
+										</button>
+									{/if}
+								</div>
+							</nav>
+						{/if}
+					{/if}
+				</div>
+			</div>
 		</div>
 	</div>
 


### PR DESCRIPTION
## Uplift U2 — public discovery surfaces

Rolls the approved poster-grade language (U1, #777) across /events, /organizations, the org profile + sub-pages (membership, resources, polls, questionnaire), and the series page — the surfaces Biagio explicitly called out.

### What's in it
- Discovery/listing pages open on celebration bands with display headers; cards and filter panels float on `shadow-poster`
- Org profile + series get the poster ribbon + org-logo sticker treatment (logo-or-nothing rule); series no longer triple-renders the org logo
- Two new codified rules (spec §9 + CLAUDE.md): band/wash pairing (ribbon→wash, theme-band→plain, never same-family) and the opaque-first-block rule for band pull-ups
- Shared floats granted here: `EmptyState` and `ResourceCard` join the border-2/shadow-poster silhouette
- The public poll page gains its first-ever h1

### Review process
Opus whole-branch review + one fix round + scoped re-review, clean. Catches: tag chips composited to 4.29:1 on the new wash under a stale passing-claim comment (now solid card chips at 6.99/6.27 with honest numbers), a translucent block straddling the band pull-up, and the filter sidebars left behind on hairlines.

### Verification
`make check` 0 errors · full suite 219 files / 2544 green · brand audit 0 failures · a11y-smoke (zero-baseline axe) 20/20 both projects · orchestrator screenshots (discovery light, org profile dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)