### PR TITLE
feat(uplift): dashboard, auth & error pages go poster-grade (U3)

### DIFF
--- a/src/lib/components/auth/AuthBandLayout.svelte
+++ b/src/lib/components/auth/AuthBandLayout.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import { cn } from '$lib/utils';
+
+	/**
+	 * The auth cluster's poster-grade Celebration shell (uplift, spec §9).
+	 *
+	 * Every sign-in / sign-up / recovery / interstitial screen was the same
+	 * vertically-centred column of white-on-paper: a hand-set kicker + h1, then
+	 * a card. This gives the whole cluster the language U1 shipped on the public
+	 * questionnaire route — a full-strength colour-block band carrying the type,
+	 * with the content pulled up over its bottom edge so cards visibly FLOAT on
+	 * colour rather than lying on the page.
+	 *
+	 * Why `bg-secondary` at full strength: `secondary` / `secondary-foreground`
+	 * is an audit-enforced pair in BOTH modes (periwinkle in light, deep indigo
+	 * in dark), so the band is a real poster panel that still respects the
+	 * light/dark axis — no mode-inert surface, no hand-computed alpha. The
+	 * kicker and subtitle inherit the band's own foreground via PageHeader's
+	 * `onBand` affordance (its default `text-primary` kicker measures 4.12:1 on
+	 * the light band, below AA — see PageHeader's `onBand` doc comment).
+	 *
+	 * Purely presentational: no form logic, no navigation, no copy of its own.
+	 * The h1 it renders is the page's only heading, with byte-identical text to
+	 * what each route passed before.
+	 */
+	interface Props {
+		/** Already-translated strings — i18n stays at the call site. */
+		title: string;
+		kicker?: string;
+		subtitle?: string;
+		/**
+		 * Decorative ornament rendered centred in the band ABOVE the title —
+		 * the interstitials' status chip, or a `brand/LogoChip`. Callers are
+		 * responsible for marking it `aria-hidden`; it must never carry copy
+		 * that isn't already in the heading or body (same rule as PageHeader's
+		 * `decoration` slot).
+		 */
+		chip?: Snippet;
+		/** Column width for both the band copy and the floating stack. */
+		width?: 'md' | 'lg' | 'xl';
+		/** The floating content. Cards already carry the 2px edge + poster float. */
+		children: Snippet;
+		class?: string;
+	}
+	const {
+		title,
+		kicker,
+		subtitle,
+		chip,
+		width = 'md',
+		children,
+		class: className = ''
+	}: Props = $props();
+
+	const widthClass = $derived(
+		width === 'md' ? 'max-w-md' : width === 'lg' ? 'max-w-lg' : 'max-w-2xl'
+	);
+</script>
+
+<div class={cn('min-h-[calc(100vh-4rem)] bg-background', className)}>
+	<section class="bg-secondary text-secondary-foreground">
+		<div class={cn('container mx-auto px-4 pb-20 pt-10 text-center sm:pt-14', widthClass)}>
+			{#if chip}
+				<div class="mb-5 flex justify-center">{@render chip()}</div>
+			{/if}
+			<PageHeader
+				volume="poster"
+				onBand
+				{kicker}
+				{title}
+				{subtitle}
+				class="text-center sm:flex-col sm:items-center"
+			/>
+		</div>
+	</section>
+
+	<!-- Pulled up over the band's bottom edge: the float is the whole point. -->
+	<div class={cn('container mx-auto -mt-12 space-y-6 px-4 pb-16', widthClass)}>
+		{@render children()}
+	</div>
+</div>

--- a/src/lib/components/auth/AuthBandLayout.svelte
+++ b/src/lib/components/auth/AuthBandLayout.svelte
@@ -40,8 +40,20 @@
 		chip?: Snippet;
 		/** Column width for both the band copy and the floating stack. */
 		width?: 'md' | 'lg' | 'xl';
-		/** The floating content. Cards already carry the 2px edge + poster float. */
-		children: Snippet;
+		/**
+		 * Marks the band's heading block as a live region (`role="status"`).
+		 * For the interstitials whose success state is reached IN PLACE (a form
+		 * submit with no navigation), where the h1 + body are the announcement.
+		 * The chip is aria-hidden ornament either way, so nothing is lost by the
+		 * region now starting at the header instead of the old wrapper div.
+		 */
+		status?: boolean;
+		/**
+		 * The floating content. Cards already carry the 2px edge + poster float.
+		 * Optional because some interstitials (a successful verification, say)
+		 * are the band and nothing else.
+		 */
+		children?: Snippet;
 		class?: string;
 	}
 	const {
@@ -50,6 +62,7 @@
 		subtitle,
 		chip,
 		width = 'md',
+		status = false,
 		children,
 		class: className = ''
 	}: Props = $props();
@@ -71,13 +84,16 @@
 				{kicker}
 				{title}
 				{subtitle}
+				role={status ? 'status' : undefined}
 				class="text-center sm:flex-col sm:items-center"
 			/>
 		</div>
 	</section>
 
 	<!-- Pulled up over the band's bottom edge: the float is the whole point. -->
