### PR TITLE
feat(primitives): EmptyState display level, PageHeader live subtitle, SectionHeader subtitle

### DIFF
--- a/src/lib/components/common/EmptyState.svelte
+++ b/src/lib/components/common/EmptyState.svelte
@@ -9,8 +9,28 @@
 		title: string;
 		body?: string;
 		tone?: Exclude<Tone, 'danger'>;
-		/** Heading level for the title; use 2 on pages whose only heading is this one. */
-		level?: 2 | 3;
+		/**
+		 * Heading level for the title; use 2 on pages whose only heading is this
+		 * one. Level 1 additionally switches the block to the DISPLAY variant —
+		 * celebration h1 scale, a bigger chip, roomier spacing — for full-page
+		 * TERMINAL interstitials (unsubscribe confirmed, contact email verified, …)
+		 * whose only heading has to be the page h1. Those pages hand-composed the
+		 * chip + heading + body stack before it existed; unsubscribe even carried a
+		 * comment saying the primitive "caps at h2/h3".
+		 *
+		 * Loading states are deliberately NOT adopters: a spinner is not a terminal
+		 * state, and this renders a static icon.
+		 *
+		 * Level 1 introduces NO new colour pair — it only changes size and
+		 * spacing, so every ratio is the one levels 2/3 already ship: title
+		 * (foreground on card) 17.46:1 light / 15.69:1 dark, body
+		 * (muted-foreground on card) 9.06:1 / 7.44:1, and the chip pairs listed
+		 * below. Only the body's SIZE moves, 14px → 16px, which loosens the
+		 * requirement rather than tightening it.
+		 *
+		 * Levels 2 and 3 render exactly as they did before level 1 existed.
+		 */
+		level?: 1 | 2 | 3;
 		action?: Snippet;
 		class?: string;
 	}
@@ -28,7 +48,8 @@
 	// palette in both modes (like the landing's stickers). Every solid pair
 	// below is an audited token pair in audit-brand-themes.py (poster section),
 	// except success, which has no poster hue and uses the theme success pair
-	// (also audited, flips in dark).
+	// (also audited, flips in dark). Level 1 changes SIZE only, never the pair,
+	// so the display variant inherits the same audited contrast.
 	const chipClasses: Record<Exclude<Tone, 'danger'>, string> = {
 		brand: 'bg-poster-purple text-poster-white',
 		info: 'bg-poster-periwinkle text-poster-ink',
@@ -37,33 +58,56 @@
 		success: 'bg-success text-success-foreground'
 	};
 
-	const headingClass = 'mt-4 text-lg font-extrabold';
+	// Each variant below holds a COMPLETE literal class string instead of a
+	// shared base plus conditional fragments. That keeps the level 2/3 strings
+	// byte-identical (same classes, same ORDER) to what shipped before level 1
+	// existed, so no adopter's rendered markup — and nothing the e2e suite
+	// matches on — shifts under the new variant.
+	const display = $derived(level === 1);
+
+	const rootClass = $derived(
+		display
+			? 'flex flex-col items-center rounded-lg border-2 bg-card px-6 py-14 text-center shadow-poster sm:py-16'
+			: 'flex flex-col items-center rounded-lg border-2 bg-card px-6 py-10 text-center shadow-poster'
+	);
+	// The display chip lands on the same size the auth band uses (h-16/w-16),
+	// which is where the hand-composed interstitials had already converged.
+	const chipClass = $derived(
+		display
+			? 'flex h-16 w-16 -rotate-2 items-center justify-center rounded-2xl shadow-sm'
+			: 'flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl shadow-sm'
+	);
+	const iconClass = $derived(display ? 'h-8 w-8' : 'h-7 w-7');
+	const headingClass = $derived(
+		display ? 'mt-5 text-3xl font-black leading-[1.12] sm:text-4xl' : 'mt-4 text-lg font-extrabold'
+	);
+	const bodyClass = $derived(
+		display
+			? 'mt-3 max-w-md text-base text-muted-foreground'
+			: 'mt-1.5 max-w-sm text-sm text-muted-foreground'
+	);
+	const actionClass = $derived(
+		display
+			? 'mt-7 flex flex-wrap justify-center gap-2'
+			: 'mt-5 flex flex-wrap justify-center gap-2'
+	);
 </script>
 
