### PR TITLE
feat(rebrand): poster-grade SEO landing pages + link-chip arrow affordance

### DIFF
--- a/src/lib/components/landing/LandingPageTemplate.svelte
+++ b/src/lib/components/landing/LandingPageTemplate.svelte
@@ -2,6 +2,7 @@
 	import type { LandingPageContent, LandingPageFeature } from '$lib/data/landing-pages';
 	import { landingPages } from '$lib/data/landing-pages';
 	import { Button } from '$lib/components/ui/button';
+	import { cn } from '$lib/utils';
 	import * as m from '$lib/paraglide/messages.js';
 	import ToneTile from '$lib/components/common/ToneTile.svelte';
 	import SectionHeader from '$lib/components/common/SectionHeader.svelte';
@@ -20,7 +21,8 @@
 		Code,
 		Clipboard,
 		ChevronDown,
-		ChevronUp
+		ChevronUp,
+		ArrowRight
 	} from '@lucide/svelte';
 
 	interface Props {
@@ -49,11 +51,42 @@
 		return iconMap[iconName] || Check;
 	}
 
+	/**
+	 * Tilt discipline (spec §3): rotation is an ACCENT, never a pattern — at most
+	 * two tilted cards per grid, and only the outer ones, so the grid still reads
+	 * as a grid. Content files ship 3–6 features, so this is always first + last.
+	 */
+	function featureTilt(index: number, total: number): string {
+		if (total < 2) return '';
+		if (index === 0) return '-rotate-1';
+		if (index === total - 1) return 'rotate-1';
+		return '';
+	}
+
 	// FAQ accordion state
 	let openFaqIndex = $state<number | null>(null);
 
 	function toggleFaq(index: number) {
 		openFaqIndex = openFaqIndex === index ? null : index;
+	}
+
+	/**
+	 * FAQ rows follow the uplift's option-row language (`QuestionnaireFillForm`
+	 * is the family reference): chunky 2px edge, sticker radius, a real hover
+	 * lift via shadow, and an expanded state that is carried by the border AND
+	 * the chevron AND `aria-expanded` — never by colour alone.
+	 *
+	 * `border-primary` measures 6.99:1 light / 6.28:1 dark against `--card`, well
+	 * over the 3:1 non-text floor, so the open row is distinguishable without
+	 * relying on the (deliberately soft) `--border` resting edge.
+	 */
+	function faqRowClass(open: boolean): string {
+		return cn(
+			'overflow-hidden rounded-2xl border-2 bg-card transition-shadow',
+			open
+				? 'border-primary shadow-poster'
+				: 'border-border hover:border-primary/50 hover:shadow-poster'
+		);
 	}
 
 	// Get related page data
@@ -87,14 +120,18 @@
      survived cn()'s merge untouched → white text on a light bg-background at
      rest (1.13:1). Fixed by adding bg-transparent + hover:text-poster-white
      so every state has an explicit bg AND text pair. Border also bumped to
-     /65 (was /60 = 2.96:1, under the 3:1 non-text floor) → 3.22:1. -->
-<section class="relative overflow-hidden bg-poster-purple py-16 md:py-24">
+     /65 (was /60 = 2.96:1, under the 3:1 non-text floor) → 3.22:1.
+
+     Uplift (spec §9): the headline moves to the celebration display scale
+     (`text-4xl font-black leading-[1.08]`) and the band's bottom edge is a
+     real poster CUT (`.poster-band-cut`, see the <style> block). `z-10` is
+     load-bearing: the tinted panel below is pulled up UNDER this band so the
+     clipped corner reveals the wash rather than the page background. -->
+<section class="poster-band-cut relative z-10 overflow-hidden bg-poster-purple py-16 md:py-24">
 	<div class="absolute inset-0 bg-[url('/grid.svg')] opacity-10"></div>
 	<div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 		<div class="text-center">
-			<h1
-				class="text-3xl font-black leading-[1.12] text-poster-white sm:text-4xl md:text-5xl lg:text-6xl"
-			>
+			<h1 class="text-4xl font-black leading-[1.08] text-poster-white sm:text-5xl lg:text-6xl">
 				{content.hero.headline}
 			</h1>
 			<p class="mx-auto mt-4 max-w-3xl text-lg text-poster-white sm:text-xl md:mt-6">