-	<div class={cn('container mx-auto -mt-12 space-y-6 px-4 pb-16', widthClass)}>
-		{@render children()}
-	</div>
+	{#if children}
+		<div class={cn('container mx-auto -mt-12 space-y-6 px-4 pb-16', widthClass)}>
+			{@render children()}
+		</div>
+	{/if}
 </div>

--- a/src/lib/components/calendar/CalendarYearView.svelte
+++ b/src/lib/components/calendar/CalendarYearView.svelte
@@ -77,7 +77,9 @@
 	}
 
 	.year-month-card {
-		@apply flex flex-col items-center justify-center rounded-lg border border-border bg-card p-6 transition-all hover:border-primary hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2;
+		/* Poster silhouette (uplift): 2px edge + the float that grows on hover,
+		   matching ui/card and the dashboard's activity tiles. */
+		@apply flex flex-col items-center justify-center rounded-lg border-2 border-border bg-card p-6 shadow-poster transition-all hover:border-primary hover:shadow-poster-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2;
 	}
 
 	.year-month-header {

--- a/src/lib/components/common/PageHeader.svelte
+++ b/src/lib/components/common/PageHeader.svelte
@@ -26,8 +26,8 @@
 		 * survive a saturated band: on the light periwinkle `--secondary` it
 		 * measures **4.12:1**, below AA for the kicker's 14px extrabold text
 		 * (4.60:1 in dark, which passes — the prop covers both so the two modes
-		 * don't drift). Inheriting takes it to the band's own pair: 9.01:1
-		 * light / 8.17:1 dark. The subtitle's `text-muted-foreground` does clear
+		 * don't drift). Inheriting takes it to the band's own pair: 9.00:1
+		 * light / 8.23:1 dark. The subtitle's `text-muted-foreground` does clear
 		 * AA on that band (5.35 / 5.46) but goes full-strength too, so the whole
 		 * header reads as one block of band copy.
 		 *

--- a/src/lib/components/common/PageHeader.test.ts
+++ b/src/lib/components/common/PageHeader.test.ts
@@ -99,7 +99,7 @@ describe('PageHeader', () => {
 	it('onBand drops the accent kicker and muted subtitle for the band foreground', () => {
 		// The reason this prop exists: `text-primary` on the light periwinkle
 		// `--secondary` band measures 4.12:1, below AA for the kicker's 14px
-		// extrabold. Inheriting the band's own audited foreground is 9.01:1.
+		// extrabold. Inheriting the band's own audited foreground is 9.00:1.
 		render(PageHeader, {
 			props: {
 				title: 'Apply',

--- a/src/lib/components/dashboard/DashboardActivityCards.svelte
+++ b/src/lib/components/dashboard/DashboardActivityCards.svelte
@@ -10,6 +10,14 @@
 		upcomingRsvpsCount: number;
 	}
 	let { activeTicketsCount, pendingInvitationsCount, upcomingRsvpsCount }: Props = $props();
+
+	// These three tiles are the first thing on the dashboard and they now sit on
+	// the welcome band's bottom edge, so they take the poster silhouette the
+	// rest of the app's surfaces gained: 2px edge, `shadow-poster` at rest,
+	// `shadow-poster-lg` on hover (the float grows instead of a generic
+	// shadow-lg). Colours are unchanged — `bg-card` + ToneTile's audited tints.
+	const activityCard =
+		'group rounded-lg border-2 bg-card p-6 shadow-poster transition-all hover:border-primary hover:shadow-poster-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2';
 </script>
 
 <!-- Activity Summary Cards -->
@@ -17,10 +25,7 @@
 	<div class="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 		<!-- Active Tickets -->
 		{#if activeTicketsCount > 0}
-			<a
-				href={resolve('/(auth)/dashboard/tickets', {})}
-				class="group rounded-lg border bg-card p-6 transition-all hover:border-primary hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-			>
+			<a href={resolve('/(auth)/dashboard/tickets', {})} class={activityCard}>
 				<div class="flex items-start justify-between">
 					<div class="flex items-center gap-3">
 						<ToneTile tone="info" icon={Ticket} size="lg" />
@@ -28,7 +33,7 @@
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['dashboard.activityCards.activeTickets']()}
 							</p>
-							<p class="text-3xl font-bold">{activeTicketsCount}</p>
+							<p class="text-3xl font-black">{activeTicketsCount}</p>
 						</div>
 					</div>
 					<ChevronRight
@@ -49,10 +54,7 @@
 		<!-- Upcoming RSVPs -->
 		{#if upcomingRsvpsCount > 0}
 			<!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() validates the path; the appended query/fragment cannot be expressed through resolve() -->
-			<a
-				href={`${resolve('/(auth)/dashboard/rsvps', {})}?status=yes,maybe`}
-				class="group rounded-lg border bg-card p-6 transition-all hover:border-primary hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-			>
+			<a href={`${resolve('/(auth)/dashboard/rsvps', {})}?status=yes,maybe`} class={activityCard}>
 				<div class="flex items-start justify-between">
 					<div class="flex items-center gap-3">
 						<ToneTile tone="success" icon={CheckCircle2} size="lg" />
@@ -60,7 +62,7 @@
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['dashboard.activityCards.upcomingRsvps']()}
 							</p>
-							<p class="text-3xl font-bold">{upcomingRsvpsCount}</p>
+							<p class="text-3xl font-black">{upcomingRsvpsCount}</p>
 						</div>
 					</div>
 					<ChevronRight
@@ -81,10 +83,7 @@
 
 		<!-- Pending Invitations -->
 		{#if pendingInvitationsCount > 0}
-			<a
-				href={resolve('/(auth)/dashboard/invitations', {})}
-				class="group rounded-lg border bg-card p-6 transition-all hover:border-primary hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-			>
+			<a href={resolve('/(auth)/dashboard/invitations', {})} class={activityCard}>
 				<div class="flex items-start justify-between">
 					<div class="flex items-center gap-3">
 						<ToneTile tone="brand" icon={Mail} size="lg" />
@@ -92,7 +91,7 @@
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['dashboard.activityCards.pendingInvitations']()}
 							</p>
-							<p class="text-3xl font-bold">{pendingInvitationsCount}</p>
+							<p class="text-3xl font-black">{pendingInvitationsCount}</p>
 						</div>
 					</div>
 					<ChevronRight

--- a/src/lib/components/dashboard/DashboardBandLayout.svelte
+++ b/src/lib/components/dashboard/DashboardBandLayout.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+
+	/**
+	 * The dashboard cluster's poster-grade Celebration shell (uplift, spec §9).
+	 *
+	 * Twin of `auth/AuthBandLayout`, kept separate because the dashboard's
+	 * header is a full-width, left-aligned page header with an actions rail —
+	 * not the auth cluster's narrow centred column — and the two would fight
+	 * over `width` / `text-center` if merged.
+	 *
+	 * `bg-secondary` / `secondary-foreground` is an audit-enforced pair in BOTH
+	 * modes, so the band is a real poster panel that still respects the
+	 * light/dark axis. The kicker and subtitle inherit the band's foreground
+	 * through PageHeader's `onBand` affordance — its default `text-primary`
+	 * kicker measures 4.12:1 there, below AA for 14px extrabold.
+	 *
+	 * Content is pulled up over the band's bottom edge so the first card
+	 * visibly floats ON the colour. Give it something with a surface (a card,
+	 * a controls panel); bare filter chips landing on the cut read as debris.
+	 *
+	 * Purely presentational: no data, no navigation, no copy of its own.
+	 */
+	interface Props {
+		/** Already-translated strings — i18n stays at the call site. */
+		title: string;
+		kicker?: string;
+		subtitle?: string;
+		/** Right-aligned on sm+, same slot PageHeader exposes. */
+		actions?: Snippet;
+		children: Snippet;
+	}
+	const { title, kicker, subtitle, actions, children }: Props = $props();
+</script>
+
+<div class="bg-background">
+	<section class="bg-secondary text-secondary-foreground">
+		<div class="container mx-auto px-4 pb-20 pt-8 md:pt-10">
+			<PageHeader volume="poster" onBand {kicker} {title} {subtitle} {actions} />
+		</div>
+	</section>
+
+	<div class="container mx-auto -mt-12 px-4 pb-8 md:pb-12">
+		{@render children()}
+	</div>
+</div>

--- a/src/lib/components/dashboard/DashboardOrganizationsSection.svelte
+++ b/src/lib/components/dashboard/DashboardOrganizationsSection.svelte
@@ -75,14 +75,14 @@
 			{#each visibleOrganizations as org (org.id)}
 				{@const descriptionText = org.description ? stripMarkdown(org.description) : ''}
 				<div
-					class="flex flex-col gap-4 rounded-lg border bg-card p-4 transition-shadow hover:shadow-md sm:flex-row sm:items-center"
+					class="flex flex-col gap-4 rounded-lg border-2 bg-card p-4 shadow-poster transition-shadow hover:shadow-poster-lg sm:flex-row sm:items-center"
 				>
 					<div class="flex min-w-0 flex-1 items-center gap-4">
 						{#if org.logo}
 							<img
 								src={getImageUrl(org.logo_thumbnail_url || org.logo)}
 								alt=""
-								class="h-16 w-16 shrink-0 rounded-full border object-cover"
+								class="h-16 w-16 shrink-0 rounded-full border-2 object-cover"
 							/>
 						{:else}
 							<div

--- a/src/lib/components/dashboard/DashboardUpcomingEvents.svelte
+++ b/src/lib/components/dashboard/DashboardUpcomingEvents.svelte
@@ -25,9 +25,13 @@
 	</a>
 {/snippet}
 
-<!-- Upcoming Events Section -->
+<!-- Upcoming Events Section. This can be the FIRST block below the dashboard's
+     -mt-12 band pull-up (brand-new user: no activity cards, no "Your Events"
+     section). It carries its own bg-card/border-2/shadow-poster wrapper so
+     that whenever it lands there, the "See all" link's `text-primary` sits on
+     an audited surface instead of the band itself (4.12:1, below AA). -->
 <section aria-labelledby="upcoming-events-heading">
-	<div class="mb-4">
+	<div class="mb-4 rounded-lg border-2 border-border bg-card p-4 shadow-poster sm:p-6">
 		<SectionHeader
 			title={m['dashboard.sections.discoverEvents']()}
 			volume="celebration"

--- a/src/lib/components/dashboard/index.ts
+++ b/src/lib/components/dashboard/index.ts
@@ -2,6 +2,7 @@
  * Dashboard section components
  */
 
+export { default as DashboardBandLayout } from './DashboardBandLayout.svelte';
 export { default as DashboardActivityCards } from './DashboardActivityCards.svelte';
 export { default as DashboardUpcomingEvents } from './DashboardUpcomingEvents.svelte';
 export { default as DashboardOrganizationsSection } from './DashboardOrganizationsSection.svelte';

--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -332,7 +332,9 @@
 
 <Card
 	class={cn(
-		'group cursor-pointer overflow-hidden transition-all hover:shadow-md',
+		// The item is a Card, so it already carries the 2px edge + `shadow-poster`
+		// (uplift); hover grows that float rather than swapping in shadow-md.
+		'group cursor-pointer overflow-hidden transition-all hover:shadow-poster-lg',
 		!isRead && 'border-l-4 border-l-primary bg-primary/5',
 		// bg-highlight/20 mirrors ToneTile's audited warning tokens (hand-verified
 		// 12.6:1 light / 6.7:1 dark — see ToneTile.svelte).

--- a/src/routes/(auth)/create-org/+page.svelte
+++ b/src/routes/(auth)/create-org/+page.svelte
@@ -84,266 +84,278 @@
 	<meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<div class="container mx-auto max-w-2xl px-4 py-8">
-	<!-- The one Celebration moment in this cluster: creating an organization is
-	     an acquisition milestone, so it gets the display-scale PageHeader while
-	     the wizard body below stays studio-calm. -->
-	<div class="mb-8 text-center">
-		<div class="mb-4 flex justify-center">
-			<div class="rounded-full bg-primary/10 p-4">
-				<Building2 class="h-8 w-8 text-primary" aria-hidden="true" />
-			</div>
+<!-- The one Celebration moment in this cluster: creating an organization is an
+     acquisition milestone, so it gets the uplift's full welcome band while the
+     wizard body below stays studio-calm. `bg-secondary` at full strength is an
+     audit-enforced pair in BOTH modes (so the band respects the light/dark
+     axis) and the kicker/subtitle inherit it through PageHeader's `onBand`
+     affordance — the default `text-primary` kicker measures 4.12:1 there,
+     below AA. The old `bg-primary/10` circle becomes the poster-tinted tilted
+     chip (EmptyState's recipe; audited purple/white pair, mode-inert by the
+     imagery rule, aria-hidden ornament). -->
+<div class="min-h-[calc(100vh-4rem)] bg-background">
+	<section class="bg-secondary text-secondary-foreground">
+		<div class="container mx-auto max-w-2xl px-4 pb-20 pt-10 text-center sm:pt-14">
+			<span
+				aria-hidden="true"
+				class="mx-auto mb-5 flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl bg-poster-purple text-poster-white shadow-poster"
+			>
+				<Building2 class="h-8 w-8" />
+			</span>
+			<PageHeader
+				volume="poster"
+				onBand
+				kicker={m['orgCreate.kicker']()}
+				title={m['orgCreate.title']()}
+				subtitle={m['orgCreate.subtitle']()}
+				class="text-center sm:flex-col sm:items-center"
+			/>
+			<p class="mt-2 text-sm">
+				{m['createOrgPage.customizeHint']()}
+			</p>
 		</div>
-		<PageHeader
-			volume="celebration"
-			kicker={m['orgCreate.kicker']()}
-			title={m['orgCreate.title']()}
-			subtitle={m['orgCreate.subtitle']()}
-			class="text-center sm:flex-col sm:items-center"
-		/>
-		<p class="mt-2 text-sm text-muted-foreground">
-			{m['createOrgPage.customizeHint']()}
-		</p>
-	</div>
+	</section>
 
-	<!-- Check if user already owns an organization -->
-	{#if ownsOrganization}
-		<!-- Warning tint mirrors ToneTile's amber recipe (see security page). -->
-		<div class="rounded-lg border border-highlight/40 bg-highlight/20 p-6">
-			<div class="flex gap-3">
-				<AlertCircle
-					class="h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
-					aria-hidden="true"
-				/>
-				<div>
-					<h3 class="font-bold text-highlight-foreground dark:text-highlight">
-						{m['orgCreate.alreadyOwner']()}
-					</h3>
-					<p class="mt-1 text-sm text-foreground">
-						{m['orgCreate.alreadyOwnerDescription']()}
-					</p>
-					<div class="mt-4">
-						<a
-							href={resolve('/(auth)/dashboard', {})}
-							class="inline-flex items-center gap-2 rounded-md bg-highlight px-4 py-2 text-sm font-medium text-highlight-foreground hover:bg-highlight/90"
-						>
-							{m['orgCreate.backToDashboard']()}
-						</a>
+	<div class="container mx-auto -mt-12 max-w-2xl px-4 pb-16">
+		<!-- Check if user already owns an organization -->
+		{#if ownsOrganization}
+			<!-- Warning tint mirrors ToneTile's amber recipe (see security page). -->
+			<div class="rounded-lg border-2 border-highlight/40 bg-highlight/20 p-6 shadow-poster">
+				<div class="flex gap-3">
+					<AlertCircle
+						class="h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
+						aria-hidden="true"
+					/>
+					<div>
+						<h3 class="font-bold text-highlight-foreground dark:text-highlight">
+							{m['orgCreate.alreadyOwner']()}
+						</h3>
+						<p class="mt-1 text-sm text-foreground">
+							{m['orgCreate.alreadyOwnerDescription']()}
+						</p>
+						<div class="mt-4">
+							<a
+								href={resolve('/(auth)/dashboard', {})}
+								class="inline-flex items-center gap-2 rounded-md bg-highlight px-4 py-2 text-sm font-medium text-highlight-foreground hover:bg-highlight/90"
+							>
+								{m['orgCreate.backToDashboard']()}
+							</a>
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-	{:else if !user?.email_verified}
-		<!-- Email not verified warning -->
-		<!-- text-destructive as a heading measures 2.68:1 in dark on this tint
+		{:else if !user?.email_verified}
+			<!-- Email not verified warning -->
+			<!-- text-destructive as a heading measures 2.68:1 in dark on this tint
 		     (below 4.5); the border/tint + icon carry the tone, text reads on
 		     --foreground. -->
-		<div class="rounded-lg border border-destructive/40 bg-destructive/10 p-6">
-			<div class="flex gap-3">
-				<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />
-				<div>
-					<h3 class="font-bold text-foreground">
-						{m['orgCreate.emailNotVerified']()}
-					</h3>
-					<p class="mt-1 text-sm text-foreground">
-						{m['orgCreate.emailNotVerifiedDescription']()}
-					</p>
-					<div class="mt-4">
-						<a
-							href={resolve('/(auth)/account/profile', {})}
-							class="inline-flex items-center gap-2 rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
-						>
-							{m['orgCreate.verifyEmail']()}
-						</a>
+			<div class="rounded-lg border-2 border-destructive/40 bg-destructive/10 p-6 shadow-poster">
+				<div class="flex gap-3">
+					<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />
+					<div>
+						<h3 class="font-bold text-foreground">
+							{m['orgCreate.emailNotVerified']()}
+						</h3>
+						<p class="mt-1 text-sm text-foreground">
+							{m['orgCreate.emailNotVerifiedDescription']()}
+						</p>
+						<div class="mt-4">
+							<a
+								href={resolve('/(auth)/account/profile', {})}
+								class="inline-flex items-center gap-2 rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
+							>
+								{m['orgCreate.verifyEmail']()}
+							</a>
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-	{:else}
-		<!-- Creation Form -->
-		<div class="rounded-lg border bg-card p-6 shadow-sm md:p-8">
-			<form
-				bind:this={formElement}
-				method="POST"
-				use:enhance={() => {
-					isSubmitting = true;
-					return async ({ result }) => {
-						isSubmitting = false;
-						await applyAction(result);
-					};
-				}}
-				class="space-y-6"
-			>
-				<!-- Organization Name -->
-				<div class="space-y-2">
-					<Label for="name" class="required">
-						{m['orgCreate.form.name']()}
-					</Label>
-					<Input
-						id="name"
-						name="name"
-						type="text"
-						bind:value={name}
-						aria-invalid={errors.name ? 'true' : undefined}
-						aria-describedby={errors.name ? 'name-error' : undefined}
-						placeholder={m['orgCreate.form.namePlaceholder']()}
-						maxlength={150}
-						required
-					/>
-					{#if errors.name}
-						<p id="name-error" class="text-sm text-destructive">
-							{errors.name}
-						</p>
-					{/if}
-					<p class="text-xs text-muted-foreground">
-						{m['orgCreate.form.nameHint']()}
-					</p>
-				</div>
-
-				<!-- Contact Email -->
-				<div class="space-y-2">
-					<Label for="contact_email" class="required">
-						{m['orgCreate.form.contactEmail']()}
-					</Label>
-					<Input
-						id="contact_email"
-						name="contact_email"
-						type="email"
-						bind:value={contactEmail}
-						aria-invalid={errors.contact_email ? 'true' : undefined}
-						aria-describedby={errors.contact_email
-							? 'contact-email-error contact-email-hint'
-							: 'contact-email-hint'}
-						placeholder={m['orgCreate.form.contactEmailPlaceholder']()}
-						required
-					/>
-					{#if errors.contact_email}
-						<p id="contact-email-error" class="text-sm text-destructive">
-							{errors.contact_email}
-						</p>
-					{/if}
-
-					<!-- Info about email verification -->
-					{#if contactEmailChanged}
-						<div class="flex gap-2 rounded-md border border-info/30 bg-info/10 p-3">
-							<Mail class="h-4 w-4 flex-shrink-0 text-info" aria-hidden="true" />
-							<p id="contact-email-hint" class="text-xs text-foreground">
-								{m['orgCreate.form.contactEmailVerificationNeeded']()}
+		{:else}
+			<!-- Creation Form -->
+			<div class="rounded-lg border-2 bg-card p-6 shadow-poster md:p-8">
+				<form
+					bind:this={formElement}
+					method="POST"
+					use:enhance={() => {
+						isSubmitting = true;
+						return async ({ result }) => {
+							isSubmitting = false;
+							await applyAction(result);
+						};
+					}}
+					class="space-y-6"
+				>
+					<!-- Organization Name -->
+					<div class="space-y-2">
+						<Label for="name" class="required">
+							{m['orgCreate.form.name']()}
+						</Label>
+						<Input
+							id="name"
+							name="name"
+							type="text"
+							bind:value={name}
+							aria-invalid={errors.name ? 'true' : undefined}
+							aria-describedby={errors.name ? 'name-error' : undefined}
+							placeholder={m['orgCreate.form.namePlaceholder']()}
+							maxlength={150}
+							required
+						/>
+						{#if errors.name}
+							<p id="name-error" class="text-sm text-destructive">
+								{errors.name}
 							</p>
-						</div>
-					{:else}
-						<div class="flex gap-2 rounded-md border border-success/30 bg-success/10 p-3">
-							<CheckCircle class="h-4 w-4 flex-shrink-0 text-success" aria-hidden="true" />
-							<p id="contact-email-hint" class="text-xs text-foreground">
-								{m['orgCreate.form.contactEmailAutoVerified']()}
+						{/if}
+						<p class="text-xs text-muted-foreground">
+							{m['orgCreate.form.nameHint']()}
+						</p>
+					</div>
+
+					<!-- Contact Email -->
+					<div class="space-y-2">
+						<Label for="contact_email" class="required">
+							{m['orgCreate.form.contactEmail']()}
+						</Label>
+						<Input
+							id="contact_email"
+							name="contact_email"
+							type="email"
+							bind:value={contactEmail}
+							aria-invalid={errors.contact_email ? 'true' : undefined}
+							aria-describedby={errors.contact_email
+								? 'contact-email-error contact-email-hint'
+								: 'contact-email-hint'}
+							placeholder={m['orgCreate.form.contactEmailPlaceholder']()}
+							required
+						/>
+						{#if errors.contact_email}
+							<p id="contact-email-error" class="text-sm text-destructive">
+								{errors.contact_email}
 							</p>
-						</div>
-					{/if}
-				</div>
+						{/if}
 
-				<!-- City -->
-				<div>
-					<CityAutocomplete
-						value={selectedCity}
-						onSelect={handleCitySelect}
-						label={m['orgCreate.form.city']()}
-						description=""
-					/>
-					<input type="hidden" name="city_id" value={selectedCity?.id || ''} />
-				</div>
-
-				<!-- Address -->
-				<div class="space-y-2">
-					<Label for="address">
-						{m['orgCreate.form.address']()}
-					</Label>
-					<Input
-						id="address"
-						name="address"
-						type="text"
-						bind:value={address}
-						aria-invalid={errors.address ? 'true' : undefined}
-						aria-describedby={errors.address ? 'address-error' : undefined}
-						placeholder={m['orgCreate.form.addressPlaceholder']()}
-					/>
-					{#if errors.address}
-						<p id="address-error" class="text-sm text-destructive">
-							{errors.address}
-						</p>
-					{/if}
-				</div>
-
-				<!-- Description -->
-				<div class="space-y-2">
-					<Label for="description">
-						{m['orgCreate.form.description']()}
-					</Label>
-					<Textarea
-						id="description"
-						name="description"
-						bind:value={description}
-						aria-invalid={errors.description ? 'true' : undefined}
-						aria-describedby={errors.description ? 'description-error' : undefined}
-						placeholder={m['orgCreate.form.descriptionPlaceholder']()}
-						rows={4}
-					/>
-					{#if errors.description}
-						<p id="description-error" class="text-sm text-destructive">
-							{errors.description}
-						</p>
-					{/if}
-					<p class="text-xs text-muted-foreground">
-						{m['orgCreate.form.descriptionHint']()}
-					</p>
-				</div>
-
-				<!-- Submit Error -->
-				{#if errors.form}
-					<div class="rounded-md border border-destructive/50 bg-destructive/10 p-4">
-						<div class="flex gap-3">
-							<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />
-							<div>
-								<h3 class="font-medium text-destructive">
-									{m['orgCreate.form.error']()}
-								</h3>
-								<p class="mt-1 text-sm text-destructive/90">
-									{errors.form}
+						<!-- Info about email verification -->
+						{#if contactEmailChanged}
+							<div class="flex gap-2 rounded-md border border-info/30 bg-info/10 p-3">
+								<Mail class="h-4 w-4 flex-shrink-0 text-info" aria-hidden="true" />
+								<p id="contact-email-hint" class="text-xs text-foreground">
+									{m['orgCreate.form.contactEmailVerificationNeeded']()}
 								</p>
 							</div>
-						</div>
-					</div>
-				{/if}
-
-				<!-- Actions -->
-				<div class="flex gap-3 border-t pt-6">
-					<Button
-						type="button"
-						variant="outline"
-						onclick={() => goto(resolve('/(auth)/dashboard', {}))}
-						disabled={isSubmitting}
-						class="flex-1"
-					>
-						{m['common.actions_cancel']()}
-					</Button>
-					<Button type="button" onclick={showConfirmation} disabled={isSubmitting} class="flex-1">
-						{#if isSubmitting}
-							<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-							{m['orgCreate.form.creating']()}
 						{:else}
-							<Building2 class="mr-2 h-4 w-4" aria-hidden="true" />
-							{m['orgCreate.form.create']()}
+							<div class="flex gap-2 rounded-md border border-success/30 bg-success/10 p-3">
+								<CheckCircle class="h-4 w-4 flex-shrink-0 text-success" aria-hidden="true" />
+								<p id="contact-email-hint" class="text-xs text-foreground">
+									{m['orgCreate.form.contactEmailAutoVerified']()}
+								</p>
+							</div>
 						{/if}
-					</Button>
-				</div>
-			</form>
-		</div>
-	{/if}
+					</div>
+
+					<!-- City -->
+					<div>
+						<CityAutocomplete
+							value={selectedCity}
+							onSelect={handleCitySelect}
+							label={m['orgCreate.form.city']()}
+							description=""
+						/>
+						<input type="hidden" name="city_id" value={selectedCity?.id || ''} />
+					</div>
+
+					<!-- Address -->
+					<div class="space-y-2">
+						<Label for="address">
+							{m['orgCreate.form.address']()}
+						</Label>
+						<Input
+							id="address"
+							name="address"
+							type="text"
+							bind:value={address}
+							aria-invalid={errors.address ? 'true' : undefined}
+							aria-describedby={errors.address ? 'address-error' : undefined}
+							placeholder={m['orgCreate.form.addressPlaceholder']()}
+						/>
+						{#if errors.address}
+							<p id="address-error" class="text-sm text-destructive">
+								{errors.address}
+							</p>
+						{/if}
+					</div>
+
+					<!-- Description -->
+					<div class="space-y-2">
+						<Label for="description">
+							{m['orgCreate.form.description']()}
+						</Label>
+						<Textarea
+							id="description"
+							name="description"
+							bind:value={description}
+							aria-invalid={errors.description ? 'true' : undefined}
+							aria-describedby={errors.description ? 'description-error' : undefined}
+							placeholder={m['orgCreate.form.descriptionPlaceholder']()}
+							rows={4}
+						/>
+						{#if errors.description}
+							<p id="description-error" class="text-sm text-destructive">
+								{errors.description}
+							</p>
+						{/if}
+						<p class="text-xs text-muted-foreground">
+							{m['orgCreate.form.descriptionHint']()}
+						</p>
+					</div>
+
+					<!-- Submit Error -->
+					{#if errors.form}
+						<div class="rounded-md border border-destructive/50 bg-destructive/10 p-4">
+							<div class="flex gap-3">
+								<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />
+								<div>
+									<h3 class="font-medium text-destructive">
+										{m['orgCreate.form.error']()}
+									</h3>
+									<p class="mt-1 text-sm text-destructive/90">
+										{errors.form}
+									</p>
+								</div>
+							</div>
+						</div>
+					{/if}
+
+					<!-- Actions -->
+					<div class="flex gap-3 border-t pt-6">
+						<Button
+							type="button"
+							variant="outline"
+							onclick={() => goto(resolve('/(auth)/dashboard', {}))}
+							disabled={isSubmitting}
+							class="flex-1"
+						>
+							{m['common.actions_cancel']()}
+						</Button>
+						<Button type="button" onclick={showConfirmation} disabled={isSubmitting} class="flex-1">
+							{#if isSubmitting}
+								<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+								{m['orgCreate.form.creating']()}
+							{:else}
+								<Building2 class="mr-2 h-4 w-4" aria-hidden="true" />
+								{m['orgCreate.form.create']()}
+							{/if}
+						</Button>
+					</div>
+				</form>
+			</div>
+		{/if}
+	</div>
 </div>
 
 <!-- Confirmation Dialog -->
 {#if showConfirmDialog}
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-xl">
+		<div class="w-full max-w-md rounded-lg border-2 bg-card p-6 shadow-poster-lg">
 			<div class="mb-4 flex justify-center">
 				<div class="rounded-full bg-highlight p-3 text-highlight-foreground">
 					<AlertCircle class="h-6 w-6" aria-hidden="true" />

--- a/src/routes/(auth)/create-org/+page.svelte
+++ b/src/routes/(auth)/create-org/+page.svelte
@@ -92,13 +92,17 @@
      affordance — the default `text-primary` kicker measures 4.12:1 there,
      below AA. The old `bg-primary/10` circle becomes the poster-tinted tilted
      chip (EmptyState's recipe; audited purple/white pair, mode-inert by the
-     imagery rule, aria-hidden ornament). -->
+     imagery rule, aria-hidden ornament) — it carries the same
+     `ring-1 ring-inset ring-border` every `ToneTile` tint chip does, since the
+     chip itself is mode-inert but the `bg-secondary` band under it is not,
+     and this pairing measures 2.23:1 (near-invisible) in dark mode without
+     the ring. -->
 <div class="min-h-[calc(100vh-4rem)] bg-background">
 	<section class="bg-secondary text-secondary-foreground">
 		<div class="container mx-auto max-w-2xl px-4 pb-20 pt-10 text-center sm:pt-14">
 			<span
 				aria-hidden="true"
-				class="mx-auto mb-5 flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl bg-poster-purple text-poster-white shadow-poster"
+				class="mx-auto mb-5 flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl bg-poster-purple text-poster-white shadow-poster ring-1 ring-inset ring-border"
 			>
 				<Building2 class="h-8 w-8" />
 			</span>

--- a/src/routes/(auth)/dashboard/+page.svelte
+++ b/src/routes/(auth)/dashboard/+page.svelte
@@ -255,6 +255,15 @@
 	const hasAdminPermissions = (orgId: string) => userHasAdminPermissions(permissions, orgId);
 	const ownsOrganization = () => userOwnsOrganization(permissions);
 
+	// The quick-action chips sit on the SATURATED welcome band, which sets
+	// `text-secondary-foreground` on everything inside it. A chip painted
+	// `bg-card` would inherit that and end up with the band's text colour on a
+	// card-coloured surface — an unaudited pair. Each chip therefore carries its
+	// own explicit `text-card-foreground`, which is also what makes it read as a
+	// white poster sticker on the colour block.
+	const secondaryAction =
+		'inline-flex items-center gap-2 rounded-lg border-2 bg-card px-6 py-3 text-sm font-bold text-card-foreground shadow-poster transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2';
+
 	// Helper to check if a filter preset is currently active
 	const isFilterActive = (preset: DashboardFilterPreset) =>
 		isFilterActiveFor(yourEventsFilters, preset);
@@ -304,12 +313,19 @@
 	<meta name="description" content={m['dashboard.pageSubtitle']()} />
 </svelte:head>
 
-<div class="container mx-auto px-4 py-6 md:py-8">
-	<!-- Welcome Header -->
+<!-- Celebration band + floating content (uplift, spec §9). The dashboard is
+     the welcome moment, so it opens on a full-strength `bg-secondary` colour
+     block — an audit-enforced pair in BOTH modes, so the band is a real poster
+     panel that still respects the light/dark axis — with the page pulled up
+     over its bottom edge so the activity cards visibly float on colour. The
+     kicker and subtitle inherit the band's foreground through PageHeader's
+     `onBand` affordance (its default `text-primary` kicker measures 4.12:1
+     there, below AA for 14px extrabold). -->
+<div class="bg-background">
 	{#snippet quickActions()}
 		<a
 			href={resolve('/(public)/events', {})}
-			class="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+			class="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-bold text-primary-foreground shadow-poster transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 		>
 			<Sparkles class="h-4 w-4" aria-hidden="true" />
 			<span>{m['dashboard.browseEventsButton']()}</span>
@@ -322,18 +338,14 @@
 					href={resolve('/(auth)/org/[slug]/admin/events/new', {
 						slug: organizations.find((org) => hasAdminPermissions(org.id))?.slug ?? ''
 					})}
-					class="inline-flex items-center gap-2 rounded-lg border bg-background px-6 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+					class={secondaryAction}
 				>
 					<Calendar class="h-4 w-4" aria-hidden="true" />
 					<span>{m['dashboard.createEventButton']()}</span>
 				</a>
 			{:else}
 				<!-- Multiple admin orgs - scroll to organizations section to choose -->
-				<button
-					type="button"
-					onclick={scrollToOrganizations}
-					class="inline-flex items-center gap-2 rounded-lg border bg-background px-6 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-				>
+				<button type="button" onclick={scrollToOrganizations} class={secondaryAction}>
 					<Calendar class="h-4 w-4" aria-hidden="true" />
 					<span>{m['dashboard.createEventButton']()}</span>
 				</button>
@@ -341,20 +353,13 @@
 		{/if}
 
 		{#if organizations.length > 0}
-			<button
-				type="button"
-				onclick={scrollToOrganizations}
-				class="inline-flex items-center gap-2 rounded-lg border bg-background px-6 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-			>
+			<button type="button" onclick={scrollToOrganizations} class={secondaryAction}>
 				<Building2 class="h-4 w-4" aria-hidden="true" />
 				<span>{m['dashboard.myOrganizationsButton']()}</span>
 			</button>
 		{/if}
 
-		<a
-			href={resolve('/(auth)/dashboard/following', {})}
-			class="inline-flex items-center gap-2 rounded-lg border bg-background px-6 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-		>
+		<a href={resolve('/(auth)/dashboard/following', {})} class={secondaryAction}>
 			<Heart class="h-4 w-4" aria-hidden="true" />
 			<span>{m['dashboard.following.title']()}</span>
 		</a>
@@ -365,181 +370,187 @@
 				href={resolve('/(auth)/org/[slug]/admin', {
 					slug: organizations.find((org) => hasAdminPermissions(org.id))?.slug ?? ''
 				})}
-				class="inline-flex items-center gap-2 rounded-lg border bg-background px-6 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+				class={secondaryAction}
 			>
 				<Shield class="h-4 w-4" aria-hidden="true" />
 				<span>{m['dashboard.adminButton']()}</span>
 			</a>
 		{:else if organizations.filter((org) => hasAdminPermissions(org.id)).length > 1}
 			<!-- Multiple admin orgs - scroll to organizations section to choose -->
-			<button
-				type="button"
-				onclick={scrollToOrganizations}
-				class="inline-flex items-center gap-2 rounded-lg border bg-background px-6 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-			>
+			<button type="button" onclick={scrollToOrganizations} class={secondaryAction}>
 				<Shield class="h-4 w-4" aria-hidden="true" />
 				<span>{m['dashboard.adminButton']()}</span>
 			</button>
 		{:else if !ownsOrganization() && features.organization_creation}
 			<!-- User doesn't own an organization - show "Create Organization" CTA -->
-			<a
-				href={resolve('/(auth)/create-org', {})}
-				class="inline-flex items-center gap-2 rounded-lg border bg-background px-6 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-			>
+			<a href={resolve('/(auth)/create-org', {})} class={secondaryAction}>
 				<PlusCircle class="h-4 w-4" aria-hidden="true" />
 				<span>{m['dashboard.createOrganizationButton']()}</span>
 			</a>
 		{/if}
 	{/snippet}
-	<PageHeader
-		title={m['dashboard.pageTitle']({ firstName })}
-		subtitle={m['dashboard.pageSubtitle']()}
-		kicker={m['userMenu.dashboard']()}
-		volume="celebration"
-		actions={quickActions}
-		class="mb-8"
-	/>
+	<section class="bg-secondary text-secondary-foreground">
+		<div class="container mx-auto px-4 pb-20 pt-8 md:pt-10">
+			<PageHeader
+				title={m['dashboard.pageTitle']({ firstName })}
+				subtitle={m['dashboard.pageSubtitle']()}
+				kicker={m['userMenu.dashboard']()}
+				volume="poster"
+				onBand
+				actions={quickActions}
+			/>
+		</div>
+	</section>
 
-	<!-- Activity Summary Cards -->
-	<DashboardActivityCards {activeTicketsCount} {pendingInvitationsCount} {upcomingRsvpsCount} />
+	<div class="container mx-auto -mt-12 px-4 pb-8 md:pb-12">
+		<!-- Activity Summary Cards -->
+		<DashboardActivityCards {activeTicketsCount} {pendingInvitationsCount} {upcomingRsvpsCount} />
 
-	<!-- Main Content Grid -->
-	<div class="space-y-8">
-		<!-- Your Events Section (with filters) - Show if user has ANY events -->
-		{#if hasAnyEvents}
-			<section aria-labelledby="your-events-heading">
-				<div class="mb-4">
-					<div class="mb-3 flex items-center justify-between">
-						<h2 id="your-events-heading" class="flex items-center gap-2 text-xl font-extrabold">
-							<Calendar class="h-5 w-5 text-primary" aria-hidden="true" />
-							<span>{m['dashboard.sections.yourEvents']()}</span>
-							{#if viewMode === 'list' && yourEvents.length > 0}
-								<span
-									class="inline-flex items-center justify-center rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
-								>
-									{yourEvents.length}
-								</span>
-							{:else if viewMode === 'calendar' && calendarEvents.length > 0}
-								<span
-									class="inline-flex items-center justify-center rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
-								>
-									{calendarEvents.length}
-								</span>
-							{/if}
-						</h2>
+		<!-- Main Content Grid -->
+		<div class="space-y-8">
+			<!-- Your Events Section (with filters) - Show if user has ANY events -->
+			{#if hasAnyEvents}
+				<section aria-labelledby="your-events-heading">
+					<div class="mb-4">
+						<div class="mb-3 flex items-center justify-between">
+							<h2 id="your-events-heading" class="flex items-center gap-2 text-xl font-extrabold">
+								<Calendar class="h-5 w-5 text-primary" aria-hidden="true" />
+								<span>{m['dashboard.sections.yourEvents']()}</span>
+								{#if viewMode === 'list' && yourEvents.length > 0}
+									<span
+										class="inline-flex items-center justify-center rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
+									>
+										{yourEvents.length}
+									</span>
+								{:else if viewMode === 'calendar' && calendarEvents.length > 0}
+									<span
+										class="inline-flex items-center justify-center rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
+									>
+										{calendarEvents.length}
+									</span>
+								{/if}
+							</h2>
 
-						<!-- View Toggle -->
-						<button
-							type="button"
-							onclick={toggleViewMode}
-							class="inline-flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-						>
-							{#if viewMode === 'list'}
-								<Calendar class="h-4 w-4" aria-hidden="true" />
-								{m['calendar.calendar_view']()}
-							{:else}
-								<List class="h-4 w-4" aria-hidden="true" />
-								{m['calendar.list_view']()}
-							{/if}
-						</button>
-					</div>
+							<!-- View Toggle -->
+							<button
+								type="button"
+								onclick={toggleViewMode}
+								class="inline-flex items-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+							>
+								{#if viewMode === 'list'}
+									<Calendar class="h-4 w-4" aria-hidden="true" />
+									{m['calendar.calendar_view']()}
+								{:else}
+									<List class="h-4 w-4" aria-hidden="true" />
+									{m['calendar.list_view']()}
+								{/if}
+							</button>
+						</div>
 
-					<!-- Filter Bar (only show in list view) -->
-					{#if viewMode === 'list'}
-						<div class="flex flex-wrap items-center gap-2">
-							<Filter class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-							{#each filterPresets as preset (preset.labelKey)}
-								<!-- Only show "Organizing" filter if user can organize events -->
-								{#if preset.labelKey !== 'dashboard.filters.organizing' || canOrganizeEvents()}
+						<!-- Filter Bar (only show in list view) -->
+						{#if viewMode === 'list'}
+							<div class="flex flex-wrap items-center gap-2">
+								<Filter class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+								{#each filterPresets as preset (preset.labelKey)}
+									<!-- Only show "Organizing" filter if user can organize events -->
+									{#if preset.labelKey !== 'dashboard.filters.organizing' || canOrganizeEvents()}
+										<button
+											type="button"
+											onclick={() => applyFilterPreset(preset)}
+											class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isFilterActive(
+												preset
+											)
+												? 'bg-primary text-primary-foreground hover:bg-primary/90'
+												: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
+										>
+											{#if preset.labelKey === 'dashboard.filters.bookmarked'}
+												<Bookmark
+													class="mr-1 inline h-4 w-4 align-text-bottom"
+													aria-hidden="true"
+												/>
+											{/if}
+											{(m as unknown as Record<string, () => string>)[preset.labelKey]()}
+										</button>
+									{/if}
+								{/each}
+
+								<!-- Ticket Type Toggle -->
+								<span class="ml-1 text-muted-foreground">|</span>
+								{#each [{ value: 'ticketed', label: m['filters.ticketType.ticketed']() }, { value: 'free', label: m['filters.ticketType.free']() }] as option (option.value)}
+									{@const isSelected = ticketType === option.value}
 									<button
 										type="button"
-										onclick={() => applyFilterPreset(preset)}
-										class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isFilterActive(
-											preset
-										)
+										onclick={() =>
+											(ticketType = isSelected ? undefined : (option.value as 'ticketed' | 'free'))}
+										class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isSelected
 											? 'bg-primary text-primary-foreground hover:bg-primary/90'
 											: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
+										aria-pressed={isSelected}
 									>
-										{#if preset.labelKey === 'dashboard.filters.bookmarked'}
-											<Bookmark class="mr-1 inline h-4 w-4 align-text-bottom" aria-hidden="true" />
-										{/if}
-										{(m as unknown as Record<string, () => string>)[preset.labelKey]()}
+										{option.label}
 									</button>
-								{/if}
-							{/each}
+								{/each}
+							</div>
+						{/if}
+					</div>
 
-							<!-- Ticket Type Toggle -->
-							<span class="ml-1 text-muted-foreground">|</span>
-							{#each [{ value: 'ticketed', label: m['filters.ticketType.ticketed']() }, { value: 'free', label: m['filters.ticketType.free']() }] as option (option.value)}
-								{@const isSelected = ticketType === option.value}
-								<button
-									type="button"
-									onclick={() =>
-										(ticketType = isSelected ? undefined : (option.value as 'ticketed' | 'free'))}
-									class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isSelected
-										? 'bg-primary text-primary-foreground hover:bg-primary/90'
-										: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
-									aria-pressed={isSelected}
-								>
-									{option.label}
-								</button>
-							{/each}
-						</div>
-					{/if}
-				</div>
-
-				{#if viewMode === 'list'}
-					<!-- List View -->
-					{#if yourEvents.length > 0}
-						<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-							{#each yourEvents.slice(0, 6) as event (event.id)}
-								<EventCard {event} />
-							{/each}
-						</div>
+					{#if viewMode === 'list'}
+						<!-- List View -->
+						{#if yourEvents.length > 0}
+							<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+								{#each yourEvents.slice(0, 6) as event (event.id)}
+									<EventCard {event} />
+								{/each}
+							</div>
+						{:else}
+							<!-- Empty state when filter returns no results -->
+							<EmptyState
+								icon={Calendar}
+								title={m['dashboard.emptyStates.noEvents']()}
+								body={m['dashboard.emptyStates.noEventsFiltered']()}
+								tone="neutral"
+							/>
+						{/if}
 					{:else}
-						<!-- Empty state when filter returns no results -->
-						<EmptyState
-							icon={Calendar}
-							title={m['dashboard.emptyStates.noEvents']()}
-							body={m['dashboard.emptyStates.noEventsFiltered']()}
-							tone="neutral"
+						<!-- Calendar View -->
+						<CalendarControls
+							view={calendarParams.view}
+							year={calendarParams.year}
+							month={calendarParams.month}
+							week={calendarParams.week}
+							baseUrl="/dashboard"
+							preserveParams={['viewMode']}
+						/>
+
+						<CalendarView
+							view={calendarParams.view}
+							year={calendarParams.year}
+							month={calendarParams.month}
+							week={calendarParams.week}
+							events={calendarEvents}
+							isLoading={isCalendarLoading}
+							onEventClick={handleEventClick}
 						/>
 					{/if}
-				{:else}
-					<!-- Calendar View -->
-					<CalendarControls
-						view={calendarParams.view}
-						year={calendarParams.year}
-						month={calendarParams.month}
-						week={calendarParams.week}
-						baseUrl="/dashboard"
-						preserveParams={['viewMode']}
-					/>
+				</section>
+			{/if}
 
-					<CalendarView
-						view={calendarParams.view}
-						year={calendarParams.year}
-						month={calendarParams.month}
-						week={calendarParams.week}
-						events={calendarEvents}
-						isLoading={isCalendarLoading}
-						onEventClick={handleEventClick}
-					/>
-				{/if}
-			</section>
-		{/if}
+			<!-- Upcoming Events Section -->
+			<DashboardUpcomingEvents {upcomingEvents} isLoading={upcomingEventsQuery.isLoading} />
 
-		<!-- Upcoming Events Section -->
-		<DashboardUpcomingEvents {upcomingEvents} isLoading={upcomingEventsQuery.isLoading} />
+			<!-- My Organizations Section -->
+			<DashboardOrganizationsSection
+				{organizations}
+				isLoading={organizationsQuery.isPending}
+				{permissions}
+			/>
+		</div>
 
-		<!-- My Organizations Section -->
-		<DashboardOrganizationsSection
-			{organizations}
-			isLoading={organizationsQuery.isPending}
-			{permissions}
+		<!-- Event Modal (for calendar clicks) -->
+		<EventModal
+			event={selectedEvent}
+			open={selectedEvent !== null}
+			onClose={handleCloseEventModal}
 		/>
 	</div>
-
-	<!-- Event Modal (for calendar clicks) -->
-	<EventModal event={selectedEvent} open={selectedEvent !== null} onClose={handleCloseEventModal} />
 </div>

--- a/src/routes/(auth)/dashboard/+page.svelte
+++ b/src/routes/(auth)/dashboard/+page.svelte
@@ -403,7 +403,16 @@
 	</section>
 
 	<div class="container mx-auto -mt-12 px-4 pb-8 md:pb-12">
-		<!-- Activity Summary Cards -->
+		<!-- Activity Summary Cards. `DashboardActivityCards` renders NOTHING
+		     when all three counts are zero (a brand-new user), so it cannot be
+		     trusted alone to land the -mt-12 pull-up on an opaque surface —
+		     the fix round found the next block down (the "Your Events" filter
+		     row here, or `DashboardUpcomingEvents`' header when this section
+		     is also hidden) sitting bare on the band's cut instead. Both of
+		     those now carry their own `bg-card border-2 shadow-poster` wrapper
+		     (matching the tickets/rsvps pages' "gather filters into one card"
+		     pattern) so whichever block ends up first is opaque
+		     UNCONDITIONALLY, regardless of activity state. -->
 		<DashboardActivityCards {activeTicketsCount} {pendingInvitationsCount} {upcomingRsvpsCount} />
 
 		<!-- Main Content Grid -->
@@ -411,7 +420,7 @@
 			<!-- Your Events Section (with filters) - Show if user has ANY events -->
 			{#if hasAnyEvents}
 				<section aria-labelledby="your-events-heading">
-					<div class="mb-4">
+					<div class="mb-4 rounded-lg border-2 border-border bg-card p-4 shadow-poster sm:p-6">
 						<div class="mb-3 flex items-center justify-between">
 							<h2 id="your-events-heading" class="flex items-center gap-2 text-xl font-extrabold">
 								<Calendar class="h-5 w-5 text-primary" aria-hidden="true" />

--- a/src/routes/(auth)/dashboard/following/+page.svelte
+++ b/src/routes/(auth)/dashboard/following/+page.svelte
@@ -13,7 +13,7 @@
 	import { Building2, Calendar, Loader2, ChevronLeft, ChevronRight } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
-	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import DashboardBandLayout from '$lib/components/dashboard/DashboardBandLayout.svelte';
 	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { toast } from 'svelte-sonner';
 	import { page } from '$app/state';
@@ -199,17 +199,11 @@
 	<title>{m['dashboard.following.title']()} - Revel</title>
 </svelte:head>
 
-<div class="container mx-auto px-4 py-6 md:py-8">
-	<!-- Page Header -->
-	<PageHeader
-		title={m['dashboard.following.title']()}
-		kicker={m['userMenu.dashboard']()}
-		volume="celebration"
-		class="mb-8"
-	/>
-
+<!-- Celebration band + floating tab card (uplift) — twin of the invitations
+     page; see DashboardBandLayout for the band's contrast contract. -->
+<DashboardBandLayout title={m['dashboard.following.title']()} kicker={m['userMenu.dashboard']()}>
 	<!-- Tabs -->
-	<div class="mb-6">
+	<div class="mb-6 rounded-lg border-2 border-border bg-card px-4 shadow-poster sm:px-6">
 		<div class="border-b border-border">
 			<nav class="-mb-px flex gap-6" aria-label={m['dashboardFollowingPage.tabsLabel']()}>
 				<button
@@ -279,7 +273,7 @@
 				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{#each organizations as follow (follow.id)}
 						{@const org = follow.organization}
-						<div class="rounded-lg border bg-card p-4">
+						<div class="rounded-lg border-2 bg-card p-4 shadow-poster">
 							<div class="mb-3 flex items-start gap-3">
 								{#if org.logo}
 									<img
@@ -412,7 +406,7 @@
 				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{#each eventSeries as follow (follow.id)}
 						{@const series = follow.event_series}
-						<div class="rounded-lg border bg-card p-4">
+						<div class="rounded-lg border-2 bg-card p-4 shadow-poster">
 							<div class="mb-3 flex items-start gap-3">
 								{#if series.logo}
 									<img
@@ -516,4 +510,4 @@
 			{/if}
 		</div>
 	{/if}
-</div>
+</DashboardBandLayout>

--- a/src/routes/(auth)/dashboard/invitations/+page.svelte
+++ b/src/routes/(auth)/dashboard/invitations/+page.svelte
@@ -8,7 +8,7 @@
 	} from '$lib/api/generated/sdk.gen';
 	import InvitationCard from '$lib/components/invitations/InvitationCard.svelte';
 	import InvitationRequestCard from '$lib/components/invitations/InvitationRequestCard.svelte';
-	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import DashboardBandLayout from '$lib/components/dashboard/DashboardBandLayout.svelte';
 	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { Mail, Send, Loader2, Filter } from '@lucide/svelte';
 	import { page } from '$app/state';
@@ -141,18 +141,18 @@
 	<meta name="description" content={m['dashboard.invitations.description']()} />
 </svelte:head>
 
-<div class="container mx-auto px-4 py-6 md:py-8">
-	<!-- Page Header -->
-	<PageHeader
-		title={m['dashboard.invitations.title']()}
-		subtitle={m['dashboard.invitations.description']()}
-		kicker={m['userMenu.dashboard']()}
-		volume="celebration"
-		class="mb-8"
-	/>
-
+<!-- Celebration band + floating tab card (uplift); see DashboardBandLayout for
+     the band's contrast contract. The tab strip is what meets the band's
+     bottom edge, so it gets a card surface of its own — a bare underline rule
+     landing on the cut reads as debris. Tab semantics (aria-current, the
+     switchTab handler, the URL params) are untouched. -->
+<DashboardBandLayout
+	title={m['dashboard.invitations.title']()}
+	subtitle={m['dashboard.invitations.description']()}
+	kicker={m['userMenu.dashboard']()}
+>
 	<!-- Tabs -->
-	<div class="mb-6">
+	<div class="mb-6 rounded-lg border-2 border-border bg-card px-4 shadow-poster sm:px-6">
 		<div class="border-b border-border">
 			<nav class="-mb-px flex gap-6" aria-label={m['dashboard.invitations.tabs']()}>
 				<button
@@ -395,4 +395,4 @@
 			{/if}
 		</div>
 	{/if}
-</div>
+</DashboardBandLayout>

--- a/src/routes/(auth)/dashboard/passes/+page.svelte
+++ b/src/routes/(auth)/dashboard/passes/+page.svelte
@@ -5,7 +5,7 @@
 	import { seriespassListMySeriesPasses } from '$lib/api';
 	import { seriesPassQueryKeys } from '$lib/queries/series-passes';
 	import HeldPassCard from '$lib/components/series-passes/HeldPassCard.svelte';
-	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import DashboardBandLayout from '$lib/components/dashboard/DashboardBandLayout.svelte';
 	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { Ticket, ChevronLeft, ChevronRight, Loader2 } from '@lucide/svelte';
 	import { page } from '$app/state';
@@ -56,23 +56,28 @@
 	<meta name="description" content={m['seriesPass.myPassesDescription']()} />
 </svelte:head>
 
-<div class="container mx-auto px-4 py-6 md:py-8">
-	<!-- Page Header -->
-	<PageHeader
-		title={m['seriesPass.myPassesTitle']()}
-		subtitle={m['seriesPass.myPassesDescription']()}
-		kicker={m['userMenu.dashboard']()}
-		volume="celebration"
-		class="mb-8"
-	/>
-
+<!-- Celebration band + floating content (uplift); see DashboardBandLayout for
+     the band's contrast contract. The pass grid, the empty state and the
+     loading/error panels are all card surfaces, so they meet the band's
+     bottom edge on their own. -->
+<DashboardBandLayout
+	title={m['seriesPass.myPassesTitle']()}
+	subtitle={m['seriesPass.myPassesDescription']()}
+	kicker={m['userMenu.dashboard']()}
+>
 	{#if passesQuery.isPending}
-		<div class="flex items-center justify-center py-16" role="status">
+		<div
+			class="flex items-center justify-center rounded-lg border-2 border-border bg-card py-16 shadow-poster"
+			role="status"
+		>
 			<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
 			<span class="sr-only">{m['seriesPass.loading']()}</span>
 		</div>
 	{:else if passesQuery.isError}
-		<div class="rounded-lg border border-destructive/40 bg-card p-8 text-center" role="alert">
+		<div
+			class="rounded-lg border-2 border-destructive/40 bg-card p-8 text-center shadow-poster"
+			role="alert"
+		>
 			<p class="mb-4 text-sm text-muted-foreground">{m['seriesPass.loadError']()}</p>
 			<button
 				type="button"
@@ -134,4 +139,4 @@
 			</nav>
 		{/if}
 	{/if}
-</div>
+</DashboardBandLayout>

--- a/src/routes/(auth)/dashboard/rsvps/+page.svelte
+++ b/src/routes/(auth)/dashboard/rsvps/+page.svelte
@@ -5,7 +5,7 @@
 	import { dashboardDashboardRsvps } from '$lib/api/generated/sdk.gen';
 	import type { RsvpStatus } from '$lib/api/generated/types.gen';
 	import RSVPCard from '$lib/components/rsvps/RSVPCard.svelte';
-	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import DashboardBandLayout from '$lib/components/dashboard/DashboardBandLayout.svelte';
 	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { CheckCircle2, Filter, ChevronLeft, ChevronRight, Loader2 } from '@lucide/svelte';
 	import { page } from '$app/state';
@@ -122,89 +122,88 @@
 	<meta name="description" content={m['dashboard.rsvps.description']()} />
 </svelte:head>
 
-<div class="container mx-auto px-4 py-6 md:py-8">
-	<!-- Page Header -->
-	<PageHeader
-		title={m['dashboard.rsvps.title']()}
-		subtitle={m['dashboard.rsvps.description']()}
-		kicker={m['userMenu.dashboard']()}
-		volume="celebration"
-		class="mb-4"
-	/>
+<!-- Celebration band + floating controls card (uplift) — twin of the tickets
+     page; see DashboardBandLayout for the band's contrast contract. -->
+<DashboardBandLayout
+	title={m['dashboard.rsvps.title']()}
+	subtitle={m['dashboard.rsvps.description']()}
+	kicker={m['userMenu.dashboard']()}
+>
+	<div class="mb-8 space-y-4 rounded-lg border-2 border-border bg-card p-4 shadow-poster sm:p-6">
+		<!-- RSVP Count -->
+		{#if !rsvpsQuery.isPending && totalCount > 0}
+			<p class="text-sm text-muted-foreground">
+				{m['dashboard.rsvps.showing']({
+					count: rsvps.length.toString(),
+					total: totalCount.toString()
+				})}
+				{totalCount === 1 ? m['dashboard.rsvps.rsvp']() : m['dashboard.rsvps.rsvps']()}
+			</p>
+		{/if}
 
-	<!-- RSVP Count -->
-	{#if !rsvpsQuery.isPending && totalCount > 0}
-		<p class="mb-6 text-sm text-muted-foreground">
-			{m['dashboard.rsvps.showing']({
-				count: rsvps.length.toString(),
-				total: totalCount.toString()
-			})}
-			{totalCount === 1 ? m['dashboard.rsvps.rsvp']() : m['dashboard.rsvps.rsvps']()}
-		</p>
-	{/if}
-
-	<!-- Search Bar -->
-	<div class="mb-6">
-		<label for="search" class="sr-only">{m['dashboard.rsvps.searchPlaceholder']()}</label>
-		<input
-			id="search"
-			type="search"
-			bind:value={searchQuery}
-			placeholder={m['dashboard.rsvps.searchPlaceholder']()}
-			class="w-full rounded-lg border border-input bg-background px-4 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-		/>
-	</div>
-
-	<!-- Filters -->
-	<div class="mb-6 space-y-4">
-		<!-- Status Filter -->
+		<!-- Search Bar -->
 		<div>
-			<div class="mb-2 flex items-center gap-2">
-				<Filter class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-				<span class="text-sm font-medium">{m['dashboard.rsvps.status']()}</span>
-			</div>
-			<div class="flex flex-wrap gap-2">
-				<button
-					type="button"
-					aria-pressed={selectedStatuses.length === 0}
-					onclick={() => setStatuses([])}
-					class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {selectedStatuses.length ===
-					0
-						? 'bg-primary text-primary-foreground hover:bg-primary/90'
-						: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
-				>
-					{m['dashboard.rsvps.status_all']()}
-				</button>
-				{#each statusToggles as toggle (toggle.value)}
-					{@const active = selectedStatuses.includes(toggle.value)}
+			<label for="search" class="sr-only">{m['dashboard.rsvps.searchPlaceholder']()}</label>
+			<input
+				id="search"
+				type="search"
+				bind:value={searchQuery}
+				placeholder={m['dashboard.rsvps.searchPlaceholder']()}
+				class="w-full rounded-lg border border-input bg-background px-4 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+			/>
+		</div>
+
+		<!-- Filters -->
+		<div class="space-y-4">
+			<!-- Status Filter -->
+			<div>
+				<div class="mb-2 flex items-center gap-2">
+					<Filter class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+					<span class="text-sm font-medium">{m['dashboard.rsvps.status']()}</span>
+				</div>
+				<div class="flex flex-wrap gap-2">
 					<button
 						type="button"
-						aria-pressed={active}
-						onclick={() => toggleStatus(toggle.value)}
-						class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {active
+						aria-pressed={selectedStatuses.length === 0}
+						onclick={() => setStatuses([])}
+						class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {selectedStatuses.length ===
+						0
 							? 'bg-primary text-primary-foreground hover:bg-primary/90'
 							: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
 					>
-						{toggle.label}
+						{m['dashboard.rsvps.status_all']()}
 					</button>
-				{/each}
+					{#each statusToggles as toggle (toggle.value)}
+						{@const active = selectedStatuses.includes(toggle.value)}
+						<button
+							type="button"
+							aria-pressed={active}
+							onclick={() => toggleStatus(toggle.value)}
+							class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {active
+								? 'bg-primary text-primary-foreground hover:bg-primary/90'
+								: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
+						>
+							{toggle.label}
+						</button>
+					{/each}
+				</div>
 			</div>
-		</div>
 
-		<!-- Include Past Events Checkbox -->
-		<div>
-			<div class="mb-2">
-				<span class="text-sm font-medium">{m['dashboardRsvpsPage.options']()}</span>
+			<!-- Include Past Events Checkbox -->
+			<div>
+				<div class="mb-2">
+					<span class="text-sm font-medium">{m['dashboardRsvpsPage.options']()}</span>
+				</div>
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="checkbox"
+						bind:checked={includePast}
+						onchange={() => navigateToPage(1)}
+						class="h-4 w-4 cursor-pointer rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
+					/>
+					<span class="text-sm">{m['dashboard.rsvps.includePast']()}</span>
+				</label>
 			</div>
-			<label class="flex cursor-pointer items-center gap-2">
-				<input
-					type="checkbox"
-					bind:checked={includePast}
-					onchange={() => navigateToPage(1)}
-					class="h-4 w-4 cursor-pointer rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
-				/>
-				<span class="text-sm">{m['dashboard.rsvps.includePast']()}</span>
-			</label>
 		</div>
 	</div>
 
@@ -288,4 +287,4 @@
 			</div>
 		{/if}
 	{/if}
-</div>
+</DashboardBandLayout>

--- a/src/routes/(auth)/dashboard/tickets/+page.svelte
+++ b/src/routes/(auth)/dashboard/tickets/+page.svelte
@@ -9,7 +9,7 @@
 	import type { PaymentMethod, TicketStatus } from '$lib/api/generated/types.gen';
 	import TicketListCard from '$lib/components/tickets/TicketListCard.svelte';
 	import HeldPassCard from '$lib/components/series-passes/HeldPassCard.svelte';
-	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import DashboardBandLayout from '$lib/components/dashboard/DashboardBandLayout.svelte';
 	import EmptyState from '$lib/components/common/EmptyState.svelte';
 	import { seriesPassQueryKeys } from '$lib/queries/series-passes';
 	import { groupTicketsWithPasses } from '$lib/utils/ticket-pass-grouping';
@@ -151,100 +151,102 @@
 	<meta name="description" content={m['dashboard.tickets.description']()} />
 </svelte:head>
 
-<div class="container mx-auto px-4 py-6 md:py-8">
-	<!-- Page Header -->
-	<PageHeader
-		title={m['dashboard.tickets.title']()}
-		subtitle={m['dashboard.tickets.description']()}
-		kicker={m['userMenu.dashboard']()}
-		volume="celebration"
-		class="mb-4"
-	/>
+<!-- Celebration band + floating controls card (uplift, spec §9). See
+     DashboardBandLayout for why `bg-secondary` at full strength is the
+     theme-aware poster panel. The count, search field and filter chips are
+     gathered into ONE card that meets the band's bottom edge — bare chips
+     landing on the cut read as debris. -->
+<DashboardBandLayout
+	title={m['dashboard.tickets.title']()}
+	subtitle={m['dashboard.tickets.description']()}
+	kicker={m['userMenu.dashboard']()}
+>
+	<div class="mb-8 space-y-4 rounded-lg border-2 border-border bg-card p-4 shadow-poster sm:p-6">
+		<!-- Ticket Count -->
+		{#if !ticketsQuery.isPending && totalCount > 0}
+			<p class="text-sm text-muted-foreground">
+				{m['dashboard.tickets.showing']({
+					count: tickets.length.toString(),
+					total: totalCount.toString()
+				})}
+				{totalCount === 1 ? m['dashboard.tickets.ticket']() : m['dashboard.tickets.tickets']()}
+			</p>
+		{/if}
 
-	<!-- Ticket Count -->
-	{#if !ticketsQuery.isPending && totalCount > 0}
-		<p class="mb-6 text-sm text-muted-foreground">
-			{m['dashboard.tickets.showing']({
-				count: tickets.length.toString(),
-				total: totalCount.toString()
-			})}
-			{totalCount === 1 ? m['dashboard.tickets.ticket']() : m['dashboard.tickets.tickets']()}
-		</p>
-	{/if}
-
-	<!-- Search Bar -->
-	<div class="mb-6">
-		<label for="search" class="sr-only">{m['dashboard.tickets.searchPlaceholder']()}</label>
-		<input
-			id="search"
-			type="search"
-			bind:value={searchQuery}
-			placeholder={m['dashboard.tickets.searchPlaceholder']()}
-			class="w-full rounded-lg border border-input bg-background px-4 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-		/>
-	</div>
-
-	<!-- Filters -->
-	<div class="mb-6 space-y-4">
-		<!-- Status Filter -->
+		<!-- Search Bar -->
 		<div>
-			<div class="mb-2 flex items-center gap-2">
-				<Filter class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-				<span class="text-sm font-medium">{m['dashboard.tickets.status']()}</span>
-			</div>
-			<div class="flex flex-wrap gap-2">
-				{#each statusFilters as filter (filter.value ?? 'all')}
-					<button
-						type="button"
-						onclick={() => applyStatusFilter(filter.value)}
-						class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isStatusFilterActive(
-							filter.value
-						)
-							? 'bg-primary text-primary-foreground hover:bg-primary/90'
-							: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
-					>
-						{filter.label}
-					</button>
-				{/each}
-			</div>
+			<label for="search" class="sr-only">{m['dashboard.tickets.searchPlaceholder']()}</label>
+			<input
+				id="search"
+				type="search"
+				bind:value={searchQuery}
+				placeholder={m['dashboard.tickets.searchPlaceholder']()}
+				class="w-full rounded-lg border border-input bg-background px-4 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+			/>
 		</div>
 
-		<!-- Payment Method Filter -->
-		<div>
-			<div class="mb-2">
-				<span class="text-sm font-medium">{m['dashboard.tickets.paymentMethod']()}</span>
+		<!-- Filters -->
+		<div class="space-y-4">
+			<!-- Status Filter -->
+			<div>
+				<div class="mb-2 flex items-center gap-2">
+					<Filter class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+					<span class="text-sm font-medium">{m['dashboard.tickets.status']()}</span>
+				</div>
+				<div class="flex flex-wrap gap-2">
+					{#each statusFilters as filter (filter.value ?? 'all')}
+						<button
+							type="button"
+							onclick={() => applyStatusFilter(filter.value)}
+							class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isStatusFilterActive(
+								filter.value
+							)
+								? 'bg-primary text-primary-foreground hover:bg-primary/90'
+								: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
+						>
+							{filter.label}
+						</button>
+					{/each}
+				</div>
 			</div>
-			<div class="flex flex-wrap gap-2">
-				{#each paymentMethodFilters as filter (filter.value ?? 'all')}
-					<button
-						type="button"
-						onclick={() => applyPaymentMethodFilter(filter.value)}
-						class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isPaymentMethodFilterActive(
-							filter.value
-						)
-							? 'bg-primary text-primary-foreground hover:bg-primary/90'
-							: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
-					>
-						{filter.label}
-					</button>
-				{/each}
-			</div>
-		</div>
 
-		<!-- Include Past Events Checkbox -->
-		<div>
-			<div class="mb-2">
-				<span class="text-sm font-medium">{m['dashboardTicketsPage.options']()}</span>
+			<!-- Payment Method Filter -->
+			<div>
+				<div class="mb-2">
+					<span class="text-sm font-medium">{m['dashboard.tickets.paymentMethod']()}</span>
+				</div>
+				<div class="flex flex-wrap gap-2">
+					{#each paymentMethodFilters as filter (filter.value ?? 'all')}
+						<button
+							type="button"
+							onclick={() => applyPaymentMethodFilter(filter.value)}
+							class="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring {isPaymentMethodFilterActive(
+								filter.value
+							)
+								? 'bg-primary text-primary-foreground hover:bg-primary/90'
+								: 'bg-background hover:bg-accent hover:text-accent-foreground'}"
+						>
+							{filter.label}
+						</button>
+					{/each}
+				</div>
 			</div>
-			<label class="flex cursor-pointer items-center gap-2">
-				<input
-					type="checkbox"
-					bind:checked={includePast}
-					onchange={() => navigateToPage(1)}
-					class="h-4 w-4 cursor-pointer rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
-				/>
-				<span class="text-sm">{m['dashboard.tickets.includePast']()}</span>
-			</label>
+
+			<!-- Include Past Events Checkbox -->
+			<div>
+				<div class="mb-2">
+					<span class="text-sm font-medium">{m['dashboardTicketsPage.options']()}</span>
+				</div>
+				<label class="flex cursor-pointer items-center gap-2">
+					<input
+						type="checkbox"
+						bind:checked={includePast}
+						onchange={() => navigateToPage(1)}
+						class="h-4 w-4 cursor-pointer rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
+					/>
+					<span class="text-sm">{m['dashboard.tickets.includePast']()}</span>
+				</label>
+			</div>
 		</div>
 	</div>
 
@@ -334,4 +336,4 @@
 			</div>
 		{/if}
 	{/if}
-</div>
+</DashboardBandLayout>

--- a/src/routes/(public)/account/confirm-deletion/+page.svelte
+++ b/src/routes/(public)/account/confirm-deletion/+page.svelte
@@ -31,6 +31,13 @@
 	<meta name="description" content={m['accountDeletion.metaDescription']()} />
 </svelte:head>
 
+<!-- DELIBERATELY NOT on the uplift's celebration band (spec §9), unlike every
+     other page in this cluster. Deleting your account is an irreversible,
+     serious moment; a saturated poster panel would be the wrong register, and
+     this page already documents that exception for its tiles and tints below.
+     It takes the depth half of the uplift only: the 2px edge + poster float
+     that the rest of the app's surfaces now carry, so the silhouette matches
+     even though the colour language stays calm. -->
 <div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
 	<div class="w-full max-w-md space-y-8">
 		{#if success}
@@ -50,7 +57,7 @@
 			     muted-foreground, both already-audited pairs. -->
 			<div
 				role="status"
-				class="rounded-md border border-success/40 bg-success/10 p-6 dark:border-success/50 dark:bg-success/15"
+				class="rounded-lg border-2 border-success/40 bg-success/10 p-6 shadow-poster dark:border-success/50 dark:bg-success/15"
 			>
 				<div class="space-y-2 text-sm">
 					<p class="font-medium text-foreground">
@@ -83,7 +90,10 @@
 				</p>
 			</div>
 
-			<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
+			<div
+				role="alert"
+				class="rounded-lg border-2 border-destructive bg-destructive/10 p-4 shadow-poster"
+			>
 				<p class="text-sm font-medium text-destructive">
 					{m['accountDeletion.invalidTokenError']()}
 				</p>
@@ -122,8 +132,8 @@
 			{/if}
 
 			<!-- Warning Box -->
-			<div class="rounded-md border border-destructive/30 bg-destructive/5 p-6">
-				<h2 class="font-semibold text-destructive">{m['accountDeletion.confirmHeading']()}</h2>
+			<div class="rounded-lg border-2 border-destructive/40 bg-destructive/5 p-6 shadow-poster">
+				<h2 class="font-bold text-destructive">{m['accountDeletion.confirmHeading']()}</h2>
 				<div class="mt-4 space-y-2">
 					<p class="text-sm font-medium">{m['accountDeletion.warningYouWillLose']()}</p>
 					<ul class="space-y-1 text-sm text-muted-foreground">

--- a/src/routes/(public)/account/confirm-email-change/+page.svelte
+++ b/src/routes/(public)/account/confirm-email-change/+page.svelte
@@ -78,6 +78,7 @@
 
 {#if success}
 	<AuthBandLayout
+		width="lg"
 		status
 		chip={successChip}
 		title={m['confirmEmailChange.success_heading']()}
@@ -96,6 +97,7 @@
 	</AuthBandLayout>
 {:else if !token}
 	<AuthBandLayout
+		width="lg"
 		chip={invalidChip}
 		title={m['confirmEmailChange.invalidLink_heading']()}
 		subtitle={m['confirmEmailChange.invalidLink_body']()}
@@ -111,6 +113,7 @@
 	</AuthBandLayout>
 {:else}
 	<AuthBandLayout
+		width="lg"
 		chip={confirmChip}
 		title={m['confirmEmailChange.confirm_heading']()}
 		subtitle={m['confirmEmailChange.confirm_intro']()}

--- a/src/routes/(public)/account/confirm-email-change/+page.svelte
+++ b/src/routes/(public)/account/confirm-email-change/+page.svelte
@@ -8,6 +8,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import type { RevelUserSchema } from '$lib/api/generated/types.gen';
 	import type { ActionData } from './$types';
+	import AuthBandLayout from '$lib/components/auth/AuthBandLayout.svelte';
 
 	interface Props {
 		form: ActionData;
@@ -37,184 +38,187 @@
 	<meta name="description" content={m['confirmEmailChange.metaDescription']()} />
 </svelte:head>
 
-<div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
-	<div class="w-full max-w-md space-y-8">
-		{#if success}
-			<!-- Hand-composed centerpiece (not the EmptyState primitive, which caps
-			     at h2/h3): this page's only heading must be an h1. role="status"
-			     because this state is reached in-place (form submit, no
-			     navigation) — same live-region treatment the reset pages use for
-			     their success box. -->
-			<div role="status" class="text-center">
-				<span
-					aria-hidden="true"
-					class="mx-auto flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl bg-success text-success-foreground shadow-sm"
-				>
-					<CheckCircle class="h-7 w-7" />
-				</span>
-				<h1 class="mt-4 text-3xl font-black leading-[1.12] sm:text-4xl">
-					{m['confirmEmailChange.success_heading']()}
-				</h1>
-				<p class="mt-1.5 text-muted-foreground">
-					{m['confirmEmailChange.success_body']({ new_email: newEmail })}
-					{m['confirmEmailChange.success_signoutNotice']()}
-				</p>
-			</div>
+<!-- Colour-block band + floating content (uplift). Each of the three states
+     keeps its own chip, h1 and copy — the chip simply moves INTO the band
+     above the title (same EmptyState poster-chip recipe, still aria-hidden
+     ornament) and the actions float on it. The success state's live region
+     moves from the old wrapper div to the band's heading block via the
+     layout's `status` prop; it still announces the same h1 + body. Every
+     string is the same key, and the form action, token input, enhance handler
+     and token-rotation logic are untouched. -->
+{#snippet successChip()}
+	<span
+		aria-hidden="true"
+		class="flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl bg-success text-success-foreground shadow-poster"
+	>
+		<CheckCircle class="h-8 w-8" />
+	</span>
+{/snippet}
 
-			<div class="text-center">
-				<a
-					href={resolve('/(auth)/account/profile', {})}
-					class="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-				>
-					{m['confirmEmailChange.success_cta']()}
-				</a>
-			</div>
-		{:else if !token}
-			<!-- Hand-composed centerpiece: this page's only heading must be an h1.
-			     No poster tint for a broken/invalid link — "warning" (amber/ink,
-			     audited pair) is the closest honest match without adopting the
-			     full destructive framing reserved for confirm-deletion. -->
-			<div class="text-center">
-				<span
-					aria-hidden="true"
-					class="mx-auto flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl bg-poster-amber text-poster-ink shadow-sm"
-				>
-					<AlertTriangle class="h-7 w-7" />
-				</span>
-				<h1 class="mt-4 text-3xl font-black leading-[1.12] sm:text-4xl">
-					{m['confirmEmailChange.invalidLink_heading']()}
-				</h1>
-				<p class="mt-1.5 text-muted-foreground">{m['confirmEmailChange.invalidLink_body']()}</p>
-			</div>
+{#snippet invalidChip()}
+	<!-- No poster tint for a broken/invalid link — "warning" (amber/ink,
+	     audited pair) is the closest honest match without adopting the full
+	     destructive framing reserved for confirm-deletion. -->
+	<span
+		aria-hidden="true"
+		class="flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl bg-poster-amber text-poster-ink shadow-poster"
+	>
+		<AlertTriangle class="h-8 w-8" />
+	</span>
+{/snippet}
 
-			<div class="text-center">
-				<a
-					href={resolve('/(auth)/account/security', {})}
-					class="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-				>
-					{m['confirmEmailChange.invalidLink_cta']()}
-				</a>
-			</div>
-		{:else}
-			<!-- Hand-composed centerpiece: this page's only heading must be an h1. -->
-			<div class="text-center">
-				<span
-					aria-hidden="true"
-					class="mx-auto flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl bg-poster-purple text-poster-white shadow-sm"
-				>
-					<Mail class="h-7 w-7" />
-				</span>
-				<h1 class="mt-4 text-3xl font-black leading-[1.12] sm:text-4xl">
-					{m['confirmEmailChange.confirm_heading']()}
-				</h1>
-				<p class="mt-1.5 text-muted-foreground">{m['confirmEmailChange.confirm_intro']()}</p>
-			</div>
+{#snippet confirmChip()}
+	<span
+		aria-hidden="true"
+		class="flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl bg-poster-purple text-poster-white shadow-poster"
+	>
+		<Mail class="h-8 w-8" />
+	</span>
+{/snippet}
 
-			<!-- Warning box: highlight/20 + border are decorative; title/body stay
-			     on foreground/muted-foreground, both already-audited pairs. -->
-			<div
-				class="rounded-md border border-highlight/30 bg-highlight/20 p-6 dark:border-highlight/40 dark:bg-highlight/25"
-				role="region"
-				aria-labelledby="confirmEmailChange_warning_title"
+{#if success}
+	<AuthBandLayout
+		status
+		chip={successChip}
+		title={m['confirmEmailChange.success_heading']()}
+		subtitle="{m['confirmEmailChange.success_body']({
+			new_email: newEmail
+		})} {m['confirmEmailChange.success_signoutNotice']()}"
+	>
+		<div class="rounded-lg border-2 border-border bg-card p-6 text-center shadow-poster">
+			<a
+				href={resolve('/(auth)/account/profile', {})}
+				class="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 			>
-				<div class="flex items-start gap-3">
-					<AlertTriangle
-						class="mt-0.5 h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
-						aria-hidden="true"
-					/>
-					<div class="flex-1 space-y-2">
-						<h2 id="confirmEmailChange_warning_title" class="font-semibold text-foreground">
-							{m['confirmEmailChange.confirm_warningTitle']()}
-						</h2>
-						<p class="text-sm text-muted-foreground">
-							{m['confirmEmailChange.confirm_warningBody']()}
-						</p>
-						<ul class="space-y-1 text-sm text-muted-foreground">
-							<li class="flex gap-2">
-								<span aria-hidden="true">•</span>
-								<span>{m['confirmEmailChange.confirm_warningBullet1']()}</span>
-							</li>
-							<li class="flex gap-2">
-								<span aria-hidden="true">•</span>
-								<span>{m['confirmEmailChange.confirm_warningBullet2']()}</span>
-							</li>
-						</ul>
+				{m['confirmEmailChange.success_cta']()}
+			</a>
+		</div>
+	</AuthBandLayout>
+{:else if !token}
+	<AuthBandLayout
+		chip={invalidChip}
+		title={m['confirmEmailChange.invalidLink_heading']()}
+		subtitle={m['confirmEmailChange.invalidLink_body']()}
+	>
+		<div class="rounded-lg border-2 border-border bg-card p-6 text-center shadow-poster">
+			<a
+				href={resolve('/(auth)/account/security', {})}
+				class="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+			>
+				{m['confirmEmailChange.invalidLink_cta']()}
+			</a>
+		</div>
+	</AuthBandLayout>
+{:else}
+	<AuthBandLayout
+		chip={confirmChip}
+		title={m['confirmEmailChange.confirm_heading']()}
+		subtitle={m['confirmEmailChange.confirm_intro']()}
+	>
+		<!-- Warning box: highlight/20 + border are decorative; title/body stay
+		     on foreground/muted-foreground, both already-audited pairs. -->
+		<div
+			class="rounded-lg border-2 border-highlight/40 bg-highlight/20 p-6 shadow-poster dark:border-highlight/50 dark:bg-highlight/25"
+			role="region"
+			aria-labelledby="confirmEmailChange_warning_title"
+		>
+			<div class="flex items-start gap-3">
+				<AlertTriangle
+					class="mt-0.5 h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
+					aria-hidden="true"
+				/>
+				<div class="flex-1 space-y-2">
+					<h2 id="confirmEmailChange_warning_title" class="font-bold text-foreground">
+						{m['confirmEmailChange.confirm_warningTitle']()}
+					</h2>
+					<p class="text-sm text-muted-foreground">
+						{m['confirmEmailChange.confirm_warningBody']()}
+					</p>
+					<ul class="space-y-1 text-sm text-muted-foreground">
+						<li class="flex gap-2">
+							<span aria-hidden="true">•</span>
+							<span>{m['confirmEmailChange.confirm_warningBullet1']()}</span>
+						</li>
+						<li class="flex gap-2">
+							<span aria-hidden="true">•</span>
+							<span>{m['confirmEmailChange.confirm_warningBullet2']()}</span>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+
+		{#if formErrorMessage}
+			<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
+				<p class="text-sm font-medium text-destructive">{formErrorMessage}</p>
+				{#if errors.form === 'expired' || errors.form === 'invalid' || errors.form === 'emailTaken'}
+					<div class="mt-3">
+						<a
+							href={resolve('/(auth)/account/security', {})}
+							class="text-sm font-medium text-destructive underline-offset-4 hover:underline"
+						>
+							{m['confirmEmailChange.error_cta']()}
+						</a>
 					</div>
-				</div>
+				{/if}
 			</div>
-
-			{#if formErrorMessage}
-				<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
-					<p class="text-sm font-medium text-destructive">{formErrorMessage}</p>
-					{#if errors.form === 'expired' || errors.form === 'invalid' || errors.form === 'emailTaken'}
-						<div class="mt-3">
-							<a
-								href={resolve('/(auth)/account/security', {})}
-								class="text-sm font-medium text-destructive underline-offset-4 hover:underline"
-							>
-								{m['confirmEmailChange.error_cta']()}
-							</a>
-						</div>
-					{/if}
-				</div>
-			{/if}
-
-			<form
-				method="POST"
-				action="?/confirmEmailChange"
-				use:enhance={() => {
-					if (isSubmitting) return;
-					isSubmitting = true;
-					return async ({ result }) => {
-						isSubmitting = false;
-						await applyAction(result);
-						if (result.type === 'success') {
-							// The backend rotated our token pair. Update the auth store
-							// eagerly so the in-memory access token + refresh timer match
-							// the new cookies we just wrote. Without this we depend on the
-							// layout's auth-sync effect, which is racy — any code touching
-							// authStore.accessToken between now and that effect would see
-							// the old token.
-							const data = result.data as
-								{ access_token?: string | null; user?: RevelUserSchema } | undefined;
-							if (data?.access_token) {
-								authStore.setAccessToken(data.access_token);
-							}
-							// initialize() is idempotent and would skip refetching while a
-							// user object is cached, so push the fresh user object directly.
-							if (data?.user) {
-								authStore.setUser(data.user);
-							}
-							// Refresh SSR data (e.g. the profile page's data.user).
-							await invalidateAll();
-						}
-					};
-				}}
-				class="space-y-4"
-			>
-				<input type="hidden" name="token" value={token} />
-
-				<div class="flex gap-3">
-					<a
-						href={resolve('/(public)', {})}
-						class="inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-					>
-						{m['confirmEmailChange.confirm_cancel']()}
-					</a>
-					<button
-						type="submit"
-						disabled={isSubmitting}
-						class="inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-					>
-						{#if isSubmitting}
-							<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
-							<span>{m['confirmEmailChange.confirm_submitting']()}</span>
-						{:else}
-							<span>{m['confirmEmailChange.confirm_submit']()}</span>
-						{/if}
-					</button>
-				</div>
-			</form>
 		{/if}
-	</div>
-</div>
+
+		<form
+			method="POST"
+			action="?/confirmEmailChange"
+			use:enhance={() => {
+				if (isSubmitting) return;
+				isSubmitting = true;
+				return async ({ result }) => {
+					isSubmitting = false;
+					await applyAction(result);
+					if (result.type === 'success') {
+						// The backend rotated our token pair. Update the auth store
+						// eagerly so the in-memory access token + refresh timer match
+						// the new cookies we just wrote. Without this we depend on the
+						// layout's auth-sync effect, which is racy — any code touching
+						// authStore.accessToken between now and that effect would see
+						// the old token.
+						const data = result.data as
+							{ access_token?: string | null; user?: RevelUserSchema } | undefined;
+						if (data?.access_token) {
+							authStore.setAccessToken(data.access_token);
+						}
+						// initialize() is idempotent and would skip refetching while a
+						// user object is cached, so push the fresh user object directly.
+						if (data?.user) {
+							authStore.setUser(data.user);
+						}
+						// Refresh SSR data (e.g. the profile page's data.user).
+						await invalidateAll();
+					}
+				};
+			}}
+			class="space-y-4"
+		>
+			<input type="hidden" name="token" value={token} />
+
+			<div class="flex gap-3">
+				<a
+					href={resolve('/(public)', {})}
+					class="inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+				>
+					{m['confirmEmailChange.confirm_cancel']()}
+				</a>
+				<button
+					type="submit"
+					disabled={isSubmitting}
+					class="inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+				>
+					{#if isSubmitting}
+						<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
+						<span>{m['confirmEmailChange.confirm_submitting']()}</span>
+					{:else}
+						<span>{m['confirmEmailChange.confirm_submit']()}</span>
+					{/if}
+				</button>
+			</div>
+		</form>
+	</AuthBandLayout>
+{/if}

--- a/src/routes/(public)/join/event/[token_id]/+page.svelte
+++ b/src/routes/(public)/join/event/[token_id]/+page.svelte
@@ -4,13 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
-	import {
-		Card,
-		CardContent,
-		CardDescription,
-		CardHeader,
-		CardTitle
-	} from '$lib/components/ui/card';
+	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Calendar, CheckCircle, Loader2, Ticket } from '@lucide/svelte';
 	import { createMutation } from '@tanstack/svelte-query';
 	import { eventpublicdiscoveryClaimInvitation } from '$lib/api/generated/sdk.gen';
@@ -20,6 +14,8 @@
 	import { formatEventDate } from '$lib/utils/date';
 	import { backendMessage } from '$lib/utils/api-error-detail';
 	import Sticker from '$lib/components/brand/Sticker.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import { getImageUrl } from '$lib/utils/url';
 
 	const { data }: { data: PageData } = $props();
 
@@ -101,124 +97,157 @@
 	{/if}
 </svelte:head>
 
-<div class="container mx-auto flex min-h-[80vh] items-center justify-center px-4 py-12">
+<!-- Poster ribbon + floating card (uplift, spec §9) — the org-token twin of
+     this page carries the same treatment. A live invitation is an IMAGERY
+     moment, so it opens on the solid Hearty Purple ribbon, mode-inert in both
+     modes by the imagery rule. Hand-verified against the fixed poster values
+     (both pairs are in scripts/audit-brand-themes.py's poster table):
+       poster-white on poster-purple → 5.52:1 (title, kicker, subtitle)
+       poster-purple on poster-white → 5.52:1 (the Sticker's own text)
+     No sticker chip here, by the sticker-chip rule: an EVENT token preview
+     carries the event's cover but no organization logo, and the Revel mark is
+     never filler on someone else's invitation. The cover art becomes the
+     ribbon's own image instead — the one identity mark this token can offer.
+
+     The rejection state stays on the theme-aware `bg-secondary` band: a link
+     that no longer works is not an invitation to celebrate. Copy and claim
+     logic are untouched throughout. -->
+<div class="min-h-[calc(100vh-4rem)] bg-background">
 	{#if rejection}
-		<Card class="w-full max-w-md">
-			<CardHeader class="text-center">
-				<CardTitle class="text-3xl font-black">{m['joinEventPage.rejectedTitle']()}</CardTitle>
-				<CardDescription class="text-lg font-bold">{rejectionBody}</CardDescription>
-			</CardHeader>
-			<CardContent class="space-y-6 text-center">
-				<p class="text-sm text-muted-foreground">{m['joinEventPage.rejectedHint']()}</p>
-				<Button size="lg" class="w-full" href={resolve('/(public)/events', {})}>
-					{m['joinEventPage.rejectedCta']()}
-				</Button>
-			</CardContent>
-		</Card>
+		<section class="bg-secondary text-secondary-foreground">
+			<div class="container mx-auto max-w-md px-4 pb-20 pt-10 text-center sm:pt-14">
+				<PageHeader
+					volume="poster"
+					onBand
+					title={m['joinEventPage.rejectedTitle']()}
+					subtitle={rejectionBody ?? undefined}
+					class="text-center sm:flex-col sm:items-center"
+				/>
+			</div>
+		</section>
+
+		<div class="container mx-auto -mt-12 max-w-md px-4 pb-16">
+			<Card>
+				<CardContent class="space-y-6 p-6 text-center sm:p-8">
+					<p class="text-sm text-muted-foreground">{m['joinEventPage.rejectedHint']()}</p>
+					<Button size="lg" class="w-full" href={resolve('/(public)/events', {})}>
+						{m['joinEventPage.rejectedCta']()}
+					</Button>
+				</CardContent>
+			</Card>
+		</div>
 	{:else if token}
-		<Card class="w-full max-w-md">
-			<CardHeader class="text-center">
+		<section class="bg-poster-purple text-poster-white">
+			<div class="container mx-auto max-w-md px-4 pb-20 pt-10 text-center sm:pt-14">
 				{#if token.event_cover_url}
+					<!-- Decorative: the event's name is the h1's own subtitle right
+					     below, so an alt would only repeat it. -->
 					<img
-						src={token.event_cover_url}
-						alt={token.event_name}
-						class="mx-auto mb-4 h-32 w-full rounded-lg object-cover"
+						src={getImageUrl(token.event_cover_url)}
+						alt=""
+						class="mx-auto mb-6 h-32 w-full rounded-lg border-2 border-poster-white object-cover shadow-poster-lg"
 					/>
 				{/if}
-				<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
-					{m['joinEventPage.kicker']()}
-				</p>
-				<CardTitle class="mt-1 flex items-center justify-center gap-2 text-3xl font-black">
-					{m['joinEventPage.invitedTitle']()}
-					<span aria-hidden="true"><Sticker tint="ink" rotate={-3}>🎉</Sticker></span>
-				</CardTitle>
-				<CardDescription class="text-lg font-bold">
-					<strong>{token.event_name}</strong>
-				</CardDescription>
-			</CardHeader>
+				{#snippet celebrate()}
+					<Sticker tint="ink" rotate={-3}>🎉</Sticker>
+				{/snippet}
+				<PageHeader
+					volume="poster"
+					onBand
+					kicker={m['joinEventPage.kicker']()}
+					title={m['joinEventPage.invitedTitle']()}
+					decoration={celebrate}
+					class="text-center sm:flex-col sm:items-center"
+				/>
+				<p class="mt-2 text-lg font-bold">{token.event_name}</p>
+			</div>
+		</section>
 
-			<CardContent class="space-y-6">
-				<!-- Event Info (the token preview exposes name/start/cover only) -->
-				<div class="space-y-3 rounded-lg bg-muted p-4">
-					{#if formattedDate}
-						<div class="flex items-start gap-2 text-sm">
-							<Calendar class="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
-							<div>
-								<div class="font-medium">{m['joinEventPage.whenLabel']()}</div>
-								<div class="text-muted-foreground">{formattedDate}</div>
-							</div>
-						</div>
-					{/if}
-
-					{#if token.ticket_tiers?.length}
-						<div class="flex items-start gap-2 text-sm">
-							<Ticket class="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
-							<div>
-								<div class="font-medium">{m['joinEventPage.ticketTierLabel']()}</div>
-								<div class="text-muted-foreground">
-									{token.ticket_tiers.map((t) => t.name).join(', ')}
+		<div class="container mx-auto -mt-12 max-w-md px-4 pb-16">
+			<Card>
+				<CardContent class="space-y-6 p-6 sm:p-8">
+					<!-- Event Info (the token preview exposes name/start/cover only) -->
+					<div class="space-y-3 rounded-lg border-2 border-border bg-muted p-4">
+						{#if formattedDate}
+							<div class="flex items-start gap-2 text-sm">
+								<Calendar class="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+								<div>
+									<div class="font-bold">{m['joinEventPage.whenLabel']()}</div>
+									<div class="text-muted-foreground">{formattedDate}</div>
 								</div>
 							</div>
+						{/if}
+
+						{#if token.ticket_tiers?.length}
+							<div class="flex items-start gap-2 text-sm">
+								<Ticket class="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+								<div>
+									<div class="font-bold">{m['joinEventPage.ticketTierLabel']()}</div>
+									<div class="text-muted-foreground">
+										{token.ticket_tiers.map((t) => t.name).join(', ')}
+									</div>
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<!-- Token Info -->
+					<div class="space-y-2 rounded-lg border-2 p-3 text-sm">
+						<div class="flex items-center justify-between">
+							<span class="text-muted-foreground">{m['joinEventPage.expiresLabel']()}</span>
+							<span class="font-bold">{expirationDisplay}</span>
+						</div>
+						<div class="flex items-center justify-between">
+							<span class="text-muted-foreground">{m['joinEventPage.usedLabel']()}</span>
+							<span class="font-bold">{usageDisplay}</span>
+						</div>
+					</div>
+
+					<!-- Custom Message -->
+					{#if token.invitation_payload?.custom_message}
+						<div class="rounded-lg border-2 border-border bg-muted p-4 text-sm">
+							<p class="italic">{token.invitation_payload.custom_message}</p>
 						</div>
 					{/if}
-				</div>
 
-				<!-- Token Info -->
-				<div class="space-y-2 rounded-lg border p-3 text-sm">
-					<div class="flex items-center justify-between">
-						<span class="text-muted-foreground">{m['joinEventPage.expiresLabel']()}</span>
-						<span class="font-medium">{expirationDisplay}</span>
-					</div>
-					<div class="flex items-center justify-between">
-						<span class="text-muted-foreground">{m['joinEventPage.usedLabel']()}</span>
-						<span class="font-medium">{usageDisplay}</span>
-					</div>
-				</div>
-
-				<!-- Custom Message -->
-				{#if token.invitation_payload?.custom_message}
-					<div class="rounded-lg bg-muted p-4 text-sm">
-						<p class="italic">{token.invitation_payload.custom_message}</p>
-					</div>
-				{/if}
-
-				<!-- What you'll get -->
-				<div class="space-y-2">
-					<h3 class="font-semibold">{m['joinEventPage.benefitsTitle']()}</h3>
-					<ul class="space-y-1 text-sm text-muted-foreground">
-						<li class="flex items-center gap-2">
-							<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-							<span>{m['joinEventPage.benefit_invitation']()}</span>
-						</li>
-						{#if token.ticket_tiers?.length}
+					<!-- What you'll get -->
+					<div class="space-y-2">
+						<h2 class="font-extrabold">{m['joinEventPage.benefitsTitle']()}</h2>
+						<ul class="space-y-1 text-sm text-muted-foreground">
 							<li class="flex items-center gap-2">
-								<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-								<span>{m['joinEventPage.benefit_autoTicket']()}</span>
+								<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+								<span>{m['joinEventPage.benefit_invitation']()}</span>
 							</li>
+							{#if token.ticket_tiers?.length}
+								<li class="flex items-center gap-2">
+									<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+									<span>{m['joinEventPage.benefit_autoTicket']()}</span>
+								</li>
+							{/if}
+							<li class="flex items-center gap-2">
+								<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+								<span>{m['joinEventPage.benefit_rsvpConfirmation']()}</span>
+							</li>
+						</ul>
+					</div>
+
+					<!-- Action Button -->
+					<Button size="lg" class="w-full" onclick={handleClaim} disabled={claimMutation.isPending}>
+						{#if claimMutation.isPending}
+							<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+							{m['joinEventPage.claimingButton']()}
+						{:else if !isAuthenticated}
+							{m['joinEventPage.signInButton']()}
+						{:else}
+							{m['joinEventPage.claimButton']()}
 						{/if}
-						<li class="flex items-center gap-2">
-							<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-							<span>{m['joinEventPage.benefit_rsvpConfirmation']()}</span>
-						</li>
-					</ul>
-				</div>
+					</Button>
 
-				<!-- Action Button -->
-				<Button size="lg" class="w-full" onclick={handleClaim} disabled={claimMutation.isPending}>
-					{#if claimMutation.isPending}
-						<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-						{m['joinEventPage.claimingButton']()}
-					{:else if !isAuthenticated}
-						{m['joinEventPage.signInButton']()}
-					{:else}
-						{m['joinEventPage.claimButton']()}
-					{/if}
-				</Button>
-
-				<p class="text-center text-xs text-muted-foreground">
-					{m['joinEventPage.agreementText']()}
-				</p>
-			</CardContent>
-		</Card>
+					<p class="text-center text-xs text-muted-foreground">
+						{m['joinEventPage.agreementText']()}
+					</p>
+				</CardContent>
+			</Card>
+		</div>
 	{/if}
 </div>

--- a/src/routes/(public)/join/event/[token_id]/+page.svelte
+++ b/src/routes/(public)/join/event/[token_id]/+page.svelte
@@ -103,7 +103,7 @@
      modes by the imagery rule. Hand-verified against the fixed poster values
      (both pairs are in scripts/audit-brand-themes.py's poster table):
        poster-white on poster-purple → 5.52:1 (title, kicker, subtitle)
-       poster-purple on poster-white → 5.52:1 (the Sticker's own text)
+       poster-white on poster-ink → 17.40:1 (the Sticker's own text — tint="ink")
      No sticker chip here, by the sticker-chip rule: an EVENT token preview
      carries the event's cover but no organization logo, and the Revel mark is
      never filler on someone else's invitation. The cover art becomes the

--- a/src/routes/(public)/join/org/[token_id]/+page.svelte
+++ b/src/routes/(public)/join/org/[token_id]/+page.svelte
@@ -4,13 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
-	import {
-		Card,
-		CardContent,
-		CardDescription,
-		CardHeader,
-		CardTitle
-	} from '$lib/components/ui/card';
+	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Users, Shield, CheckCircle, Clock, Loader2 } from '@lucide/svelte';
 	import { createMutation } from '@tanstack/svelte-query';
 	import { organizationClaimInvitation } from '$lib/api/generated/sdk.gen';
@@ -20,6 +14,8 @@
 	import { escapeHtml } from '$lib/utils/sanitize';
 	import { backendMessage } from '$lib/utils/api-error-detail';
 	import Sticker from '$lib/components/brand/Sticker.svelte';
+	import LogoChip from '$lib/components/brand/LogoChip.svelte';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -107,122 +103,159 @@
 	{/if}
 </svelte:head>
 
-<div class="container mx-auto flex min-h-[80vh] items-center justify-center px-4 py-12">
+<!-- Poster ribbon + floating card (uplift, spec §9). A live invitation is an
+     IMAGERY moment — an organization is inviting you — so it opens on the
+     solid Hearty Purple ribbon the event page uses, mode-inert in both modes
+     by the imagery rule, carrying the org's own logo as a tilted white
+     sticker. Pairs are hand-verified against the fixed poster values (a
+     poster-palette pair is invisible to scripts/audit-brand-themes.py, though
+     these two ARE in its table):
+       poster-white on poster-purple → 5.52:1 (title, kicker, subtitle)
+       poster-purple on poster-white → 5.52:1 (the Sticker's own text)
+     Sticker-chip rule: the chip shows the ORG'S logo or renders nothing —
+     LogoChip enforces that itself, so a logo-less org simply gets a clean
+     ribbon rather than the Revel mark as filler.
+
+     The rejection state deliberately stays on the theme-aware `bg-secondary`
+     band instead: "this link is no longer valid" is not an invitation, and a
+     full-strength brand ribbon would be celebrating something that isn't
+     happening. Copy and claim logic are untouched throughout. -->
+<div class="min-h-[calc(100vh-4rem)] bg-background">
 	{#if rejection}
-		<Card class="w-full max-w-md">
-			<CardHeader class="text-center">
-				<CardTitle class="text-3xl font-black">{m['joinOrgPage.rejectedTitle']()}</CardTitle>
-				<CardDescription class="text-lg font-bold">{rejectionBody}</CardDescription>
-			</CardHeader>
-			<CardContent class="space-y-6 text-center">
-				<p class="text-sm text-muted-foreground">{m['joinOrgPage.rejectedHint']()}</p>
-				<Button size="lg" class="w-full" href={resolve('/(public)/events', {})}>
-					{m['joinOrgPage.rejectedCta']()}
-				</Button>
-			</CardContent>
-		</Card>
+		<section class="bg-secondary text-secondary-foreground">
+			<div class="container mx-auto max-w-md px-4 pb-20 pt-10 text-center sm:pt-14">
+				<PageHeader
+					volume="poster"
+					onBand
+					title={m['joinOrgPage.rejectedTitle']()}
+					subtitle={rejectionBody ?? undefined}
+					class="text-center sm:flex-col sm:items-center"
+				/>
+			</div>
+		</section>
+
+		<div class="container mx-auto -mt-12 max-w-md px-4 pb-16">
+			<Card>
+				<CardContent class="space-y-6 p-6 text-center sm:p-8">
+					<p class="text-sm text-muted-foreground">{m['joinOrgPage.rejectedHint']()}</p>
+					<Button size="lg" class="w-full" href={resolve('/(public)/events', {})}>
+						{m['joinOrgPage.rejectedCta']()}
+					</Button>
+				</CardContent>
+			</Card>
+		</div>
 	{:else if token}
-		<Card class="w-full max-w-md">
-			<CardHeader class="text-center">
-				{#if token.organization_logo_url}
-					<img
-						src={token.organization_logo_url}
-						alt={token.organization_name}
-						class="mx-auto mb-4 h-20 w-20 rounded-full object-cover"
-					/>
-				{/if}
-				<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
-					{m['joinOrgPage.kicker']()}
-				</p>
-				<CardTitle class="mt-1 flex items-center justify-center gap-2 text-3xl font-black">
-					{m['joinOrgPage.invitedTitle']()}
-					<span aria-hidden="true"><Sticker tint="ink" rotate={-3}>🎉</Sticker></span>
-				</CardTitle>
-				<CardDescription class="text-lg font-bold">
-					<!-- eslint-disable-next-line svelte/no-at-html-tags -- API-derived organization name neutralized via escapeHtml before interpolation into a developer-authored i18n template -->
+		<section class="bg-poster-purple text-poster-white">
+			<div class="container relative mx-auto max-w-md px-4 pb-20 pt-10 text-center sm:pt-14">
+				<!-- Pinned top-right; LogoChip owns its own transform, so the
+				     positioning lives on this wrapper. Hidden on mobile, where the
+				     column is too narrow for the type to clear it. -->
+				<div class="absolute right-2 top-6 hidden sm:block">
+					<LogoChip rotate={-8} logo={token.organization_logo_url} />
+				</div>
+				{#snippet celebrate()}
+					<Sticker tint="ink" rotate={-3}>🎉</Sticker>
+				{/snippet}
+				<PageHeader
+					volume="poster"
+					onBand
+					kicker={m['joinOrgPage.kicker']()}
+					title={m['joinOrgPage.invitedTitle']()}
+					decoration={celebrate}
+					class="text-center sm:flex-col sm:items-center sm:pr-24"
+				/>
+				<!-- eslint-disable svelte/no-at-html-tags -- API-derived organization name neutralized via escapeHtml before interpolation into a developer-authored i18n template. Block form, not disable-next-line: prettier reflows the interpolation onto its own line and the single-line pragma stops lining up. -->
+				<p class="mt-2 text-lg font-bold">
 					{@html m['joinOrgPage.joinSubtitle']({
 						organizationName: escapeHtml(token.organization_name)
 					})}
-				</CardDescription>
-			</CardHeader>
+				</p>
+				<!-- eslint-enable svelte/no-at-html-tags -->
+			</div>
+		</section>
 
-			<CardContent class="space-y-6">
-				<!-- Token Info -->
-				<div class="space-y-3 rounded-lg bg-muted p-4">
-					<div class="flex items-center gap-2 text-sm">
-						<Icon class="h-4 w-4" aria-hidden="true" />
-						<span class="font-medium">{m['joinOrgPage.accessTypeLabel']()}</span>
-						<span>{accessType}</span>
+		<div class="container mx-auto -mt-12 max-w-md px-4 pb-16">
+			<Card>
+				<CardContent class="space-y-6 p-6 sm:p-8">
+					<!-- Token Info -->
+					<div class="space-y-3 rounded-lg border-2 border-border bg-muted p-4">
+						<div class="flex items-center gap-2 text-sm">
+							<Icon class="h-4 w-4" aria-hidden="true" />
+							<span class="font-bold">{m['joinOrgPage.accessTypeLabel']()}</span>
+							<span>{accessType}</span>
+						</div>
+
+						<div class="flex items-center gap-2 text-sm">
+							<Clock class="h-4 w-4" aria-hidden="true" />
+							<span class="font-bold">{m['joinOrgPage.expiresLabel']()}</span>
+							<span>{expirationDisplay}</span>
+						</div>
+
+						<div class="flex items-center gap-2 text-sm">
+							<Users class="h-4 w-4" aria-hidden="true" />
+							<span class="font-bold">{m['joinOrgPage.usedLabel']()}</span>
+							<span>{usageDisplay}</span>
+						</div>
 					</div>
 
-					<div class="flex items-center gap-2 text-sm">
-						<Clock class="h-4 w-4" aria-hidden="true" />
-						<span class="font-medium">{m['joinOrgPage.expiresLabel']()}</span>
-						<span>{expirationDisplay}</span>
-					</div>
-
-					<div class="flex items-center gap-2 text-sm">
-						<Users class="h-4 w-4" aria-hidden="true" />
-						<span class="font-medium">{m['joinOrgPage.usedLabel']()}</span>
-						<span>{usageDisplay}</span>
-					</div>
-				</div>
-
-				<!-- What you'll get -->
-				<div class="space-y-2">
-					<h3 class="font-semibold">{m['joinOrgPage.benefitsTitle']()}</h3>
-					<ul class="space-y-1 text-sm text-muted-foreground">
-						{#if token.grants_staff_status}
-							<li class="flex items-center gap-2">
-								<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-								<span>{m['joinOrgPage.benefit_staffAccess']()}</span>
-							</li>
-							<li class="flex items-center gap-2">
-								<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-								<span>{m['joinOrgPage.benefit_manageEventsMembers']()}</span>
-							</li>
-						{:else if token.grants_membership}
-							<li class="flex items-center gap-2">
-								<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-								<span>{m['joinOrgPage.benefit_memberAccess']()}</span>
-							</li>
-							{#if token.membership_tier_name}
+					<!-- What you'll get -->
+					<div class="space-y-2">
+						<h2 class="font-extrabold">{m['joinOrgPage.benefitsTitle']()}</h2>
+						<ul class="space-y-1 text-sm text-muted-foreground">
+							{#if token.grants_staff_status}
 								<li class="flex items-center gap-2">
-									<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-									<span>
-										{m['joinOrgPage.benefit_memberTier']({ tierName: token.membership_tier_name })}
-									</span>
+									<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+									<span>{m['joinOrgPage.benefit_staffAccess']()}</span>
+								</li>
+								<li class="flex items-center gap-2">
+									<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+									<span>{m['joinOrgPage.benefit_manageEventsMembers']()}</span>
+								</li>
+							{:else if token.grants_membership}
+								<li class="flex items-center gap-2">
+									<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+									<span>{m['joinOrgPage.benefit_memberAccess']()}</span>
+								</li>
+								{#if token.membership_tier_name}
+									<li class="flex items-center gap-2">
+										<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+										<span>
+											{m['joinOrgPage.benefit_memberTier']({
+												tierName: token.membership_tier_name
+											})}
+										</span>
+									</li>
+								{/if}
+								<li class="flex items-center gap-2">
+									<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+									<span>{m['joinOrgPage.benefit_membersOnlyEvents']()}</span>
+								</li>
+							{:else}
+								<li class="flex items-center gap-2">
+									<CheckCircle class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+									<span>{m['joinOrgPage.benefit_viewDetails']()}</span>
 								</li>
 							{/if}
-							<li class="flex items-center gap-2">
-								<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-								<span>{m['joinOrgPage.benefit_membersOnlyEvents']()}</span>
-							</li>
+						</ul>
+					</div>
+
+					<!-- Action Button -->
+					<Button size="lg" class="w-full" onclick={handleClaim} disabled={claimMutation.isPending}>
+						{#if claimMutation.isPending}
+							<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+							{m['joinOrgPage.claimingButton']()}
+						{:else if !isAuthenticated}
+							{m['joinOrgPage.signInButton']()}
 						{:else}
-							<li class="flex items-center gap-2">
-								<CheckCircle class="h-4 w-4 text-success" aria-hidden="true" />
-								<span>{m['joinOrgPage.benefit_viewDetails']()}</span>
-							</li>
+							{m['joinOrgPage.claimButton']({ accessType })}
 						{/if}
-					</ul>
-				</div>
+					</Button>
 
-				<!-- Action Button -->
-				<Button size="lg" class="w-full" onclick={handleClaim} disabled={claimMutation.isPending}>
-					{#if claimMutation.isPending}
-						<Loader2 class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-						{m['joinOrgPage.claimingButton']()}
-					{:else if !isAuthenticated}
-						{m['joinOrgPage.signInButton']()}
-					{:else}
-						{m['joinOrgPage.claimButton']({ accessType })}
-					{/if}
-				</Button>
-
-				<p class="text-center text-xs text-muted-foreground">
-					{m['joinOrgPage.agreementText']({ organizationName: token.organization_name })}
-				</p>
-			</CardContent>
-		</Card>
+					<p class="text-center text-xs text-muted-foreground">
+						{m['joinOrgPage.agreementText']({ organizationName: token.organization_name })}
+					</p>
+				</CardContent>
+			</Card>
+		</div>
 	{/if}
 </div>

--- a/src/routes/(public)/join/org/[token_id]/+page.svelte
+++ b/src/routes/(public)/join/org/[token_id]/+page.svelte
@@ -111,7 +111,7 @@
      poster-palette pair is invisible to scripts/audit-brand-themes.py, though
      these two ARE in its table):
        poster-white on poster-purple → 5.52:1 (title, kicker, subtitle)
-       poster-purple on poster-white → 5.52:1 (the Sticker's own text)
+       poster-white on poster-ink → 17.40:1 (the Sticker's own text — tint="ink")
      Sticker-chip rule: the chip shows the ORG'S logo or renders nothing —
      LogoChip enforces that itself, so a logo-less org simply gets a clean
      ribbon rather than the Revel mark as filler.
@@ -147,9 +147,17 @@
 	{:else if token}
 		<section class="bg-poster-purple text-poster-white">
 			<div class="container relative mx-auto max-w-md px-4 pb-20 pt-10 text-center sm:pt-14">
+				<!-- Mobile-first: org identity is the whole point of this page, so
+				     the chip renders in-flow and centred below `sm`, the same
+				     `chip` slot pattern `AuthBandLayout` uses. At `sm`+ the column
+				     is wide enough for the type to clear a pinned corner chip, so
+				     that absolute placement takes over instead (and this in-flow
+				     copy hides, rather than showing the chip twice). -->
+				<div class="mb-5 flex justify-center sm:hidden">
+					<LogoChip rotate={-8} logo={token.organization_logo_url} />
+				</div>
 				<!-- Pinned top-right; LogoChip owns its own transform, so the
-				     positioning lives on this wrapper. Hidden on mobile, where the
-				     column is too narrow for the type to clear it. -->
+				     positioning lives on this wrapper. -->
 				<div class="absolute right-2 top-6 hidden sm:block">
 					<LogoChip rotate={-8} logo={token.organization_logo_url} />
 				</div>

--- a/src/routes/(public)/login/+page.svelte
+++ b/src/routes/(public)/login/+page.svelte
@@ -8,6 +8,7 @@
 	import TwoFactorInput from '$lib/components/forms/TwoFactorInput.svelte';
 	import { Eye, EyeOff, Loader2, ArrowLeft, ExternalLink } from '@lucide/svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
+	import AuthBandLayout from '$lib/components/auth/AuthBandLayout.svelte';
 	import { appStore } from '$lib/stores/app.svelte';
 	import {
 		DEMO_ACCOUNTS,
@@ -105,341 +106,331 @@
 
 <SeoHead config={data.seo} />
 
-<div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
-	<div class="w-full max-w-md space-y-6">
-		<!-- Header -->
-		<div class="text-center">
-			<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
-				{m['login.kicker']()}
-			</p>
-			<h1 class="mt-1 text-3xl font-black leading-[1.12] sm:text-4xl">
-				{requires2FA ? m['login.twoFactorAuth']() : m['login.welcomeBack']()}
-			</h1>
-			<p class="mt-2 text-muted-foreground">
-				{requires2FA ? m['login.enterCodeFromApp']() : m['login.signInToContinue']()}
-			</p>
-		</div>
+<!-- Colour-block band + floating card (uplift). Copy, form logic, action URLs
+     and every field id/aria wiring below are untouched — this is the shell
+     only. -->
+<AuthBandLayout
+	kicker={m['login.kicker']()}
+	title={requires2FA ? m['login.twoFactorAuth']() : m['login.welcomeBack']()}
+	subtitle={requires2FA ? m['login.enterCodeFromApp']() : m['login.signInToContinue']()}
+>
+	<Card>
+		<CardContent class="space-y-6 p-6 sm:p-8">
+			<!-- Error Summary -->
+			{#if errors.form}
+				<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
+					<p class="text-sm font-medium text-destructive">{errors.form}</p>
+				</div>
+			{/if}
 
-		<Card>
-			<CardContent class="space-y-6 p-6 sm:p-8">
-				<!-- Error Summary -->
-				{#if errors.form}
-					<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
-						<p class="text-sm font-medium text-destructive">{errors.form}</p>
-					</div>
-				{/if}
-
-				{#if !requires2FA}
-					{#if useDemoDropdown}
-						<!-- Demo Mode: Account Selector -->
-						<div class="space-y-6">
-							<!-- highlight/20 + highlight/30 border are decorative (no text-contrast
+			{#if !requires2FA}
+				{#if useDemoDropdown}
+					<!-- Demo Mode: Account Selector -->
+					<div class="space-y-6">
+						<!-- highlight/20 + highlight/30 border are decorative (no text-contrast
 							     requirement); the body copy and link stay on the default foreground/
 							     primary tokens, both already audited pairs. -->
-							<div
-								class="rounded-md border border-highlight/30 bg-highlight/20 p-4 dark:border-highlight/40 dark:bg-highlight/25"
+						<div
+							class="rounded-md border border-highlight/30 bg-highlight/20 p-4 dark:border-highlight/40 dark:bg-highlight/25"
+						>
+							<p class="text-sm text-foreground">
+								{m['login.demoNotice']()}
+							</p>
+							<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
+							<a
+								href={DEMO_ACCOUNTS_README_URL}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-primary underline-offset-4 hover:underline"
 							>
-								<p class="text-sm text-foreground">
-									{m['login.demoNotice']()}
-								</p>
-								<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL (off-site); not an internal route -->
-								<a
-									href={DEMO_ACCOUNTS_README_URL}
-									target="_blank"
-									rel="noopener noreferrer"
-									class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-primary underline-offset-4 hover:underline"
-								>
-									{m['login.viewAllTestAccounts']()}
-									<ExternalLink class="h-3 w-3" aria-hidden="true" />
-								</a>
-								<!-- eslint-enable svelte/no-navigation-without-resolve -->
-							</div>
-
-							<form
-								method="POST"
-								action="?/login{returnUrlSuffix}"
-								use:enhance={handleSubmit}
-								class="space-y-4"
-							>
-								<!-- Demo Account Selector -->
-								<div class="space-y-2">
-									<label for="demo-account" class="block text-sm font-medium">
-										{m['login.selectTestAccount']()}
-									</label>
-									<select
-										id="demo-account"
-										bind:value={selectedAccountEmail}
-										onchange={() => selectDemoAccount(selectedAccountEmail)}
-										disabled={isSubmitting}
-										class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-									>
-										<option value="">{m['login.chooseAccount']()}</option>
-										{#each DEMO_ACCOUNTS as account (account.email)}
-											<option value={account.email}>
-												{account.name} ({account.role}{account.organization
-													? ` - ${account.organization}`
-													: ''})
-											</option>
-										{/each}
-									</select>
-								</div>
-
-								<!-- Hidden inputs for form submission -->
-								<input type="hidden" name="email" value={email} />
-								<input type="hidden" name="password" value={password} />
-								<input type="hidden" name="rememberMe" value={rememberMe ? 'on' : ''} />
-
-								<!-- Selected Account Info -->
-								{#if selectedAccountEmail}
-									{@const account = DEMO_ACCOUNTS.find((a) => a.email === selectedAccountEmail)}
-									{#if account}
-										<div class="rounded-md border border-muted bg-muted/30 p-3">
-											<p class="text-sm font-medium">{account.name}</p>
-											<p class="mt-1 text-xs text-muted-foreground">{account.email}</p>
-											{#if account.description}
-												<p class="mt-1 text-xs text-muted-foreground">{account.description}</p>
-											{/if}
-										</div>
-									{/if}
-								{/if}
-
-								<!-- Submit Button -->
-								<button
-									type="submit"
-									disabled={isSubmitting || !selectedAccountEmail}
-									class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-								>
-									{#if isSubmitting}
-										<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
-										<span>{m['login.signingIn']()}</span>
-									{:else}
-										<span
-											>{m['login.signInAs']()}
-											{selectedAccountEmail
-												? DEMO_ACCOUNTS.find((a) => a.email === selectedAccountEmail)?.name
-												: 'test user'}</span
-										>
-									{/if}
-								</button>
-							</form>
-
-							<!-- Toggle to the real email/password form -->
-							<div class="text-center text-sm">
-								<button
-									type="button"
-									onclick={() => {
-										showLoginForm = true;
-										// The toggle unmounts itself in the swap — move focus to the
-										// revealed form so keyboard users aren't dropped on <body>.
-										// tick(), not rAF: the input only exists after the swap
-										// flushes, but rAF is paint-bound and under load can fire
-										// seconds late, stealing focus from a field the user (or a
-										// password manager) is already typing into — the same
-										// keystroke-spray bug as the register nudge (#608/#609).
-										// tick()'s microtask resolves before any further input
-										// events can interleave.
-										void tick().then(() => document.getElementById('email')?.focus());
-									}}
-									class="text-primary underline-offset-4 hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-								>
-									{m['login.showLoginForm']()}
-								</button>
-							</div>
+								{m['login.viewAllTestAccounts']()}
+								<ExternalLink class="h-3 w-3" aria-hidden="true" />
+							</a>
+							<!-- eslint-enable svelte/no-navigation-without-resolve -->
 						</div>
-					{:else}
-						<!-- Standard Login Form -->
+
 						<form
 							method="POST"
 							action="?/login{returnUrlSuffix}"
 							use:enhance={handleSubmit}
-							class="space-y-6"
+							class="space-y-4"
 						>
-							<!-- Email Field -->
+							<!-- Demo Account Selector -->
 							<div class="space-y-2">
-								<label for="email" class="block text-sm font-medium">
-									{m['login.emailAddress']()}
+								<label for="demo-account" class="block text-sm font-medium">
+									{m['login.selectTestAccount']()}
 								</label>
-								<input
-									id="email"
-									name="email"
-									type="email"
-									autocomplete="email"
-									required
-									bind:value={email}
-									aria-invalid={!!errors.email}
-									aria-describedby={errors.email ? 'email-error' : undefined}
+								<select
+									id="demo-account"
+									bind:value={selectedAccountEmail}
+									onchange={() => selectDemoAccount(selectedAccountEmail)}
 									disabled={isSubmitting}
-									class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.email
-										? 'border-destructive'
-										: ''}"
-									placeholder={m['login.emailPlaceholder']()}
-								/>
-								{#if errors.email}
-									<p id="email-error" class="text-sm text-destructive" role="alert">
-										{errors.email}
-									</p>
-								{/if}
+									class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+								>
+									<option value="">{m['login.chooseAccount']()}</option>
+									{#each DEMO_ACCOUNTS as account (account.email)}
+										<option value={account.email}>
+											{account.name} ({account.role}{account.organization
+												? ` - ${account.organization}`
+												: ''})
+										</option>
+									{/each}
+								</select>
 							</div>
 
-							<!-- Password Field -->
-							<div class="space-y-2">
-								<div class="flex items-center justify-between">
-									<label for="password" class="block text-sm font-medium">
-										{m['login.password']()}
-									</label>
-									<a
-										href={resolve('/(public)/password-reset', {})}
-										class="text-sm text-primary underline-offset-4 hover:underline"
-									>
-										{m['login.forgotPassword']()}
-									</a>
-								</div>
-								<div class="relative">
-									<input
-										id="password"
-										name="password"
-										type={showPassword ? 'text' : 'password'}
-										autocomplete="current-password"
-										required
-										bind:value={password}
-										onpaste={() => {
-											// Ensure paste always works on mobile
-											// This explicit handler prevents any interference from browser autofill
-											// that might block paste operations on iOS Safari
-										}}
-										aria-invalid={!!errors.password}
-										aria-describedby={errors.password ? 'password-error' : undefined}
-										disabled={isSubmitting}
-										class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.password
-											? 'border-destructive'
-											: ''}"
-										placeholder={m['login.passwordPlaceholder']()}
-									/>
-									<button
-										type="button"
-										onclick={() => (showPassword = !showPassword)}
-										class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-										aria-label={showPassword
-											? m['login.hidePassword']()
-											: m['login.showPassword']()}
-									>
-										{#if showPassword}
-											<EyeOff class="h-4 w-4" aria-hidden="true" />
-										{:else}
-											<Eye class="h-4 w-4" aria-hidden="true" />
+							<!-- Hidden inputs for form submission -->
+							<input type="hidden" name="email" value={email} />
+							<input type="hidden" name="password" value={password} />
+							<input type="hidden" name="rememberMe" value={rememberMe ? 'on' : ''} />
+
+							<!-- Selected Account Info -->
+							{#if selectedAccountEmail}
+								{@const account = DEMO_ACCOUNTS.find((a) => a.email === selectedAccountEmail)}
+								{#if account}
+									<div class="rounded-md border border-muted bg-muted/30 p-3">
+										<p class="text-sm font-medium">{account.name}</p>
+										<p class="mt-1 text-xs text-muted-foreground">{account.email}</p>
+										{#if account.description}
+											<p class="mt-1 text-xs text-muted-foreground">{account.description}</p>
 										{/if}
-									</button>
-								</div>
-								{#if errors.password}
-									<p id="password-error" class="text-sm text-destructive" role="alert">
-										{errors.password}
-									</p>
+									</div>
 								{/if}
-							</div>
-
-							<!-- Remember Me Checkbox -->
-							<div class="flex items-center gap-2">
-								<input
-									id="rememberMe"
-									name="rememberMe"
-									type="checkbox"
-									bind:checked={rememberMe}
-									disabled={isSubmitting}
-									class="h-4 w-4 rounded border-input text-primary transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-								/>
-								<label for="rememberMe" class="text-sm"> {m['login.rememberMe']()} </label>
-							</div>
+							{/if}
 
 							<!-- Submit Button -->
 							<button
 								type="submit"
-								disabled={isSubmitting}
+								disabled={isSubmitting || !selectedAccountEmail}
 								class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 							>
 								{#if isSubmitting}
 									<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
 									<span>{m['login.signingIn']()}</span>
 								{:else}
-									<span>{m['login.signIn']()}</span>
+									<span
+										>{m['login.signInAs']()}
+										{selectedAccountEmail
+											? DEMO_ACCOUNTS.find((a) => a.email === selectedAccountEmail)?.name
+											: 'test user'}</span
+									>
 								{/if}
 							</button>
 						</form>
 
-						{#if isDemoMode}
-							<!-- Inverse toggle back to the demo-account dropdown -->
-							<div class="mt-4 text-center text-sm">
-								<button
-									type="button"
-									onclick={() => {
-										showLoginForm = false;
-										// Same focus hand-off as the inverse toggle above.
-										requestAnimationFrame(() => document.getElementById('demo-account')?.focus());
-									}}
-									class="text-primary underline-offset-4 hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-								>
-									{m['login.useADemoAccount']()}
-								</button>
-							</div>
-						{/if}
-					{/if}
+						<!-- Toggle to the real email/password form -->
+						<div class="text-center text-sm">
+							<button
+								type="button"
+								onclick={() => {
+									showLoginForm = true;
+									// The toggle unmounts itself in the swap — move focus to the
+									// revealed form so keyboard users aren't dropped on <body>.
+									// tick(), not rAF: the input only exists after the swap
+									// flushes, but rAF is paint-bound and under load can fire
+									// seconds late, stealing focus from a field the user (or a
+									// password manager) is already typing into — the same
+									// keystroke-spray bug as the register nudge (#608/#609).
+									// tick()'s microtask resolves before any further input
+									// events can interleave.
+									void tick().then(() => document.getElementById('email')?.focus());
+								}}
+								class="text-primary underline-offset-4 hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+							>
+								{m['login.showLoginForm']()}
+							</button>
+						</div>
+					</div>
 				{:else}
-					<!-- 2FA Verification Form -->
+					<!-- Standard Login Form -->
 					<form
 						method="POST"
-						action="?/verify2FA{returnUrlSuffix}"
+						action="?/login{returnUrlSuffix}"
 						use:enhance={handleSubmit}
 						class="space-y-6"
 					>
-						<input type="hidden" name="tempToken" value={tempToken} />
-						<input type="hidden" name="rememberMe" value={rememberMe ? 'true' : 'false'} />
+						<!-- Email Field -->
+						<div class="space-y-2">
+							<label for="email" class="block text-sm font-medium">
+								{m['login.emailAddress']()}
+							</label>
+							<input
+								id="email"
+								name="email"
+								type="email"
+								autocomplete="email"
+								required
+								bind:value={email}
+								aria-invalid={!!errors.email}
+								aria-describedby={errors.email ? 'email-error' : undefined}
+								disabled={isSubmitting}
+								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.email
+									? 'border-destructive'
+									: ''}"
+								placeholder={m['login.emailPlaceholder']()}
+							/>
+							{#if errors.email}
+								<p id="email-error" class="text-sm text-destructive" role="alert">
+									{errors.email}
+								</p>
+							{/if}
+						</div>
 
-						<!-- 2FA Code Input -->
-						<TwoFactorInput bind:value={otpCode} error={errors.code} disabled={isSubmitting} />
+						<!-- Password Field -->
+						<div class="space-y-2">
+							<div class="flex items-center justify-between">
+								<label for="password" class="block text-sm font-medium">
+									{m['login.password']()}
+								</label>
+								<a
+									href={resolve('/(public)/password-reset', {})}
+									class="text-sm text-primary underline-offset-4 hover:underline"
+								>
+									{m['login.forgotPassword']()}
+								</a>
+							</div>
+							<div class="relative">
+								<input
+									id="password"
+									name="password"
+									type={showPassword ? 'text' : 'password'}
+									autocomplete="current-password"
+									required
+									bind:value={password}
+									onpaste={() => {
+										// Ensure paste always works on mobile
+										// This explicit handler prevents any interference from browser autofill
+										// that might block paste operations on iOS Safari
+									}}
+									aria-invalid={!!errors.password}
+									aria-describedby={errors.password ? 'password-error' : undefined}
+									disabled={isSubmitting}
+									class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.password
+										? 'border-destructive'
+										: ''}"
+									placeholder={m['login.passwordPlaceholder']()}
+								/>
+								<button
+									type="button"
+									onclick={() => (showPassword = !showPassword)}
+									class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+									aria-label={showPassword ? m['login.hidePassword']() : m['login.showPassword']()}
+								>
+									{#if showPassword}
+										<EyeOff class="h-4 w-4" aria-hidden="true" />
+									{:else}
+										<Eye class="h-4 w-4" aria-hidden="true" />
+									{/if}
+								</button>
+							</div>
+							{#if errors.password}
+								<p id="password-error" class="text-sm text-destructive" role="alert">
+									{errors.password}
+								</p>
+							{/if}
+						</div>
 
-						<!-- Hidden input for form submission -->
-						<input type="hidden" name="code" value={otpCode} />
+						<!-- Remember Me Checkbox -->
+						<div class="flex items-center gap-2">
+							<input
+								id="rememberMe"
+								name="rememberMe"
+								type="checkbox"
+								bind:checked={rememberMe}
+								disabled={isSubmitting}
+								class="h-4 w-4 rounded border-input text-primary transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+							/>
+							<label for="rememberMe" class="text-sm"> {m['login.rememberMe']()} </label>
+						</div>
 
-						<!-- Action Buttons -->
-						<div class="space-y-3">
-							<button
-								type="submit"
-								disabled={isSubmitting || otpCode.length !== 6}
-								class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-							>
-								{#if isSubmitting}
-									<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
-									<span>{m['login.verifying']()}</span>
-								{:else}
-									<span>{m['login.verifyAndSignIn']()}</span>
-								{/if}
-							</button>
+						<!-- Submit Button -->
+						<button
+							type="submit"
+							disabled={isSubmitting}
+							class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+						>
+							{#if isSubmitting}
+								<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
+								<span>{m['login.signingIn']()}</span>
+							{:else}
+								<span>{m['login.signIn']()}</span>
+							{/if}
+						</button>
+					</form>
 
+					{#if isDemoMode}
+						<!-- Inverse toggle back to the demo-account dropdown -->
+						<div class="mt-4 text-center text-sm">
 							<button
 								type="button"
-								onclick={backToLogin}
-								disabled={isSubmitting}
-								class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+								onclick={() => {
+									showLoginForm = false;
+									// Same focus hand-off as the inverse toggle above.
+									requestAnimationFrame(() => document.getElementById('demo-account')?.focus());
+								}}
+								class="text-primary underline-offset-4 hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 							>
-								<ArrowLeft class="h-4 w-4" aria-hidden="true" />
-								<span>{m['login.backToLogin']()}</span>
+								{m['login.useADemoAccount']()}
 							</button>
 						</div>
-					</form>
+					{/if}
 				{/if}
-			</CardContent>
-		</Card>
-
-		<!-- Register Link -->
-		{#if !requires2FA}
-			<div class="text-center text-sm">
-				<span class="text-muted-foreground">{m['login.dontHaveAccount']()}</span>
-				<a
-					href={resolve('/(public)/register', {})}
-					class="ml-1 text-primary underline-offset-4 hover:underline"
+			{:else}
+				<!-- 2FA Verification Form -->
+				<form
+					method="POST"
+					action="?/verify2FA{returnUrlSuffix}"
+					use:enhance={handleSubmit}
+					class="space-y-6"
 				>
-					{m['login.createAccount']()}
-				</a>
-			</div>
-		{/if}
-	</div>
-</div>
+					<input type="hidden" name="tempToken" value={tempToken} />
+					<input type="hidden" name="rememberMe" value={rememberMe ? 'true' : 'false'} />
+
+					<!-- 2FA Code Input -->
+					<TwoFactorInput bind:value={otpCode} error={errors.code} disabled={isSubmitting} />
+
+					<!-- Hidden input for form submission -->
+					<input type="hidden" name="code" value={otpCode} />
+
+					<!-- Action Buttons -->
+					<div class="space-y-3">
+						<button
+							type="submit"
+							disabled={isSubmitting || otpCode.length !== 6}
+							class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+						>
+							{#if isSubmitting}
+								<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
+								<span>{m['login.verifying']()}</span>
+							{:else}
+								<span>{m['login.verifyAndSignIn']()}</span>
+							{/if}
+						</button>
+
+						<button
+							type="button"
+							onclick={backToLogin}
+							disabled={isSubmitting}
+							class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+						>
+							<ArrowLeft class="h-4 w-4" aria-hidden="true" />
+							<span>{m['login.backToLogin']()}</span>
+						</button>
+					</div>
+				</form>
+			{/if}
+		</CardContent>
+	</Card>
+
+	<!-- Register Link -->
+	{#if !requires2FA}
+		<div class="text-center text-sm">
+			<span class="text-muted-foreground">{m['login.dontHaveAccount']()}</span>
+			<a
+				href={resolve('/(public)/register', {})}
+				class="ml-1 text-primary underline-offset-4 hover:underline"
+			>
+				{m['login.createAccount']()}
+			</a>
+		</div>
+	{/if}
+</AuthBandLayout>

--- a/src/routes/(public)/login/reset-password/+page.svelte
+++ b/src/routes/(public)/login/reset-password/+page.svelte
@@ -7,6 +7,7 @@
 	import PasswordStrengthIndicator from '$lib/components/forms/PasswordStrengthIndicator.svelte';
 	import { Loader2, Eye, EyeOff, CheckCircle } from '@lucide/svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
+	import AuthBandLayout from '$lib/components/auth/AuthBandLayout.svelte';
 
 	interface Props {
 		form: ActionData;
@@ -36,222 +37,212 @@
 	<meta name="description" content="Set a new password for your Revel account" />
 </svelte:head>
 
-<div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
-	<div class="w-full max-w-md space-y-6">
-		<!-- Header -->
-		<div class="text-center">
-			<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
-				{m['resetPasswordPage.kicker']()}
-			</p>
-			<h1 class="mt-1 text-3xl font-black leading-[1.12] sm:text-4xl">
-				{success ? m['resetPasswordPage.headingSuccess']() : m['resetPasswordPage.heading']()}
-			</h1>
-			<p class="mt-2 text-muted-foreground">
-				{success ? m['resetPasswordPage.subtitleSuccess']() : m['resetPasswordPage.subtitle']()}
-			</p>
-		</div>
-
-		<Card>
-			<CardContent class="space-y-6 p-6 sm:p-8">
-				{#if success}
-					<!-- Success State: success/10 + border are decorative (no text-contrast
+<!-- Colour-block band + floating card (uplift). Shell only. -->
+<AuthBandLayout
+	kicker={m['resetPasswordPage.kicker']()}
+	title={success ? m['resetPasswordPage.headingSuccess']() : m['resetPasswordPage.heading']()}
+	subtitle={success ? m['resetPasswordPage.subtitleSuccess']() : m['resetPasswordPage.subtitle']()}
+>
+	<Card>
+		<CardContent class="space-y-6 p-6 sm:p-8">
+			{#if success}
+				<!-- Success State: success/10 + border are decorative (no text-contrast
 					     requirement); title/body stay on foreground/muted-foreground, both
 					     already-audited pairs. -->
-					<div
-						role="status"
-						class="rounded-md border border-success/40 bg-success/10 p-6 dark:border-success/50 dark:bg-success/15"
-					>
-						<div class="flex items-start gap-3">
-							<CheckCircle class="h-6 w-6 flex-shrink-0 text-success" aria-hidden="true" />
-							<div class="flex-1 space-y-2">
-								<p class="text-sm font-medium text-foreground">
-									{m['resetPasswordPage.successHeading']()}
-								</p>
-								<p class="text-sm text-muted-foreground">
-									{m['resetPasswordPage.successBody']()}
-								</p>
-							</div>
+				<div
+					role="status"
+					class="rounded-md border border-success/40 bg-success/10 p-6 dark:border-success/50 dark:bg-success/15"
+				>
+					<div class="flex items-start gap-3">
+						<CheckCircle class="h-6 w-6 flex-shrink-0 text-success" aria-hidden="true" />
+						<div class="flex-1 space-y-2">
+							<p class="text-sm font-medium text-foreground">
+								{m['resetPasswordPage.successHeading']()}
+							</p>
+							<p class="text-sm text-muted-foreground">
+								{m['resetPasswordPage.successBody']()}
+							</p>
 						</div>
 					</div>
+				</div>
 
-					<!-- Login Button -->
-					<a
-						href={resolve('/(public)/login', {})}
-						class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-					>
-						{m['resetPasswordPage.signInToAccount']()}
-					</a>
-				{:else if !token}
-					<!-- Missing Token Error -->
+				<!-- Login Button -->
+				<a
+					href={resolve('/(public)/login', {})}
+					class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+				>
+					{m['resetPasswordPage.signInToAccount']()}
+				</a>
+			{:else if !token}
+				<!-- Missing Token Error -->
+				<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
+					<h2 class="text-sm font-medium text-destructive">
+						{m['resetPasswordPage.invalidTokenTitle']()}
+					</h2>
+					<p class="mt-2 text-sm text-muted-foreground">
+						{m['resetPasswordPage.invalidTokenDescription']()}
+					</p>
+				</div>
+
+				<a
+					href={resolve('/(public)/password-reset', {})}
+					class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+				>
+					{m['resetPasswordPage.requestNewLink']()}
+				</a>
+			{:else}
+				<!-- Error Summary -->
+				{#if errors.form}
 					<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
-						<h2 class="text-sm font-medium text-destructive">
-							{m['resetPasswordPage.invalidTokenTitle']()}
-						</h2>
-						<p class="mt-2 text-sm text-muted-foreground">
-							{m['resetPasswordPage.invalidTokenDescription']()}
-						</p>
-					</div>
-
-					<a
-						href={resolve('/(public)/password-reset', {})}
-						class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-					>
-						{m['resetPasswordPage.requestNewLink']()}
-					</a>
-				{:else}
-					<!-- Error Summary -->
-					{#if errors.form}
-						<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
-							<p class="text-sm font-medium text-destructive">{errors.form}</p>
-						</div>
-					{/if}
-
-					<!-- Password Reset Form -->
-					<form
-						method="POST"
-						action="?/resetPassword"
-						use:enhance={() => {
-							// Prevent duplicate submissions
-							if (isSubmitting) return;
-							isSubmitting = true;
-
-							return async ({ update }) => {
-								isSubmitting = false;
-								await update();
-							};
-						}}
-						class="space-y-6"
-					>
-						<input type="hidden" name="token" value={token} />
-
-						<!-- New Password Field -->
-						<div class="space-y-2">
-							<label for="password" class="block text-sm font-medium"
-								>{m['resetPasswordPage.newPasswordLabel']()}</label
-							>
-							<div class="relative">
-								<input
-									id="password"
-									name="password"
-									type={showPassword ? 'text' : 'password'}
-									autocomplete="new-password"
-									required
-									bind:value={password}
-									onpaste={() => {
-										// Ensure paste always works on mobile
-										// This explicit handler prevents any interference from browser autofill
-										// that might block paste operations on iOS Safari
-									}}
-									aria-invalid={!!errors.password}
-									aria-describedby={errors.password ? 'password-error' : 'password-requirements'}
-									disabled={isSubmitting}
-									class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.password
-										? 'border-destructive'
-										: ''}"
-									placeholder={m['resetPasswordPage.newPasswordPlaceholder']()}
-								/>
-								<button
-									type="button"
-									onclick={() => (showPassword = !showPassword)}
-									class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-									aria-label={showPassword
-										? m['resetPasswordPage.hidePassword']()
-										: m['resetPasswordPage.showPassword']()}
-									tabindex={-1}
-								>
-									{#if showPassword}
-										<EyeOff class="h-4 w-4" aria-hidden="true" />
-									{:else}
-										<Eye class="h-4 w-4" aria-hidden="true" />
-									{/if}
-								</button>
-							</div>
-							{#if errors.password}
-								<p id="password-error" class="text-sm text-destructive" role="alert">
-									{errors.password}
-								</p>
-							{/if}
-						</div>
-
-						<!-- Password Strength Indicator -->
-						<div id="password-requirements">
-							<PasswordStrengthIndicator {password} />
-						</div>
-
-						<!-- Confirm Password Field -->
-						<div class="space-y-2">
-							<label for="confirmPassword" class="block text-sm font-medium"
-								>{m['resetPasswordPage.confirmPasswordLabel']()}</label
-							>
-							<div class="relative">
-								<input
-									id="confirmPassword"
-									name="confirmPassword"
-									type={showConfirmPassword ? 'text' : 'password'}
-									autocomplete="new-password"
-									required
-									bind:value={confirmPassword}
-									onpaste={() => {
-										// Ensure paste always works on mobile
-										// This explicit handler prevents any interference from browser autofill
-										// that might block paste operations on iOS Safari
-									}}
-									aria-invalid={!!errors.confirmPassword}
-									aria-describedby={errors.confirmPassword ? 'confirm-password-error' : undefined}
-									disabled={isSubmitting}
-									class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.confirmPassword
-										? 'border-destructive'
-										: ''}"
-									placeholder={m['resetPasswordPage.confirmPasswordPlaceholder']()}
-								/>
-								<button
-									type="button"
-									onclick={() => (showConfirmPassword = !showConfirmPassword)}
-									class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-									aria-label={showConfirmPassword
-										? m['resetPasswordPage.hidePassword']()
-										: m['resetPasswordPage.showPassword']()}
-									tabindex={-1}
-								>
-									{#if showConfirmPassword}
-										<EyeOff class="h-4 w-4" aria-hidden="true" />
-									{:else}
-										<Eye class="h-4 w-4" aria-hidden="true" />
-									{/if}
-								</button>
-							</div>
-							{#if errors.confirmPassword}
-								<p id="confirm-password-error" class="text-sm text-destructive" role="alert">
-									{errors.confirmPassword}
-								</p>
-							{/if}
-						</div>
-
-						<!-- Submit Button -->
-						<button
-							type="submit"
-							disabled={isSubmitting}
-							class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-						>
-							{#if isSubmitting}
-								<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
-								<span>{m['resetPasswordPage.submitting']()}</span>
-							{:else}
-								<span>{m['resetPasswordPage.submit']()}</span>
-							{/if}
-						</button>
-					</form>
-
-					<!-- Back to Login Link -->
-					<div class="text-center text-sm">
-						<a
-							href={resolve('/(public)/login', {})}
-							class="text-primary underline-offset-4 hover:underline"
-							>{m['resetPasswordPage.backToLogin']()}</a
-						>
+						<p class="text-sm font-medium text-destructive">{errors.form}</p>
 					</div>
 				{/if}
-			</CardContent>
-		</Card>
-	</div>
-</div>
+
+				<!-- Password Reset Form -->
+				<form
+					method="POST"
+					action="?/resetPassword"
+					use:enhance={() => {
+						// Prevent duplicate submissions
+						if (isSubmitting) return;
+						isSubmitting = true;
+
+						return async ({ update }) => {
+							isSubmitting = false;
+							await update();
+						};
+					}}
+					class="space-y-6"
+				>
+					<input type="hidden" name="token" value={token} />
+
+					<!-- New Password Field -->
+					<div class="space-y-2">
+						<label for="password" class="block text-sm font-medium"
+							>{m['resetPasswordPage.newPasswordLabel']()}</label
+						>
+						<div class="relative">
+							<input
+								id="password"
+								name="password"
+								type={showPassword ? 'text' : 'password'}
+								autocomplete="new-password"
+								required
+								bind:value={password}
+								onpaste={() => {
+									// Ensure paste always works on mobile
+									// This explicit handler prevents any interference from browser autofill
+									// that might block paste operations on iOS Safari
+								}}
+								aria-invalid={!!errors.password}
+								aria-describedby={errors.password ? 'password-error' : 'password-requirements'}
+								disabled={isSubmitting}
+								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.password
+									? 'border-destructive'
+									: ''}"
+								placeholder={m['resetPasswordPage.newPasswordPlaceholder']()}
+							/>
+							<button
+								type="button"
+								onclick={() => (showPassword = !showPassword)}
+								class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+								aria-label={showPassword
+									? m['resetPasswordPage.hidePassword']()
+									: m['resetPasswordPage.showPassword']()}
+								tabindex={-1}
+							>
+								{#if showPassword}
+									<EyeOff class="h-4 w-4" aria-hidden="true" />
+								{:else}
+									<Eye class="h-4 w-4" aria-hidden="true" />
+								{/if}
+							</button>
+						</div>
+						{#if errors.password}
+							<p id="password-error" class="text-sm text-destructive" role="alert">
+								{errors.password}
+							</p>
+						{/if}
+					</div>
+
+					<!-- Password Strength Indicator -->
+					<div id="password-requirements">
+						<PasswordStrengthIndicator {password} />
+					</div>
+
+					<!-- Confirm Password Field -->
+					<div class="space-y-2">
+						<label for="confirmPassword" class="block text-sm font-medium"
+							>{m['resetPasswordPage.confirmPasswordLabel']()}</label
+						>
+						<div class="relative">
+							<input
+								id="confirmPassword"
+								name="confirmPassword"
+								type={showConfirmPassword ? 'text' : 'password'}
+								autocomplete="new-password"
+								required
+								bind:value={confirmPassword}
+								onpaste={() => {
+									// Ensure paste always works on mobile
+									// This explicit handler prevents any interference from browser autofill
+									// that might block paste operations on iOS Safari
+								}}
+								aria-invalid={!!errors.confirmPassword}
+								aria-describedby={errors.confirmPassword ? 'confirm-password-error' : undefined}
+								disabled={isSubmitting}
+								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.confirmPassword
+									? 'border-destructive'
+									: ''}"
+								placeholder={m['resetPasswordPage.confirmPasswordPlaceholder']()}
+							/>
+							<button
+								type="button"
+								onclick={() => (showConfirmPassword = !showConfirmPassword)}
+								class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+								aria-label={showConfirmPassword
+									? m['resetPasswordPage.hidePassword']()
+									: m['resetPasswordPage.showPassword']()}
+								tabindex={-1}
+							>
+								{#if showConfirmPassword}
+									<EyeOff class="h-4 w-4" aria-hidden="true" />
+								{:else}
+									<Eye class="h-4 w-4" aria-hidden="true" />
+								{/if}
+							</button>
+						</div>
+						{#if errors.confirmPassword}
+							<p id="confirm-password-error" class="text-sm text-destructive" role="alert">
+								{errors.confirmPassword}
+							</p>
+						{/if}
+					</div>
+
+					<!-- Submit Button -->
+					<button
+						type="submit"
+						disabled={isSubmitting}
+						class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						{#if isSubmitting}
+							<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
+							<span>{m['resetPasswordPage.submitting']()}</span>
+						{:else}
+							<span>{m['resetPasswordPage.submit']()}</span>
+						{/if}
+					</button>
+				</form>
+
+				<!-- Back to Login Link -->
+				<div class="text-center text-sm">
+					<a
+						href={resolve('/(public)/login', {})}
+						class="text-primary underline-offset-4 hover:underline"
+						>{m['resetPasswordPage.backToLogin']()}</a
+					>
+				</div>
+			{/if}
+		</CardContent>
+	</Card>
+</AuthBandLayout>

--- a/src/routes/(public)/password-reset/+page.svelte
+++ b/src/routes/(public)/password-reset/+page.svelte
@@ -5,6 +5,7 @@
 	import type { ActionData, PageData } from './$types';
 	import { Loader2, ArrowLeft, Mail, AlertTriangle } from '@lucide/svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
+	import AuthBandLayout from '$lib/components/auth/AuthBandLayout.svelte';
 	import { SeoHead } from '$lib/seo';
 
 	interface Props {
@@ -27,149 +28,140 @@
 
 <SeoHead config={data.seo} />
 
-<div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
-	<div class="w-full max-w-md space-y-6">
-		<!-- Header -->
-		<div class="text-center">
-			<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
-				{m['passwordResetPage.kicker']()}
-			</p>
-			<h1 class="mt-1 text-3xl font-black leading-[1.12] sm:text-4xl">
-				{success
-					? m['passwordResetPage.checkYourEmail']()
-					: m['passwordResetPage.resetYourPassword']()}
-			</h1>
-			<p class="mt-2 text-muted-foreground">
-				{success
-					? m['passwordResetPage.emailSentDescription']()
-					: m['passwordResetPage.enterEmailDescription']()}
-			</p>
-		</div>
-
-		<Card>
-			<CardContent class="space-y-6 p-6 sm:p-8">
-				{#if success}
-					<!-- Success State: success/10 + border are decorative (no text-contrast
+<!-- Colour-block band + floating card (uplift). Shell only: the action URLs,
+     enhance handler, field ids and aria wiring below are untouched. -->
+<AuthBandLayout
+	kicker={m['passwordResetPage.kicker']()}
+	title={success
+		? m['passwordResetPage.checkYourEmail']()
+		: m['passwordResetPage.resetYourPassword']()}
+	subtitle={success
+		? m['passwordResetPage.emailSentDescription']()
+		: m['passwordResetPage.enterEmailDescription']()}
+>
+	<Card>
+		<CardContent class="space-y-6 p-6 sm:p-8">
+			{#if success}
+				<!-- Success State: success/10 + border are decorative (no text-contrast
 					     requirement); title/body stay on foreground/muted-foreground, both
 					     already-audited pairs, so the token swap can't regress contrast. -->
-					<div
-						role="status"
-						class="rounded-md border border-success/40 bg-success/10 p-6 dark:border-success/50 dark:bg-success/15"
-					>
-						<div class="flex items-start gap-3">
-							<Mail class="h-6 w-6 flex-shrink-0 text-success" aria-hidden="true" />
-							<div class="flex-1 space-y-3">
-								<p class="text-sm font-medium text-foreground">
-									{m['passwordResetPage.emailSentTitle']()}
-								</p>
-								<p class="text-sm text-muted-foreground">
-									{m['passwordResetPage.emailSentMessage']()}
-								</p>
-							</div>
+				<div
+					role="status"
+					class="rounded-md border border-success/40 bg-success/10 p-6 dark:border-success/50 dark:bg-success/15"
+				>
+					<div class="flex items-start gap-3">
+						<Mail class="h-6 w-6 flex-shrink-0 text-success" aria-hidden="true" />
+						<div class="flex-1 space-y-3">
+							<p class="text-sm font-medium text-foreground">
+								{m['passwordResetPage.emailSentTitle']()}
+							</p>
+							<p class="text-sm text-muted-foreground">
+								{m['passwordResetPage.emailSentMessage']()}
+							</p>
 						</div>
 					</div>
+				</div>
 
-					<!-- Spam Warning -->
-					<div
-						class="flex items-start gap-3 rounded-md border border-highlight/30 bg-highlight/20 p-4 dark:border-highlight/40 dark:bg-highlight/25"
+				<!-- Spam Warning -->
+				<div
+					class="flex items-start gap-3 rounded-md border border-highlight/30 bg-highlight/20 p-4 dark:border-highlight/40 dark:bg-highlight/25"
+				>
+					<AlertTriangle
+						class="mt-0.5 h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
+						aria-hidden="true"
+					/>
+					<p class="text-sm font-medium text-foreground">
+						{m['passwordResetPage.checkSpam']()}
+					</p>
+				</div>
+
+				<!-- Back to Login -->
+				<div class="text-center">
+					<a
+						href={resolve('/(public)/login', {})}
+						class="inline-flex items-center gap-2 text-sm text-primary underline-offset-4 hover:underline"
 					>
-						<AlertTriangle
-							class="mt-0.5 h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
-							aria-hidden="true"
-						/>
-						<p class="text-sm font-medium text-foreground">
-							{m['passwordResetPage.checkSpam']()}
-						</p>
-					</div>
-
-					<!-- Back to Login -->
-					<div class="text-center">
-						<a
-							href={resolve('/(public)/login', {})}
-							class="inline-flex items-center gap-2 text-sm text-primary underline-offset-4 hover:underline"
-						>
-							<ArrowLeft class="h-4 w-4" aria-hidden="true" />
-							{m['passwordResetPage.backToLogin']()}
-						</a>
-					</div>
-				{:else}
-					<!-- Error Summary -->
-					{#if errors.form}
-						<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
-							<p class="text-sm font-medium text-destructive">{errors.form}</p>
-						</div>
-					{/if}
-
-					<!-- Reset Request Form -->
-					<form
-						method="POST"
-						action="?/resetRequest"
-						use:enhance={() => {
-							// Prevent duplicate submissions
-							if (isSubmitting) return;
-							isSubmitting = true;
-
-							return async ({ update }) => {
-								isSubmitting = false;
-								await update();
-							};
-						}}
-						class="space-y-6"
-					>
-						<!-- Email Field -->
-						<div class="space-y-2">
-							<label for="email" class="block text-sm font-medium">
-								{m['passwordResetPage.emailLabel']()}
-							</label>
-							<input
-								id="email"
-								name="email"
-								type="email"
-								autocomplete="email"
-								required
-								bind:value={email}
-								aria-invalid={!!errors.email}
-								aria-describedby={errors.email ? 'email-error' : undefined}
-								disabled={isSubmitting}
-								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.email
-									? 'border-destructive'
-									: ''}"
-								placeholder={m['passwordResetPage.emailPlaceholder']()}
-							/>
-							{#if errors.email}
-								<p id="email-error" class="text-sm text-destructive" role="alert">
-									{errors.email}
-								</p>
-							{/if}
-						</div>
-
-						<!-- Submit Button -->
-						<button
-							type="submit"
-							disabled={isSubmitting}
-							class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-						>
-							{#if isSubmitting}
-								<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
-								<span>{m['passwordResetPage.sendingLink']()}</span>
-							{:else}
-								<span>{m['passwordResetPage.sendLink']()}</span>
-							{/if}
-						</button>
-					</form>
-
-					<!-- Back to Login Link -->
-					<div class="text-center">
-						<a
-							href={resolve('/(public)/login', {})}
-							class="inline-flex items-center gap-2 text-sm text-primary underline-offset-4 hover:underline"
-						>
-							<ArrowLeft class="h-4 w-4" aria-hidden="true" />
-							{m['passwordResetPage.backToLogin']()}
-						</a>
+						<ArrowLeft class="h-4 w-4" aria-hidden="true" />
+						{m['passwordResetPage.backToLogin']()}
+					</a>
+				</div>
+			{:else}
+				<!-- Error Summary -->
+				{#if errors.form}
+					<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
+						<p class="text-sm font-medium text-destructive">{errors.form}</p>
 					</div>
 				{/if}
-			</CardContent>
-		</Card>
-	</div>
-</div>
+
+				<!-- Reset Request Form -->
+				<form
+					method="POST"
+					action="?/resetRequest"
+					use:enhance={() => {
+						// Prevent duplicate submissions
+						if (isSubmitting) return;
+						isSubmitting = true;
+
+						return async ({ update }) => {
+							isSubmitting = false;
+							await update();
+						};
+					}}
+					class="space-y-6"
+				>
+					<!-- Email Field -->
+					<div class="space-y-2">
+						<label for="email" class="block text-sm font-medium">
+							{m['passwordResetPage.emailLabel']()}
+						</label>
+						<input
+							id="email"
+							name="email"
+							type="email"
+							autocomplete="email"
+							required
+							bind:value={email}
+							aria-invalid={!!errors.email}
+							aria-describedby={errors.email ? 'email-error' : undefined}
+							disabled={isSubmitting}
+							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.email
+								? 'border-destructive'
+								: ''}"
+							placeholder={m['passwordResetPage.emailPlaceholder']()}
+						/>
+						{#if errors.email}
+							<p id="email-error" class="text-sm text-destructive" role="alert">
+								{errors.email}
+							</p>
+						{/if}
+					</div>
+
+					<!-- Submit Button -->
+					<button
+						type="submit"
+						disabled={isSubmitting}
+						class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						{#if isSubmitting}
+							<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
+							<span>{m['passwordResetPage.sendingLink']()}</span>
+						{:else}
+							<span>{m['passwordResetPage.sendLink']()}</span>
+						{/if}
+					</button>
+				</form>
+
+				<!-- Back to Login Link -->
+				<div class="text-center">
+					<a
+						href={resolve('/(public)/login', {})}
+						class="inline-flex items-center gap-2 text-sm text-primary underline-offset-4 hover:underline"
+					>
+						<ArrowLeft class="h-4 w-4" aria-hidden="true" />
+						{m['passwordResetPage.backToLogin']()}
+					</a>
+				</div>
+			{/if}
+		</CardContent>
+	</Card>
+</AuthBandLayout>

--- a/src/routes/(public)/register/+page.svelte
+++ b/src/routes/(public)/register/+page.svelte
@@ -7,6 +7,7 @@
 	import PasswordStrengthIndicator from '$lib/components/forms/PasswordStrengthIndicator.svelte';
 	import ReferralCodeInput from '$lib/components/referral/ReferralCodeInput.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
+	import AuthBandLayout from '$lib/components/auth/AuthBandLayout.svelte';
 	import { Eye, EyeOff, Loader2, Sparkles, ArrowRight } from '@lucide/svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import { SeoHead } from '$lib/seo';
@@ -171,11 +172,18 @@
 		onkeydown={onNudgeKeydown}
 	>
 		<div
-			class="w-full max-w-md space-y-6 rounded-lg border border-border bg-card p-6 text-center shadow-lg"
+			class="w-full max-w-md space-y-6 rounded-lg border-2 border-border bg-card p-6 text-center shadow-poster-lg"
 		>
-			<div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-				<Sparkles class="h-6 w-6 text-primary" aria-hidden="true" />
-			</div>
+			<!-- Poster-tinted chip, same recipe as EmptyState's internal chip
+			     (audited pair bg-poster-purple / text-poster-white, mode-inert by
+			     the imagery rule). Decorative — the dialog already has an
+			     accessible name from demo-nudge-title. -->
+			<span
+				aria-hidden="true"
+				class="mx-auto flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl bg-poster-purple text-poster-white shadow-poster"
+			>
+				<Sparkles class="h-7 w-7" />
+			</span>
 			<div class="space-y-2">
 				<h2 id="demo-nudge-title" class="text-xl font-bold tracking-tight">
 					{m['register.demoNudgeTitle']()}
@@ -206,261 +214,254 @@
 	</div>
 {/if}
 
-<div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
-	<div class="w-full max-w-md space-y-6">
-		<!-- Header -->
-		<div class="text-center">
-			<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
-				{m['register.kicker']()}
-			</p>
-			<h1 class="mt-1 text-3xl font-black leading-[1.12] sm:text-4xl">
-				{m['register.createAccount']()}
-			</h1>
-			<p class="mt-2 text-muted-foreground">{m['register.joinRevel']()}</p>
-		</div>
+<!-- Colour-block band + floating card (uplift). The nudge overlay above, the
+     form logic, field ids and aria wiring are untouched — shell only. -->
+<AuthBandLayout
+	kicker={m['register.kicker']()}
+	title={m['register.createAccount']()}
+	subtitle={m['register.joinRevel']()}
+>
+	<Card>
+		<CardContent class="space-y-6 p-6 sm:p-8">
+			<!-- Error Summary -->
+			{#if hasErrors && errors.form}
+				<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
+					<p class="text-sm font-medium text-destructive">{errors.form}</p>
+				</div>
+			{/if}
 
-		<Card>
-			<CardContent class="space-y-6 p-6 sm:p-8">
-				<!-- Error Summary -->
-				{#if hasErrors && errors.form}
-					<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-4">
-						<p class="text-sm font-medium text-destructive">{errors.form}</p>
-					</div>
-				{/if}
+			<!-- Registration Form -->
+			<form
+				method="POST"
+				bind:this={formEl}
+				use:enhance={() => {
+					// Prevent duplicate submissions
+					if (isSubmitting) return;
+					isSubmitting = true;
 
-				<!-- Registration Form -->
-				<form
-					method="POST"
-					bind:this={formEl}
-					use:enhance={() => {
-						// Prevent duplicate submissions
-						if (isSubmitting) return;
-						isSubmitting = true;
+					// Safety timeout: reset isSubmitting if the response never arrives
+					// (e.g., network hang, browser extension interference)
+					const safetyTimeout = setTimeout(() => {
+						isSubmitting = false;
+					}, 30_000);
 
-						// Safety timeout: reset isSubmitting if the response never arrives
-						// (e.g., network hang, browser extension interference)
-						const safetyTimeout = setTimeout(() => {
-							isSubmitting = false;
-						}, 30_000);
+					return async ({ update }) => {
+						clearTimeout(safetyTimeout);
+						isSubmitting = false;
+						await update();
+					};
+				}}
+				class="space-y-6"
+			>
+				<!-- Email Field -->
+				<div class="space-y-2">
+					<label for="email" class="block text-sm font-medium">
+						{m['register.emailAddress']()}
+					</label>
+					<input
+						id="email"
+						name="email"
+						type="email"
+						autocomplete="email"
+						required
+						bind:value={email}
+						aria-invalid={!!errors.email}
+						aria-describedby={errors.email ? 'email-error' : undefined}
+						disabled={isSubmitting}
+						class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.email
+							? 'border-destructive'
+							: ''}"
+						placeholder={m['register.emailPlaceholder']()}
+					/>
+					{#if errors.email}
+						<p id="email-error" class="text-sm text-destructive" role="alert">
+							{errors.email}
+						</p>
+					{/if}
+				</div>
 
-						return async ({ update }) => {
-							clearTimeout(safetyTimeout);
-							isSubmitting = false;
-							await update();
-						};
-					}}
-					class="space-y-6"
-				>
-					<!-- Email Field -->
-					<div class="space-y-2">
-						<label for="email" class="block text-sm font-medium">
-							{m['register.emailAddress']()}
-						</label>
+				<!-- Password Field -->
+				<div class="space-y-2">
+					<label for="password" class="block text-sm font-medium">
+						{m['register.password']()}
+					</label>
+					<div class="relative">
 						<input
-							id="email"
-							name="email"
-							type="email"
-							autocomplete="email"
+							id="password"
+							name="password"
+							type={showPassword ? 'text' : 'password'}
+							autocomplete="new-password"
 							required
-							bind:value={email}
-							aria-invalid={!!errors.email}
-							aria-describedby={errors.email ? 'email-error' : undefined}
+							bind:value={password}
+							onpaste={() => {
+								// Ensure paste always works on mobile
+								// This explicit handler prevents any interference from browser autofill
+								// that might block paste operations on iOS Safari
+							}}
+							aria-invalid={!!errors.password}
+							aria-describedby={errors.password
+								? 'password-error password-requirements'
+								: 'password-requirements'}
 							disabled={isSubmitting}
-							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.email
+							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.password
 								? 'border-destructive'
 								: ''}"
-							placeholder={m['register.emailPlaceholder']()}
+							placeholder={m['register.passwordPlaceholder']()}
 						/>
-						{#if errors.email}
-							<p id="email-error" class="text-sm text-destructive" role="alert">
-								{errors.email}
-							</p>
-						{/if}
+						<button
+							type="button"
+							onclick={() => (showPassword = !showPassword)}
+							class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+							aria-label={showPassword
+								? m['register.hidePassword']()
+								: m['register.showPassword']()}
+						>
+							{#if showPassword}
+								<EyeOff class="h-4 w-4" aria-hidden="true" />
+							{:else}
+								<Eye class="h-4 w-4" aria-hidden="true" />
+							{/if}
+						</button>
 					</div>
 
-					<!-- Password Field -->
-					<div class="space-y-2">
-						<label for="password" class="block text-sm font-medium">
-							{m['register.password']()}
-						</label>
-						<div class="relative">
-							<input
-								id="password"
-								name="password"
-								type={showPassword ? 'text' : 'password'}
-								autocomplete="new-password"
-								required
-								bind:value={password}
-								onpaste={() => {
-									// Ensure paste always works on mobile
-									// This explicit handler prevents any interference from browser autofill
-									// that might block paste operations on iOS Safari
-								}}
-								aria-invalid={!!errors.password}
-								aria-describedby={errors.password
-									? 'password-error password-requirements'
-									: 'password-requirements'}
-								disabled={isSubmitting}
-								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.password
-									? 'border-destructive'
-									: ''}"
-								placeholder={m['register.passwordPlaceholder']()}
-							/>
-							<button
-								type="button"
-								onclick={() => (showPassword = !showPassword)}
-								class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-								aria-label={showPassword
-									? m['register.hidePassword']()
-									: m['register.showPassword']()}
-							>
-								{#if showPassword}
-									<EyeOff class="h-4 w-4" aria-hidden="true" />
-								{:else}
-									<Eye class="h-4 w-4" aria-hidden="true" />
-								{/if}
-							</button>
-						</div>
-
-						{#if errors.password}
-							<p id="password-error" class="text-sm text-destructive" role="alert">
-								{errors.password}
-							</p>
-						{/if}
-
-						<!-- Password Strength Indicator with Requirements -->
-						{#if password}
-							<PasswordStrengthIndicator {password} showRequirements={true} />
-						{/if}
-					</div>
-
-					<!-- Confirm Password Field -->
-					<div class="space-y-2">
-						<label for="confirmPassword" class="block text-sm font-medium">
-							{m['register.confirmPassword']()}
-						</label>
-						<div class="relative">
-							<input
-								id="confirmPassword"
-								name="confirmPassword"
-								type={showConfirmPassword ? 'text' : 'password'}
-								autocomplete="new-password"
-								required
-								bind:value={confirmPassword}
-								onpaste={() => {
-									// Ensure paste always works on mobile
-									// This explicit handler prevents any interference from browser autofill
-									// that might block paste operations on iOS Safari
-								}}
-								aria-invalid={!!errors.confirmPassword}
-								aria-describedby={errors.confirmPassword ? 'confirm-password-error' : undefined}
-								disabled={isSubmitting}
-								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.confirmPassword
-									? 'border-destructive'
-									: ''}"
-								placeholder={m['register.confirmPasswordPlaceholder']()}
-							/>
-							<button
-								type="button"
-								onclick={() => (showConfirmPassword = !showConfirmPassword)}
-								class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-								aria-label={showConfirmPassword
-									? m['register.hidePassword']()
-									: m['register.showPassword']()}
-							>
-								{#if showConfirmPassword}
-									<EyeOff class="h-4 w-4" aria-hidden="true" />
-								{:else}
-									<Eye class="h-4 w-4" aria-hidden="true" />
-								{/if}
-							</button>
-						</div>
-						{#if errors.confirmPassword}
-							<p id="confirm-password-error" class="text-sm text-destructive" role="alert">
-								{errors.confirmPassword}
-							</p>
-						{/if}
-					</div>
-
-					<!-- Terms and Privacy Checkbox -->
-					<div class="flex items-start gap-3">
-						<input
-							id="acceptTerms"
-							name="acceptTerms"
-							type="checkbox"
-							required
-							bind:checked={acceptTerms}
-							aria-invalid={!!errors.acceptTerms}
-							aria-describedby={errors.acceptTerms ? 'terms-error' : undefined}
-							disabled={isSubmitting}
-							class="mt-1 h-4 w-4 rounded border-input text-primary transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-						/>
-						<label for="acceptTerms" class="text-sm">
-							{m['register.acceptTerms']()}
-							<a
-								href={resolve('/(public)/legal/terms', {})}
-								target="_blank"
-								rel="noopener noreferrer"
-								class="text-primary underline-offset-4 hover:underline"
-								>{m['footer.termsOfService']()}</a
-							>
-							{m['register.and']()}
-							<a
-								href={resolve('/(public)/legal/privacy', {})}
-								target="_blank"
-								rel="noopener noreferrer"
-								class="text-primary underline-offset-4 hover:underline"
-								>{m['footer.privacyPolicy']()}</a
-							>
-						</label>
-					</div>
-					{#if errors.acceptTerms}
-						<p id="terms-error" class="text-sm text-destructive" role="alert">
-							{errors.acceptTerms}
+					{#if errors.password}
+						<p id="password-error" class="text-sm text-destructive" role="alert">
+							{errors.password}
 						</p>
 					{/if}
 
-					<!-- Referral Code (collapsible) -->
-					<ReferralCodeInput
-						initialCode={initialReferralCode}
-						isProcessing={isSubmitting}
-						validatedCode={referralCode}
-						onValidated={(code) => (referralCode = code)}
-						onRemove={() => (referralCode = '')}
-					/>
-
-					<!-- Hidden referral code input for form submission -->
-					{#if referralCode}
-						<input type="hidden" name="referralCode" value={referralCode} />
+					<!-- Password Strength Indicator with Requirements -->
+					{#if password}
+						<PasswordStrengthIndicator {password} showRequirements={true} />
 					{/if}
+				</div>
 
-					<!-- Submit Button -->
-					<button
-						type="submit"
-						disabled={!canSubmit}
-						aria-disabled={!canSubmit}
-						class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-					>
-						{#if isSubmitting}
-							<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
-							<span>{m['register.creatingAccount']()}</span>
-						{:else}
-							<span>{m['register.createAccount']()}</span>
-						{/if}
-					</button>
-				</form>
-			</CardContent>
-		</Card>
+				<!-- Confirm Password Field -->
+				<div class="space-y-2">
+					<label for="confirmPassword" class="block text-sm font-medium">
+						{m['register.confirmPassword']()}
+					</label>
+					<div class="relative">
+						<input
+							id="confirmPassword"
+							name="confirmPassword"
+							type={showConfirmPassword ? 'text' : 'password'}
+							autocomplete="new-password"
+							required
+							bind:value={confirmPassword}
+							onpaste={() => {
+								// Ensure paste always works on mobile
+								// This explicit handler prevents any interference from browser autofill
+								// that might block paste operations on iOS Safari
+							}}
+							aria-invalid={!!errors.confirmPassword}
+							aria-describedby={errors.confirmPassword ? 'confirm-password-error' : undefined}
+							disabled={isSubmitting}
+							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm transition-colors placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {errors.confirmPassword
+								? 'border-destructive'
+								: ''}"
+							placeholder={m['register.confirmPasswordPlaceholder']()}
+						/>
+						<button
+							type="button"
+							onclick={() => (showConfirmPassword = !showConfirmPassword)}
+							class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+							aria-label={showConfirmPassword
+								? m['register.hidePassword']()
+								: m['register.showPassword']()}
+						>
+							{#if showConfirmPassword}
+								<EyeOff class="h-4 w-4" aria-hidden="true" />
+							{:else}
+								<Eye class="h-4 w-4" aria-hidden="true" />
+							{/if}
+						</button>
+					</div>
+					{#if errors.confirmPassword}
+						<p id="confirm-password-error" class="text-sm text-destructive" role="alert">
+							{errors.confirmPassword}
+						</p>
+					{/if}
+				</div>
 
-		<!-- Login Link -->
-		<div class="text-center text-sm">
-			<span class="text-muted-foreground">{m['register.alreadyHaveAccount']()}</span>
-			<a
-				href={resolve('/(public)/login', {})}
-				class="ml-1 text-primary underline-offset-4 hover:underline"
-			>
-				{m['auth.login']()}
-			</a>
-		</div>
+				<!-- Terms and Privacy Checkbox -->
+				<div class="flex items-start gap-3">
+					<input
+						id="acceptTerms"
+						name="acceptTerms"
+						type="checkbox"
+						required
+						bind:checked={acceptTerms}
+						aria-invalid={!!errors.acceptTerms}
+						aria-describedby={errors.acceptTerms ? 'terms-error' : undefined}
+						disabled={isSubmitting}
+						class="mt-1 h-4 w-4 rounded border-input text-primary transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+					/>
+					<label for="acceptTerms" class="text-sm">
+						{m['register.acceptTerms']()}
+						<a
+							href={resolve('/(public)/legal/terms', {})}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="text-primary underline-offset-4 hover:underline"
+							>{m['footer.termsOfService']()}</a
+						>
+						{m['register.and']()}
+						<a
+							href={resolve('/(public)/legal/privacy', {})}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="text-primary underline-offset-4 hover:underline"
+							>{m['footer.privacyPolicy']()}</a
+						>
+					</label>
+				</div>
+				{#if errors.acceptTerms}
+					<p id="terms-error" class="text-sm text-destructive" role="alert">
+						{errors.acceptTerms}
+					</p>
+				{/if}
+
+				<!-- Referral Code (collapsible) -->
+				<ReferralCodeInput
+					initialCode={initialReferralCode}
+					isProcessing={isSubmitting}
+					validatedCode={referralCode}
+					onValidated={(code) => (referralCode = code)}
+					onRemove={() => (referralCode = '')}
+				/>
+
+				<!-- Hidden referral code input for form submission -->
+				{#if referralCode}
+					<input type="hidden" name="referralCode" value={referralCode} />
+				{/if}
+
+				<!-- Submit Button -->
+				<button
+					type="submit"
+					disabled={!canSubmit}
+					aria-disabled={!canSubmit}
+					class="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+				>
+					{#if isSubmitting}
+						<Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" />
+						<span>{m['register.creatingAccount']()}</span>
+					{:else}
+						<span>{m['register.createAccount']()}</span>
+					{/if}
+				</button>
+			</form>
+		</CardContent>
+	</Card>
+
+	<!-- Login Link -->
+	<div class="text-center text-sm">
+		<span class="text-muted-foreground">{m['register.alreadyHaveAccount']()}</span>
+		<a
+			href={resolve('/(public)/login', {})}
+			class="ml-1 text-primary underline-offset-4 hover:underline"
+		>
+			{m['auth.login']()}
+		</a>
 	</div>
-</div>
+</AuthBandLayout>

--- a/src/routes/(public)/register/check-email/+page.svelte
+++ b/src/routes/(public)/register/check-email/+page.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/stores';
 	import { Mail, Loader2, AlertTriangle } from '@lucide/svelte';
 	import { accountResendVerificationEmail } from '$lib/api/generated/sdk.gen';
+	import AuthBandLayout from '$lib/components/auth/AuthBandLayout.svelte';
 
 	const email = $derived($page.url.searchParams.get('email') || '');
 	let isResending = $state(false);
@@ -57,32 +58,31 @@
 	<meta name="description" content="Verify your email to complete registration" />
 </svelte:head>
 
-<div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
-	<div class="w-full max-w-md space-y-8 text-center">
-		<div>
-			<!-- Hand-composed centerpiece (not the EmptyState primitive, which caps
-			     at h2/h3): this page's only heading must be an h1. Chip recipe
-			     mirrors EmptyState's internal poster-tinted chip (audited pair:
-			     bg-poster-purple/text-poster-white). -->
-			<span
-				aria-hidden="true"
-				class="mx-auto flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl bg-poster-purple text-poster-white shadow-sm"
-			>
-				<Mail class="h-7 w-7" />
-			</span>
-			<h1 class="mt-4 text-3xl font-black leading-[1.12] sm:text-4xl">
-				{m['checkEmailPage.checkYourEmail']()}
-			</h1>
-			<p class="mt-1.5 text-muted-foreground">{m['checkEmailPage.verificationLink']()}</p>
-			{#if email}
-				<p class="mt-1.5 font-medium">{email}</p>
-			{/if}
-		</div>
+<!-- Colour-block band + floating card (uplift). The mail chip moves INTO the
+     band above the title (same EmptyState poster-chip recipe, still
+     aria-hidden ornament); everything that follows floats on it. Copy, the
+     resend handler and all live-region roles are unchanged. -->
+{#snippet mailChip()}
+	<span
+		aria-hidden="true"
+		class="flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl bg-poster-purple text-poster-white shadow-poster"
+	>
+		<Mail class="h-8 w-8" />
+	</span>
+{/snippet}
+
+<AuthBandLayout
+	chip={mailChip}
+	title={m['checkEmailPage.checkYourEmail']()}
+	subtitle={m['checkEmailPage.verificationLink']()}
+>
+	<div class="space-y-6 rounded-lg border-2 border-border bg-card p-6 text-center shadow-poster">
+		{#if email}
+			<p class="font-bold">{email}</p>
+		{/if}
 
 		<!-- Instructions -->
-		<div class="space-y-4 text-sm text-muted-foreground">
-			<p>{m['checkEmailPage.clickLink']()}</p>
-		</div>
+		<p class="text-sm text-muted-foreground">{m['checkEmailPage.clickLink']()}</p>
 
 		<!-- Spam Warning: highlight/20 + border are decorative; body text stays on
 		     the default foreground token (already-audited pair). -->
@@ -99,7 +99,7 @@
 		</div>
 
 		<!-- Resend Section -->
-		<div class="space-y-3 border-t pt-6">
+		<div class="space-y-3 border-t-2 pt-6">
 			<p class="text-sm text-muted-foreground">{m['checkEmailPage.didNotReceive']()}</p>
 
 			{#if resendSuccess}
@@ -135,15 +135,15 @@
 				{/if}
 			</button>
 		</div>
-
-		<!-- Back to Login -->
-		<div class="text-sm">
-			<a
-				href={resolve('/(public)/login', {})}
-				class="text-primary underline-offset-4 hover:underline"
-			>
-				{m['checkEmailPage.backToLogin']()}
-			</a>
-		</div>
 	</div>
-</div>
+
+	<!-- Back to Login -->
+	<div class="text-center text-sm">
+		<a
+			href={resolve('/(public)/login', {})}
+			class="text-primary underline-offset-4 hover:underline"
+		>
+			{m['checkEmailPage.backToLogin']()}
+		</a>
+	</div>
+</AuthBandLayout>

--- a/src/routes/(public)/verify/+page.svelte
+++ b/src/routes/(public)/verify/+page.svelte
@@ -4,6 +4,7 @@
 	import type { PageData } from './$types';
 	import { CheckCircle, XCircle } from '@lucide/svelte';
 	import { SeoHead } from '$lib/seo';
+	import AuthBandLayout from '$lib/components/auth/AuthBandLayout.svelte';
 
 	interface Props {
 		data: PageData;
@@ -14,39 +15,37 @@
 
 <SeoHead config={data.seo} />
 
-<div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
-	<div class="w-full max-w-md space-y-8 text-center">
-		<!-- Hand-composed centerpiece (not the EmptyState primitive, which caps
-		     at h2/h3): this page's only heading must be an h1. Chip recipe
-		     mirrors EmptyState's internal poster-tinted chip. Failure has no
-		     "danger" tone in the poster palette — "warning" (amber/ink, audited
-		     pair) reads as the closest honest match for an expired/invalid link,
-		     short of the full destructive framing reserved for confirm-deletion. -->
-		<div>
-			<span
-				aria-hidden="true"
-				class="mx-auto flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl shadow-sm {data.success
-					? 'bg-success text-success-foreground'
-					: 'bg-poster-amber text-poster-ink'}"
-			>
-				{#if data.success}
-					<CheckCircle class="h-7 w-7" />
-				{:else}
-					<XCircle class="h-7 w-7" />
-				{/if}
-			</span>
-			<h1 class="mt-4 text-3xl font-black leading-[1.12] sm:text-4xl">
-				{data.success ? m['verifyPage.emailVerified']() : m['verifyPage.verificationFailed']()}
-			</h1>
-			<p class="mt-1.5 text-muted-foreground">
-				{data.success
-					? m['verifyPage.successRedirect']()
-					: `${data.error || m['verifyPage.couldNotVerify']()} ${m['verifyPage.linkExpiredOrInvalid']()}`}
-			</p>
-		</div>
+<!-- Colour-block band + floating action card (uplift). The status chip moves
+     INTO the band above the title — same recipe as before (EmptyState's
+     poster-tinted tilted chip), still aria-hidden ornament. Failure has no
+     "danger" tone in the poster palette; "warning" (amber/ink, audited pair)
+     stays the closest honest match for an expired/invalid link, short of the
+     full destructive framing reserved for confirm-deletion. The h1 and body
+     copy are unchanged keys, now carried by the band. -->
+{#snippet statusChip()}
+	<span
+		aria-hidden="true"
+		class="flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl shadow-poster {data.success
+			? 'bg-success text-success-foreground'
+			: 'bg-poster-amber text-poster-ink'}"
+	>
+		{#if data.success}
+			<CheckCircle class="h-8 w-8" />
+		{:else}
+			<XCircle class="h-8 w-8" />
+		{/if}
+	</span>
+{/snippet}
 
-		<!-- Actions -->
-		{#if !data.success}
+<AuthBandLayout
+	chip={statusChip}
+	title={data.success ? m['verifyPage.emailVerified']() : m['verifyPage.verificationFailed']()}
+	subtitle={data.success
+		? m['verifyPage.successRedirect']()
+		: `${data.error || m['verifyPage.couldNotVerify']()} ${m['verifyPage.linkExpiredOrInvalid']()}`}
+>
+	{#if !data.success}
+		<div class="rounded-lg border-2 border-border bg-card p-6 shadow-poster">
 			<div class="flex flex-col gap-3 sm:flex-row sm:justify-center">
 				<a
 					href={resolve('/(public)/register', {})}
@@ -61,6 +60,6 @@
 					{m['verifyPage.backToLogin']()}
 				</a>
 			</div>
-		{/if}
-	</div>
-</div>
+		</div>
+	{/if}
+</AuthBandLayout>

--- a/src/routes/(public)/verify/+page.svelte
+++ b/src/routes/(public)/verify/+page.svelte
@@ -38,6 +38,7 @@
 {/snippet}
 
 <AuthBandLayout
+	width="lg"
 	chip={statusChip}
 	title={data.success ? m['verifyPage.emailVerified']() : m['verifyPage.verificationFailed']()}
 	subtitle={data.success

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -135,10 +135,11 @@
 	<meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<!-- Poster ribbon + floating card (uplift, spec §9). The page was a column of
-     centred type on bare background; it now opens on a full-strength
-     `bg-secondary` colour block — an audit-enforced pair in BOTH modes
-     (9.01:1 light / 8.17:1 dark for its own foreground), so the ribbon is a
+<!-- Celebration band + floating card (uplift, spec §9). The page was a column
+     of centred type on bare background; it now opens on a full-strength
+     `bg-secondary` colour block — theme-aware, not the mode-inert poster
+     ribbon the join pages use — an audit-enforced pair in BOTH modes
+     (9.00:1 light / 8.23:1 dark for its own foreground), so the band is a
      real poster panel that still respects the light/dark axis. The kicker and
      description inherit the band's foreground through PageHeader's `onBand`
      affordance; its default `text-primary` kicker measures 4.12:1 there,

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -14,6 +14,7 @@
 	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import Sticker from '$lib/components/brand/Sticker.svelte';
 	import type { Tone } from '$lib/components/common/tones';
+	import PageHeader from '$lib/components/common/PageHeader.svelte';
 
 	// Get error details from page store
 	const status = $derived($page.status);
@@ -134,58 +135,65 @@
 	<meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<div class="flex min-h-screen items-center justify-center bg-background px-4 py-16">
-	<div class="w-full max-w-2xl">
-		<!-- Error Icon + status-code Sticker: the flagship personality moment.
-		     Both are decorative art, not a second announcement of the title —
-		     the h1 below is the actual accessible heading, and the status code
-		     is separately in the accessible errorPage.errorLabel text. ToneTile
-		     omits `label` (→ aria-hidden by default) rather than repeating
-		     config.title() as its accessible name; the Sticker is likewise
-		     wrapped aria-hidden. -->
-		<div class="mb-8 flex flex-col items-center gap-4">
-			<ToneTile tone={config.tone} icon={ErrorIcon} size="lg" />
-			<span aria-hidden="true">
-				<Sticker tint="purple" rotate={-3} class="text-2xl">{status}</Sticker>
-			</span>
+<!-- Poster ribbon + floating card (uplift, spec §9). The page was a column of
+     centred type on bare background; it now opens on a full-strength
+     `bg-secondary` colour block — an audit-enforced pair in BOTH modes
+     (9.01:1 light / 8.17:1 dark for its own foreground), so the ribbon is a
+     real poster panel that still respects the light/dark axis. The kicker and
+     description inherit the band's foreground through PageHeader's `onBand`
+     affordance; its default `text-primary` kicker measures 4.12:1 there,
+     below AA for 14px extrabold.
+
+     The status Sticker is the band's ornament: a white poster sticker whose
+     purple-on-white pair is audited and mode-inert by the imagery rule.
+     The ToneTile deliberately did NOT move onto the band — its soft `/10`
+     tints and their icon ratios are computed against `bg-card`/page surfaces
+     (see ToneTile's table), so it stays inside the floating card where those
+     numbers hold. Both remain decorative art, not a second announcement: the
+     h1 is the accessible heading and the status code is separately in the
+     errorPage.errorLabel copy. -->
+<div class="min-h-screen bg-background">
+	<section class="bg-secondary text-secondary-foreground">
+		<div class="container mx-auto max-w-2xl px-4 pb-20 pt-12 text-center sm:pt-16">
+			<div class="mb-6 flex justify-center">
+				<span aria-hidden="true">
+					<Sticker tint="purple" rotate={-3} class="text-4xl sm:text-5xl">{status}</Sticker>
+				</span>
+			</div>
+			<PageHeader
+				volume="poster"
+				onBand
+				kicker={m['errorPage.errorLabel']({ status: status.toString() })}
+				title={config.title()}
+				subtitle={config.description()}
+				class="text-center sm:flex-col sm:items-center"
+			/>
 		</div>
+	</section>
 
-		<!-- Error Content -->
-		<div class="text-center">
-			<!-- Status Code -->
-			<p class="mb-2 text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
-				{m['errorPage.errorLabel']({ status: status.toString() })}
-			</p>
-
-			<!-- Title -->
-			<h1 class="mb-4 text-3xl font-black leading-[1.12] sm:text-4xl">
-				{config.title()}
-			</h1>
-
-			<!-- Description -->
-			<p class="mb-8 text-lg text-muted-foreground">
-				{config.description()}
-			</p>
+	<div class="container mx-auto -mt-12 max-w-2xl space-y-6 px-4 pb-16">
+		<div class="rounded-lg border-2 border-border bg-card p-6 shadow-poster sm:p-8">
+			<div class="flex justify-center">
+				<ToneTile tone={config.tone} icon={ErrorIcon} size="lg" />
+			</div>
 
 			<!-- Suggestions -->
 			{#if config.suggestions && config.suggestions().length > 0}
-				<div class="mb-8 rounded-lg border bg-card p-6 text-left">
-					<h2 class="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-						{m['errorPage.whatYouCanDo']()}
-					</h2>
-					<ul class="space-y-2 text-sm">
-						{#each config.suggestions() as suggestion, i (i)}
-							<li class="flex items-start gap-2">
-								<span class="mt-1 text-primary" aria-hidden="true">•</span>
-								<span>{suggestion}</span>
-							</li>
-						{/each}
-					</ul>
-				</div>
+				<h2 class="mt-6 text-sm font-extrabold uppercase tracking-[0.12em] text-muted-foreground">
+					{m['errorPage.whatYouCanDo']()}
+				</h2>
+				<ul class="mt-4 space-y-2 text-left text-sm">
+					{#each config.suggestions() as suggestion, i (i)}
+						<li class="flex items-start gap-2">
+							<span class="mt-1 text-primary" aria-hidden="true">•</span>
+							<span>{suggestion}</span>
+						</li>
+					{/each}
+				</ul>
 			{/if}
 
 			<!-- Action Buttons -->
-			<div class="flex flex-wrap items-center justify-center gap-3">
+			<div class="mt-8 flex flex-wrap items-center justify-center gap-3">
 				{#if config.showBackButton}
 					<button
 						type="button"
@@ -219,16 +227,16 @@
 					</a>
 				{/if}
 			</div>
-
-			<!-- Debug Info (only in development) -->
-			{#if import.meta.env.DEV && message}
-				<div class="mt-8 rounded-lg border border-muted bg-muted/50 p-4 text-left">
-					<h3 class="mb-2 text-sm font-semibold text-muted-foreground">
-						{m['errorPage.debugInfo']()}
-					</h3>
-					<pre class="overflow-x-auto text-xs text-muted-foreground">{message}</pre>
-				</div>
-			{/if}
 		</div>
+
+		<!-- Debug Info (only in development) -->
+		{#if import.meta.env.DEV && message}
+			<div class="rounded-lg border-2 border-muted bg-muted/50 p-4 text-left">
+				<h3 class="mb-2 text-sm font-semibold text-muted-foreground">
+					{m['errorPage.debugInfo']()}
+				</h3>
+				<pre class="overflow-x-auto text-xs text-muted-foreground">{message}</pre>
+			</div>
+		{/if}
 	</div>
 </div>


### PR DESCRIPTION
## Uplift U3 — dashboard, auth, join, error

The final branch of the rebrand program: the approved poster-grade language across the user dashboard (6 pages), all auth/interstitial pages, the join invitations, and the error page.

### What's in it
- Dashboard home opens on a celebration welcome band; every page's band pull-up lands on an opaque surface in ALL reachable states (the review caught the zero-activity new-user path dropping a bare 4.12:1 link on the band — fixed and verified live in both states)
- Auth pages get the band + floating card treatment (auth logic byte-untouched — verified attribute-level); join pages get the full ribbon with the org LogoChip visible at every viewport (mobile in-flow chip pattern)
- `/join/event` deliberately has no chip — the token schema exposes no org logo and the logo-or-nothing rule forbids Revel-mark filler; the event cover carries the ribbon
- `/account/confirm-deletion` keeps its danger-framing exception (no band, depth only) — most conservative treatment of the spec-pinned page
- Error page rides the celebration band; join pages upgraded to true h1s

### Review process
Opus whole-branch review + one fix round + scoped re-review, clean; rebased over U2 (no conflicts), full gates re-run on the rebased tip.

### Verification
`make check` 0 errors · full suite 219 files / 2544 green · brand audit 0 failures · a11y-smoke (zero-baseline axe on /login, /dashboard, /dashboard/tickets) 20/20 both projects · live verification of both dashboard band states · orchestrator screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)