### PR TITLE
chore: Paraglide freshness gate + rebrand sweep leftovers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build preview format format-check lint lint-fix types types-canary i18n-check i18n-hardcoded i18n-hardcoded-update file-length no-ssr-token audit-images audit-soft-404 audit licensecheck audit-deps check fix test test-coverage test-e2e generate-api bump-version bump-minor release
+.PHONY: dev build preview format format-check lint lint-fix types types-canary i18n-check i18n-freshness i18n-hardcoded i18n-hardcoded-update file-length no-ssr-token audit-images audit-soft-404 audit licensecheck audit-deps check fix test test-coverage test-e2e generate-api bump-version bump-minor release
 
 # ─────────────────────────────────────────────
 # Development
@@ -41,6 +41,15 @@ types-canary:
 
 i18n-check:
 	pnpm i18n:compile
+
+# Assert the compiled Paraglide bundle (src/lib/paraglide/messages/*.js) covers
+# every key in messages/*.json, BEFORE i18n-check recompiles it out from under
+# us. A stale bundle here means messages/*.json changed and `pnpm
+# paraglide:compile` wasn't re-run and committed — any page referencing the
+# missing key hard-500s at runtime (#789). Also the first step of `pnpm build`
+# so the same staleness fails a build, not just `make check`.
+i18n-freshness:
+	@node scripts/check-paraglide-freshness.mjs
 
 # Guard against shipping untranslated user-facing copy: fails if a NEW hardcoded
 # string (toast / aria-label / placeholder / title / alt / visible text) appears
@@ -91,7 +100,7 @@ audit-deps: audit licensecheck
 # i18n-check runs before the type checks: it compiles the Paraglide messages that
 # svelte-check resolves `$$lib/paraglide/*` against, and the canary refuses to run
 # without them (see scripts/check-type-gate-armed.sh).
-check: format-check lint i18n-check types types-canary i18n-hardcoded file-length no-ssr-token audit-images
+check: format-check lint i18n-freshness i18n-check types types-canary i18n-hardcoded file-length no-ssr-token audit-images
 
 # Auto-fix everything that can be auto-fixed
 fix: format lint-fix

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "svelte-kit sync && vite build",
+		"build": "node scripts/check-paraglide-freshness.mjs && svelte-kit sync && vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -23,6 +23,7 @@
 		"i18n:validate": "node scripts/validate-translations.js",
 		"i18n:check-imports": "bash scripts/check-i18n-imports.sh",
 		"i18n:hardcoded": "node scripts/check-i18n-hardcoded.mjs",
+		"i18n:check-freshness": "node scripts/check-paraglide-freshness.mjs",
 		"i18n:compile": "pnpm paraglide:compile && pnpm i18n:validate",
 		"audit:images": "tsx scripts/audit-image-alt.ts"
 	},