@@ -126,97 +163,163 @@
 	</div>
 </section>
 
-<!-- Intro Section -->
-<section class="bg-background py-12 md:py-16">
-	<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
-		<div class="prose prose-lg mx-auto dark:prose-invert">
-			{#each content.intro.paragraphs as paragraph, i (i)}
-				<p class="text-base leading-relaxed text-muted-foreground md:text-lg">
-					{paragraph}
-				</p>
-			{/each}
+<!--
+	Intro + Features on ONE tinted content panel (uplift, spec §9). Band/wash
+	pairing: the hero is a mode-INERT poster-solid ribbon, so per the CLAUDE.md
+	rule it takes a theme-aware tinted wash below it — the same composite the
+	org-profile and event-detail pages use, so an SEO page and the product it
+	sells read as one surface. Composited alphas are invisible to
+	scripts/audit-brand-themes.py, so the honest numbers (computed, not
+	estimated):
+	  light — secondary@55 over background ⇒ foreground 12.36:1 ·
+	          muted-foreground 6.43:1 · primary 4.97:1
+	  dark  — secondary@28 over background ⇒ foreground 15.68:1 ·
+	          muted-foreground 7.44:1 · primary 6.30:1
+	Everything landing directly on the wash is covered: the SectionHeader
+	kickers (`primary`) and headings (`foreground`).
+
+	`-mt-14` slides this panel up UNDER the hero by exactly the cut depth, so the
+	band's clipped corner reveals the wash (a section is not positioned, so its
+	background paints below the hero's `z-10`; the content wrapper takes `z-20`
+	to come back out on top). The intro card is then pulled up across the cut —
+	pull-up opacity rule: the first block landing on a band's edge is opaque
+	`bg-card`, never an alpha surface.
+-->
+<section class="-mt-14 bg-secondary/55 pb-12 pt-16 dark:bg-secondary/[0.28] md:pb-16">
+	<div class="relative z-20 mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+		<!-- Intro Section -->
+		<div
+			class="mx-auto -mt-8 max-w-4xl rounded-[1.5rem] border-2 border-border bg-card p-6 shadow-poster sm:p-8"
+		>
+			<div class="prose prose-lg mx-auto dark:prose-invert">
+				{#each content.intro.paragraphs as paragraph, i (i)}
+					<p class="text-base leading-relaxed text-muted-foreground md:text-lg">
+						{paragraph}
+					</p>
+				{/each}
+			</div>
+		</div>
+
+		<!-- Features Section -->
+		<div class="mt-14 md:mt-20">
+			<SectionHeader
+				title={m['landingTemplate.featuresHeading']({}, { locale: content.locale })}
+				volume="celebration"
+				class="mb-8 justify-center text-center"
+			/>
+			<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+				{#each content.features as feature, i (feature.title)}
+					{@const IconComponent = getIcon(feature.icon)}
+					<div
+						class="rounded-2xl border-2 border-border bg-card p-6 shadow-poster {featureTilt(
+							i,
+							content.features.length
+						)}"
+					>
+						<!-- Uniform brand tone: ToneTile's tone axis is semantic, and these
+						     marketing bullets carry no per-feature meaning to encode — the
+						     identity `tint` axis is for destinations, and these cards go
+						     nowhere. -->
+						<ToneTile tone="brand" icon={IconComponent} size="lg" class="mb-4" />
+						<h3 class="mb-2 text-lg font-bold text-foreground">{feature.title}</h3>
+						<p class="text-sm text-muted-foreground">{feature.description}</p>
+					</div>
+				{/each}
+			</div>
 		</div>
 	</div>
 </section>
 