-<div
-	class={cn(
-		'flex flex-col items-center rounded-lg border-2 bg-card px-6 py-10 text-center shadow-poster',
-		className
-	)}
->
-	<span
-		aria-hidden="true"
-		class={cn(
-			'flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl shadow-sm',
-			chipClasses[tone]
-		)}
-	>
-		<Icon class="h-7 w-7" />
+<div class={cn(rootClass, className)}>
+	<span aria-hidden="true" class={cn(chipClass, chipClasses[tone])}>
+		<Icon class={iconClass} />
 	</span>
-	{#if level === 2}
+	{#if level === 1}
+		<h1 class={headingClass}>{title}</h1>
+	{:else if level === 2}
 		<h2 class={headingClass}>{title}</h2>
 	{:else}
 		<h3 class={headingClass}>{title}</h3>
 	{/if}
 	{#if body}
-		<p class="mt-1.5 max-w-sm text-sm text-muted-foreground">{body}</p>
+		<p class={bodyClass}>{body}</p>
 	{/if}
 	{#if action}
-		<div class="mt-5 flex flex-wrap justify-center gap-2">{@render action()}</div>
+		<div class={actionClass}>{@render action()}</div>
 	{/if}
 </div>

--- a/src/lib/components/common/EmptyState.test.ts
+++ b/src/lib/components/common/EmptyState.test.ts
@@ -42,4 +42,73 @@ describe('EmptyState', () => {
 		});
 		expect(screen.getByRole('heading', { level: 2, name: 'No events yet' })).toBeInTheDocument();
 	});
+
+	describe('level 1 (display variant)', () => {
+		it('renders an h1 carrying the celebration display scale', () => {
+			render(EmptyState, {
+				props: { icon: CalendarX, title: 'Preferences updated', level: 1 }
+			});
+			const h1 = screen.getByRole('heading', { level: 1, name: 'Preferences updated' });
+			expect(h1.className).toContain('text-3xl');
+			expect(h1.className).toContain('font-black');
+			expect(h1.className).toContain('leading-[1.12]');
+			expect(h1.className).toContain('sm:text-4xl');
+		});
+
+		it('scales the chip up but keeps the audited poster pair', () => {
+			const { container } = render(EmptyState, {
+				props: { icon: CalendarX, title: 'Done', level: 1 }
+			});
+			const chip = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+			expect(chip.className).toContain('h-16');
+			expect(chip.className).toContain('w-16');
+			// Level 1 changes size only — the tone pair is untouched, so it
+			// inherits the same audited contrast levels 2/3 have.
+			expect(chip.className).toContain('bg-poster-purple');
+			expect(chip.className).toContain('text-poster-white');
+			expect(chip.className).toContain('-rotate-2');
+		});
+
+		it('gives body and actions the roomier display spacing', () => {
+			const { container } = render(EmptyState, {
+				props: {
+					icon: CalendarX,
+					title: 'Done',
+					body: 'You are all set.',
+					level: 1,
+					action: snip('Go home')
+				}
+			});
+			expect((container.firstElementChild as HTMLElement).className).toContain('py-14');
+			expect(screen.getByText('You are all set.').className).toContain('text-base');
+			expect(screen.getByText('Go home').parentElement?.className).toContain('mt-7');
+		});
+
+		it('leaves the level 2/3 class strings byte-identical', () => {
+			// Level 1 arrived as a whole extra set of literal class strings rather
+			// than conditional fragments spliced into the old ones, specifically so
+			// that no existing adopter's markup (or the e2e suite's DOM) shifts.
+			// These are the exact strings that shipped before it existed.
+			const { container, unmount } = render(EmptyState, {
+				props: { icon: CalendarX, title: 'Empty', body: 'Nothing here.', action: snip('Add') }
+			});
+			const root = container.firstElementChild as HTMLElement;
+			expect(root.getAttribute('class')).toBe(
+				'flex flex-col items-center rounded-lg border-2 bg-card px-6 py-10 text-center shadow-poster'
+			);
+			expect(root.querySelector('[aria-hidden="true"]')?.getAttribute('class')).toBe(
+				'flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl shadow-sm bg-poster-purple text-poster-white'
+			);
+			expect(screen.getByRole('heading', { level: 3 }).getAttribute('class')).toBe(
+				'mt-4 text-lg font-extrabold'
+			);
+			expect(screen.getByText('Nothing here.').getAttribute('class')).toBe(
+				'mt-1.5 max-w-sm text-sm text-muted-foreground'
+			);
+			expect(screen.getByText('Add').parentElement?.getAttribute('class')).toBe(
+				'mt-5 flex flex-wrap justify-center gap-2'
+			);
+			unmount();
+		});
+	});
 });