--- a/scripts/check-paraglide-freshness.mjs
+++ b/scripts/check-paraglide-freshness.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Paraglide compiled-bundle freshness gate (#789).
+//
+// A stale compiled bundle happens when `messages/*.json` gains (or loses) keys
+// but nobody re-ran `pnpm paraglide:compile` and committed the result. Any page
+// that references a key missing from the compiled bundle hard-500s at runtime —
+// this produced 22 false e2e failures in one checkpoint run and is invisible
+// until the page actually renders.
+//
+// Detection strategy: recompile the catalogs into a scratch directory with the
+// exact same compiler `pnpm paraglide:compile` uses, then diff the exported
+// message identifiers against what's checked into `src/lib/paraglide/messages/`.
+// This deliberately does NOT try to reimplement Paraglide's key -> identifier
+// scheme (lowercased, underscore-joined, numeric disambiguation suffix per
+// message — e.g. `eventSchedule.title` -> `eventschedule_title1`, catalogs use
+// BOTH flat and nested dotted keys and the suffix is an internal compiler detail
+// that can change across versions). Recompiling and diffing is the only
+// reliable way to know whether the compiler's output changed, and it's cheap
+// (~1s for ~2,400 keys x 6 locales).
+//
+// Wired into `make check` (i18n-freshness target) and as the first step of
+// `pnpm build`, so a stale bundle fails loudly and immediately instead of
+// surfacing as a runtime 500 or a silent gap in e2e coverage.
+//
+// Usage: node scripts/check-paraglide-freshness.mjs
+
+import { compile } from '@inlang/paraglide-js';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
+const COMMITTED_MESSAGES_DIR = join(ROOT, 'src/lib/paraglide/messages');
+const EXPORT_RE = /^export const (\w+)/gm;
+
+/** @param {string} source */
+function extractExportNames(source) {
+	return new Set([...source.matchAll(EXPORT_RE)].map((m) => m[1]));
+}
+
+/** @param {string} dir */
+async function loadLocaleExports(dir) {
+	const files = (await readdir(dir)).filter((f) => f.endsWith('.js') && f !== '_index.js');
+	/** @type {Map<string, Set<string>>} */
+	const result = new Map();
+	for (const file of files) {
+		const source = await readFile(join(dir, file), 'utf-8');
+		result.set(file, extractExportNames(source));
+	}
+	return result;
+}
+
+async function main() {
+	const scratchDir = await mkdtemp(join(tmpdir(), 'paraglide-freshness-'));
+
+	try {
+		await compile({
+			project: join(ROOT, 'project.inlang'),
+			outdir: scratchDir,
+			outputStructure: 'locale-modules'
+		});
+
+		const fresh = await loadLocaleExports(join(scratchDir, 'messages'));
+		const committed = await loadLocaleExports(COMMITTED_MESSAGES_DIR);
+
+		/** @type {{ file: string; missing: string[]; extra: string[] }[]} */
+		const problems = [];
+
+		const allFiles = new Set([...fresh.keys(), ...committed.keys()]);
+		for (const file of allFiles) {
+			const freshKeys = fresh.get(file) ?? new Set();
+			const committedKeys = committed.get(file) ?? new Set();
+			const missing = [...freshKeys].filter((k) => !committedKeys.has(k)).sort();
+			const extra = [...committedKeys].filter((k) => !freshKeys.has(k)).sort();
+			if (missing.length > 0 || extra.length > 0) {
+				problems.push({ file, missing, extra });
+			}
+		}
+
+		if (problems.length > 0) {
+			console.error(
+				'\n✗ Paraglide compiled bundle is stale (messages/*.json != compiled output).\n'
+			);
+			for (const { file, missing, extra } of problems) {
+				if (missing.length > 0) {
+					console.error(`  ${file}: ${missing.length} message(s) missing from the compiled bundle`);
+					for (const key of missing.slice(0, 5)) console.error(`    - ${key}`);
+					if (missing.length > 5) console.error(`    ... and ${missing.length - 5} more`);
+				}
+				if (extra.length > 0) {
+					console.error(`  ${file}: ${extra.length} compiled message(s) no longer in the catalog`);
+					for (const key of extra.slice(0, 5)) console.error(`    - ${key}`);
+					if (extra.length > 5) console.error(`    ... and ${extra.length - 5} more`);
+				}
+			}
+			console.error('\nRun `pnpm paraglide:compile` and commit the result.\n');
+			process.exitCode = 1;
+			return;
+		}
+
+		console.log(
+			`✓ Paraglide compiled bundle is up to date (${committed.size} locale files checked)`
+		);
+	} finally {
+		await rm(scratchDir, { recursive: true, force: true });
+	}
+}
+
+main().catch((err) => {
+	console.error('✗ Paraglide freshness check failed to run:', err);
+	console.error('\nRun `pnpm paraglide:compile` and commit the result.\n');
+	process.exitCode = 1;
+});

--- a/src/lib/components/events/waitlist/ActiveOfferBanner.svelte
+++ b/src/lib/components/events/waitlist/ActiveOfferBanner.svelte
@@ -108,9 +108,14 @@
 				<span class="text-sm font-extrabold uppercase tracking-[0.12em] text-primary">
 					{m['activeOffer.eyebrow']()}
 				</span>
-				<h2 class="text-xl font-extrabold leading-tight sm:text-2xl">
+				<!-- Not a heading: this banner can render above the event title (page
+				     h1, in EventHeader), which would make a real <h2> here precede
+				     the h1 in DOM order (axe heading-order, #790). The alert role +
+				     aria-live on the wrapper already announces this to AT. Visual
+				     classes unchanged. -->
+				<p class="text-xl font-extrabold leading-tight sm:text-2xl">
 					{expired ? m['activeOffer.expired']() : m['activeOffer.header']()}
-				</h2>
+				</p>
 				{#if !expired}
 					<p class="text-sm sm:text-base">
 						{m['activeOffer.body']({ time: formattedExpiry })}

--- a/src/lib/components/notifications/NotificationBadge.example.svelte
+++ b/src/lib/components/notifications/NotificationBadge.example.svelte
@@ -95,7 +95,7 @@
 			<Bell class="h-5 w-5" />
 			<NotificationBadge
 				{authToken}
-				class="-right-2 -top-2 h-6 w-6 bg-blue-500 text-xs text-white"
+				class="-right-2 -top-2 h-6 w-6 bg-info text-xs text-info-foreground"
 			/>
 		</Button>
 	</section>
@@ -137,13 +137,16 @@
 				<Button variant="ghost" size="icon">
 					<Bell class="h-5 w-5" />
 				</Button>
-				<NotificationBadge {authToken} class="-right-1 -top-1 bg-orange-500" />
+				<NotificationBadge
+					{authToken}
+					class="-right-1 -top-1 bg-highlight text-highlight-foreground"
+				/>
 			</div>
 			<div class="relative">
 				<Button variant="ghost" size="icon">
 					<Bell class="h-5 w-5" />
 				</Button>
-				<NotificationBadge {authToken} class="-right-1 -top-1 bg-green-500" />
+				<NotificationBadge {authToken} class="-right-1 -top-1 bg-success text-success-foreground" />
 			</div>
 		</div>
 	</section>

--- a/src/lib/components/notifications/NotificationDropdown.example.svelte
+++ b/src/lib/components/notifications/NotificationDropdown.example.svelte
@@ -146,39 +146,39 @@
 				<CardContent>
 					<ul class="space-y-2 text-sm">
 						<li class="flex items-start gap-2">
-							<span class="font-bold text-green-500">✓</span>
+							<span class="font-bold text-success">✓</span>
 							<span
 								><strong>Unread Badge:</strong> Shows count of unread notifications on bell icon</span
 							>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="font-bold text-green-500">✓</span>
+							<span class="font-bold text-success">✓</span>
 							<span
 								><strong>Compact List:</strong> Displays recent notifications in a scrollable dropdown</span
 							>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="font-bold text-green-500">✓</span>
+							<span class="font-bold text-success">✓</span>
 							<span><strong>View All Link:</strong> Direct link to full notifications page</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="font-bold text-green-500">✓</span>
+							<span class="font-bold text-success">✓</span>
 							<span
 								><strong>Keyboard Accessible:</strong> Tab to focus, Enter to open, Escape to close</span
 							>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="font-bold text-green-500">✓</span>
+							<span class="font-bold text-success">✓</span>
 							<span><strong>Mobile Responsive:</strong> Dropdown width adjusts to screen size</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="font-bold text-green-500">✓</span>
+							<span class="font-bold text-success">✓</span>
 							<span
 								><strong>Real-time Polling:</strong> Automatically checks for new notifications</span
 							>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="font-bold text-green-500">✓</span>
+							<span class="font-bold text-success">✓</span>
 							<span
 								><strong>Auto-close on Click:</strong> Navigates to notification detail and closes dropdown</span
 							>

--- a/src/lib/components/notifications/NotificationItem.example.svelte
+++ b/src/lib/components/notifications/NotificationItem.example.svelte
@@ -116,7 +116,7 @@
 			notification={readNotification}
 			{authToken}
 			onStatusChange={handleStatusChange}
-			class="border-2 border-blue-500"
+			class="border-2 border-info"
 		/>
 	</section>
 </div>

--- a/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
@@ -151,7 +151,11 @@
 								<ToneTile tone="neutral" icon={Folder} size="lg" />
 							{/if}
 							<div class="min-w-0 flex-1">
-								<h3 class="line-clamp-1 font-bold">{series.name}</h3>
+								<!-- Card title, not a heading: the page h1 (PageHeader) is followed
+								     directly by this card with no intervening h2, so an <h3> here
+								     would skip a level (axe heading-order, #790). Visual classes
+								     unchanged. -->
+								<p class="line-clamp-1 font-bold">{series.name}</p>
 								<p class="text-sm text-muted-foreground">{series.organization.name}</p>
 							</div>
 						</div>


### PR DESCRIPTION
Closes #789, Closes #790.

- **#789** `scripts/check-paraglide-freshness.mjs`: recompiles the catalogs with the real Paraglide `compile()` into a scratch dir and diffs exported identifiers against the working bundle (all 6 locales, both missing and extra, no self-heal) — hand-reimplementing Paraglide's identifier scheme would be version-fragile. Wired as `make i18n-freshness` (inside `make check`, deliberately *before* `i18n-check`, which recompiles and would mask staleness) and as the first step of `pnpm build`. Proof-of-failure performed per the #704 lesson: injected fake key → exit 1 naming the missing identifier; reverted → exit 0. Note: the compiled bundle is gitignored, so CI (which always compiles fresh) can't see staleness by construction — the gate's audience is local checkouts and e2e-runner worktrees, exactly where the 22 false e2e failures came from.
- **#790** notifications `.example.svelte` raw hues → `success`/`info`/`highlight` tokens (all pairs already audit-enforced); heading-order fixes: ActiveOfferBanner's h2-before-h1 (banner intentionally renders above the hero) → `p` with classes unchanged, wrapper keeps `role="alert"`; event-series admin card h3 was actually a *level skip*, not a literal order violation — demoted to `p`, discrepancy documented. No e2e locator targets either heading (verified read-only).

Review: independent review APPROVE — it fault-injected the freshness gate itself and confirmed exit 1 + clean revert. Second `CadenceDriftBanner` level-skip found during investigation, left out of scope (ledgered).

`make check` green (freshness gate firing) · full unit suite 2545 passed · `pnpm build` green · brand audit 0 · e2e/messages untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>