-<!-- Features Section -->
-<section class="bg-muted/50 py-12 md:py-16">
-	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-		<SectionHeader
-			title={m['landingTemplate.featuresHeading']({}, { locale: content.locale })}
-			volume="celebration"
-			class="mb-8 justify-center text-center"
-		/>
-		<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-			{#each content.features as feature (feature.title)}
-				{@const IconComponent = getIcon(feature.icon)}
-				<div class="rounded-lg border bg-card p-6 shadow-sm transition-shadow hover:shadow-md">
-					<!-- Uniform brand tone: ToneTile's tone axis is semantic, and these
-					     marketing bullets carry no per-feature meaning to encode — the
-					     identity/tint axis for "same tone, different accent color per
-					     destination" lands with PR 7's poster-tint prop. -->
-					<ToneTile tone="brand" icon={IconComponent} size="lg" class="mb-4" />
-					<h3 class="mb-2 text-lg font-bold text-foreground">{feature.title}</h3>
-					<p class="text-sm text-muted-foreground">{feature.description}</p>
-				</div>
-			{/each}
-		</div>
-	</div>
-</section>
-
-<!-- Benefits Section -->
-<section class="bg-background py-12 md:py-16">
+<!--
+	Benefits + FAQ share one plain `--background` region: both are floating
+	`shadow-poster` blocks, so the rhythm comes from the FLOAT, not from a
+	second tint stacked under the one above. The generous bottom padding is
+	load-bearing — the CTA band's cut strip reaches 3.5rem up into it.
+-->
+<section class="bg-background py-12 pb-24 md:py-16 md:pb-28">
 	<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+		<!-- Benefits -->
 		<SectionHeader
 			title={content.benefits.title}
 			kicker={m['landingTemplate.benefitsKicker']({}, { locale: content.locale })}
 			volume="celebration"
 			class="mb-8 justify-center text-center"
 		/>
-		<ul class="space-y-4">
+		<ul
+			class="divide-y-2 divide-border overflow-hidden rounded-[1.5rem] border-2 border-border bg-card shadow-poster"
+		>
 			{#each content.benefits.items as item, i (i)}
-				<li class="flex items-start gap-3">
-					<Check class="mt-1 h-5 w-5 flex-shrink-0 text-primary" />
-					<span class="text-base text-muted-foreground">{item}</span>
+				<li class="flex items-start gap-4 p-5 sm:p-6">
+					<!-- Solid `bg-primary`/`text-primary-foreground` chip: an audited token
+					     pair, and it lifts the row marker off the muted-grey it used to be. -->
+					<span
+						class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
+					>
+						<Check class="h-4 w-4" aria-hidden="true" />
+					</span>
+					<span class="text-base font-medium text-foreground">{item}</span>
 				</li>
 			{/each}
 		</ul>
-	</div>
-</section>
 
-<!-- FAQ Section -->
-<section class="bg-muted/50 py-12 md:py-16">
-	<div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
-		<SectionHeader
-			title={m['landingTemplate.faqHeading']({}, { locale: content.locale })}
-			kicker={m['landingTemplate.faqKicker']({}, { locale: content.locale })}
-			volume="celebration"
-			class="mb-8 justify-center text-center"
-		/>
-		<div class="space-y-4">
-			{#each content.faq as faq, index (faq.question)}
-				<div class="overflow-hidden rounded-lg border bg-card">
-					<button
-						type="button"
-						class="flex w-full items-center justify-between p-4 text-left transition-colors hover:bg-muted/50"
-						onclick={() => toggleFaq(index)}
-						aria-expanded={openFaqIndex === index}
-						aria-controls={`faq-answer-${index}`}
-					>
-						<span class="pr-4 font-medium text-foreground">{faq.question}</span>
+		<!-- FAQ -->
+		<div class="mt-14 md:mt-20">
+			<SectionHeader
+				title={m['landingTemplate.faqHeading']({}, { locale: content.locale })}
+				kicker={m['landingTemplate.faqKicker']({}, { locale: content.locale })}
+				volume="celebration"
+				class="mb-8 justify-center text-center"
+			/>
+			<div class="space-y-4">
+				{#each content.faq as faq, index (faq.question)}
+					<div class={faqRowClass(openFaqIndex === index)}>
+						<!-- `transition-colors`, never `transition-all`, on the focusable
+						     element: `transition-all` fades the focus ring in. The row's
+						     shadow/border transition lives on the wrapper above, which is
+						     not focusable.
+
+						     The focus ring is drawn INSIDE the button (negative
+						     outline-offset) because the wrapper clips (`overflow-hidden`,
+						     needed so the answer panel respects the row's radius) — the
+						     UA's default outward ring loses its left and right edges there.
+						     `--ring` is `--primary`: 6.99:1 light / 6.28:1 dark on `--card`,
+						     over the 3:1 non-text floor. -->
+						<button
+							type="button"
+							class="flex min-h-14 w-full items-center justify-between gap-3 px-4 py-4 text-left transition-colors hover:bg-primary/5 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring sm:px-5"
+							onclick={() => toggleFaq(index)}
+							aria-expanded={openFaqIndex === index}
+							aria-controls={`faq-answer-${index}`}
+						>
+							<span class="font-bold text-foreground">{faq.question}</span>
+							<!-- The chevron chip inverts when open (primary fill), a second
+							     non-colour cue on top of the arrow direction itself. -->
+							<span
+								class={cn(
+									'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+									openFaqIndex === index
+										? 'bg-primary text-primary-foreground'
+										: 'bg-muted text-muted-foreground'
+								)}
+							>
+								{#if openFaqIndex === index}
+									<ChevronUp class="h-4 w-4" aria-hidden="true" />
+								{:else}
+									<ChevronDown class="h-4 w-4" aria-hidden="true" />
+								{/if}
+							</span>
+						</button>
 						{#if openFaqIndex === index}
-							<ChevronUp class="h-5 w-5 flex-shrink-0 text-muted-foreground" />
-						{:else}
-							<ChevronDown class="h-5 w-5 flex-shrink-0 text-muted-foreground" />
+							<div
+								id={`faq-answer-${index}`}
+								class="border-t-2 border-border px-4 pb-5 pt-4 sm:px-5"
+							>
+								<p class="text-sm leading-relaxed text-muted-foreground">{faq.answer}</p>
+							</div>
 						{/if}
-					</button>
-					{#if openFaqIndex === index}
-						<div id={`faq-answer-${index}`} class="border-t px-4 pb-4 pt-3">
-							<p class="text-sm text-muted-foreground">{faq.answer}</p>
-						</div>
-					{/if}
-				</div>
-			{/each}
+					</div>
+				{/each}
+			</div>
 		</div>
 	</div>
 </section>
@@ -224,8 +327,17 @@
 <!-- CTA Section: same fixed poster-purple treatment as the hero, plus a
      Sticker accent (the "optionally one Sticker" flagship touch). The
      Sticker is real, meaningful content (not decoration), so it's rendered
-     normally — not aria-hidden — same as the poster's own sticker usage. -->
-<section class="bg-poster-purple py-12 md:py-16">
+     normally — not aria-hidden — same as the poster's own sticker usage.
+
+     Uplift: this is the page's CLOSING band, so it gets a diagonal cut on its
+     top edge (painted from below, over the section above) and the display
+     type scale on the h2. -->
+<section class="relative bg-poster-purple py-12 md:py-16">
+	<div
+		class="cut-from-below cut-purple pointer-events-none absolute inset-x-0 bottom-full h-14"
+		style="--cut-angle: 176deg"
+		aria-hidden="true"
+	></div>
 	<div class="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
 		<p class="text-sm font-extrabold uppercase tracking-[0.12em] text-poster-white">
 			{m['landingTemplate.ctaKicker']({}, { locale: content.locale })}
@@ -235,7 +347,7 @@
 				>{m['landingTemplate.ctaSticker']({}, { locale: content.locale })}</Sticker
 			>
 		</p>
-		<h2 class="text-2xl font-extrabold text-poster-white md:text-3xl">
+		<h2 class="text-3xl font-black leading-[1.12] text-poster-white sm:text-4xl">
 			{content.cta.title}
 		</h2>
 		<p class="mx-auto mt-4 max-w-2xl text-poster-white">
@@ -264,7 +376,11 @@
 	</div>
 </section>
 
-<!-- Related Pages Section -->
+<!-- Related Pages Section. Same chip language as the poster landing's
+     use-case list (FeaturesPanel): a bold pill with a trailing arrow, so the
+     links READ as links — they used to be washed-out `text-primary` text.
+     `text-foreground` on `bg-card` is 17.40:1 light / 15.64:1 dark; the hover
+     `text-primary` on the same card is 6.99:1 / 6.28:1. -->
 {#if content.relatedPages.length > 0}
 	<section class="bg-background py-12 md:py-16">
 		<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
@@ -274,14 +390,21 @@
 				volume="celebration"
 				class="mb-6 justify-center text-center"
 			/>
-			<div class="flex flex-wrap justify-center gap-4">
+			<div class="flex flex-wrap justify-center gap-3">
 				{#each content.relatedPages as relatedSlug (relatedSlug)}
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing-page path built from a runtime slug; not a static route id -->
 					<a
 						href={getRelatedPageUrl(relatedSlug)}
-						class="rounded-lg border px-4 py-2 text-sm text-primary transition-colors hover:bg-muted hover:text-primary/80"
+						class="group inline-flex items-center gap-1.5 rounded-full border-2 border-border bg-card px-4 py-2 text-sm font-bold text-foreground shadow-poster transition-colors hover:border-primary hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
 					>
 						{getRelatedPageTitle(relatedSlug)}
+						<!-- Decorative: the link's accessible name stays the page title. The
+						     nudge is scoped to the arrow, never `transition-all` on the
+						     focusable <a> (that fades the focus ring). -->
+						<ArrowRight
+							class="h-3.5 w-3.5 shrink-0 transition-transform group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5"
+							aria-hidden="true"
+						/>
 					</a>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				{/each}
@@ -289,3 +412,34 @@
 		</div>
 	</section>
 {/if}
+
+<style>
+	/*
+	 * Poster diagonal cuts. Both sides of every boundary on this page can't be
+	 * expressed the poster's way: landing/poster/PosterPanel paints the NEXT
+	 * panel's fixed colour into a gradient strip, but here the "other side" is
+	 * always a theme token (the tinted wash, `--background`) with no `.cut-*`
+	 * helper — and freezing one in would break the light/dark axis. Hence two
+	 * different devices:
+	 *
+	 * `.poster-band-cut` — clips the BAND itself, so the reveal is whatever sits
+	 * behind it (the wash, pulled up under the band). Used at the hero, whose
+	 * cut spans the full page width: a gradient strip cannot do this job at
+	 * arbitrary widths, because once the diagonal runs past the strip's height
+	 * the fill ends in a hard horizontal step (measured: at 1280px the 176deg
+	 * line drops ~90px, well past a 56px strip). A clip-path is width-agnostic.
+	 *
+	 * `.cut-from-below` — PosterPanel's gradient strip, mirrored: transparent
+	 * above the diagonal, poster colour below, sitting just ABOVE a band
+	 * (`bottom-full`). This form has no step failure mode — the coloured half
+	 * always meets the band it extends, and the transparent half always meets
+	 * the strip's top edge. `--cut-color` comes from the global `.cut-purple`
+	 * helper in app.css.
+	 */
+	.poster-band-cut {
+		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 calc(100% - 3.5rem));
+	}
+	.cut-from-below {
+		background: linear-gradient(var(--cut-angle), transparent 49%, var(--cut-color) 49.5%);
+	}
+</style>

--- a/src/lib/components/landing/LandingPageTemplate.svelte
+++ b/src/lib/components/landing/LandingPageTemplate.svelte
@@ -78,7 +78,10 @@
 	 *
 	 * `border-primary` measures 6.99:1 light / 6.28:1 dark against `--card`, well
 	 * over the 3:1 non-text floor, so the open row is distinguishable without
-	 * relying on the (deliberately soft) `--border` resting edge.
+	 * relying on the (deliberately soft) `--border` resting edge. That floor
+	 * applies to the OPEN state only: the hover half-tone border (~2.5:1) is a
+	 * courtesy affordance, not a state indicator — hover is carried by the
+	 * shadow lift.
 	 */
 	function faqRowClass(open: boolean): string {
 		return cn(
@@ -286,7 +289,7 @@
 						     over the 3:1 non-text floor. -->
 						<button
 							type="button"
-							class="flex min-h-14 w-full items-center justify-between gap-3 px-4 py-4 text-left transition-colors hover:bg-primary/5 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring sm:px-5"
+							class="flex min-h-14 w-full items-center justify-between gap-3 rounded-2xl px-4 py-4 text-left transition-colors hover:bg-primary/5 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring sm:px-5"
 							onclick={() => toggleFaq(index)}
 							aria-expanded={openFaqIndex === index}
 							aria-controls={`faq-answer-${index}`}

--- a/src/lib/components/landing/poster/FeaturesPanel.svelte
+++ b/src/lib/components/landing/poster/FeaturesPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import { ArrowRight } from '@lucide/svelte';
 	import PosterPanel from './PosterPanel.svelte';
 
 	interface Props {
@@ -89,9 +90,18 @@
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- locale-prefixed landing path; the prefix comes from getLocale() and cannot map to a single static route id -->
 					<a
 						href="{landingPagePrefix}{uc.path}"
-						class="inline-block rounded-full border-2 border-[hsl(var(--poster-ink)/0.25)] px-3.5 py-1.5 text-sm font-bold hover:border-[hsl(var(--poster-purple))] hover:text-[hsl(var(--poster-purple))] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[hsl(var(--poster-purple))]"
+						class="group inline-flex items-center gap-1.5 rounded-full border-2 border-[hsl(var(--poster-ink)/0.25)] px-3.5 py-1.5 text-sm font-bold hover:border-[hsl(var(--poster-purple))] hover:text-[hsl(var(--poster-purple))] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[hsl(var(--poster-purple))]"
 					>
 						{uc.label}
+						<!-- Clickability affordance: these read as plain chips otherwise.
+							 Decorative only — aria-hidden, and NOT added to the message
+							 string, so the link's accessible name is still the label. The
+							 nudge is scoped to the arrow: `transition-all` on the <a> itself
+							 would fade the focus-visible outline in. -->
+						<ArrowRight
+							class="h-3.5 w-3.5 shrink-0 transition-transform group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5"
+							aria-hidden="true"
+						/>
 					</a>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				</li>

--- a/src/lib/components/landing/poster/FeaturesPanel.test.ts
+++ b/src/lib/components/landing/poster/FeaturesPanel.test.ts
@@ -34,4 +34,13 @@ describe('FeaturesPanel', () => {
 			expect(hrefs).toContain(path);
 		}
 	});
+
+	it('keeps the trailing arrow affordance decorative (accessible name = label only)', () => {
+		render(FeaturesPanel, { props: { landingPagePrefix: '' } });
+		// The arrow is an aria-hidden icon, never part of the message string — the
+		// link must still be reachable by its exact label.
+		const link = screen.getByRole('link', { name: m['footer.solutionEventbrite']() });
+		expect(link.getAttribute('href')).toBe('/eventbrite-alternative');
+		expect(link.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
+	});
 });


### PR DESCRIPTION
Follow-on to the rebrand program: Biagio's post-program review flagged that the SEO pages were missed by the uplift and that the landing's use-case link chips don't read as clickable.

## What

**`LandingPageTemplate.svelte`** — the shared template behind all 36 SEO pages (6 slugs × en/de/es/fr/it/pt) — goes poster-grade:
- Hero becomes a real poster band: mode-inert poster-purple with a diagonal cut edge, the intro paragraph now a floating `border-2 shadow-poster` card overlapping the cut (opaque-first-block rule).
- Feature cards adopt the uplift depth system (`border-2 bg-card shadow-poster`) on a theme-aware wash below the band (band/wash pairing rule — legal because the band is mode-inert).
- Benefits checklist floats in a single divided card; FAQ rows follow the thick option-row family (`border-2 rounded-2xl`, primary open border, inverting chevron chip, ring drawn inside the clipping wrapper).
- CTA stays a poster-purple band (gradient-strip cut) with its Sticker; related-page links restyled as arrow chips.
- Zero new message keys; every `m[…]({}, { locale: content.locale })` call keeps the content-locale binding.

**`FeaturesPanel.svelte`** (landing, only the use-case chip list) — trailing `ArrowRight` affordance on the chips: `aria-hidden`, outside the message strings (copy freeze intact), arrow nudges on hover/focus with a transition scoped to the arrow (never `transition-all` on the focusable).

Also fixes a pre-existing a11y defect found during verification: the FAQ wrapper's `overflow-hidden` clipped the keyboard focus ring; it is now drawn inside via negative outline offset and follows the row radius.

## Verification

- Independent opus review: APPROVED-WITH-MINORS, spec-compliant; every claimed contrast ratio independently recomputed; the two actionable minors are folded in (`bbe8f11f`).
- `make check` green, 27 landing unit tests green, `audit-brand-themes.py` 0 failures.
- Screenshot QA: en 1280 light+dark, en+fr 390 (long-label chip wrap verified to read as tappable rows), landing chips.
- `tests/e2e/**` untouched (no spec covers these surfaces); existing `messages/*.json` values byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>