### PR TITLE
fix(a11y): destructive fill/text token split + composited-alpha audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1117,6 +1117,28 @@ introduce new raw palette hues.
 - **Use tokens, never raw hexes** in components (`bg-primary`, `text-muted-foreground`, …). Palette hexes appear only in `app.css`.
 - **The theme must respect the light/dark axis.** The app styles content with `dark:` utilities (e.g. `prose dark:prose-invert`), which assume the `.dark` class controls surface darkness. A theme that keeps dark surfaces in light mode breaks readability everywhere.
 - **WCAG AA contract:** every `*-foreground` on its surface ≥ 4.5:1; `--primary` vs `--background` ≥ 3:1 (links, focus rings).
+- **Destructive is TWO tokens.** `--destructive` is the FILL (buttons, badges,
+  `StatusBadge danger`) and pairs with `--destructive-foreground`; it only owes
+  1.4.11's 3:1. `--destructive-text` is destructive-as-TEXT/ICON and owes 4.5:1.
+  `tailwind.config.ts` overrides `theme.extend.textColor.destructive`, so
+  `text-destructive` — and every variant of it (`hover:`, `focus:`,
+  `group-hover:`, `data-[…]:`, `text-destructive/90`) — resolves to
+  `--destructive-text`, while `bg-/border-/ring-/divide-/fill-destructive` keep
+  the fill. Light mode defines the two identically; only dark mode splits them.
+  Three consequences: (a) the restated `foreground` key next to the override is
+  defensive redundancy — Tailwind deep-merges `extend.textColor`, so omitting it
+  would still compile (proven by compiling both variants); keep it anyway for
+  explicitness; (b) **raw CSS is NOT covered** — inside a `<style>` block write
+  `hsl(var(--destructive-text))` for text/icons, never `hsl(var(--destructive))`;
+  (c) `decoration-/placeholder-/caret-/accent-destructive` still resolve to the
+  fill, so don't reach for them to colour text.
+- **Every translucent recipe belongs in `COMPOSITED_PAIRS`** in
+  `scripts/audit-brand-themes.py` — a `dark:` variant that swaps the tint or the
+  foreground is a *different* recipe, not the same one measured twice. Let the
+  script print the ratio and paste **that** into the code comment, never the
+  reverse: hand-written ratios were wrong repeatedly during the 2026-08 rebrand
+  (#783), and the script now FAILS on unknown token names instead of skipping
+  them, so a token rename can't silently disarm rows.
 - **Color-blind safety:** separate semantic colors (primary/accent/destructive/highlight) by _lightness_, not hue alone — protanopia/deuteranopia collapse red/purple/amber hue differences. Never encode meaning by color alone; pair with icon or text.
 - **Validate after any theme edit:** `python3 scripts/audit-brand-themes.py` checks the WCAG pairs and simulated color-blind separation. Keep it at 0 failures.
 

--- a/scripts/audit-brand-themes.py
+++ b/scripts/audit-brand-themes.py
@@ -132,6 +132,16 @@ TEXT_PAIRS = [  # (fg, bg, min_ratio, note)
     ("accent-foreground", "accent", 4.5, "accent label"),
     ("highlight-foreground", "highlight", 4.5, "highlight label"),
     ("destructive-foreground", "destructive", 4.5, "destructive label"),
+    # The destructive pair is SPLIT (issue #781): --destructive is the fill and
+    # only owes 1.4.11's 3:1, while destructive-as-text owes 4.5:1 and reads
+    # --destructive-text (wired to `text-destructive` in tailwind.config.ts).
+    # The dark fill measured 3.11:1 / 2.85:1 as text, which is why it is checked
+    # here at the non-text floor only and the text token carries the 4.5 rows.
+    ("destructive", "background", 3.0, "destructive as border/ring on page"),
+    ("destructive-text", "background", 4.5, "text-destructive on page"),
+    ("destructive-text", "card", 4.5, "text-destructive on card"),
+    ("destructive-text", "popover", 4.5, "text-destructive in popover/dialog"),
+    ("destructive-text", "muted", 4.5, "text-destructive on muted bg"),
     ("success-foreground", "success", 4.5, "success badge label"),
     ("info-foreground", "info", 4.5, "info badge label"),
     ("success", "background", 3.0, "success as icon/accent on page"),
@@ -189,6 +199,10 @@ COMPOSITED_PAIRS = [
     ("highlight-foreground", 1, "highlight", 0.20, "card", 3.0, ("light",), "ToneTile warning on card"),
     ("highlight", 1, "highlight", 0.20, "background", 3.0, ("dark",), "ToneTile warning on page"),
     ("highlight", 1, "highlight", 0.20, "card", 3.0, ("dark",), "ToneTile warning on card"),
+    ("destructive-text", 1, "destructive", 0.10, "background", 3.0, ("light",), "ToneTile danger on page"),
+    ("destructive-text", 1, "destructive", 0.10, "card", 3.0, ("light",), "ToneTile danger on card"),
+    ("destructive-text", 1, "destructive", 0.25, "background", 3.0, ("dark",), "ToneTile danger on page (dark bumps the tint)"),
+    ("destructive-text", 1, "destructive", 0.25, "card", 3.0, ("dark",), "ToneTile danger on card"),
     # Tag chips — EventCard / EventSeriesCard / OrganizationCard. Bold 12px: text.
     ("primary", 1, "primary", 0.10, "card", 4.5, BOTH, "tag chip label on a card"),
     # Stat/banner tints. AttendeeStats keeps an opaque bg-card UNDER the success
@@ -196,6 +210,8 @@ COMPOSITED_PAIRS = [
     ("success", 1, "success", 0.10, "card", 4.5, BOTH, "AttendeeStats/EventWizard success stat (opaque card layer)"),
     ("highlight-foreground", 1, "highlight", 0.10, "background", 4.5, ("light",), "AttendeeStats maybe stat"),
     ("highlight", 1, "highlight", 0.10, "background", 4.5, ("dark",), "AttendeeStats maybe stat"),
+    ("destructive-text", 1, "destructive", 0.10, "background", 4.5, ("light",), "AttendeeStats no stat"),
+    ("destructive-text", 1, "destructive", 0.25, "background", 4.5, ("dark",), "AttendeeStats no stat"),
     # Info / highlight banners (MyTicket on a card, MyTicketModal on a dialog).
     ("info", 1, "info", 0.10, "card", 4.5, BOTH, "MyTicket info banner"),
     ("info", 1, "info", 0.10, "background", 4.5, BOTH, "MyTicketModal / DemoBanner info banner"),
@@ -215,6 +231,10 @@ COMPOSITED_PAIRS = [
     ("foreground", 1, "primary", 0.10, "card", 4.5, BOTH, "QuestionnaireFillForm/PollVoteForm selected label"),
     ("foreground", 1, "success", 0.10, "background", 4.5, BOTH, "RSVPButtons / EventRSVP unselected tint"),
     ("foreground", 1, "destructive", 0.10, "background", 4.5, BOTH, "RSVPButtons / EventRSVP unselected tint"),
+    # Impersonation banner (bg on an opaque --background shell, not on scrolled
+    # content — see the component comment for why the tint moved inward).
+    ("destructive-text", 1, "destructive", 0.10, "background", 4.5, ("light",), "ImpersonationBanner copy"),
+    ("destructive-text", 1, "destructive", 0.25, "background", 4.5, ("dark",), "ImpersonationBanner copy"),
     # Public page wash: bg-secondary/55, thinned to /28 in dark.
     ("foreground", 1, "secondary", 0.55, "background", 4.5, ("light",), "public page secondary wash"),
     ("muted-foreground", 1, "secondary", 0.55, "background", 4.5, ("light",), "muted copy on the secondary wash"),
@@ -241,8 +261,14 @@ COMPOSITED_PAIRS = [
     ("poster-white", 1, "poster-ink", 0.45, "poster-lavender", 4.5, BOTH, "event header scrim (mid-gradient)"),
 ]
 
-SEMANTIC = ["primary", "secondary", "accent", "destructive", "highlight", "success", "info"]
-SEMANTIC_EXEMPT = set()  # pairs that are the same semantic in two roles; see issue #781
+SEMANTIC = [
+    "primary", "secondary", "accent", "destructive", "destructive-text",
+    "highlight", "success", "info",
+]
+# destructive and destructive-text are the same semantic in two roles (fill vs
+# text, issue #781) — they are SUPPOSED to look alike, so the pair is exempt
+# from the "meaning must not be hue-only" check. Nothing else is.
+SEMANTIC_EXEMPT = {frozenset(("destructive", "destructive-text"))}
 
 
 def blend(over, alpha, base):

--- a/scripts/audit-brand-themes.py
+++ b/scripts/audit-brand-themes.py
@@ -235,6 +235,28 @@ COMPOSITED_PAIRS = [
     # content — see the component comment for why the tint moved inward).
     ("destructive-text", 1, "destructive", 0.10, "background", 4.5, ("light",), "ImpersonationBanner copy"),
     ("destructive-text", 1, "destructive", 0.25, "background", 4.5, ("dark",), "ImpersonationBanner copy"),
+    # THE most common destructive recipe in the app: full-opacity error copy or
+    # an alert icon on a flat `bg-destructive/10` panel (OrgImageUploader,
+    # StripeConnect, admin settings/resources/invitations, create-org, the
+    # ticket/tier error boxes, the account/security disable-2FA panel at /5 —
+    # /10 is the worse of the two, so it covers /5). Checked over BOTH plausible
+    # containers because these panels move between page and card freely, and the
+    # per-site comments quote the worse of the two figures.
+    ("destructive-text", 1, "destructive", 0.10, "background", 4.5, BOTH, "error panel copy on a /10 tint (page)"),
+    ("destructive-text", 1, "destructive", 0.10, "card", 4.5, BOTH, "error panel copy on a /10 tint (card/dialog)"),
+    # Error panels whose SECONDARY copy is dimmed with the alpha modifier
+    # (`text-destructive/90`: TicketingStep, TierForm, WaitlistEntriesTable,
+    # the questionnaire/poll save errors). /90 is the floor — /80 measures
+    # 4.71:1 over the page and 4.40:1 over a card, i.e. it FAILS the moment such
+    # a panel is moved inside a Card. Both container surfaces are checked here
+    # so the panels can be relocated without re-deriving anything.
+    ("destructive-text", 0.9, "destructive", 0.10, "background", 4.5, BOTH, "dimmed error detail on an error panel (page)"),
+    ("destructive-text", 0.9, "destructive", 0.10, "card", 4.5, BOTH, "dimmed error detail on an error panel (card/dialog)"),
+    # StripeConnect's status icon: the same aria-hidden AlertCircle renders in a
+    # warning-tone card too, which is the tightest surface destructive lands on.
+    # Icon, so the 1.4.11 non-text floor applies — but audited so that the day
+    # someone puts TEXT on an amber tint, the script says so.
+    ("destructive-text", 1, "highlight", 0.20, "card", 3.0, BOTH, "StripeConnect status icon on a warning-tone card"),
     # Public page wash: bg-secondary/55, thinned to /28 in dark.
     ("foreground", 1, "secondary", 0.55, "background", 4.5, ("light",), "public page secondary wash"),
     ("muted-foreground", 1, "secondary", 0.55, "background", 4.5, ("light",), "muted copy on the secondary wash"),
@@ -275,15 +297,39 @@ def blend(over, alpha, base):
     """Paint `over` at `alpha` on an opaque `base`, the way a browser does."""
     return tuple(alpha * o + (1 - alpha) * b for o, b in zip(over, base))
 
+
 failures = 0
 confusables = 0
 for (brand, mode), toks in sorted(themes.items()):
     print(f"\n=== {brand} / {mode} ===")
     rgb = {k: hsl_to_rgb(*v) for k, v in toks.items() if k not in ("radius",)}
+
+    # A pair that names a token this theme does not define is a BROKEN pair, not
+    # an absent one — `hsl(var(--typo))` compiles to `hsl( / 1)`, which browsers
+    # drop, silently reverting the element to its inherited color. Skipping such
+    # rows would let a rename delete checks AND keep the audit green: renaming
+    # --destructive-text once dropped 16 PASS rows and still exited 0.
+    #
+    # The optional [data-brand=…] evaluation blocks legitimately declare only a
+    # subset of the palette, so they keep the lenient behaviour; the live theme
+    # must account for every token it references.
+    strict = brand == "default"
+
+    def resolve(token, note):
+        """Look a token up; in the live theme, a miss is a failure."""
+        global failures
+        if token is None or token in rgb:
+            return rgb[token] if token is not None else None
+        if strict:
+            failures += 1
+            print(f"  FAIL   ----  UNKNOWN TOKEN --{token}  [{note}]")
+        return "missing"
+
     for fg, bg, need, note in TEXT_PAIRS:
-        if fg not in rgb or bg not in rgb:
+        fg_c, bg_c = resolve(fg, note), resolve(bg, note)
+        if fg_c == "missing" or bg_c == "missing":
             continue
-        r = contrast(rgb[fg], rgb[bg])
+        r = contrast(fg_c, bg_c)
         ok = r >= need
         if not ok:
             failures += 1
@@ -294,10 +340,12 @@ for (brand, mode), toks in sorted(themes.items()):
     for fg, fg_a, wash, wash_a, base, need, modes, note in COMPOSITED_PAIRS:
         if mode not in modes:
             continue
-        if fg not in rgb or base not in rgb or (wash is not None and wash not in rgb):
+        fg_c, base_c, wash_c = resolve(fg, note), resolve(base, note), resolve(wash, note)
+        if "missing" in (fg_c, base_c, wash_c):
             continue
-        surface = rgb[base] if wash is None else blend(rgb[wash], wash_a, rgb[base])
-        ink = rgb[fg] if fg_a == 1 else blend(rgb[fg], fg_a, surface)
+        rgb_fg, rgb_base = fg_c, base_c
+        surface = rgb_base if wash is None else blend(wash_c, wash_a, rgb_base)
+        ink = rgb_fg if fg_a == 1 else blend(rgb_fg, fg_a, surface)
         r = contrast(ink, surface)
         ok = r >= need
         if not ok:

--- a/scripts/audit-brand-themes.py
+++ b/scripts/audit-brand-themes.py
@@ -7,6 +7,21 @@ against WCAG AA and simulates protanopia/deuteranopia/tritanopia to flag
 hue-only distinctions between semantic colors (primary / accent /
 destructive / highlight). Keep this at 0 failures after ANY token edit —
 this is the accessibility contract documented in app.css and CLAUDE.md.
+
+Three families of check, each of which can fail the exit code:
+
+1. TEXT_PAIRS — opaque token-on-token pairs (`text-foreground` on `bg-card`).
+2. COMPOSITED_PAIRS — translucent recipes (`text-primary` on `bg-primary/10`
+   over `bg-card`). See that list's own comment. This family exists because
+   alpha over a surface is exactly where AA fails silently: hand-computed
+   ratios written into code comments were wrong repeatedly during the 2026-08
+   rebrand (a claimed "3.1" that measured 2.95; a ToneTile table that did not
+   reproduce; an 18.46 that was really 17.46) because nothing executed them.
+   These entries execute them. Issue #783.
+3. Color-blind separation between the semantic colors.
+
+When you add a translucent recipe to a component, add it here too and let the
+script produce the number for the comment, rather than the other way round.
 """
 
 import re
@@ -139,7 +154,100 @@ TEXT_PAIRS = [  # (fg, bg, min_ratio, note)
     ("poster-ink", "poster-lavender", 4.5, "identity tile: ink icon on lavender"),
 ]
 
+BOTH = ("light", "dark")
+
+# --- Composited-alpha pairs (issue #783) ---
+#
+# A translucent layer has no token of its own, so TEXT_PAIRS above cannot see
+# it: `bg-primary/10` on a card is neither `primary` nor `card`, it is a third
+# color that only exists at paint time. Every entry below is a recipe that ships
+# in a component, resolved the way the browser resolves it:
+#
+#     surface = wash_alpha * wash + (1 - wash_alpha) * base   (wash None -> base)
+#     ink     = fg_alpha   * fg   + (1 - fg_alpha)   * surface
+#     contrast(ink, surface) >= need
+#
+# Fields: (fg, fg_alpha, wash, wash_alpha, base, need, modes, note).
+#   need  4.5 for text, 3.0 for icons/borders (WCAG 1.4.11 non-text).
+#   modes some recipes are one-sided — a `dark:` variant that swaps the tint or
+#         the foreground means the light and dark rows are DIFFERENT recipes,
+#         not one recipe measured twice.
+#
+# Deliberate limits: exactly one wash layer (the two stacked-tint sites, e.g.
+# ImpersonationBanner's chip-on-banner, are not expressible and stay hand-
+# checked), and only token-valued colors — one-off `bg-[hsl(...)]` literals that
+# do not resolve to a token cannot be audited from app.css alone.
+COMPOSITED_PAIRS = [
+    # ToneTile (common/ToneTile.svelte) — soft icon tiles. Icons: 3:1 floor.
+    ("primary", 1, "primary", 0.10, "background", 3.0, BOTH, "ToneTile brand on page"),
+    ("primary", 1, "primary", 0.10, "card", 3.0, BOTH, "ToneTile brand on card"),
+    ("info", 1, "info", 0.10, "background", 3.0, BOTH, "ToneTile info on page"),
+    ("info", 1, "info", 0.10, "card", 3.0, BOTH, "ToneTile info on card"),
+    ("success", 1, "success", 0.10, "background", 3.0, BOTH, "ToneTile success on page"),
+    ("success", 1, "success", 0.10, "card", 3.0, BOTH, "ToneTile success on card"),
+    ("highlight-foreground", 1, "highlight", 0.20, "background", 3.0, ("light",), "ToneTile warning on page (light: amber itself is 1.8:1)"),
+    ("highlight-foreground", 1, "highlight", 0.20, "card", 3.0, ("light",), "ToneTile warning on card"),
+    ("highlight", 1, "highlight", 0.20, "background", 3.0, ("dark",), "ToneTile warning on page"),
+    ("highlight", 1, "highlight", 0.20, "card", 3.0, ("dark",), "ToneTile warning on card"),
+    # Tag chips — EventCard / EventSeriesCard / OrganizationCard. Bold 12px: text.
+    ("primary", 1, "primary", 0.10, "card", 4.5, BOTH, "tag chip label on a card"),
+    # Stat/banner tints. AttendeeStats keeps an opaque bg-card UNDER the success
+    # tint precisely because the same tint over --background measures 4.39:1.
+    ("success", 1, "success", 0.10, "card", 4.5, BOTH, "AttendeeStats/EventWizard success stat (opaque card layer)"),
+    ("highlight-foreground", 1, "highlight", 0.10, "background", 4.5, ("light",), "AttendeeStats maybe stat"),
+    ("highlight", 1, "highlight", 0.10, "background", 4.5, ("dark",), "AttendeeStats maybe stat"),
+    # Info / highlight banners (MyTicket on a card, MyTicketModal on a dialog).
+    ("info", 1, "info", 0.10, "card", 4.5, BOTH, "MyTicket info banner"),
+    ("info", 1, "info", 0.10, "background", 4.5, BOTH, "MyTicketModal / DemoBanner info banner"),
+    ("highlight-foreground", 1, "highlight", 0.20, "card", 4.5, ("light",), "MyTicket warning banner"),
+    ("highlight", 1, "highlight", 0.20, "card", 4.5, ("dark",), "MyTicket warning banner"),
+    ("highlight-foreground", 1, "highlight", 0.20, "background", 4.5, ("light",), "MyTicketModal warning banner"),
+    ("highlight", 1, "highlight", 0.20, "background", 4.5, ("dark",), "MyTicketModal warning banner"),
+    # Dietary/EventDetails cells: body copy stays on --foreground over the tint.
+    ("foreground", 1, "destructive", 0.20, "card", 4.5, BOTH, "DietarySummary allergen cell"),
+    ("foreground", 1, "destructive", 0.10, "card", 4.5, BOTH, "DietarySummary restriction cell"),
+    ("foreground", 1, "highlight", 0.10, "card", 4.5, BOTH, "DietarySummary / EventActionSidebar note"),
+    ("highlight-foreground", 1, "highlight", 0.10, "card", 4.5, ("light",), "EventDetails highlight cell"),
+    ("highlight", 1, "highlight", 0.10, "card", 4.5, ("dark",), "EventDetails highlight cell"),
+    # Selected-option fills: the label stays --foreground, the BORDER carries the
+    # selection, so the 3:1 non-text floor is the one that matters.
+    ("primary", 1, "primary", 0.10, "card", 3.0, BOTH, "QuestionnaireFillForm/PollVoteForm selected border"),
+    ("foreground", 1, "primary", 0.10, "card", 4.5, BOTH, "QuestionnaireFillForm/PollVoteForm selected label"),
+    ("foreground", 1, "success", 0.10, "background", 4.5, BOTH, "RSVPButtons / EventRSVP unselected tint"),
+    ("foreground", 1, "destructive", 0.10, "background", 4.5, BOTH, "RSVPButtons / EventRSVP unselected tint"),
+    # Public page wash: bg-secondary/55, thinned to /28 in dark.
+    ("foreground", 1, "secondary", 0.55, "background", 4.5, ("light",), "public page secondary wash"),
+    ("muted-foreground", 1, "secondary", 0.55, "background", 4.5, ("light",), "muted copy on the secondary wash"),
+    ("primary", 1, "secondary", 0.55, "background", 3.0, ("light",), "links on the secondary wash"),
+    ("foreground", 1, "secondary", 0.28, "background", 4.5, ("dark",), "public page secondary wash"),
+    ("muted-foreground", 1, "secondary", 0.28, "background", 4.5, ("dark",), "muted copy on the secondary wash"),
+    ("primary", 1, "secondary", 0.28, "background", 3.0, ("dark",), "links on the secondary wash"),
+    # Footer cookie notice: a DOUBLE composite — a --background/10 panel on the
+    # opaque ink band, with --background/90 text measured over that panel (the
+    # full-opacity number, 11.85:1, was quoted here once and was wrong).
+    ("background", 0.90, "background", 0.10, "poster-ink", 4.5, ("light",), "footer cookie notice"),
+    ("muted-foreground", 1, "muted", 0.50, "card", 4.5, ("dark",), "footer cookie notice"),
+    # Poster / seat-map surfaces. Mode-inert by design (fixed brand values), so
+    # both modes are checked and must agree.
+    ("poster-ink", 0.72, None, 0, "poster-white", 4.5, BOTH, "poster mock body copy (ink @72%)"),
+    ("poster-white", 0.50, None, 0, "poster-ink", 4.5, BOTH, "open-source panel meta label (white @50%)"),
+    ("poster-white", 0.80, None, 0, "poster-ink", 4.5, BOTH, "poster panel secondary copy (white @80%)"),
+    ("poster-white", 1, "poster-white", 0.14, "poster-ink", 4.5, BOTH, "seat-map stage pill / legend strip"),
+    ("poster-white", 1, "poster-white", 0.12, "poster-ink", 4.5, BOTH, "seat-map zone chip"),
+    ("poster-ink", 1, "poster-white", 0.95, "poster-crimson-deep", 4.5, BOTH, "venues panel pill"),
+    ("poster-white", 1, "poster-ink", 0.20, "poster-purple", 4.5, BOTH, "hero panel stat wash (purple end)"),
+    ("poster-white", 1, "poster-ink", 0.20, "poster-crimson-deep", 4.5, BOTH, "hero panel stat wash (crimson end)"),
+    ("poster-white", 1, "poster-ink", 0.85, "poster-lavender", 4.5, BOTH, "event header scrim (top, lightest ramp stop)"),
+    ("poster-white", 1, "poster-ink", 0.45, "poster-lavender", 4.5, BOTH, "event header scrim (mid-gradient)"),
+]
+
 SEMANTIC = ["primary", "secondary", "accent", "destructive", "highlight", "success", "info"]
+SEMANTIC_EXEMPT = set()  # pairs that are the same semantic in two roles; see issue #781
+
+
+def blend(over, alpha, base):
+    """Paint `over` at `alpha` on an opaque `base`, the way a browser does."""
+    return tuple(alpha * o + (1 - alpha) * b for o, b in zip(over, base))
 
 failures = 0
 confusables = 0
@@ -154,11 +262,28 @@ for (brand, mode), toks in sorted(themes.items()):
         if not ok:
             failures += 1
         print(f"  {'PASS' if ok else 'FAIL'}  {r:5.2f} (need {need})  {fg} on {bg}  [{note}]")
+    # Composited-alpha recipes (issue #783): resolve the translucent layers,
+    # then contrast-check the result. Same output shape as the pairs above.
+    print("  -- composited alpha (recipe resolved at paint time) --")
+    for fg, fg_a, wash, wash_a, base, need, modes, note in COMPOSITED_PAIRS:
+        if mode not in modes:
+            continue
+        if fg not in rgb or base not in rgb or (wash is not None and wash not in rgb):
+            continue
+        surface = rgb[base] if wash is None else blend(rgb[wash], wash_a, rgb[base])
+        ink = rgb[fg] if fg_a == 1 else blend(rgb[fg], fg_a, surface)
+        r = contrast(ink, surface)
+        ok = r >= need
+        if not ok:
+            failures += 1
+        recipe = f"{fg}{'' if fg_a == 1 else f'/{fg_a:g}'} on "
+        recipe += base if wash is None else f"{wash}/{wash_a:g} over {base}"
+        print(f"  {'PASS' if ok else 'FAIL'}  {r:5.2f} (need {need})  {recipe}  [{note}]")
     # colorblind confusability between semantic colors
     print("  -- colorblind separation (redmean dE, sim'd; <60 = confusable) --")
     for i, a in enumerate(SEMANTIC):
         for b in SEMANTIC[i + 1:]:
-            if a not in rgb or b not in rgb:
+            if a not in rgb or b not in rgb or frozenset((a, b)) in SEMANTIC_EXEMPT:
                 continue
             worst_kind, worst = None, 1e9
             for kind in CVD:

--- a/src/app.css
+++ b/src/app.css
@@ -121,7 +121,7 @@
 		--accent-foreground: 173 40% 8%;
 		--highlight: 38 94% 60%;
 		--highlight-foreground: 30 60% 10%;
-		--destructive: 0 70% 45%; /* FILL only: white label = 5.5:1; as TEXT it is 3.11:1 on --background / 2.85:1 on --card (issue #781) */
+		--destructive: 0 70% 45%; /* FILL only: white label = 5.88:1; as TEXT it is 3.11:1 on --background / 2.85:1 on --card (issue #781) */
 		--destructive-foreground: 0 0% 100%;
 		/* The text-safe half of the destructive pair (issue #781). The fill above
 		   must stay dark enough for a white label, which leaves it far under
@@ -129,12 +129,14 @@
 		   rather than the fill's pure red: it keeps the light-mode maroon's hue
 		   family and stays clear of --accent (3 85% 62%, the crimson "heart"),
 		   which a plain lightened red would collide with under protanopia.
-		   Hand-computed, reproduced by scripts/audit-brand-themes.py:
+		   All figures below are PRINTED BY scripts/audit-brand-themes.py, not
+		   hand-computed — paste from the script, never the reverse (#783):
 		     7.02:1 on --background · 6.42:1 on --card/--popover · 5.74:1 on
 		     --muted · 4.74:1 on --secondary · 6.05:1 on bg-destructive/10 over
 		     card · 5.37:1 on bg-destructive/25 over card.
 		   Color-blind separation vs the other semantics (worst simulated
-		   redmean dE): accent 104, success 70, highlight 122, primary 153. */
+		   redmean dE): accent 107.9, success 67.5, highlight 108.4,
+		   primary 148.9, info 185.6. */
 		--destructive-text: 352 85% 72%;
 		--success: 145 55% 65%; /* glow green, ink label — mirrors the dark primary pattern */
 		--success-foreground: 173 40% 8%;

--- a/src/app.css
+++ b/src/app.css
@@ -42,6 +42,16 @@
 		--highlight-foreground: 30 55% 12%;
 		--destructive: 350 78% 30%; /* maroon, never brand crimson */
 		--destructive-foreground: 0 0% 100%;
+		/* Destructive as TEXT/ICON on a surface, as opposed to --destructive the
+		   FILL (buttons, badges, which pair with --destructive-foreground).
+		   A fill only owes WCAG 1.4.11's 3:1; text owes 4.5:1, and the dark fill
+		   value cannot serve both — see the .dark definition. Light mode has no
+		   such tension, so this is deliberately IDENTICAL to --destructive here
+		   and light-mode rendering is unchanged to the byte.
+		   Wired to `text-destructive` in tailwind.config.ts (textColor override),
+		   so every existing `text-destructive` call site resolves here while
+		   `bg-/border-/ring-destructive` keep the fill value. */
+		--destructive-text: 350 78% 30%; /* == --destructive; 8.63:1 on --background, 9.75:1 on --card */
 		/* Rebrand additions (2026-08 platform rebrand): success/info join the
 		   semantic set — values tuned so audit-brand-themes.py passes both the
 		   AA pairs and the color-blind (lightness) separation. */
@@ -111,8 +121,21 @@
 		--accent-foreground: 173 40% 8%;
 		--highlight: 38 94% 60%;
 		--highlight-foreground: 30 60% 10%;
-		--destructive: 0 70% 45%;
+		--destructive: 0 70% 45%; /* FILL only: white label = 5.5:1; as TEXT it is 3.11:1 on --background / 2.85:1 on --card (issue #781) */
 		--destructive-foreground: 0 0% 100%;
+		/* The text-safe half of the destructive pair (issue #781). The fill above
+		   must stay dark enough for a white label, which leaves it far under
+		   4.5:1 when borrowed as text — so dark mode splits the token. Rose
+		   rather than the fill's pure red: it keeps the light-mode maroon's hue
+		   family and stays clear of --accent (3 85% 62%, the crimson "heart"),
+		   which a plain lightened red would collide with under protanopia.
+		   Hand-computed, reproduced by scripts/audit-brand-themes.py:
+		     7.02:1 on --background · 6.42:1 on --card/--popover · 5.74:1 on
+		     --muted · 4.74:1 on --secondary · 6.05:1 on bg-destructive/10 over
+		     card · 5.37:1 on bg-destructive/25 over card.
+		   Color-blind separation vs the other semantics (worst simulated
+		   redmean dE): accent 104, success 70, highlight 122, primary 153. */
+		--destructive-text: 352 85% 72%;
 		--success: 145 55% 65%; /* glow green, ink label — mirrors the dark primary pattern */
 		--success-foreground: 173 40% 8%;
 		--info: 226 100% 82%; /* periwinkle glow, ink label */

--- a/src/lib/components/attendees/AttendeeStats.svelte
+++ b/src/lib/components/attendees/AttendeeStats.svelte
@@ -38,18 +38,19 @@
 		</div>
 	{/if}
 
-	<!-- Stats grid. Tint recipes mirror common/ToneTile's audited pairs, hand-
-	     verified (composited alpha is invisible to audit-brand-themes.py).
-	     Ratios below are text-vs-composited-tint, light / dark:
+	<!-- Stats grid. Tint recipes mirror common/ToneTile's audited pairs; all
+	     three are COMPOSITED_PAIRS entries in scripts/audit-brand-themes.py
+	     (issue #783), so the ratios below are printed, not asserted by hand.
+	     Text-vs-composited-tint, light / dark:
 	       success  4.39 (FAILS 4.5, bare bg-success/10 over --background) /
-	                8.73 — light needs an opaque bg-card layer under the tint
-	                to reach 4.94; dark already clears the bar unaided.
+	                8.71 — light needs an opaque bg-card layer under the tint
+	                to reach 4.93; dark already clears the bar unaided.
 	       highlight (text-highlight-foreground light / text-highlight dark)
-	                13.28 / 8.41 — clears both, no split needed beyond the
+	                13.27 / 8.40 — clears both, no split needed beyond the
 	                existing foreground/dark swap.
-	       destructive (text-destructive light / text-destructive-foreground
-	                dark on the dark-only bg-destructive/25) 7.19 / 15.26 —
-	                clears both. -->
+	       destructive 7.20 / 5.84 — `text-destructive` in both modes now that
+	                the token is split (issue #781); the dark row keeps the /25
+	                tint but no longer whites out the copy. -->
 	<div class="grid gap-4 sm:grid-cols-4">
 		<div class="rounded-lg border border-border bg-card p-4">
 			<p class="text-sm font-medium text-muted-foreground">{m['attendeesAdmin.statsTotal']()}</p>
@@ -73,10 +74,10 @@
 		<div
 			class="rounded-lg border border-destructive/30 bg-destructive/10 p-4 dark:bg-destructive/25"
 		>
-			<p class="text-sm font-medium text-destructive dark:text-destructive-foreground">
+			<p class="text-sm font-medium text-destructive">
 				{m['attendeesAdmin.statsNo']()}
 			</p>
-			<p class="mt-1 text-2xl font-bold text-destructive dark:text-destructive-foreground">
+			<p class="mt-1 text-2xl font-bold text-destructive">
 				{stats.noCount}
 			</p>
 		</div>

--- a/src/lib/components/common/ImpersonationBanner.svelte
+++ b/src/lib/components/common/ImpersonationBanner.svelte
@@ -65,19 +65,30 @@
 	     wrapper, which now genuinely sits on --background.
 
 	     Soft fill reuses ToneTile's audited danger pair: text-destructive on
-	     bg-destructive/10 measures 7.19:1 on the page background (light); dark
-	     switches to bg-destructive/25 + text-destructive-foreground (plain /10
-	     text-destructive measures only 2.95:1 in dark — see ToneTile's inline
-	     note) which measures 15.26:1. The "less prominent" (opacity-80) spans
-	     dim that same pair to 5.02:1 (light) / 10.14:1 (dark) — still clear of
-	     the 4.5:1 floor. The inline time-remaining chip layers a second tint
-	     over the already-tinted banner: /20 on /10 (light) = 5.04:1, /30 on
-	     /25 (dark, text-destructive-foreground) = 11.82:1; the pulsing
-	     "expiring soon" chip is a fully opaque bg-destructive/text-destructive-
-	     foreground pair (9.74:1 light / 5.87:1 dark), same as StatusBadge. -->
+	     bg-destructive/10 measures 7.20:1 on the page background (light); dark
+	     keeps the stronger bg-destructive/25 tint (a /10 red wash is nearly
+	     invisible on aubergine) and measures 5.84:1 — both rows are
+	     COMPOSITED_PAIRS entries in scripts/audit-brand-themes.py. Since #781
+	     split the destructive token, `text-destructive` is the AA-safe text
+	     half in both modes; it used to resolve to the FILL value, which
+	     measured 2.95:1 in dark and forced a white-out here.
+
+	     Two recipes here stay HAND-checked, because the audit script models a
+	     single alpha layer and both of these stack two:
+	       · the "less prominent" spans dim the pair with `opacity-90` — 6.10:1
+	         light / 5.03:1 dark. They were opacity-80 while the dark copy was
+	         white; at the semantic rose that same 80% measured 4.28:1, under
+	         the floor, so the dimming was eased rather than the color dropped.
+	       · the time-remaining chip lays a second tint over the tinted banner.
+	         It is `bg-destructive/20` in BOTH modes now (it used to bump to /30
+	         under the white text): 5.04:1 light / 4.97:1 dark. At /30 the dark
+	         figure fell to 4.54:1 — passing, but with no room for a token nudge.
+	     The pulsing "expiring soon" chip is a fully opaque bg-destructive /
+	     text-destructive-foreground pair (9.75:1 light / 5.88:1 dark), same as
+	     StatusBadge, and IS audited. -->
 	<div class="sticky top-0 z-[100] bg-background" role="alert" aria-live="assertive">
 		<div
-			class="border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground"
+			class="border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-destructive dark:bg-destructive/25"
 		>
 			<div class="container mx-auto flex flex-wrap items-center justify-between gap-2">
 				<div class="flex items-center gap-3">
@@ -92,11 +103,11 @@
 								>{authStore.user?.display_name ?? authStore.user?.email}</span
 							>
 							{#if authStore.user?.email}
-								<span class="opacity-80">({authStore.user.email})</span>
+								<span class="opacity-90">({authStore.user.email})</span>
 							{/if}
 						</span>
 						{#if impersonationInfo.impersonatedByName || impersonationInfo.impersonatedByEmail}
-							<span class="opacity-80">
+							<span class="opacity-90">
 								| {m['impersonationBanner.by']()}
 								<span class="font-medium">
 									{impersonationInfo.impersonatedByName ?? impersonationInfo.impersonatedByEmail}
@@ -110,7 +121,7 @@
 					<div
 						class="flex items-center gap-2 rounded-md px-2 py-1 text-sm font-bold {isExpiringSoon
 							? 'animate-pulse bg-destructive text-destructive-foreground'
-							: 'bg-destructive/20 text-destructive dark:bg-destructive/30 dark:text-destructive-foreground'}"
+							: 'bg-destructive/20 text-destructive'}"
 						title={m['impersonationBanner.timeRemainingTitle']()}
 					>
 						<Clock class="h-4 w-4" aria-hidden="true" />
@@ -121,7 +132,7 @@
 				{/if}
 			</div>
 
-			<p class="container mx-auto mt-1 text-xs opacity-80">
+			<p class="container mx-auto mt-1 text-xs opacity-90">
 				{m['impersonationBanner.notice']()}
 			</p>
 		</div>

--- a/src/lib/components/common/MaintenanceBanner.svelte
+++ b/src/lib/components/common/MaintenanceBanner.svelte
@@ -74,9 +74,8 @@
 		},
 		error: {
 			icon: AlertCircle,
-			classes:
-				'border-destructive/30 bg-destructive/10 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground',
-			iconClasses: 'text-destructive dark:text-destructive-foreground'
+			classes: 'border-destructive/30 bg-destructive/10 text-destructive dark:bg-destructive/25',
+			iconClasses: 'text-destructive'
 		},
 		critical: {
 			icon: AlertOctagon,
@@ -101,7 +100,7 @@
 				<div class="flex-1 text-sm">
 					<p class="font-semibold">{banner.message}</p>
 					{#if banner.scheduled_at || banner.ends_at}
-						<p class="mt-1 text-xs opacity-80">
+						<p class="mt-1 text-xs opacity-90">
 							{#if banner.scheduled_at}
 								<span
 									>{m['maintenanceBanner.scheduled']({

--- a/src/lib/components/common/ToneTile.svelte
+++ b/src/lib/components/common/ToneTile.svelte
@@ -26,21 +26,25 @@
 
 	// Soft tint + strong icon (replaces the app's hand-picked bg-blue-50
 	// dark:bg-blue-950 tiles). The composited tint is ~the surface color, so the
-	// icon-vs-surface ratio governs; independently recomputed >= 3:1 (WCAG 1.4.11,
-	// non-text) in both modes — composited alpha is invisible to
-	// scripts/audit-brand-themes.py. Ratios as (light page/card | dark page/card):
-	//   brand 5.3/5.9 | 5.9/5.3 · info 8.3/9.3 | 8.0/7.2 · success 4.4/4.9 | 8.7/7.8
-	//   danger 7.2/8.1 | 12.0/11.0 (dark flips to white icon on /25 red tint —
-	//   dark destructive text on the /10 tint measured 2.95:1, under the floor)
-	//   warning 12.6/13.9 | 6.7/6.0 (amber on light is 1.8:1 -> highlight-foreground)
-	// Recompute if any of these token values move.
+	// icon-vs-surface ratio governs; every pair below is >= 3:1 (WCAG 1.4.11,
+	// non-text) in both modes. These are no longer hand-verified: they are
+	// COMPOSITED_PAIRS entries in scripts/audit-brand-themes.py (issue #783),
+	// which prints them. Ratios as (light page/card | dark page/card):
+	//   brand 5.29/5.94 | 5.93/5.35 · info 8.29/9.32 | 7.97/7.16
+	//   success 4.39/4.93 | 8.71/7.84 · danger 7.20/8.10 | 5.84/5.37
+	//   warning 12.55/13.90 | 6.63/5.96 (amber on light is 1.8:1 -> the
+	//   -foreground swap; the dark tone keeps the amber itself)
+	// The danger tone kept its dark /25 tint bump — a /10 red wash is close to
+	// invisible on the aubergine surface — but no longer whites out the icon:
+	// `text-destructive` resolves to --destructive-text, the AA-safe half of the
+	// split token (issue #781), instead of the fill value that measured 2.95:1.
+	// Re-run the audit script if any of these token values move.
 	const toneClasses: Record<Tone, string> = {
 		brand: 'bg-primary/10 text-primary',
 		info: 'bg-info/10 text-info',
 		success: 'bg-success/10 text-success',
 		warning: 'bg-highlight/20 text-highlight-foreground dark:text-highlight',
-		danger:
-			'bg-destructive/10 text-destructive dark:bg-destructive/25 dark:text-destructive-foreground',
+		danger: 'bg-destructive/10 text-destructive dark:bg-destructive/25',
 		neutral: 'bg-muted text-muted-foreground'
 	};
 	// Identity tint axis: SOLID fixed poster chips, same classes in both modes

--- a/src/lib/components/events/admin/TicketingStep.svelte
+++ b/src/lib/components/events/admin/TicketingStep.svelte
@@ -250,6 +250,9 @@
 			</div>
 		</div>
 	{:else if tiersQuery.isError}
+		<!-- Dimmed destructive copy stops at /90 — see WaitlistEntriesTable for the
+		     numbers. /80 on this tint is 4.71:1 over the page and 4.40:1 over a
+		     card; /90 is 5.61:1 / 5.18:1 and is audited on both surfaces. -->
 		<div class="rounded-lg border border-destructive bg-destructive/10 p-4" role="alert">
 			<p class="font-medium text-destructive">{m['ticketingStep.errorLoadingTiers']()}</p>
 			<p class="mt-1 text-sm text-destructive/90">
@@ -259,12 +262,12 @@
 				<div class="mt-2 space-y-1">
 					{#if Array.isArray(tiersErrorInfo.detail)}
 						{#each tiersErrorInfo.detail as detail, i (i)}
-							<p class="text-xs text-destructive/80">
+							<p class="text-xs text-destructive/90">
 								• {detail.loc ? detail.loc.join(' → ') + ': ' : ''}{detail.msg}
 							</p>
 						{/each}
 					{:else}
-						<p class="text-xs text-destructive/80">{tiersErrorInfo.detail}</p>
+						<p class="text-xs text-destructive/90">{tiersErrorInfo.detail}</p>
 					{/if}
 				</div>
 			{/if}

--- a/src/lib/components/events/admin/TierForm.svelte
+++ b/src/lib/components/events/admin/TierForm.svelte
@@ -668,6 +668,10 @@
 				{@const fieldErrors = extractFieldErrors(error)}
 				{@const errorMsg = extractErrorMessage(error)}
 				{@const isBillingError = isBillingInfoRequiredError(errorMsg)}
+				<!-- This panel renders inside DialogContent (bg-background), but the
+				     dimmed copy stops at /90 so it stays AA on a card surface too:
+				     5.61:1 / 5.18:1 dark, vs 4.71:1 / 4.40:1 at /80. Audited on both
+				     in scripts/audit-brand-themes.py. -->
 				<div class="rounded-lg bg-destructive/10 p-3" role="alert">
 					<p class="font-medium text-destructive">{m['tierForm.error']()}</p>
 
@@ -690,7 +694,7 @@
 					{#if isBillingError}
 						<a
 							href={resolve('/(auth)/org/[slug]/admin/billing', { slug: organizationSlug })}
-							class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-destructive underline hover:text-destructive/80"
+							class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-destructive underline hover:text-destructive/90"
 						>
 							{m['tierForm.completeBillingInfo']()}
 						</a>

--- a/src/lib/components/events/waitlist/admin/WaitlistEntriesTable.svelte
+++ b/src/lib/components/events/waitlist/admin/WaitlistEntriesTable.svelte
@@ -86,6 +86,11 @@
 		<span class="sr-only">{m['orgAdmin.waitlist.loading']()}</span>
 	</div>
 {:else if isError}
+	<!-- Dimmed destructive copy stops at /90. On this bg-destructive/10 panel the
+	     text token measures 5.61:1 (dark) / 6.11:1 (light) at /90, but only
+	     4.71:1 at /80 — and 4.40:1 at /80 if the panel is ever moved onto a
+	     `bg-card` surface, which fails. Both /90 surfaces are COMPOSITED_PAIRS
+	     rows in scripts/audit-brand-themes.py, so the panel can move freely. -->
 	<div
 		class="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center"
 		role="alert"
@@ -94,7 +99,7 @@
 		<h3 class="mt-4 text-lg font-semibold text-destructive">
 			{m['orgAdmin.waitlist.error.title']()}
 		</h3>
-		<p class="mt-2 text-sm text-destructive/80">
+		<p class="mt-2 text-sm text-destructive/90">
 			{m['orgAdmin.waitlist.error.description']()}
 		</p>
 	</div>

--- a/src/lib/components/forms/PasswordStrengthIndicator.svelte
+++ b/src/lib/components/forms/PasswordStrengthIndicator.svelte
@@ -83,24 +83,20 @@
 	{/if}
 
 	<!-- Requirements checklist: row text stays on text-muted-foreground; only the
-	     Check/X icons carry the met/unmet color. `text-destructive` on the X icon
-	     is fine in light mode (8.63:1 on background/card) but the dark token is
-	     only ~2.85:1 against dark card — under the 3:1 non-text floor (WCAG
-	     1.4.11) — so dark mode swaps to destructive-foreground (white,
-	     16.8-18.3:1), matching ToneTile's danger-tone pairing for the same
-	     reason. Hand-verified since destructive-on-card isn't in
-	     audit-brand-themes.py's TEXT_PAIRS (only the solid destructive-foreground-
-	     on-destructive pair is). -->
+	     Check/X icons carry the met/unmet color. `text-destructive` resolves to
+	     --destructive-text (issue #781), which is 8.63:1 on the light background
+	     and 7.02:1 / 6.42:1 on the dark background / card — comfortably over the
+	     3:1 non-text floor (WCAG 1.4.11) in both modes. The earlier dark-mode
+	     swap to white existed only because the utility used to resolve to the
+	     FILL value, which measured 2.85:1 here; both rows are TEXT_PAIRS in
+	     scripts/audit-brand-themes.py now, so this can't drift unnoticed. -->
 	{#if showRequirements && password.length > 0}
 		<div class="space-y-1.5 text-xs">
 			<div class="flex items-center gap-2 text-muted-foreground">
 				{#if hasMinLength}
 					<Check class="h-3.5 w-3.5 text-success" aria-hidden="true" />
 				{:else}
-					<X
-						class="h-3.5 w-3.5 text-destructive dark:text-destructive-foreground"
-						aria-hidden="true"
-					/>
+					<X class="h-3.5 w-3.5 text-destructive" aria-hidden="true" />
 				{/if}
 				<span>{m['passwordStrength.atLeast8']()}</span>
 			</div>
@@ -109,10 +105,7 @@
 				{#if hasUppercase}
 					<Check class="h-3.5 w-3.5 text-success" aria-hidden="true" />
 				{:else}
-					<X
-						class="h-3.5 w-3.5 text-destructive dark:text-destructive-foreground"
-						aria-hidden="true"
-					/>
+					<X class="h-3.5 w-3.5 text-destructive" aria-hidden="true" />
 				{/if}
 				<span>{m['passwordStrength.oneUppercase']()}</span>
 			</div>
@@ -121,10 +114,7 @@
 				{#if hasLowercase}
 					<Check class="h-3.5 w-3.5 text-success" aria-hidden="true" />
 				{:else}
-					<X
-						class="h-3.5 w-3.5 text-destructive dark:text-destructive-foreground"
-						aria-hidden="true"
-					/>
+					<X class="h-3.5 w-3.5 text-destructive" aria-hidden="true" />
 				{/if}
 				<span>{m['passwordStrength.oneLowercase']()}</span>
 			</div>
@@ -133,10 +123,7 @@
 				{#if hasDigit}
 					<Check class="h-3.5 w-3.5 text-success" aria-hidden="true" />
 				{:else}
-					<X
-						class="h-3.5 w-3.5 text-destructive dark:text-destructive-foreground"
-						aria-hidden="true"
-					/>
+					<X class="h-3.5 w-3.5 text-destructive" aria-hidden="true" />
 				{/if}
 				<span>{m['passwordStrength.oneNumber']()}</span>
 			</div>
@@ -145,10 +132,7 @@
 				{#if hasSpecial}
 					<Check class="h-3.5 w-3.5 text-success" aria-hidden="true" />
 				{:else}
-					<X
-						class="h-3.5 w-3.5 text-destructive dark:text-destructive-foreground"
-						aria-hidden="true"
-					/>
+					<X class="h-3.5 w-3.5 text-destructive" aria-hidden="true" />
 				{/if}
 				<span>{m['passwordStrength.oneSpecial']()}</span>
 			</div>

--- a/src/lib/components/landing/poster/QuestionnaireMock.svelte
+++ b/src/lib/components/landing/poster/QuestionnaireMock.svelte
@@ -25,8 +25,10 @@
 			{m['home.poster.qMockQuestion']()}
 		</p>
 		<div class="mt-2.5 flex flex-col gap-1.5 text-sm">
-			<!-- ink@72% composited on the WHITE card is ~9.7:1 — hand-verified, since a
-				 composited alpha is invisible to scripts/audit-brand-themes.py. -->
+			<!-- ink@72% composited on the WHITE card is 6.92:1 — audited as a
+				 COMPOSITED_PAIRS row in scripts/audit-brand-themes.py (issue #783).
+				 The comment here previously claimed ~9.7:1, which the script does not
+				 reproduce; FeaturesPanel measured the identical recipe at "6.8". -->
 			<div
 				class="rounded-[10px] border-2 border-[hsl(var(--poster-paper))] px-3 py-2 text-[hsl(var(--poster-ink)/0.72)]"
 			>

--- a/src/lib/components/members/ManageMemberModal.svelte
+++ b/src/lib/components/members/ManageMemberModal.svelte
@@ -302,18 +302,16 @@
 						{@render billingNotice('text-sm text-muted-foreground')}
 					{/if}
 					{#if selectedStatus === 'banned'}
-						<!-- dark:bg-destructive/25 dark:text-destructive-foreground
-						     (AutoEvalRecommendation's pattern): plain text-destructive on this
-						     /10 tint measured 2.69-2.95:1 in dark mode, under the 3:1 non-text
-						     floor; the /25 tint + destructive-foreground (white) icon pairing
-						     measures ~14-15:1 instead. -->
+						<!-- dark:bg-destructive/25 (AutoEvalRecommendation's pattern): a /10
+						     red wash is nearly invisible on the dark surface, so dark
+						     strengthens the tint. The icon stays `text-destructive`, which is
+						     --destructive-text since #781 — 8.10:1 light on /10, 5.37:1 dark on
+						     /25, both audited in scripts/audit-brand-themes.py. The old FILL
+						     value measured 2.69-2.95:1 here, under the 3:1 non-text floor. -->
 						<div
 							class="flex gap-2 rounded-md border border-destructive bg-destructive/10 p-3 text-sm dark:bg-destructive/25"
 						>
-							<AlertTriangle
-								class="h-4 w-4 shrink-0 text-destructive dark:text-destructive-foreground"
-								aria-hidden="true"
-							/>
+							<AlertTriangle class="h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
 							<div class="space-y-2 text-foreground">
 								<p>{m['manageMemberModal.bannedWarning']()}</p>
 								<!-- The confirm panel below restates this line, so show it here only
@@ -481,26 +479,22 @@
 					<!-- Blacklist Button/Confirmation -->
 					{#if onBlacklist}
 						{#if !showBlacklistConfirm}
-							<!-- Label stays text-foreground (danger framing rule): dark-mode
-							     `text-destructive` on this transparent/bg-background surface
-							     measured 3.13:1, under the 4.5:1 text floor (it replaced a
-							     passing pre-rebrand `dark:text-red-400`). Only the Ban icon
-							     carries the tone, split per mode since raw `text-destructive`
-							     has no audited page/background pair (trap 5): light keeps
-							     `text-destructive` (8.61:1 on background), dark swaps to
-							     `text-destructive-foreground` — white — which is 18.36:1 on
-							     the dark background. Hover keeps the same text-foreground
-							     label with the destructive/10 tint underneath.  -->
+							<!-- Label stays text-foreground (danger framing rule): meaning is
+							     never carried by color alone, and the destructive framing here
+							     is a whole sentence. Only the Ban icon carries the tone, and it
+							     no longer needs a per-mode split — `text-destructive` resolves
+							     to --destructive-text (#781): 8.63:1 light / 7.02:1 dark on the
+							     page background, both TEXT_PAIRS rows in
+							     scripts/audit-brand-themes.py. Before the split the same
+							     utility measured 3.13:1 in dark, under the text floor. Hover
+							     keeps the text-foreground label with the /10 tint underneath. -->
 							<Button
 								variant="outline"
 								onclick={handleBlacklistClick}
 								disabled={isProcessing}
 								class="w-full justify-start border-destructive bg-transparent text-foreground hover:bg-destructive/10 hover:text-foreground"
 							>
-								<Ban
-									class="mr-2 h-4 w-4 text-destructive dark:text-destructive-foreground"
-									aria-hidden="true"
-								/>
+								<Ban class="mr-2 h-4 w-4 text-destructive" aria-hidden="true" />
 								{m['manageMemberModal.addToBlacklist']()}
 							</Button>
 						{:else}

--- a/src/lib/components/members/ManageMemberModal.svelte
+++ b/src/lib/components/members/ManageMemberModal.svelte
@@ -305,9 +305,12 @@
 						<!-- dark:bg-destructive/25 (AutoEvalRecommendation's pattern): a /10
 						     red wash is nearly invisible on the dark surface, so dark
 						     strengthens the tint. The icon stays `text-destructive`, which is
-						     --destructive-text since #781 — 8.10:1 light on /10, 5.37:1 dark on
-						     /25, both audited in scripts/audit-brand-themes.py. The old FILL
-						     value measured 2.69-2.95:1 here, under the 3:1 non-text floor. -->
+						     --destructive-text since #781. This panel is inside DialogContent
+						     (bg-background), so the governing figures are 7.20:1 light on /10
+						     and 5.84:1 dark on /25; over a bg-card container the same recipe is
+						     8.10:1 / 5.37:1. All four are audited rows in
+						     scripts/audit-brand-themes.py. The old FILL value measured
+						     2.69-2.95:1 here, under the 3:1 non-text floor. -->
 						<div
 							class="flex gap-2 rounded-md border border-destructive bg-destructive/10 p-3 text-sm dark:bg-destructive/25"
 						>

--- a/src/lib/components/organization/OrgImageUploader.svelte
+++ b/src/lib/components/organization/OrgImageUploader.svelte
@@ -192,9 +192,11 @@
 	<SectionHeader title={m['orgAdmin.settings.branding.heading']()} />
 
 	{#if uploadError}
-		<!-- Icon carries the tone, not the body text: dark --destructive as TEXT on
-		     this composite measures ~2.7-2.95:1 (fails both the 3:1 non-text and
-		     4.5:1 text floors). -->
+		<!-- Icon carries the tone, not the body text (danger-framing rule). The
+		     icon's `text-destructive` is --destructive-text since #781: 8.10:1
+		     light / 6.05:1 dark on this bg-destructive/10 composite, both audited
+		     in scripts/audit-brand-themes.py. The FILL value it used to resolve to
+		     measured ~2.7-2.95:1 here, failing even the 3:1 non-text floor. -->
 		<div
 			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-foreground"
 			role="alert"

--- a/src/lib/components/organization/OrgImageUploader.svelte
+++ b/src/lib/components/organization/OrgImageUploader.svelte
@@ -193,9 +193,11 @@
 
 	{#if uploadError}
 		<!-- Icon carries the tone, not the body text (danger-framing rule). The
-		     icon's `text-destructive` is --destructive-text since #781: 8.10:1
-		     light / 6.05:1 dark on this bg-destructive/10 composite, both audited
-		     in scripts/audit-brand-themes.py. The FILL value it used to resolve to
+		     icon's `text-destructive` is --destructive-text since #781: at worst
+		     7.20:1 light / 6.05:1 dark on this bg-destructive/10 composite —
+		     "at worst" because the panel reads --card or --background depending on
+		     where it renders and both are audited rows in
+		     scripts/audit-brand-themes.py. The FILL value it used to resolve to
 		     measured ~2.7-2.95:1 here, failing even the 3:1 non-text floor. -->
 		<div
 			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-foreground"

--- a/src/lib/components/organization/StripeConnect.svelte
+++ b/src/lib/components/organization/StripeConnect.svelte
@@ -324,15 +324,15 @@
 									<span class="text-foreground">{m['stripeConnect.yes']()}</span>
 								{:else}
 									<!-- This dl can render inside ANY status card (e.g. the
-									     warning-tone "incomplete" card, bg-highlight/20), not
-									     just the danger-tone one — plain text-destructive there
-									     measured 1.85:1 in dark (destructive's dark hue sits too
-									     close to the amber tint's lightness). destructive-foreground
-									     (white) on that same composite measures 10.88:1. -->
-									<AlertCircle
-										class="h-3 w-3 text-destructive dark:text-destructive-foreground"
-										aria-hidden="true"
-									/>
+									     warning-tone "incomplete" card, bg-highlight/20), not just
+									     the danger-tone one — which is the tightest surface this
+									     icon lands on. With the split destructive token (#781)
+									     `text-destructive` measures 4.16:1 there in dark and
+									     8.54:1 in light; the icon is decorative (aria-hidden, the
+									     "no" label carries the meaning) so the 3:1 non-text floor
+									     applies and both clear it. The FILL value this utility
+									     used to resolve to measured 1.85:1 on the same composite. -->
+									<AlertCircle class="h-3 w-3 text-destructive" aria-hidden="true" />
 									<span class="text-foreground">{m['stripeConnect.no']()}</span>
 								{/if}
 							</dd>
@@ -349,10 +349,12 @@
 			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-foreground"
 			role="alert"
 		>
-			<!-- Icon carries the tone, not the body text: dark --destructive as TEXT
-			     on this composite measures ~2.7-2.95:1 (fails both the 3:1 non-text
-			     and 4.5:1 text floors) — see StripeConnect's status-card comment for
-			     the same trap. -->
+			<!-- Icon carries the tone; the body copy stays on --foreground for the
+			     same reason it always has (meaning is never color-only). The icon's
+			     `text-destructive` is --destructive-text since #781: 8.10:1 light /
+			     6.05:1 dark on this bg-destructive/10 composite, both audited in
+			     scripts/audit-brand-themes.py. The FILL value it used to resolve to
+			     was ~2.7-2.95:1 here, failing even the 3:1 non-text floor. -->
 			<AlertCircle class="h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
 			<p class="text-sm">{connectMutation.error.message}</p>
 		</div>

--- a/src/lib/components/organization/StripeConnect.svelte
+++ b/src/lib/components/organization/StripeConnect.svelte
@@ -351,9 +351,10 @@
 		>
 			<!-- Icon carries the tone; the body copy stays on --foreground for the
 			     same reason it always has (meaning is never color-only). The icon's
-			     `text-destructive` is --destructive-text since #781: 8.10:1 light /
-			     6.05:1 dark on this bg-destructive/10 composite, both audited in
-			     scripts/audit-brand-themes.py. The FILL value it used to resolve to
+			     `text-destructive` is --destructive-text since #781: at worst 7.20:1
+			     light / 6.05:1 dark on this bg-destructive/10 composite (--card and
+			     --background containers are both audited rows in
+			     scripts/audit-brand-themes.py). The FILL value it used to resolve to
 			     was ~2.7-2.95:1 here, failing even the 3:1 non-text floor. -->
 			<AlertCircle class="h-4 w-4 shrink-0 text-destructive" aria-hidden="true" />
 			<p class="text-sm">{connectMutation.error.message}</p>

--- a/src/lib/components/profile/DietaryRestrictionsManager.svelte
+++ b/src/lib/components/profile/DietaryRestrictionsManager.svelte
@@ -359,9 +359,11 @@
 						{/if}
 
 						{#if restriction.restriction_type === 'severe_allergy'}
-							<!-- Bare on card: text-destructive measures 2.85:1 in dark (below
-							     4.5). Only the icon carries the tone; the line reads on
-							     --foreground, same pattern as the tinted-banner headings. -->
+							<!-- Only the icon carries the tone; the line reads on --foreground,
+							     same pattern as the tinted-banner headings. That is the
+							     danger-framing rule, not a contrast workaround: bare
+							     `text-destructive` on this card is 9.75:1 light / 6.42:1 dark
+							     since the token split (#781), against 2.85:1 before it. -->
 							<div class="flex items-center gap-2 text-sm text-foreground">
 								<AlertTriangle class="h-4 w-4 text-destructive" aria-hidden="true" />
 								<span>{m['dietaryRestrictionsManager.severeAllergyWarning']()}</span>

--- a/src/lib/components/questionnaires/AutoEvalRecommendation.svelte
+++ b/src/lib/components/questionnaires/AutoEvalRecommendation.svelte
@@ -30,8 +30,10 @@
 	// so it reuses `bg-highlight/20` + `text-highlight-foreground
 	// dark:text-highlight`; `danger` keeps a stronger /25 tint in dark (a /10 red
 	// wash is nearly invisible on aubergine) with `text-destructive` in both
-	// modes — 7.20:1 light / 5.84:1 dark since the destructive token was split
-	// into fill and text halves (#781). `success` passes AA as direct icon color.
+	// modes — at worst 7.20:1 light / 5.37:1 dark since the destructive token was
+	// split into fill and text halves (#781); this chip renders on both --card and
+	// --background surfaces and every combination is audited in
+	// scripts/audit-brand-themes.py. `success` passes AA as direct icon color.
 	const statusConfig = $derived.by(() => {
 		if (!evaluation || (evaluation.status as QuestionnaireEvaluationStatus) === 'pending review') {
 			return {

--- a/src/lib/components/questionnaires/AutoEvalRecommendation.svelte
+++ b/src/lib/components/questionnaires/AutoEvalRecommendation.svelte
@@ -28,10 +28,10 @@
 	// `iconBgClass`/`iconClass` pair copied verbatim from `ToneTile`'s audited
 	// tone table (`common/ToneTile.svelte`): `warning` has no `--warning` token,
 	// so it reuses `bg-highlight/20` + `text-highlight-foreground
-	// dark:text-highlight`; `danger`'s dark mode flips to a stronger /25 tint
-	// with `text-destructive-foreground` because plain `text-destructive` on a
-	// /10 tint measures 2.95:1 in dark mode (under the AA floor — see
-	// ToneTile's own ratio comment). `success` passes AA as direct icon color.
+	// dark:text-highlight`; `danger` keeps a stronger /25 tint in dark (a /10 red
+	// wash is nearly invisible on aubergine) with `text-destructive` in both
+	// modes — 7.20:1 light / 5.84:1 dark since the destructive token was split
+	// into fill and text halves (#781). `success` passes AA as direct icon color.
 	const statusConfig = $derived.by(() => {
 		if (!evaluation || (evaluation.status as QuestionnaireEvaluationStatus) === 'pending review') {
 			return {
@@ -64,7 +64,7 @@
 			bgClass: 'bg-destructive/10',
 			borderClass: 'border-destructive/50',
 			iconBgClass: 'bg-destructive/10 dark:bg-destructive/25',
-			iconClass: 'text-destructive dark:text-destructive-foreground'
+			iconClass: 'text-destructive'
 		};
 	});
 

--- a/src/lib/components/resources/ResourceModal.svelte
+++ b/src/lib/components/resources/ResourceModal.svelte
@@ -276,19 +276,18 @@
 
 			<!-- Error Message -->
 			{#if errorMessage}
-				<!-- dark:bg-destructive/25 dark:text-destructive-foreground (AutoEvalRecommendation's
-				     pattern): plain text-destructive on this /10 tint measured 2.69-2.95:1 in
-				     dark mode, under the 3:1 non-text floor; the /25 tint + destructive-foreground
-				     (white) icon pairing measures ~14-15:1 instead. -->
+				<!-- dark:bg-destructive/25 (AutoEvalRecommendation's pattern): a /10 red
+				     wash is nearly invisible on the dark surface, so dark strengthens the
+				     tint. The icon stays `text-destructive`, which is --destructive-text
+				     since #781 — 8.10:1 light on /10, 5.37:1 dark on /25, both audited in
+				     scripts/audit-brand-themes.py. The old FILL value measured 2.69-2.95:1
+				     here, under even the 3:1 non-text floor. -->
 				<div
 					class="mb-6 flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4 dark:bg-destructive/25"
 					role="alert"
 					aria-live="assertive"
 				>
-					<AlertTriangle
-						class="h-5 w-5 shrink-0 text-destructive dark:text-destructive-foreground"
-						aria-hidden="true"
-					/>
+					<AlertTriangle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
 					<div>
 						<p class="font-semibold text-foreground">{m['resourceModal.error']()}</p>
 						<p class="mt-1 text-sm text-foreground">{errorMessage}</p>

--- a/src/lib/components/resources/ResourceModal.svelte
+++ b/src/lib/components/resources/ResourceModal.svelte
@@ -279,9 +279,11 @@
 				<!-- dark:bg-destructive/25 (AutoEvalRecommendation's pattern): a /10 red
 				     wash is nearly invisible on the dark surface, so dark strengthens the
 				     tint. The icon stays `text-destructive`, which is --destructive-text
-				     since #781 — 8.10:1 light on /10, 5.37:1 dark on /25, both audited in
-				     scripts/audit-brand-themes.py. The old FILL value measured 2.69-2.95:1
-				     here, under even the 3:1 non-text floor. -->
+				     since #781. This panel sits on the modal's own bg-background (line
+				     252), so the governing figures are 7.20:1 light on /10 and 5.84:1 dark
+				     on /25; over a bg-card container the same recipe is 8.10:1 / 5.37:1.
+				     All four are audited rows in scripts/audit-brand-themes.py. The old
+				     FILL value measured 2.69-2.95:1 here, under the 3:1 non-text floor. -->
 				<div
 					class="mb-6 flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4 dark:bg-destructive/25"
 					role="alert"

--- a/src/lib/utils/destructive-text-token.test.ts
+++ b/src/lib/utils/destructive-text-token.test.ts
@@ -7,12 +7,21 @@
  * text it measured 3.11:1 on `--background` and 2.85:1 on `--card`.
  *
  * The fix is `--destructive-text`, wired to the `text-destructive` utility via a
- * `textColor` override in tailwind.config.ts so all ~520 existing call sites are
+ * `textColor` override in tailwind.config.ts so all ~525 existing call sites are
  * corrected at once and future ones are safe by default. Two things therefore
  * have to stay true, and neither is visible to a type checker:
- *   1. the utility wiring (text→text token, fill utilities→fill token, and the
- *      `foreground` key restated so `text-destructive-foreground` still exists);
+ *   1. the utility wiring — `text-destructive` on the text token, the fill
+ *      utilities still on the fill token, `text-destructive-foreground` intact;
  *   2. the dark value actually clearing 4.5:1 on the surfaces it lands on.
+ *
+ * (1) is asserted against `resolveConfig()` rather than the config literal, so
+ * it tests what Tailwind DOES with the override, not what we wrote. Mutation-
+ * tested: deleting the `textColor` override fails this file.
+ *
+ * Note the boundary this does NOT cover: the remap is a Tailwind theme key, so
+ * it reaches Tailwind utilities only. Raw CSS in a `<style>` block must name
+ * `--destructive-text` itself (see create-org/+page.svelte), and
+ * `decoration-/placeholder-/caret-/accent-destructive` still resolve to the fill.
  *
  * scripts/audit-brand-themes.py checks (2) as well, but it is a separate manual
  * gate; this keeps the regression inside `pnpm test`.
@@ -20,12 +29,21 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import resolveTailwindConfig from 'tailwindcss/resolveConfig';
 import tailwindConfig from '../../../tailwind.config';
 
 type ColorScale = { DEFAULT: string; foreground: string };
 
-const colors = tailwindConfig.theme.extend.colors as unknown as Record<string, ColorScale>;
-const textColor = tailwindConfig.theme.extend.textColor as unknown as Record<string, ColorScale>;
+// The RESOLVED theme, not the config literal. "`extend.textColor` replaces
+// `colors.destructive` for the text scale" is an assumption about Tailwind's
+// merge semantics, and asserting the literal would only prove what we typed: if
+// a future Tailwind merged instead of replaced, `text-destructive` would revert
+// to the fill while a literal-based test stayed green.
+const resolved = resolveTailwindConfig(tailwindConfig).theme as unknown as {
+	textColor: Record<string, ColorScale>;
+	backgroundColor: Record<string, ColorScale>;
+	borderColor: Record<string, ColorScale>;
+};
 
 // Read the stylesheet off disk rather than importing it: `?raw` still routes
 // through Vite's CSS pipeline, and the theme lives in plain text either way.
@@ -104,16 +122,21 @@ function composite(
 
 describe('the destructive text/fill token split (#781)', () => {
 	it('routes `text-destructive` to the text token and fill utilities to the fill token', () => {
-		expect(textColor.destructive.DEFAULT).toContain('var(--destructive-text)');
+		expect(resolved.textColor.destructive.DEFAULT).toContain('var(--destructive-text)');
 		// `colors` still drives bg-/border-/ring-/divide-destructive.
-		expect(colors.destructive.DEFAULT).toContain('var(--destructive)');
-		expect(colors.destructive.DEFAULT).not.toContain('var(--destructive-text)');
+		expect(resolved.backgroundColor.destructive.DEFAULT).toContain('var(--destructive)');
+		expect(resolved.backgroundColor.destructive.DEFAULT).not.toContain('var(--destructive-text)');
+		expect(resolved.borderColor.destructive.DEFAULT).toContain('var(--destructive)');
+		expect(resolved.borderColor.destructive.DEFAULT).not.toContain('var(--destructive-text)');
 	});
 
-	it('restates `foreground` so `text-destructive-foreground` survives the override', () => {
-		// The textColor key REPLACES colors.destructive for that scale, so an
-		// override with only DEFAULT would silently delete the fill's label class.
-		expect(textColor.destructive.foreground).toContain('var(--destructive-foreground)');
+	it('keeps `text-destructive-foreground` pointing at the fill label', () => {
+		// Asserts the INVARIANT, not the mechanism. Tailwind deep-merges the
+		// override into `colors.destructive` (compile-verified), so this survives
+		// whether or not tailwind.config.ts restates the key — which is exactly
+		// why it is written against the resolved scale: it stays true under merge
+		// OR replace semantics, and only fails if the pair itself is broken.
+		expect(resolved.textColor.destructive.foreground).toContain('var(--destructive-foreground)');
 	});
 
 	it('leaves light mode byte-identical to the fill token', () => {

--- a/src/lib/utils/destructive-text-token.test.ts
+++ b/src/lib/utils/destructive-text-token.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The destructive token SPLIT (issue #781), pinned as an executable contract.
+ *
+ * `--destructive` is a FILL (buttons, badges) whose label is
+ * `--destructive-foreground`; a fill only owes WCAG 1.4.11's 3:1. Destructive
+ * TEXT owes 4.5:1, and in dark mode the fill value cannot do both — borrowed as
+ * text it measured 3.11:1 on `--background` and 2.85:1 on `--card`.
+ *
+ * The fix is `--destructive-text`, wired to the `text-destructive` utility via a
+ * `textColor` override in tailwind.config.ts so all ~520 existing call sites are
+ * corrected at once and future ones are safe by default. Two things therefore
+ * have to stay true, and neither is visible to a type checker:
+ *   1. the utility wiring (text→text token, fill utilities→fill token, and the
+ *      `foreground` key restated so `text-destructive-foreground` still exists);
+ *   2. the dark value actually clearing 4.5:1 on the surfaces it lands on.
+ *
+ * scripts/audit-brand-themes.py checks (2) as well, but it is a separate manual
+ * gate; this keeps the regression inside `pnpm test`.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import tailwindConfig from '../../../tailwind.config';
+
+type ColorScale = { DEFAULT: string; foreground: string };
+
+const colors = tailwindConfig.theme.extend.colors as unknown as Record<string, ColorScale>;
+const textColor = tailwindConfig.theme.extend.textColor as unknown as Record<string, ColorScale>;
+
+// Read the stylesheet off disk rather than importing it: `?raw` still routes
+// through Vite's CSS pipeline, and the theme lives in plain text either way.
+// (Vitest runs from the project root; `import.meta.url` is an http: URL under
+// the jsdom environment, so a path relative to cwd is the portable choice.)
+const appCss = readFileSync(resolve(process.cwd(), 'src/app.css'), 'utf8');
+
+/** Slice out a rule body by brace-matching from its selector. */
+function ruleBody(selector: string): string {
+	const start = appCss.indexOf(selector);
+	if (start === -1) throw new Error(`no \`${selector}\` rule in app.css`);
+	const open = appCss.indexOf('{', start);
+	let depth = 0;
+	for (let i = open; i < appCss.length; i++) {
+		if (appCss[i] === '{') depth++;
+		else if (appCss[i] === '}' && --depth === 0) return appCss.slice(open + 1, i);
+	}
+	throw new Error(`unbalanced braces after \`${selector}\``);
+}
+
+const BLOCKS = { light: ruleBody(':root'), dark: ruleBody('.dark') };
+
+/** Pull an `--x: H S% L%;` triple out of a `:root {}` / `.dark {}` block. */
+function readToken(mode: 'light' | 'dark', token: string): [number, number, number] {
+	// Dark inherits anything it does not restate (e.g. --destructive-text would
+	// be a light-only token if the split were ever undone).
+	const source = BLOCKS[mode];
+	const pattern = new RegExp(`--${token}:\\s*([\\d.]+)\\s+([\\d.]+)%\\s+([\\d.]+)%\\s*;`);
+	const decl = pattern.exec(source) ?? (mode === 'dark' ? pattern.exec(BLOCKS.light) : null);
+	if (!decl) throw new Error(`--${token} not declared in ${mode} mode`);
+	return [Number(decl[1]), Number(decl[2]), Number(decl[3])];
+}
+
+function hslToRgb([h, s, l]: [number, number, number]): [number, number, number] {
+	const sat = s / 100;
+	const lig = l / 100;
+	const c = (1 - Math.abs(2 * lig - 1)) * sat;
+	const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+	const m = lig - c / 2;
+	const [r, g, b] =
+		h < 60
+			? [c, x, 0]
+			: h < 120
+				? [x, c, 0]
+				: h < 180
+					? [0, c, x]
+					: h < 240
+						? [0, x, c]
+						: h < 300
+							? [x, 0, c]
+							: [c, 0, x];
+	return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+}
+
+function luminance(rgb: [number, number, number]): number {
+	const [r, g, b] = rgb.map((v) => {
+		const c = v / 255;
+		return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+	});
+	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a: [number, number, number], b: [number, number, number]): number {
+	const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+/** `bg-<token>/<alpha>` painted over an opaque surface. */
+function composite(
+	over: [number, number, number],
+	alpha: number,
+	base: [number, number, number]
+): [number, number, number] {
+	return [0, 1, 2].map((i) => alpha * over[i] + (1 - alpha) * base[i]) as [number, number, number];
+}
+
+describe('the destructive text/fill token split (#781)', () => {
+	it('routes `text-destructive` to the text token and fill utilities to the fill token', () => {
+		expect(textColor.destructive.DEFAULT).toContain('var(--destructive-text)');
+		// `colors` still drives bg-/border-/ring-/divide-destructive.
+		expect(colors.destructive.DEFAULT).toContain('var(--destructive)');
+		expect(colors.destructive.DEFAULT).not.toContain('var(--destructive-text)');
+	});
+
+	it('restates `foreground` so `text-destructive-foreground` survives the override', () => {
+		// The textColor key REPLACES colors.destructive for that scale, so an
+		// override with only DEFAULT would silently delete the fill's label class.
+		expect(textColor.destructive.foreground).toContain('var(--destructive-foreground)');
+	});
+
+	it('leaves light mode byte-identical to the fill token', () => {
+		expect(readToken('light', 'destructive-text')).toEqual(readToken('light', 'destructive'));
+	});
+
+	it('splits the token in dark mode, where the fill value fails as text', () => {
+		const fill = hslToRgb(readToken('dark', 'destructive'));
+		const background = hslToRgb(readToken('dark', 'background'));
+		// The bug this token exists for — kept as a live assertion so a future
+		// lightening of the fill makes this test tell us the split is redundant.
+		expect(contrast(fill, background)).toBeLessThan(4.5);
+		expect(readToken('dark', 'destructive-text')).not.toEqual(readToken('dark', 'destructive'));
+	});
+
+	it.each([
+		['background', 4.5],
+		['card', 4.5],
+		['popover', 4.5],
+		['muted', 4.5]
+	])('clears AA text contrast on --%s in both modes', (surface, need) => {
+		for (const mode of ['light', 'dark'] as const) {
+			const ratio = contrast(
+				hslToRgb(readToken(mode, 'destructive-text')),
+				hslToRgb(readToken(mode, surface))
+			);
+			expect(ratio, `${mode}: destructive-text on --${surface}`).toBeGreaterThanOrEqual(need);
+		}
+	});
+
+	it.each([0.1, 0.25])(
+		'clears AA on its own bg-destructive/%s wash over the card',
+		(alpha: number) => {
+			for (const mode of ['light', 'dark'] as const) {
+				const wash = composite(
+					hslToRgb(readToken(mode, 'destructive')),
+					alpha,
+					hslToRgb(readToken(mode, 'card'))
+				);
+				const ratio = contrast(hslToRgb(readToken(mode, 'destructive-text')), wash);
+				expect(
+					ratio,
+					`${mode}: destructive-text on destructive/${alpha} over card`
+				).toBeGreaterThanOrEqual(4.5);
+			}
+		}
+	);
+});

--- a/src/routes/(auth)/account/privacy/+page.svelte
+++ b/src/routes/(auth)/account/privacy/+page.svelte
@@ -364,9 +364,11 @@
 				<AlertTriangle class="h-6 w-6 text-destructive" aria-hidden="true" />
 			</div>
 			<div class="flex-1">
-				<!-- text-destructive as a heading would measure 2.85:1 in dark on this
-				     tint (below 4.5) — the same trap as the create-org/referral
-				     headings; the icon + border/tint already carry "danger zone". -->
+				<!-- The icon + border/tint already carry "danger zone", so the heading
+				     stays on the body-text pair (danger-framing rule). Since #781 a
+				     destructive heading would also pass here (6.05:1 dark, against
+				     2.85:1 before the token split) — the rule is editorial, not a
+				     contrast workaround. -->
 				<SectionHeader title={m['accountPrivacyPage.dangerZone']()} class="flex-1" />
 				<p class="mt-2 text-sm text-muted-foreground">
 					{m['accountPrivacyPage.dangerZoneDescription']()}

--- a/src/routes/(auth)/account/profile/+page.svelte
+++ b/src/routes/(auth)/account/profile/+page.svelte
@@ -393,9 +393,10 @@
 				{/if}
 
 				{#if verificationError}
-					<!-- text-destructive as lead text measures 2.68:1 in dark on this tint
-					     (below 4.5); the border/tint carry the tone, text reads on
-					     --foreground. -->
+					<!-- Border/tint carry the tone, the message reads on --foreground
+					     (danger-framing rule). `text-destructive` would clear AA on this
+					     tint too — 6.05:1 in dark since #781, against 2.68:1 before the
+					     token split — but error copy stays on the body-text pair. -->
 					<div role="alert" class="rounded-md border border-destructive bg-destructive/10 p-3">
 						<p class="text-sm font-medium text-foreground">
 							{verificationError}

--- a/src/routes/(auth)/account/referral/+page.svelte
+++ b/src/routes/(auth)/account/referral/+page.svelte
@@ -341,9 +341,10 @@
 									<dt class="font-medium text-muted-foreground">
 										{m['referral.chargesEnabled']()}
 									</dt>
-									<!-- Bare on card: text-destructive measures 2.85:1 in dark
-									     (below 4.5). Only the icon carries the tone; the label
-									     reads on --foreground. -->
+									<!-- Only the icon carries the tone; the label reads on
+									     --foreground (danger-framing rule). Bare
+									     `text-destructive` on this card is 6.42:1 in dark since
+									     the token split (#781), against 2.85:1 before it. -->
 									<dd class="mt-0.5 flex items-center gap-1">
 										{#if stripeChargesEnabled}
 											<Check class="h-3 w-3 text-success" aria-hidden="true" />
@@ -361,9 +362,10 @@
 			</div>
 
 			{#if stripeConnectMutation.error}
-				<!-- text-destructive as lead text measures 2.85:1 in dark on this card
-				     tint (below 4.5); the border/tint + icon carry the tone, text reads
-				     on --foreground. -->
+				<!-- Border/tint + icon carry the tone, the message reads on
+				     --foreground (danger-framing rule). `text-destructive` would clear
+				     AA on this tint too — 6.05:1 in dark since #781, against 2.85:1
+				     before it — but error copy stays on the body-text pair. -->
 				<div
 					class="mt-3 flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-foreground"
 					role="alert"

--- a/src/routes/(auth)/create-org/+page.svelte
+++ b/src/routes/(auth)/create-org/+page.svelte
@@ -150,9 +150,11 @@
 			</div>
 		{:else if !user?.email_verified}
 			<!-- Email not verified warning -->
-			<!-- text-destructive as a heading measures 2.68:1 in dark on this tint
-		     (below 4.5); the border/tint + icon carry the tone, text reads on
-		     --foreground. -->
+			<!-- Border/tint + icon carry the tone and the heading reads on
+		     --foreground (danger-framing rule: meaning is never color-only).
+		     `text-destructive` would now be safe here too — 6.05:1 in dark since
+		     the token split (#781), against 2.68:1 before it — but the framing
+		     rule stands on its own. -->
 			<div class="rounded-lg border-2 border-destructive/40 bg-destructive/10 p-6 shadow-poster">
 				<div class="flex gap-3">
 					<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />

--- a/src/routes/(auth)/create-org/+page.svelte
+++ b/src/routes/(auth)/create-org/+page.svelte
@@ -394,6 +394,13 @@
 <style>
 	:global(.required::after) {
 		content: ' *';
-		color: hsl(var(--destructive));
+		/* --destructive-text, NOT --destructive. The `text-destructive` utility is
+		   remapped to the text half of the split token in tailwind.config.ts, but
+		   that remap is a Tailwind theme key — it cannot reach raw CSS. Written as
+		   the fill value this asterisk measured 2.85:1 on the bg-card panel it sits
+		   in (dark), failing even the 3:1 non-text floor; the text token is 6.42:1
+		   there and 9.75:1 in light. Any `<style>` block colouring text or icons
+		   destructive must reach for this token by name. */
+		color: hsl(var(--destructive-text));
 	}
 </style>

--- a/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/discount-codes/+page.svelte
@@ -429,7 +429,7 @@
 										<button
 											type="button"
 											onclick={() => handleDelete(code)}
-											class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-destructive"
+											class="rounded-md p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
 											title={willHardDelete(code)
 												? m['discountCodesAdmin.delete.titleHardDelete']()
 												: m['discountCodesAdmin.delete.titleDeactivate']()}

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.svelte
@@ -101,9 +101,11 @@
 	     background (below 4.5 for this normal-size text) — the card backing
 	     brings it to 4.94:1 (hand-verified). The error banner's heading/body
 	     stay on `text-foreground` (always-audited body-text pair) with the
-	     icon alone carrying the destructive tone — `text-destructive` on
-	     `bg-destructive/10` measures ~2.95:1 in dark mode, well under AA, and
-	     neither half of that pair is covered by audit-brand-themes.py. -->
+	     icon alone carrying the destructive tone — the danger-framing rule,
+	     not a contrast workaround: since #781 `text-destructive` resolves to
+	     --destructive-text and measures 8.10:1 light / 6.05:1 dark on this
+	     tint (a COMPOSITED_PAIRS row now). It was 2.95:1 in dark before the
+	     split, which is why this note used to read as an apology. -->
 	{#if form?.success}
 		<div class="relative overflow-hidden rounded-lg border border-success/40 bg-card" role="alert">
 			<div class="absolute inset-0 bg-success/10" aria-hidden="true"></div>

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/invitations/+page.svelte
@@ -103,9 +103,10 @@
 	     stay on `text-foreground` (always-audited body-text pair) with the
 	     icon alone carrying the destructive tone — the danger-framing rule,
 	     not a contrast workaround: since #781 `text-destructive` resolves to
-	     --destructive-text and measures 8.10:1 light / 6.05:1 dark on this
-	     tint (a COMPOSITED_PAIRS row now). It was 2.95:1 in dark before the
-	     split, which is why this note used to read as an apology. -->
+	     --destructive-text and measures at worst 7.20:1 light / 6.05:1 dark on
+	     this tint, over either container (both are COMPOSITED_PAIRS rows now).
+	     It was 2.95:1 in dark before the split, which is why this note used to
+	     read as an apology. -->
 	{#if form?.success}
 		<div class="relative overflow-hidden rounded-lg border border-success/40 bg-card" role="alert">
 			<div class="absolute inset-0 bg-success/10" aria-hidden="true"></div>

--- a/src/routes/(auth)/org/[slug]/admin/resources/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/resources/+page.svelte
@@ -184,9 +184,10 @@
 	{#if error}
 		<!-- dark:bg-destructive/25 (AutoEvalRecommendation's pattern): a /10 red wash is
 		     nearly invisible on the dark surface, so dark strengthens the tint. The icon
-		     stays `text-destructive`, which is --destructive-text since #781 — 8.10:1 light
-		     on /10, 5.37:1 dark on /25, both audited in scripts/audit-brand-themes.py. The
-		     old FILL value measured 2.69-2.95:1 here, under the 3:1 non-text floor. -->
+		     stays `text-destructive`, which is --destructive-text since #781 — at worst
+		     7.20:1 light on /10 and 5.37:1 dark on /25, over either container; all four
+		     figures are audited rows in scripts/audit-brand-themes.py. The old FILL value
+		     measured 2.69-2.95:1 here, under the 3:1 non-text floor. -->
 		<div
 			class="flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4 dark:bg-destructive/25"
 			role="alert"

--- a/src/routes/(auth)/org/[slug]/admin/resources/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/resources/+page.svelte
@@ -182,18 +182,16 @@
 
 	<!-- Content -->
 	{#if error}
-		<!-- dark:bg-destructive/25 dark:text-destructive-foreground (AutoEvalRecommendation's
-		     pattern): plain text-destructive on this /10 tint measured 2.69-2.95:1 in dark
-		     mode, under the 3:1 non-text floor; the /25 tint + destructive-foreground (white)
-		     icon pairing measures ~14-15:1 instead. -->
+		<!-- dark:bg-destructive/25 (AutoEvalRecommendation's pattern): a /10 red wash is
+		     nearly invisible on the dark surface, so dark strengthens the tint. The icon
+		     stays `text-destructive`, which is --destructive-text since #781 — 8.10:1 light
+		     on /10, 5.37:1 dark on /25, both audited in scripts/audit-brand-themes.py. The
+		     old FILL value measured 2.69-2.95:1 here, under the 3:1 non-text floor. -->
 		<div
 			class="flex gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4 dark:bg-destructive/25"
 			role="alert"
 		>
-			<AlertTriangle
-				class="h-5 w-5 shrink-0 text-destructive dark:text-destructive-foreground"
-				aria-hidden="true"
-			/>
+			<AlertTriangle class="h-5 w-5 shrink-0 text-destructive" aria-hidden="true" />
 			<div>
 				<p class="font-semibold text-foreground">{m['orgAdmin.resources.error.title']()}</p>
 				<p class="mt-1 text-sm text-foreground">{m['orgAdmin.resources.error.description']()}</p>

--- a/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
@@ -148,10 +148,12 @@
 	<!-- Error Message -->
 	{#if form?.errors && 'form' in form.errors}
 		<!-- Icon carries the tone, not the body text (danger-framing rule). The
-		     icon's `text-destructive` is --destructive-text since #781: 8.10:1
-		     light / 6.05:1 dark on this bg-destructive/10 composite, both audited
-		     in scripts/audit-brand-themes.py. The FILL value it used to resolve to
-		     measured ~2.7-2.95:1 here, failing even the 3:1 non-text floor. -->
+		     icon's `text-destructive` is --destructive-text since #781: at worst
+		     7.20:1 light / 6.05:1 dark on this bg-destructive/10 composite (the
+		     figure depends on whether the panel reads --card or --background;
+		     both are audited rows in scripts/audit-brand-themes.py). The FILL
+		     value it used to resolve to measured ~2.7-2.95:1 here, failing even
+		     the 3:1 non-text floor. -->
 		<div
 			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-foreground"
 			role="alert"

--- a/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
@@ -147,9 +147,11 @@
 
 	<!-- Error Message -->
 	{#if form?.errors && 'form' in form.errors}
-		<!-- Icon carries the tone, not the body text: dark --destructive as TEXT on
-		     this composite measures ~2.7-2.95:1 (fails both the 3:1 non-text and
-		     4.5:1 text floors). -->
+		<!-- Icon carries the tone, not the body text (danger-framing rule). The
+		     icon's `text-destructive` is --destructive-text since #781: 8.10:1
+		     light / 6.05:1 dark on this bg-destructive/10 composite, both audited
+		     in scripts/audit-brand-themes.py. The FILL value it used to resolve to
+		     measured ~2.7-2.95:1 here, failing even the 3:1 non-text floor. -->
 		<div
 			class="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-foreground"
 			role="alert"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -103,14 +103,33 @@ export default {
 			// --destructive-text. Light mode defines the two identically, so this
 			// changes nothing there; dark mode gets the AA-safe rose.
 			//
-			// Overriding `textColor` rather than sweeping ~520 call sites keeps the
+			// Overriding `textColor` rather than sweeping ~525 call sites keeps the
 			// class name every author already reaches for correct by construction —
 			// a new `text-destructive` written tomorrow is safe with no review.
-			// Only the textColor scale is remapped: border-/ring-/divide-/fill-
-			// destructive still resolve to --destructive via `colors` above.
-			// NOTE: this key REPLACES colors.destructive for the textColor scale,
-			// so `foreground` must be restated or `text-destructive-foreground`
-			// (the fill's label, ~67 call sites) would stop compiling.
+			//
+			// SCOPE, precisely: this remaps the `textColor` scale and nothing else,
+			// so it covers `text-destructive` and every variant of it (`hover:`,
+			// `focus:`, `group-hover:`, `data-[…]:`, and the alpha modifier
+			// `text-destructive/90`). It does NOT cover
+			//   · border-/ring-/divide-/fill-/stroke-/from-/to-destructive — correct,
+			//     those are the FILL and owe 1.4.11's 3:1, not 4.5:1;
+			//   · decoration-/placeholder-/caret-/accent-destructive — text-ish, but
+			//     separate Tailwind scales, so they still resolve to the fill. Zero
+			//     call sites today; don't reach for them to colour text;
+			//   · raw CSS in a `<style>` block — write `hsl(var(--destructive-text))`
+			//     by hand there (see routes/(auth)/create-org/+page.svelte).
+			// MERGE SEMANTICS, verified by compiling both variants rather than
+			// assumed: Tailwind DEEP-MERGES this key into the `colors.destructive`
+			// scale, it does not replace it. So `text-destructive-foreground` (the
+			// fill's label, 44 call sites) is inherited from `colors` and compiles
+			// even if the `foreground` line below is deleted. It is restated anyway
+			// — the pair is the point of this key, and stating it costs nothing and
+			// survives a future Tailwind that replaces instead of merging. What is
+			// genuinely load-bearing is `DEFAULT`: delete it and every
+			// `text-destructive` silently reverts to the fill. That direction IS
+			// covered by src/lib/utils/destructive-text-token.test.ts, which asserts
+			// resolveConfig() output (compiled reality, not this literal) and was
+			// mutation-tested to confirm it fails when the override is removed.
 			textColor: {
 				destructive: {
 					DEFAULT: 'hsl(var(--destructive-text) / <alpha-value>)',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -95,6 +95,28 @@ export default {
 					white: 'hsl(var(--poster-white) / <alpha-value>)'
 				}
 			},
+			// `text-destructive` is destructive-as-TEXT, which owes WCAG 4.5:1 —
+			// a different obligation from `bg-destructive`, the FILL, which owes
+			// 3:1 and carries --destructive-foreground as its label. In dark mode
+			// one value cannot satisfy both (issue #781: the fill measured
+			// 3.11:1/2.85:1 when borrowed as text), so the text half reads
+			// --destructive-text. Light mode defines the two identically, so this
+			// changes nothing there; dark mode gets the AA-safe rose.
+			//
+			// Overriding `textColor` rather than sweeping ~520 call sites keeps the
+			// class name every author already reaches for correct by construction —
+			// a new `text-destructive` written tomorrow is safe with no review.
+			// Only the textColor scale is remapped: border-/ring-/divide-/fill-
+			// destructive still resolve to --destructive via `colors` above.
+			// NOTE: this key REPLACES colors.destructive for the textColor scale,
+			// so `foreground` must be restated or `text-destructive-foreground`
+			// (the fill's label, ~67 call sites) would stop compiling.
+			textColor: {
+				destructive: {
+					DEFAULT: 'hsl(var(--destructive-text) / <alpha-value>)',
+					foreground: 'hsl(var(--destructive-foreground) / <alpha-value>)'
+				}
+			},
 			borderRadius: {
 				lg: 'var(--radius)',
 				md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
Closes #781, Closes #783.

## #783 — audit script first

`scripts/audit-brand-themes.py` gains **COMPOSITED_PAIRS**: declared (foreground, alpha-layer, base-surface) recipes it composites and contrast-checks per mode. The machinery reproduced ~40 hand-verified ratios — and found one false comment (QuestionnaireMock's claimed ~9.7:1 is actually 6.92:1). It now also **fails on unknown token names** instead of skipping them (previously, renaming a token silently dropped PASS rows and stayed green — proven both directions in review with fault injection: 26 UNKNOWN TOKEN rows / exit 1).

## #781 — dark destructive as TEXT

The issue estimated ~70 failing sites; the real count is **520 `text-destructive` uses across 235 files**. Instead of a sweep, one atomic mechanism: new `--destructive-text` token (light = `--destructive` byte-identical; dark = a 352° rose at 7.02:1 on background / 6.42:1 on card, chosen over a plain lightened red to keep protanopia separation from `--accent`), wired via a `theme.extend.textColor.destructive` override — so `text-destructive` and every variant of it resolves to the text token while `bg-/border-/ring-destructive` keep the fill. The invariant (no `text-destructive` on mode-inert or fill surfaces) was independently attacked in review across poster panels, embed routes, print, the forced-dark seat theatre, and shadcn internals — it holds. Raw CSS is *outside* the remap; the one raw-CSS instance app-wide (create-org required-asterisk, 2.85:1 dark) is fixed, and CLAUDE.md now documents the boundary.

Also: retiring the white-out patterns made two dimmed sites regress — caught and fixed (ImpersonationBanner, MaintenanceBanner time chip); a pre-existing red-on-red hover in discount-codes fixed; all `/80` dimming steps bumped to `/90` so the worst-case container passes with margin, with the recipes audit-pinned.

Review: independent opus review APPROVE WITH CHANGES → fix round → scoped re-review **ALL ADDRESSED** (every number independently recomputed; the fix round also corrected a reviewer-accepted claim with compiler evidence — Tailwind deep-merges the override, so the restated `foreground` key is defensive, not load-bearing). Dark-mode visual pass done (failed-login alert: rose legible, still reads as error-red).

`make check` green · vitest 2555 passed · audit 0 failures and proven able to fail · `tests/e2e/**` and `messages/*.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>