--- a/src/lib/components/common/PageHeader.svelte
+++ b/src/lib/components/common/PageHeader.svelte
@@ -102,9 +102,13 @@
 			{/if}
 		</div>
 		{#if subtitle || subtitleAttrs}
+			<!-- Spread BEFORE class: the type excludes `class`, but only for literal
+			     objects — an aliased object could smuggle one past tsc, and a spread
+			     placed after `class` would replace the whole attribute (and with it
+			     the onBand color contract). Source order makes that impossible. -->
 			<p
-				class={cn('mt-2 max-w-prose', onBand ? 'text-current' : 'text-muted-foreground')}
 				{...subtitleAttrs}
+				class={cn('mt-2 max-w-prose', onBand ? 'text-current' : 'text-muted-foreground')}
 			>
 				{subtitle}
 			</p>

--- a/src/lib/components/common/PageHeader.svelte
+++ b/src/lib/components/common/PageHeader.svelte
@@ -9,6 +9,23 @@
 		kicker?: string;
 		subtitle?: string;
 		/**
+		 * Extra attributes for the SUBTITLE node — the documented way to make it a
+		 * live region (`{ 'aria-live': 'polite' }`), which `restProps` cannot do
+		 * because those land on `<header>` and would announce the whole header.
+		 * `class` is excluded on purpose: the subtitle's colour is the `onBand`
+		 * contract above, and a caller-supplied `class` would silently win over it.
+		 *
+		 * Passing this also makes the subtitle node render UNCONDITIONALLY. An
+		 * `aria-live` region only announces changes that happen while it is already
+		 * in the DOM — a region that appears together with its first text is a
+		 * plain insertion and is silent in every screen reader. Callers whose
+		 * subtitle can be empty (a result count with no results) therefore need the
+		 * empty node to exist, and asking each of them to remember that is how the
+		 * announcement got lost the first time. Callers that pass no attrs keep the
+		 * old `{#if subtitle}` behaviour exactly.
+		 */
+		subtitleAttrs?: Omit<HTMLAttributes<HTMLParagraphElement>, 'children' | 'class'>;
+		/**
 		 * 'celebration' = display scale (public/user surfaces); 'studio' =
 		 * admin/dense; 'poster' = celebration one notch louder, for the handful
 		 * of hero screens that carry a color-block band (uplift prototype).
@@ -44,6 +61,7 @@
 		title,
 		kicker,
 		subtitle,
+		subtitleAttrs,
 		volume = 'studio',
 		onBand = false,
 		actions,
@@ -83,8 +101,11 @@
 				<span aria-hidden="true">{@render decoration()}</span>
 			{/if}
 		</div>
-		{#if subtitle}
-			<p class={cn('mt-2 max-w-prose', onBand ? 'text-current' : 'text-muted-foreground')}>
+		{#if subtitle || subtitleAttrs}
+			<p
+				class={cn('mt-2 max-w-prose', onBand ? 'text-current' : 'text-muted-foreground')}
+				{...subtitleAttrs}
+			>
 				{subtitle}
 			</p>
 		{/if}

--- a/src/lib/components/common/PageHeader.test.ts
+++ b/src/lib/components/common/PageHeader.test.ts
@@ -127,6 +127,42 @@ describe('PageHeader', () => {
 		expect(h1.className).toContain('text-4xl');
 	});
 
+	it('subtitleAttrs land on the subtitle node, not the header', () => {
+		// The whole point of the prop: restProps can only reach <header>, and an
+		// aria-live there would announce the entire header, kicker and title
+		// included, every time a result count ticks.
+		const { container } = render(PageHeader, {
+			props: {
+				title: 'Events',
+				subtitle: '12 events',
+				subtitleAttrs: { 'aria-live': 'polite', id: 'events-count' }
+			}
+		});
+		const subtitle = screen.getByText('12 events');
+		expect(subtitle.getAttribute('aria-live')).toBe('polite');
+		expect(subtitle.id).toBe('events-count');
+		expect(container.querySelector('header')?.hasAttribute('aria-live')).toBe(false);
+		// The attrs must not cost the subtitle its own styling.
+		expect(subtitle.className).toContain('text-muted-foreground');
+	});
+
+	it('subtitleAttrs pin the subtitle node in the DOM even with no subtitle', () => {
+		// A live region only announces changes made while it is already mounted —
+		// a region that appears together with its first text is a plain insertion
+		// and is silent. Callers whose count can be empty need the empty node.
+		const { container } = render(PageHeader, {
+			props: { title: 'Events', subtitleAttrs: { 'aria-live': 'polite' } }
+		});
+		const subtitle = container.querySelector('p[aria-live="polite"]') as HTMLElement;
+		expect(subtitle).not.toBeNull();
+		expect(subtitle.textContent).toBe('');
+	});
+
+	it('without subtitleAttrs an absent subtitle still renders no node at all', () => {
+		const { container } = render(PageHeader, { props: { title: 'Events' } });
+		expect(container.querySelectorAll('p')).toHaveLength(0);
+	});
+
 	it('decoration also renders in poster volume', () => {
 		render(PageHeader, { props: { title: 'Hey', volume: 'poster', decoration: snip('New!') } });
 		expect(screen.getByText('New!').closest('[aria-hidden="true"]')).not.toBeNull();

--- a/src/lib/components/common/SectionHeader.svelte
+++ b/src/lib/components/common/SectionHeader.svelte
@@ -6,6 +6,15 @@
 		/** Already-translated strings — i18n stays at the call site. */
 		title: string;
 		kicker?: string;
+		/**
+		 * One-line explainer under the title, mirroring `PageHeader`'s subtitle.
+		 * Sections used to hand-place the same paragraph as a SIBLING of the
+		 * header, which put it on the parent's `space-y-*` rhythm instead of the
+		 * heading's — reliably a step too far from the title it explains. It is
+		 * deliberately NOT a snippet: it is one line of already-translated copy,
+		 * same contract as `title`/`kicker`.
+		 */
+		subtitle?: string;
 		level?: 2 | 3;
 		/**
 		 * 'celebration' = public/user surfaces; 'studio' = admin/dense;
@@ -24,6 +33,7 @@
 	const {
 		title,
 		kicker,
+		subtitle,
 		level = 2,
 		volume = 'studio',
 		id,
@@ -52,6 +62,9 @@
 			<h2 class={headingClass} {id}>{title}</h2>
 		{:else}
 			<h3 class={headingClass} {id}>{title}</h3>
+		{/if}
+		{#if subtitle}
+			<p class="mt-1 max-w-prose text-sm text-muted-foreground">{subtitle}</p>
 		{/if}
 	</div>
 	{#if actions}

--- a/src/lib/components/common/SectionHeader.test.ts
+++ b/src/lib/components/common/SectionHeader.test.ts
@@ -64,6 +64,42 @@ describe('SectionHeader', () => {
 		expect(screen.getByRole('heading', { level: 2 }).className).toContain('text-lg');
 	});
 
+	it('renders the subtitle under the heading, inside the heading block', () => {
+		const { container } = render(SectionHeader, {
+			props: { title: 'Social links', subtitle: 'Shown on your public page.' }
+		});
+		const subtitle = screen.getByText('Shown on your public page.');
+		expect(subtitle.tagName).toBe('P');
+		expect(subtitle.className).toContain('text-sm');
+		expect(subtitle.className).toContain('text-muted-foreground');
+		// It belongs to the heading's own column, not the flex row — that is the
+		// whole point over the hand-placed sibling paragraph it replaces, which
+		// sat on the parent section's spacing rhythm instead of the title's.
+		const heading = screen.getByRole('heading', { level: 2 });
+		expect(subtitle.parentElement).toBe(heading.parentElement);
+		expect(heading.nextElementSibling).toBe(subtitle);
+		expect(container.querySelector('p')).toBe(subtitle);
+	});
+
+	it('renders no subtitle node when the prop is absent', () => {
+		const { container } = render(SectionHeader, { props: { title: 'Social links' } });
+		expect(container.querySelectorAll('p')).toHaveLength(0);
+	});
+
+	it('subtitle coexists with kicker and actions', () => {
+		render(SectionHeader, {
+			props: {
+				title: 'Reports',
+				kicker: 'Owner',
+				subtitle: 'Delivered to your billing email.',
+				actions: snip('Configure')
+			}
+		});
+		expect(screen.getByText('Owner')).toBeInTheDocument();
+		expect(screen.getByText('Delivered to your billing email.')).toBeInTheDocument();
+		expect(screen.getByText('Configure')).toBeInTheDocument();
+	});
+
 	it('passes id through to the heading element', () => {
 		render(SectionHeader, { props: { title: 'Tickets', id: 'tickets-heading' } });
 		expect(screen.getByRole('heading', { level: 2 }).id).toBe('tickets-heading');

--- a/src/lib/components/organization/OrgSubscriptionPolicySection.svelte
+++ b/src/lib/components/organization/OrgSubscriptionPolicySection.svelte
@@ -34,10 +34,10 @@
 </script>
 
 <section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-	<SectionHeader title={m['orgSettingsPage.subscriptionPolicy.heading']()} />
-	<p class="text-sm text-muted-foreground">
-		{m['orgSettingsPage.subscriptionPolicy.description']()}
-	</p>
+	<SectionHeader
+		title={m['orgSettingsPage.subscriptionPolicy.heading']()}
+		subtitle={m['orgSettingsPage.subscriptionPolicy.description']()}
+	/>
 
 	<!-- Grace period (days) -->
 	<div>

--- a/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
@@ -355,8 +355,10 @@
 
 		<!-- Social Media Links -->
 		<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-			<SectionHeader title={m['orgAdmin.settings.social.heading']()} />
-			<p class="text-sm text-muted-foreground">{m['orgAdmin.settings.social.description']()}</p>
+			<SectionHeader
+				title={m['orgAdmin.settings.social.heading']()}
+				subtitle={m['orgAdmin.settings.social.description']()}
+			/>
 
 			<div class="grid gap-4 md:grid-cols-2">
 				<!-- Instagram -->
@@ -602,8 +604,10 @@
 		     endpoints; staff with edit_organization must not change report delivery) -->
 		{#if data.isOwner}
 			<section class="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
-				<SectionHeader title={m['orgSettingsPage.reports.heading']()} />
-				<p class="text-sm text-muted-foreground">{m['orgSettingsPage.reports.description']()}</p>
+				<SectionHeader
+					title={m['orgSettingsPage.reports.heading']()}
+					subtitle={m['orgSettingsPage.reports.description']()}
+				/>
 
 				<div>
 					<label for="revenue_report_cadence" class="block text-sm font-medium">

--- a/src/routes/(public)/events/+page.svelte
+++ b/src/routes/(public)/events/+page.svelte
@@ -206,13 +206,21 @@
 
 			<!-- Page Header. The result count rides `subtitle`, exactly as /organizations
 			     does, rather than a paragraph pulled back under the header with a
-			     negative margin that breaks the moment the header wraps. -->
+			     negative margin that breaks the moment the header wraps.
+
+			     `subtitleAttrs` makes that subtitle a polite live region so the tally
+			     is announced when filters change or the view flips between list and
+			     calendar — the announcement this page had before it adopted
+			     PageHeader. Passing the attrs also pins the node in the DOM even when
+			     `countLabel` is undefined (zero results / error), which is what makes
+			     the NEXT count an announced change rather than a silent insertion. -->
 			<PageHeader
 				volume="poster"
 				onBand
 				kicker={m['browse.events_kicker']()}
 				title={m['browse.events_title']()}
 				subtitle={countLabel}
+				subtitleAttrs={{ 'aria-live': 'polite' }}
 			>
 				{#snippet actions()}
 					<!-- View Toggle. Left on the stock `outline` chrome on purpose: its

--- a/src/routes/(public)/org/[slug]/verify-contact-email/+page.svelte
+++ b/src/routes/(public)/org/[slug]/verify-contact-email/+page.svelte
@@ -3,6 +3,7 @@
 	import type { PageData } from './$types';
 	import { CheckCircle, XCircle, Loader2 } from '@lucide/svelte';
 	import * as m from '$lib/paraglide/messages.js';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	interface Props {
 		data: PageData;
@@ -20,87 +21,89 @@
 	<meta name="description" content={m['orgVerifyContactEmail.pageDescription']()} />
 </svelte:head>
 
+<!-- Both TERMINAL states are now the EmptyState display variant (level 1) rather
+     than a hand-composed disc + h1 + body stack: same shape the primitive owns,
+     and level 1 exists exactly so the page's only heading can stay an h1. The
+     verifying branch below is deliberately left hand-composed — a spinner is not
+     a terminal state and the primitive renders a static icon. -->
+{#snippet settingsAction()}
+	<a
+		href={resolve('/(auth)/org/[slug]/admin/settings', { slug: data.organizationSlug ?? '' })}
+		class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+	>
+		{m['orgVerifyContactEmail.goToSettings']()}
+	</a>
+{/snippet}
+
+{#snippet failureAction()}
+	<div class="w-full space-y-3">
+		<p class="text-sm text-muted-foreground">
+			{m['orgVerifyContactEmail.linkExpired']()}
+		</p>
+		<div class="flex flex-col gap-3 sm:flex-row sm:justify-center">
+			<a
+				href={resolve('/(auth)/dashboard', {})}
+				class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+			>
+				{m['orgVerifyContactEmail.goToDashboard']()}
+			</a>
+			<a
+				href={resolve('/(public)/login', {})}
+				class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-6 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+			>
+				{m['orgVerifyContactEmail.backToLogin']()}
+			</a>
+		</div>
+	</div>
+{/snippet}
+
 <div class="container mx-auto flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-8">
-	<div class="w-full max-w-md space-y-8 text-center">
-		<!-- Icon -->
-		<div class="flex justify-center">
-			{#if data.isVerifying}
-				<!-- Tinted status discs on semantic tokens. Icon-vs-surface only (no
-				     text sits on these), independently >= 3:1 in both modes — the same
-				     tints ToneTile measures: info 8.3 light / 8.0 dark, success 4.4 /
-				     8.7. -->
-				<div class="rounded-full bg-info/10 p-6">
-					<Loader2 class="h-12 w-12 animate-spin text-info" aria-hidden="true" />
-				</div>
-			{:else if data.success}
-				<div class="rounded-full bg-success/10 p-6">
-					<CheckCircle class="h-12 w-12 text-success" aria-hidden="true" />
-				</div>
-			{:else}
-				<div class="rounded-full bg-destructive/10 p-6">
-					<XCircle class="h-12 w-12 text-destructive" aria-hidden="true" />
-				</div>
-			{/if}
-		</div>
-
-		<!-- Message -->
-		<div class="space-y-2">
-			{#if data.isVerifying}
-				<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
-					{m['orgVerifyContactEmail.verifying']()}
-				</h1>
-				<p class="text-muted-foreground">
-					{m['orgVerifyContactEmail.verifyingDescription']()}
-				</p>
-			{:else if data.success}
-				<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
-					{m['orgVerifyContactEmail.success']()}
-				</h1>
-				<p class="text-muted-foreground">
-					{m['orgVerifyContactEmail.successDescription']({
-						organizationName: data.organizationName || 'Your organization'
-					})}
-				</p>
-			{:else}
-				<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
-					{m['orgVerifyContactEmail.failure']()}
-				</h1>
-				<p class="text-muted-foreground">
-					{data.error || m['orgVerifyContactEmail.failureDescription']()}
-				</p>
-			{/if}
-		</div>
-
-		<!-- Actions -->
-		{#if !data.isVerifying}
-			<div class="space-y-3 border-t pt-6">
-				{#if data.success && data.organizationSlug}
-					<a
-						href={resolve('/(auth)/org/[slug]/admin/settings', { slug: data.organizationSlug })}
-						class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-					>
-						{m['orgVerifyContactEmail.goToSettings']()}
-					</a>
-				{:else if !data.success}
-					<p class="text-sm text-muted-foreground">
-						{m['orgVerifyContactEmail.linkExpired']()}
-					</p>
-					<div class="flex flex-col gap-3 sm:flex-row sm:justify-center">
-						<a
-							href={resolve('/(auth)/dashboard', {})}
-							class="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-						>
-							{m['orgVerifyContactEmail.goToDashboard']()}
-						</a>
-						<a
-							href={resolve('/(public)/login', {})}
-							class="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-6 py-2 text-sm font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-						>
-							{m['orgVerifyContactEmail.backToLogin']()}
-						</a>
+	<div class="w-full max-w-md">
+		{#if data.isVerifying}
+			<div class="space-y-8 text-center">
+				<!-- Tinted status disc on a semantic token. Icon-vs-surface only (no
+				     text sits on it), independently >= 3:1 in both modes — the same
+				     tint ToneTile measures: info 8.3 light / 8.0 dark. -->
+				<div class="flex justify-center">
+					<div class="rounded-full bg-info/10 p-6">
+						<Loader2 class="h-12 w-12 animate-spin text-info" aria-hidden="true" />
 					</div>
-				{/if}
+				</div>
+				<div class="space-y-2">
+					<h1 class="text-3xl font-black leading-[1.12] sm:text-4xl">
+						{m['orgVerifyContactEmail.verifying']()}
+					</h1>
+					<p class="text-muted-foreground">
+						{m['orgVerifyContactEmail.verifyingDescription']()}
+					</p>
+				</div>
 			</div>
+		{:else if data.success}
+			<EmptyState
+				level={1}
+				tone="success"
+				icon={CheckCircle}
+				title={m['orgVerifyContactEmail.success']()}
+				body={m['orgVerifyContactEmail.successDescription']({
+					organizationName: data.organizationName || 'Your organization'
+				})}
+				action={data.organizationSlug ? settingsAction : undefined}
+			/>
+		{:else}
+			<!-- The poster palette has no "danger" hue and EmptyState's tone axis
+			     excludes it; warning (amber/ink) is the same honest stand-in the auth
+			     verify page settled on for an expired/invalid link, short of the full
+			     destructive framing reserved for deletion. Mode-inert pair (imagery
+			     rule), measured 9.42:1 — and the icon is aria-hidden ornament, so the
+			     failure is never signalled by colour alone: the heading says it. -->
+			<EmptyState
+				level={1}
+				tone="warning"
+				icon={XCircle}
+				title={m['orgVerifyContactEmail.failure']()}
+				body={data.error || m['orgVerifyContactEmail.failureDescription']()}
+				action={failureAction}
+			/>
 		{/if}
 	</div>
 </div>

--- a/src/routes/(public)/unsubscribe/+page.svelte
+++ b/src/routes/(public)/unsubscribe/+page.svelte
@@ -8,6 +8,7 @@
 	import { Bell } from '@lucide/svelte';
 	import { SeoHead } from '$lib/seo';
 	import PageHeader from '$lib/components/common/PageHeader.svelte';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -55,25 +56,19 @@
 			</a>
 		</div>
 	{:else if success}
-		<!-- Success message: hand-composed centerpiece (not the EmptyState
-		     primitive, which caps at h2/h3) so the page's only heading can be
-		     an h1 — mirrors the auth pages' interstitial pattern (see
-		     verify/+page.svelte). Chip recipe mirrors EmptyState's internal
-		     poster-tinted chip; success tone is right for "preferences saved". -->
-		<div class="text-center">
-			<span
-				aria-hidden="true"
-				class="mx-auto flex h-14 w-14 -rotate-2 items-center justify-center rounded-2xl bg-success text-success-foreground shadow-sm"
-			>
-				<Bell class="h-7 w-7" />
-			</span>
-			<h1 class="mt-4 text-3xl font-black leading-[1.12] sm:text-4xl">
-				{m['unsubscribePage.successTitle']()}
-			</h1>
-			<p class="mt-1.5 text-muted-foreground">
-				{m['unsubscribePage.successDescription']()}
-			</p>
-		</div>
+		<!-- Success message: the EmptyState DISPLAY variant (level 1). This block
+		     used to be hand-composed precisely because the primitive capped at
+		     h2/h3 and the page's only heading has to be an h1; level 1 lifts that
+		     cap, so the chip recipe, display scale and spacing now come from the
+		     primitive instead of being re-typed here. Success tone is still the
+		     right one for "preferences saved". -->
+		<EmptyState
+			level={1}
+			tone="success"
+			icon={Bell}
+			title={m['unsubscribePage.successTitle']()}
+			body={m['unsubscribePage.successDescription']()}
+		/>
 		<p class="mt-4 text-center text-sm text-muted-foreground">
 			{m['unsubscribePage.redirecting']()}
 		</p>


### PR DESCRIPTION
Closes #784, Closes #785, Closes #786.

Additive extensions to three contract primitives; when the new props are absent, rendered markup is byte-identical (literal class strings per variant, pinned by `toBe` snapshot tests — cn() joins in source order, so shared-base-plus-fragment refactors would reorder classes and fail loudly).

- **EmptyState `level={1}`** — display-scale h1 variant for full-page interstitials; adopted at unsubscribe success and org verify-contact-email success/failure (the failure state uses the audited mode-inert warning chip at 9.42:1; failure is carried by text, not color).
- **PageHeader `subtitleAttrs`** — spread on the subtitle node, `class` excluded at the type level AND spread before `class` so the `onBand` color contract can't be replaced. Passing the prop pins the node in the DOM — a live region must exist before its first mutation to announce — which is what makes the /events calendar-mode result count actually reach screen readers.
- **SectionHeader `subtitle`** — rendered inside the heading's `min-w-0` column (the point: replaced sibling-paragraph sites were landing on the section's `space-y` rhythm instead); adopted at admin settings ×2 and OrgSubscriptionPolicySection; placement asserted in tests, not just presence.

Review: independent opus review APPROVED-WITH-MINORS, spec compliance FULL — it compiled both PageHeader forms with the worktree's Svelte compiler to prove the no-attrs path is SSR-identical, and reproduced all five claimed contrast ratios exactly. M1 (spread order) folded; remaining minors ledgered (double polite announcement on /events, /organizations sibling divergence, empty-p `mt-2` in zero-result state).

`make check` green · vitest 2555 passed · brand audit 0 · `tests/e2e/**` and `messages/*.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>