### PR TITLE
fix(a11y): global :focus-visible floor + transition scoping

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -202,9 +202,19 @@
 	 *      exactly the indicator they had; nothing double-rings. (Author-origin
 	 *      specificity 0 still beats the user-agent default ring, which is the
 	 *      whole point.)
-	 *   2. It is outline-based, not box-shadow/ring-based, so it never fights a
-	 *      `shadow-poster` float or a ring used for selection state, and an
-	 *      `overflow-hidden` ancestor cannot clip it.
+	 *      (The suppressing utility compiles to a TRANSPARENT 2px outline, not
+	 *      `outline: none` — so it is a genuine override at 0,2,0, not a no-op.)
+	 *   2. It is outline-based, not box-shadow/ring-based. An outline is not part
+	 *      of layout or scroll geometry, so it can never shift a sibling or grow
+	 *      a scroll container, and it occupies a different property from the
+	 *      `shadow-poster` float and from any ring used for selection state — so
+	 *      the floor and those two can coexist on one element without either
+	 *      overwriting the other. It is NOT immune to clipping: an
+	 *      `overflow: hidden` ancestor clips a descendant's outline exactly as it
+	 *      clips a ring (verified by pixel test). Elements whose indicator would
+	 *      be clipped away — e.g. EventCard's `absolute inset-0` overlay link
+	 *      inside an `overflow-hidden` article — are why those containers carry
+	 *      `focus-within:ring-*` on the clipping ancestor itself.
 	 *
 	 * CONTRAST — `--ring` is `--primary`, one of the pairs the accessibility
 	 * contract above pins and `scripts/audit-brand-themes.py` enforces
@@ -213,10 +223,19 @@
 	 *   light  6.17:1 on --background, 6.99:1 on --card, 4.12:1 on --secondary
 	 *   dark   6.87:1 on --background, 6.27:1 on --card, 4.60:1 on --secondary
 	 * WCAG 2.1 AA wants 3:1 for non-text UI, so every theme surface clears it.
-	 * The fixed poster panels are the one place `--ring` does NOT (purple ring
-	 * on a purple panel is 1.27:1) — which is why every focusable that sits on
-	 * a poster panel declares its own explicit focus outline (amber on ink,
-	 * ink on amber, ...) and overrides this rule via mechanism 1.
+	 *
+	 * The fixed poster panels are the one place `--ring` does NOT clear it: a
+	 * purple ring on a purple panel is 1.27:1 light / 2.07:1 dark. Most
+	 * focusables that sit on a poster panel therefore declare their own explicit
+	 * focus outline (amber on ink, ink on amber, ...) and override this rule via
+	 * mechanism 1 — but NOT all of them. `LandingPageTemplate.svelte` (the SEO
+	 * landing pages) renders plain shadcn Buttons on poster panels, which keep
+	 * the Button base's `--ring` ring. Those are not invisible, because the same
+	 * base adds a `ring-offset-background` band between button and ring, and
+	 * that band measures 4.88:1 light / 3.33:1 dark against poster-purple — so
+	 * the COMPOSITE indicator clears 3:1 in both modes today. It is off-brand
+	 * rather than non-compliant; issue #796 tracks a proper poster-panel focus
+	 * treatment. Do not read this rule as a guarantee for poster surfaces.
 	 */
 	:where(:focus-visible) {
 		outline: 2px solid hsl(var(--ring));

--- a/src/app.css
+++ b/src/app.css
@@ -183,6 +183,46 @@
 		@apply bg-background text-foreground;
 	}
 
+	/*
+	 * GLOBAL KEYBOARD-FOCUS FLOOR (#780).
+	 *
+	 * Before this rule the app had no base focus style at all, so anything that
+	 * declared no focus styling of its own depended on the browser's default
+	 * ring — and any element carrying an unconditional outline utility silently
+	 * swallowed it (that is the seat-picker regression the issue describes).
+	 * This gives every focusable element a token-driven ring as a FLOOR.
+	 *
+	 * Two mechanisms keep it a floor rather than a second ring stacked on top
+	 * of the ~318 call sites that already style their own focus:
+	 *
+	 *   1. `:where()` collapses the selector to specificity 0,0,0. Every
+	 *      Tailwind utility (0,1,0) and every scoped component rule therefore
+	 *      overrides it — including the outline-suppressing utility that each
+	 *      shadcn-svelte primitive here pairs with its own 2px ring. Those keep
+	 *      exactly the indicator they had; nothing double-rings. (Author-origin
+	 *      specificity 0 still beats the user-agent default ring, which is the
+	 *      whole point.)
+	 *   2. It is outline-based, not box-shadow/ring-based, so it never fights a
+	 *      `shadow-poster` float or a ring used for selection state, and an
+	 *      `overflow-hidden` ancestor cannot clip it.
+	 *
+	 * CONTRAST — `--ring` is `--primary`, one of the pairs the accessibility
+	 * contract above pins and `scripts/audit-brand-themes.py` enforces
+	 * (primary vs background >= 3:1). Measured (not estimated) against the
+	 * surfaces the 2px offset gap can expose, worst case per mode:
+	 *   light  6.17:1 on --background, 6.99:1 on --card, 4.12:1 on --secondary
+	 *   dark   6.87:1 on --background, 6.27:1 on --card, 4.60:1 on --secondary
+	 * WCAG 2.1 AA wants 3:1 for non-text UI, so every theme surface clears it.
+	 * The fixed poster panels are the one place `--ring` does NOT (purple ring
+	 * on a purple panel is 1.27:1) — which is why every focusable that sits on
+	 * a poster panel declares its own explicit focus outline (amber on ink,
+	 * ink on amber, ...) and overrides this rule via mechanism 1.
+	 */
+	:where(:focus-visible) {
+		outline: 2px solid hsl(var(--ring));
+		outline-offset: 2px;
+	}
+
 	/* Safe area insets for notched devices (iPhone X+, etc.) */
 	header.sticky,
 	.sticky-header {

--- a/src/lib/a11y/focus-visible.guard.test.ts
+++ b/src/lib/a11y/focus-visible.guard.test.ts
@@ -4,21 +4,37 @@
  * The floor itself is a single `@layer base` rule in `src/app.css`. Nothing in
  * jsdom can prove a CSS outline paints, and nothing in the component tests
  * notices when a *new* call site quietly re-breaks focus visibility — which is
- * exactly how the seat-picker regression shipped. So this file asserts the two
- * invariants that keep the floor working, both by reading source:
+ * exactly how the seat-picker regression shipped. So this file reads source and
+ * pins the invariants that keep the floor working.
  *
- *  1. The base rule exists, is zero-specificity (`:where`), is outline-based,
- *     and is token-driven. Those four properties are the whole mechanism: a
- *     specificity-0 author rule beats the user-agent ring but loses to every
- *     Tailwind utility, so components that style their own focus keep exactly
- *     the indicator they had and nothing double-rings.
+ * WHY `transition-all` IS THE THING BEING HUNTED
  *
- *  2. No source file puts `transition-all` on an element that also declares a
- *     focus indicator. `transition-all` animates `outline-color`/`box-shadow`,
- *     so the ring fades in instead of appearing — the indicator is present but
- *     not immediate. Scoped transitions (`transition-colors`,
- *     `transition-transform`, `transition-shadow`, explicit property lists)
- *     are all fine; only `all` is banned on a focus-styled element.
+ * `transition-all` animates `outline-color`, `outline-width` and `box-shadow` —
+ * every property a focus indicator can be made of. On a focusable element it
+ * therefore fades the indicator in rather than showing it at once. Both kinds of
+ * focusable are affected, so the ban is unconditional:
+ *
+ *   - one that styles its own ring  -> `transition-all` fades that ring;
+ *   - one that styles nothing       -> `transition-all` fades the app.css floor.
+ *
+ * The second kind is the one the floor created, and it is the easier one to
+ * miss, because nothing in the element's own classes hints that it has a focus
+ * indicator at all.
+ *
+ * KNOWN LIMITS OF STATIC SCANNING — documented rather than papered over, because
+ * a guard that overclaims is worse than one with a stated gap:
+ *
+ *   - "Focusable" is decided from the opening tag: a natively focusable element,
+ *     or any tag carrying `tabindex` / a widget `role`. A component that renders
+ *     a focusable element internally without either marker (`<Foo />` whose root
+ *     is a `<button>`) is invisible here.
+ *   - Class strings reached through a helper function, a prop, or a runtime
+ *     conditional are not resolved. Module-level `const` class strings ARE
+ *     resolved (pass 1 below), because that is this codebase's dominant style
+ *     for long class lists.
+ *   - Nothing here proves a pixel. The keyboard walk recorded in the PR body is
+ *     the evidence that the floor actually paints; this file only stops the
+ *     known regressions from silently reappearing.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
@@ -40,6 +56,101 @@ function walk(dir: string, out: string[] = []): string[] {
 	return out;
 }
 
+const sourceFiles = walk(SRC).filter((f) => !f.endsWith('.test.ts') && !f.endsWith('.spec.ts'));
+
+const rel = (f: string) => relative(process.cwd(), f);
+const lineOf = (text: string, index: number) => text.slice(0, index).split('\n').length;
+
+/**
+ * Blank out comments before scanning, preserving every character offset (so
+ * reported line numbers stay true) by replacing content with spaces.
+ *
+ * This is load-bearing, not tidiness. Prose in this codebase quotes class names
+ * in backticks — "`transition-shadow` (was `transition-all`)" — and a literal
+ * scanner reads those backticks as template strings, so an explanatory comment
+ * would report itself as an offender. The same aliasing could equally MASK a
+ * real offender, so comments are removed rather than special-cased. String
+ * literals are tracked so a `//` inside a URL is never mistaken for a comment.
+ */
+function stripComments(text: string): string {
+	const out = text.split('');
+	let i = 0;
+	let quote: string | null = null;
+	const blank = (from: number, to: number) => {
+		for (let k = from; k < to && k < out.length; k++) if (out[k] !== '\n') out[k] = ' ';
+	};
+
+	while (i < text.length) {
+		const c = text[i];
+		if (quote) {
+			if (c === '\\') i += 2;
+			else {
+				if (c === quote) quote = null;
+				i++;
+			}
+			continue;
+		}
+		if (c === "'" || c === '"' || c === '`') {
+			quote = c;
+			i++;
+		} else if (c === '/' && text[i + 1] === '*') {
+			const end = text.indexOf('*/', i + 2);
+			const stop = end === -1 ? text.length : end + 2;
+			blank(i, stop);
+			i = stop;
+		} else if (c === '/' && text[i + 1] === '/') {
+			const end = text.indexOf('\n', i);
+			const stop = end === -1 ? text.length : end;
+			blank(i, stop);
+			i = stop;
+		} else if (c === '<' && text.startsWith('<!--', i)) {
+			const end = text.indexOf('-->', i + 4);
+			const stop = end === -1 ? text.length : end + 3;
+			blank(i, stop);
+			i = stop;
+		} else {
+			i++;
+		}
+	}
+	return out.join('');
+}
+
+/**
+ * Concatenated string literals are the house style for long class lists
+ * (`'a b ' + 'c d'`, and `cn('a b', 'c d')`). Scanning each literal in isolation
+ * lets a regression hide by straddling the join, so adjacent literals are glued
+ * into one logical string before matching. `+` and `,` both count as joins.
+ */
+function logicalClassStrings(text: string): { value: string; index: number }[] {
+	const literal = /(['"`])((?:[^'"`\\\n]|\\.)*)\1/g;
+	const out: { value: string; index: number }[] = [];
+	let current: { value: string; index: number } | null = null;
+	let previousEnd = -1;
+
+	for (const m of text.matchAll(literal)) {
+		const start = m.index ?? 0;
+		const gap = previousEnd >= 0 ? text.slice(previousEnd, start) : '';
+		// Glue only across a pure join: whitespace plus a single `+` or `,`.
+		const isJoin = /^\s*[+,]\s*$/.test(gap);
+		if (current && isJoin) {
+			current.value += ' ' + m[2];
+		} else {
+			if (current) out.push(current);
+			current = { value: m[2], index: start };
+		}
+		previousEnd = start + m[0].length;
+	}
+	if (current) out.push(current);
+	return out;
+}
+
+/**
+ * Exact token match, so `after:transition-all` (which animates a pseudo-element,
+ * never the host's own outline or ring) is correctly not an offender.
+ */
+const hasBareTransitionAll = (s: string): boolean =>
+	s.split(/\s+/).some((token) => token === 'transition-all');
+
 describe('global :focus-visible floor (#780)', () => {
 	const appCss = readFileSync(join(SRC, 'app.css'), 'utf-8');
 
@@ -48,8 +159,8 @@ describe('global :focus-visible floor (#780)', () => {
 		expect(rule, 'app.css must declare a `:where(:focus-visible)` base rule').not.toBeNull();
 
 		const body = rule?.[1] ?? '';
-		// Outline, not box-shadow: a ring would fight `shadow-poster` and be
-		// clipped by `overflow-hidden` ancestors.
+		// Outline, not box-shadow: an outline is outside layout, and it occupies a
+		// different property from `shadow-poster` and from selection rings.
 		expect(body).toMatch(/outline:\s*2px solid/);
 		expect(body).toMatch(/outline-offset:/);
 		expect(body).not.toMatch(/box-shadow/);
@@ -58,48 +169,107 @@ describe('global :focus-visible floor (#780)', () => {
 		expect(body).toContain('hsl(var(--ring))');
 	});
 
-	it('keeps the rule inside a base layer so every utility outranks it', () => {
-		const baseLayerStarts = [...appCss.matchAll(/@layer base\s*\{/g)].map((m) => m.index ?? -1);
-		expect(baseLayerStarts.length).toBeGreaterThan(0);
+	it('keeps the rule inside an `@layer base` block', () => {
 		const ruleIndex = appCss.indexOf(':where(:focus-visible)');
-		// The rule must sit after some `@layer base {` opener.
-		expect(baseLayerStarts.some((start) => start >= 0 && start < ruleIndex)).toBe(true);
+		expect(ruleIndex, 'rule must exist').toBeGreaterThan(-1);
+
+		// Brace-match each `@layer base { ... }` block so this actually tests
+		// membership. Checking only that some opener appears earlier in the file
+		// is vacuous: the first opener is near the top, so *everything* passes.
+		const blocks: [number, number][] = [];
+		for (const opener of appCss.matchAll(/@layer\s+base\s*\{/g)) {
+			const start = (opener.index ?? 0) + opener[0].length;
+			let depth = 1;
+			let i = start;
+			for (; i < appCss.length && depth > 0; i++) {
+				if (appCss[i] === '{') depth++;
+				else if (appCss[i] === '}') depth--;
+			}
+			blocks.push([start, i - 1]);
+		}
+		expect(blocks.length, 'app.css must have at least one `@layer base` block').toBeGreaterThan(0);
+		expect(
+			blocks.some(([start, end]) => ruleIndex > start && ruleIndex < end),
+			'the `:where(:focus-visible)` rule must sit INSIDE an `@layer base { ... }` block'
+		).toBe(true);
 	});
 });
 
-describe('no focus indicator is faded in by an unscoped transition (#780)', () => {
+describe('`transition-all` never sits on anything that shows a focus indicator (#780)', () => {
 	/** A class string declares a focus indicator if it styles focus at all. */
 	const DECLARES_FOCUS =
 		/(focus|focus-visible|focus-within|peer-focus|peer-focus-visible|group-focus|group-focus-visible)(-[a-z-]+)?:(ring|outline|border|shadow)/;
 
-	/**
-	 * Pseudo-element transitions (`after:transition-all`) animate the pseudo,
-	 * never the host's own outline or ring, so they are not offenders.
-	 */
-	const BARE_TRANSITION_ALL = /(^|[\s'"`])transition-all([\s'"`]|$)/;
-
 	it('has no class string combining `transition-all` with focus styling', () => {
 		const offenders: string[] = [];
-
-		for (const file of walk(SRC)) {
-			const text = readFileSync(file, 'utf-8');
-			// Class strings are quoted literals; scan each one independently so a
-			// `transition-all` in one attribute cannot alias a focus utility in
-			// another.
-			for (const match of text.matchAll(/(['"`])((?:[^'"`\\\n]|\\.)*)\1/g)) {
-				const s = match[2];
-				if (!BARE_TRANSITION_ALL.test(s)) continue;
-				if (!DECLARES_FOCUS.test(s)) continue;
-				const line = text.slice(0, match.index).split('\n').length;
-				offenders.push(`${relative(process.cwd(), file)}:${line}`);
+		for (const file of sourceFiles) {
+			const text = stripComments(readFileSync(file, 'utf-8'));
+			for (const s of logicalClassStrings(text)) {
+				if (!hasBareTransitionAll(s.value)) continue;
+				if (!DECLARES_FOCUS.test(s.value)) continue;
+				offenders.push(`${rel(file)}:${lineOf(text, s.index)}`);
 			}
 		}
-
 		expect(
 			offenders,
 			'`transition-all` animates outline-color and box-shadow, so it fades the focus ring in. ' +
 				'Scope the transition (transition-colors / transition-transform / transition-shadow / an ' +
 				'explicit property list) on any element that styles its own focus.'
+		).toEqual([]);
+	});
+
+	/**
+	 * The complement, and the case the floor created: a focusable element with NO
+	 * focus utilities of its own now shows the app.css outline, and
+	 * `transition-all` fades that outline in. `NotificationItem`'s
+	 * `role="button" tabindex={0}` Card is exactly this shape and had to be found
+	 * by hand — the assertion above cannot see it, because it styles no focus.
+	 */
+	const FOCUSABLE_TAG = /^(button|a|input|select|textarea|summary|details)$/i;
+	const WIDGET_ROLE =
+		/role=["'](button|link|checkbox|radio|switch|tab|menuitem|menuitemcheckbox|menuitemradio|option|slider|spinbutton|textbox|combobox|treeitem)["']/;
+
+	it('has no focusable element carrying `transition-all`', () => {
+		const offenders: string[] = [];
+
+		for (const file of sourceFiles.filter((f) => f.endsWith('.svelte'))) {
+			const text = stripComments(readFileSync(file, 'utf-8'));
+
+			// Pass 1: module-level class consts whose value contains the offender.
+			// Long class lists live in consts in this codebase
+			// (`const seatButtonClass = '...' + '...'`), so resolving them closes
+			// the largest blind spot a tag-only scan would leave.
+			const taintedConsts = new Set<string>();
+			for (const m of text.matchAll(/\b(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=/g)) {
+				const start = m.index ?? 0;
+				const strings = logicalClassStrings(text.slice(start, start + 900));
+				if (strings.some((s) => hasBareTransitionAll(s.value))) taintedConsts.add(m[1]);
+			}
+
+			// Pass 2: opening tags. `[^>]*?` stops at the tag's own `>`, which is
+			// enough for the attribute soup these components use.
+			for (const tag of text.matchAll(/<([A-Za-z][\w.-]*)([^>]*?)\/?>/g)) {
+				const [, name, attrs] = tag;
+				const focusable =
+					FOCUSABLE_TAG.test(name) || /\btabindex[=\s]/.test(attrs) || WIDGET_ROLE.test(attrs);
+				if (!focusable) continue;
+				// An `<a>` without href is not focusable; skip to avoid noise.
+				if (/^a$/i.test(name) && !/\bhref[=\s]/.test(attrs) && !/\btabindex[=\s]/.test(attrs))
+					continue;
+
+				const inTag = logicalClassStrings(attrs).some((s) => hasBareTransitionAll(s.value));
+				const viaConst = [...taintedConsts].some((c) =>
+					new RegExp(`class=\\{[^}]*\\b${c}\\b`).test(attrs)
+				);
+				if (inTag || viaConst) offenders.push(`${rel(file)}:${lineOf(text, tag.index ?? 0)}`);
+			}
+		}
+
+		expect(
+			offenders,
+			'A focusable element with `transition-all` fades in whichever focus indicator it uses — ' +
+				'its own ring, or the global outline floor in app.css when it declares none. Scope the ' +
+				'transition to the properties that actually need to animate.'
 		).toEqual([]);
 	});
 });

--- a/src/lib/a11y/focus-visible.guard.test.ts
+++ b/src/lib/a11y/focus-visible.guard.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Structural guard for #780 — the global keyboard-focus floor.
+ *
+ * The floor itself is a single `@layer base` rule in `src/app.css`. Nothing in
+ * jsdom can prove a CSS outline paints, and nothing in the component tests
+ * notices when a *new* call site quietly re-breaks focus visibility — which is
+ * exactly how the seat-picker regression shipped. So this file asserts the two
+ * invariants that keep the floor working, both by reading source:
+ *
+ *  1. The base rule exists, is zero-specificity (`:where`), is outline-based,
+ *     and is token-driven. Those four properties are the whole mechanism: a
+ *     specificity-0 author rule beats the user-agent ring but loses to every
+ *     Tailwind utility, so components that style their own focus keep exactly
+ *     the indicator they had and nothing double-rings.
+ *
+ *  2. No source file puts `transition-all` on an element that also declares a
+ *     focus indicator. `transition-all` animates `outline-color`/`box-shadow`,
+ *     so the ring fades in instead of appearing — the indicator is present but
+ *     not immediate. Scoped transitions (`transition-colors`,
+ *     `transition-transform`, `transition-shadow`, explicit property lists)
+ *     are all fine; only `all` is banned on a focus-styled element.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const SRC = join(process.cwd(), 'src');
+
+function walk(dir: string, out: string[] = []): string[] {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			// Generated API client and compiled messages carry no markup.
+			if (entry.name === 'paraglide' || entry.name === 'generated') continue;
+			walk(full, out);
+		} else if (entry.name.endsWith('.svelte') || entry.name.endsWith('.ts')) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+describe('global :focus-visible floor (#780)', () => {
+	const appCss = readFileSync(join(SRC, 'app.css'), 'utf-8');
+
+	it('declares a zero-specificity, outline-based, token-driven base rule', () => {
+		const rule = appCss.match(/:where\(:focus-visible\)\s*\{([^}]*)\}/);
+		expect(rule, 'app.css must declare a `:where(:focus-visible)` base rule').not.toBeNull();
+
+		const body = rule?.[1] ?? '';
+		// Outline, not box-shadow: a ring would fight `shadow-poster` and be
+		// clipped by `overflow-hidden` ancestors.
+		expect(body).toMatch(/outline:\s*2px solid/);
+		expect(body).toMatch(/outline-offset:/);
+		expect(body).not.toMatch(/box-shadow/);
+		// Token-driven: `--ring` is `--primary`, the pair audit-brand-themes.py
+		// pins at >= 3:1 against `--background` in both modes.
+		expect(body).toContain('hsl(var(--ring))');
+	});
+
+	it('keeps the rule inside a base layer so every utility outranks it', () => {
+		const baseLayerStarts = [...appCss.matchAll(/@layer base\s*\{/g)].map((m) => m.index ?? -1);
+		expect(baseLayerStarts.length).toBeGreaterThan(0);
+		const ruleIndex = appCss.indexOf(':where(:focus-visible)');
+		// The rule must sit after some `@layer base {` opener.
+		expect(baseLayerStarts.some((start) => start >= 0 && start < ruleIndex)).toBe(true);
+	});
+});
+
+describe('no focus indicator is faded in by an unscoped transition (#780)', () => {
+	/** A class string declares a focus indicator if it styles focus at all. */
+	const DECLARES_FOCUS =
+		/(focus|focus-visible|focus-within|peer-focus|peer-focus-visible|group-focus|group-focus-visible)(-[a-z-]+)?:(ring|outline|border|shadow)/;
+
+	/**
+	 * Pseudo-element transitions (`after:transition-all`) animate the pseudo,
+	 * never the host's own outline or ring, so they are not offenders.
+	 */
+	const BARE_TRANSITION_ALL = /(^|[\s'"`])transition-all([\s'"`]|$)/;
+
+	it('has no class string combining `transition-all` with focus styling', () => {
+		const offenders: string[] = [];
+
+		for (const file of walk(SRC)) {
+			const text = readFileSync(file, 'utf-8');
+			// Class strings are quoted literals; scan each one independently so a
+			// `transition-all` in one attribute cannot alias a focus utility in
+			// another.
+			for (const match of text.matchAll(/(['"`])((?:[^'"`\\\n]|\\.)*)\1/g)) {
+				const s = match[2];
+				if (!BARE_TRANSITION_ALL.test(s)) continue;
+				if (!DECLARES_FOCUS.test(s)) continue;
+				const line = text.slice(0, match.index).split('\n').length;
+				offenders.push(`${relative(process.cwd(), file)}:${line}`);
+			}
+		}
+
+		expect(
+			offenders,
+			'`transition-all` animates outline-color and box-shadow, so it fades the focus ring in. ' +
+				'Scope the transition (transition-colors / transition-transform / transition-shadow / an ' +
+				'explicit property list) on any element that styles its own focus.'
+		).toEqual([]);
+	});
+});

--- a/src/lib/components/calendar/CalendarYearView.svelte
+++ b/src/lib/components/calendar/CalendarYearView.svelte
@@ -78,8 +78,10 @@
 
 	.year-month-card {
 		/* Poster silhouette (uplift): 2px edge + the float that grows on hover,
-		   matching ui/card and the dashboard's activity tiles. */
-		@apply flex flex-col items-center justify-center rounded-lg border-2 border-border bg-card p-6 shadow-poster transition-all hover:border-primary hover:shadow-poster-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2;
+		   matching ui/card and the dashboard's activity tiles.
+		   The transition is scoped to colours (was "all"): the focus ring is a
+		   box-shadow, so animating box-shadow would fade the ring in. */
+		@apply flex flex-col items-center justify-center rounded-lg border-2 border-border bg-card p-6 shadow-poster transition-colors hover:border-primary hover:shadow-poster-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2;
 	}
 
 	.year-month-header {

--- a/src/lib/components/dashboard/DashboardActivityCards.svelte
+++ b/src/lib/components/dashboard/DashboardActivityCards.svelte
@@ -16,8 +16,12 @@
 	// rest of the app's surfaces gained: 2px edge, `shadow-poster` at rest,
 	// `shadow-poster-lg` on hover (the float grows instead of a generic
 	// shadow-lg). Colours are unchanged — `bg-card` + ToneTile's audited tints.
+	//
+	// The transition is scoped to colours (was `transition-all`): the focus ring
+	// is a box-shadow, so transitioning box-shadow would fade it in instead of
+	// showing it at once. The border colour still animates; the float snaps.
 	const activityCard =
-		'group rounded-lg border-2 bg-card p-6 shadow-poster transition-all hover:border-primary hover:shadow-poster-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2';
+		'group rounded-lg border-2 bg-card p-6 shadow-poster transition-colors hover:border-primary hover:shadow-poster-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2';
 </script>
 
 <!-- Activity Summary Cards -->

--- a/src/lib/components/events/BookmarkButton.svelte
+++ b/src/lib/components/events/BookmarkButton.svelte
@@ -87,7 +87,7 @@
 
 	const buttonClasses = $derived(
 		cn(
-			'inline-flex h-9 w-9 items-center justify-center transition-all focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60',
+			'inline-flex h-9 w-9 items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60',
 			variant === 'float' &&
 				'rounded-full bg-black/45 text-white backdrop-blur-sm hover:bg-black/65 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/50',
 			variant === 'inline' &&

--- a/src/lib/components/events/EventCard.svelte
+++ b/src/lib/components/events/EventCard.svelte
@@ -110,13 +110,17 @@
 	// Container classes based on variant
 	const containerClasses = $derived(
 		cn(
-			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-all',
+			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-transform',
 			// Same silhouette and lift on all three discovery cards (event / series /
 			// organization): the thick edge + poster float that `ui/card` took
 			// globally in the uplift, applied by hand because these are bare
 			// `<article>`s rather than the Card primitive. The float is the point —
 			// discovery pages now sit on a tinted panel, so a card has to read as a
 			// white sticker ON it, not a rectangle cut out of it.
+			// `transition-transform`, not `transition-all`: the ring below is a
+			// box-shadow, and transitioning box-shadow would fade it in on focus.
+			// Scoping to transform keeps the hover lift and makes the ring instant
+			// (the shadow swap snaps, which is imperceptible next to the lift).
 			'hover:-translate-y-1 hover:shadow-poster-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',

--- a/src/lib/components/events/EventHeader.svelte
+++ b/src/lib/components/events/EventHeader.svelte
@@ -129,7 +129,7 @@
 					<button
 						type="button"
 						onclick={handleDownloadCalendar}
-						class="group flex items-center gap-2 transition-all hover:text-poster-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50"
+						class="group flex items-center gap-2 transition-colors hover:text-poster-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50"
 						title={m['eventHeader.downloadCalendarEventTitle']()}
 						aria-label={m['eventHeader.downloadCalendarEventFor']({ name: event.name })}
 					>
@@ -147,7 +147,7 @@
 							href={mapsUrl}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="group flex items-center gap-2 transition-all hover:text-poster-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50"
+							class="group flex items-center gap-2 transition-colors hover:text-poster-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50"
 							aria-label="{locationDisplay} - {m['eventQuickInfo.openInMaps']()}"
 						>
 							<MapPin class="h-5 w-5 shrink-0" aria-hidden="true" />
@@ -168,7 +168,7 @@
 			<button
 				type="button"
 				onclick={handleShare}
-				class="absolute right-6 top-6 hidden rounded-full bg-poster-white/20 p-3 backdrop-blur-sm transition-all hover:bg-poster-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50 md:block"
+				class="absolute right-6 top-6 hidden rounded-full bg-poster-white/20 p-3 backdrop-blur-sm transition-colors hover:bg-poster-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-poster-white focus-visible:ring-offset-2 focus-visible:ring-offset-poster-ink/50 md:block"
 				aria-label={m['eventHeader.shareEvent']()}
 			>
 				<Share2 class="h-5 w-5 text-poster-white" aria-hidden="true" />

--- a/src/lib/components/events/EventSeriesCard.svelte
+++ b/src/lib/components/events/EventSeriesCard.svelte
@@ -82,9 +82,13 @@
 	// Container classes based on variant
 	const containerClasses = $derived(
 		cn(
-			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-all',
+			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-transform',
 			// Same silhouette and lift on all three discovery cards (event / series /
 			// organization) — see EventCard for why it is spelled out by hand.
+			// `transition-transform`, not `transition-all`: the ring below is a
+			// box-shadow, and transitioning box-shadow would fade it in on focus.
+			// Scoping to transform keeps the hover lift and makes the ring instant
+			// (the shadow swap snaps, which is imperceptible next to the lift).
 			'hover:-translate-y-1 hover:shadow-poster-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',

--- a/src/lib/components/events/RSVPButtons.svelte
+++ b/src/lib/components/events/RSVPButtons.svelte
@@ -55,7 +55,7 @@
 
 		return cn(
 			// Base styles
-			'flex h-12 w-full min-w-0 items-center justify-center gap-2 rounded-md px-4 py-3 text-sm font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+			'flex h-12 w-full min-w-0 items-center justify-center gap-2 rounded-md px-4 py-3 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 			// Mobile, Tablet, Desktop: Full width, 48px height for touch
 			'xl:h-auto xl:min-w-[120px]',
 			// The yes/maybe/no triad IS the semantic triad, so it now rides the
@@ -177,11 +177,3 @@
 		<span>{m['rsvp.no_button']()}</span>
 	</button>
 </div>
-
-<style>
-	/* Ensure focus indicators are always visible */
-	button:focus-visible {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/lib/components/events/admin/EventResources.svelte
+++ b/src/lib/components/events/admin/EventResources.svelte
@@ -164,7 +164,7 @@
 					onclick={() => resource.id && toggleResource(resource.id)}
 					{disabled}
 					class={cn(
-						'flex w-full items-center gap-3 rounded-md border p-3 text-left transition-all hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+						'flex w-full items-center gap-3 rounded-md border p-3 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
 						isSelected(resource.id || '') && 'border-primary bg-primary/5'
 					)}
 				>

--- a/src/lib/components/forms/FileUploader.svelte
+++ b/src/lib/components/forms/FileUploader.svelte
@@ -416,7 +416,7 @@
 			aria-label={m['fileUploader.uploadFile']()}
 			aria-describedby={error ? `${inputId}-error` : `${inputId}-hint`}
 			class={cn(
-				'flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-6 transition-all',
+				'flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-6 transition-colors',
 				'hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-800/50',
 				'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
 				isDragging && 'border-primary bg-primary/5',

--- a/src/lib/components/forms/ImageUploader.svelte
+++ b/src/lib/components/forms/ImageUploader.svelte
@@ -325,7 +325,7 @@
 			aria-label={m['imageUploader.uploadImage']()}
 			aria-describedby={error ? `${inputId}-error` : `${inputId}-hint`}
 			class={cn(
-				'flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-all',
+				'flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors',
 				'hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-800/50',
 				'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
 				isDragging && 'border-primary bg-primary/5',

--- a/src/lib/components/forms/MarkdownEditor.svelte
+++ b/src/lib/components/forms/MarkdownEditor.svelte
@@ -234,7 +234,7 @@
 		{#if sourceMode && editor}
 			<button
 				type="button"
-				class="text-sm text-muted-foreground underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+				class="text-sm text-muted-foreground underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
 				onclick={exitSource}
 			>
 				{m['markdownEditor.exitSource']()}

--- a/src/lib/components/forms/editor/EditorToolbar.svelte
+++ b/src/lib/components/forms/editor/EditorToolbar.svelte
@@ -188,7 +188,7 @@
 			title={cmd.label}
 			onclick={cmd.run}
 			onfocus={() => (focusIndex = i)}
-			class="rounded p-1.5 transition-colors hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 aria-pressed:bg-primary/15 dark:hover:bg-gray-700"
+			class="rounded p-1.5 transition-colors hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 aria-pressed:bg-primary/15 dark:hover:bg-gray-700"
 		>
 			<cmd.icon class="h-4 w-4" aria-hidden="true" />
 		</button>
@@ -202,7 +202,7 @@
 		title={m['markdownEditor.insertLink']()}
 		onclick={onInsertLink}
 		onfocus={() => (focusIndex = linkIndex)}
-		class="rounded p-1.5 hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 dark:hover:bg-gray-700"
+		class="rounded p-1.5 hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 dark:hover:bg-gray-700"
 	>
 		<LinkIcon class="h-4 w-4" aria-hidden="true" />
 	</button>
@@ -215,7 +215,7 @@
 		title={m['markdownEditor.viewSource']()}
 		onclick={onToggleSource}
 		onfocus={() => (focusIndex = sourceIndex)}
-		class="ml-auto rounded p-1.5 hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 dark:hover:bg-gray-700"
+		class="ml-auto rounded p-1.5 hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 dark:hover:bg-gray-700"
 	>
 		<SquareCode class="h-4 w-4" aria-hidden="true" />
 	</button>

--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -334,7 +334,11 @@
 	class={cn(
 		// The item is a Card, so it already carries the 2px edge + `shadow-poster`
 		// (uplift); hover grows that float rather than swapping in shadow-md.
-		'group cursor-pointer overflow-hidden transition-all hover:shadow-poster-lg',
+		// The card is `role="button" tabindex="0"` with no focus utilities of its
+		// own, so its focus indicator is the global outline floor in app.css.
+		// `transition-shadow` (was `transition-all`) keeps the float animating
+		// while leaving that outline instant — `all` would have faded it in.
+		'group cursor-pointer overflow-hidden transition-shadow hover:shadow-poster-lg',
 		!isRead && 'border-l-4 border-l-primary bg-primary/5',
 		// bg-highlight/20 mirrors ToneTile's audited warning tokens (hand-verified
 		// 12.6:1 light / 6.7:1 dark — see ToneTile.svelte).

--- a/src/lib/components/notifications/NotificationList.svelte
+++ b/src/lib/components/notifications/NotificationList.svelte
@@ -150,7 +150,7 @@
 					size="sm"
 					onclick={handleFilterToggle}
 					aria-pressed={unreadOnly}
-					class="text-xs transition-all {unreadOnly
+					class="text-xs transition-colors {unreadOnly
 						? 'bg-primary text-primary-foreground hover:bg-primary/90'
 						: 'hover:bg-accent hover:text-accent-foreground'}"
 				>

--- a/src/lib/components/organizations/OrganizationCard.svelte
+++ b/src/lib/components/organizations/OrganizationCard.svelte
@@ -61,9 +61,13 @@
 	// Container classes based on variant
 	const containerClasses = $derived(
 		cn(
-			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-all',
+			'group relative overflow-hidden rounded-lg border-2 bg-card shadow-poster transition-transform',
 			// Same silhouette and lift on all three discovery cards (event / series /
 			// organization) — see EventCard for why it is spelled out by hand.
+			// `transition-transform`, not `transition-all`: the ring below is a
+			// box-shadow, and transitioning box-shadow would fade it in on focus.
+			// Scoping to transform keeps the hover lift and makes the ring instant
+			// (the shadow swap snaps, which is imperceptible next to the lift).
 			'hover:-translate-y-1 hover:shadow-poster-lg focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
 			variant === 'compact' && 'flex flex-row md:flex-col',
 			variant === 'standard' && 'flex flex-col',

--- a/src/lib/components/questionnaires/FileUploadQuestion.svelte
+++ b/src/lib/components/questionnaires/FileUploadQuestion.svelte
@@ -386,7 +386,7 @@
 				ondrop={handleDrop}
 				aria-label={m['fileUploadQuestion.uploadFile']()}
 				class={cn(
-					'flex flex-1 cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-4 transition-all',
+					'flex flex-1 cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-4 transition-colors',
 					'hover:border-primary hover:bg-muted/50',
 					'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
 					isDragging && 'border-primary bg-primary/5',

--- a/src/lib/components/resources/ResourceForm.svelte
+++ b/src/lib/components/resources/ResourceForm.svelte
@@ -156,7 +156,7 @@
 					type="button"
 					onclick={() => handleTypeChange('file')}
 					class={cn(
-						'flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+						'flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 						resourceType === 'file'
 							? 'border-primary bg-primary/5 text-primary'
 							: 'border-border hover:border-primary/50'
@@ -171,7 +171,7 @@
 					type="button"
 					onclick={() => handleTypeChange('link')}
 					class={cn(
-						'flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+						'flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 						resourceType === 'link'
 							? 'border-primary bg-primary/5 text-primary'
 							: 'border-border hover:border-primary/50'
@@ -186,7 +186,7 @@
 					type="button"
 					onclick={() => handleTypeChange('text')}
 					class={cn(
-						'flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+						'flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 						resourceType === 'text'
 							? 'border-primary bg-primary/5 text-primary'
 							: 'border-border hover:border-primary/50'

--- a/src/lib/components/tickets/SeatSelector.svelte
+++ b/src/lib/components/tickets/SeatSelector.svelte
@@ -110,7 +110,7 @@
 	 */
 	const seatButtonClass =
 		'relative flex h-9 w-9 flex-col items-center justify-center rounded-full text-[11px] font-extrabold ' +
-		'transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ' +
+		'transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ' +
 		'focus-visible:outline-poster-amber [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11';
 
 	/**

--- a/src/lib/components/ui/tabs/tabs-trigger.svelte
+++ b/src/lib/components/ui/tabs/tabs-trigger.svelte
@@ -12,7 +12,7 @@
 <TabsPrimitive.Trigger
 	bind:ref
 	class={cn(
-		'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+		'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/venues/SeatGrid.svelte
+++ b/src/lib/components/venues/SeatGrid.svelte
@@ -236,7 +236,7 @@
 		const inRect = isInSelectionRect(row, col);
 
 		const base =
-			'w-10 h-10 rounded transition-all duration-75 flex items-center justify-center text-xs font-medium select-none';
+			'w-10 h-10 rounded transition-colors duration-75 flex items-center justify-center text-xs font-medium select-none';
 
 		if (isSelected) {
 			return `${base} bg-primary text-primary-foreground ring-2 ring-primary ring-offset-1`;

--- a/src/routes/(auth)/org/[slug]/admin/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/+page.svelte
@@ -252,11 +252,15 @@
 			{#each quickActions as action (action.href)}
 				{@const Icon = action.icon}
 				{@const isDisabled = !!action.badge}
+				<!-- No transition class here on purpose: the only animatable hover change
+				     is the shadow, and the focus ring is itself a box-shadow — any
+				     transition covering it would fade the ring in instead of showing it
+				     at once. The shadow swap snaps instead. -->
 				<button
 					type="button"
 					onclick={() => navigateTo(action.href, isDisabled)}
 					disabled={isDisabled}
-					class="group relative rounded-lg border border-border bg-card p-6 text-left shadow-sm transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+					class="group relative rounded-lg border border-border bg-card p-6 text-left shadow-sm hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
 				>
 					<!-- Coming Soon Badge -->
 					{#if action.badge}
@@ -382,11 +386,3 @@
 	onClose={() => (announcementModalOpen = false)}
 	onSuccess={() => (announcementModalOpen = false)}
 />
-
-<style>
-	/* Ensure consistent focus states for accessibility */
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/+page.svelte
@@ -228,11 +228,3 @@
 	organizationSlug={organization.slug}
 	onClose={() => (showNewSeriesPicker = false)}
 />
-
-<style>
-	/* Ensure consistent focus states for accessibility */
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/event-series/[series_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/[series_id]/+page.svelte
@@ -474,10 +474,3 @@
 		onClose={() => (showPublishOccurrence = false)}
 	/>
 {/if}
-
-<style>
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/event-series/new-recurring/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/new-recurring/+page.svelte
@@ -53,10 +53,3 @@
 		questionnaires={data.questionnaires}
 	/>
 </div>
-
-<style>
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/event-series/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/event-series/new/+page.svelte
@@ -175,11 +175,3 @@
 		</div>
 	</form>
 </div>
-
-<style>
-	/* Ensure consistent focus states for accessibility */
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/+page.svelte
@@ -504,11 +504,3 @@
 {#if cancelEventId}
 	<CancelEventDialog bind:open={showCancelEventDialog} eventId={cancelEventId} />
 {/if}
-
-<style>
-	/* Ensure consistent focus states for accessibility */
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/edit/+page.svelte
@@ -409,11 +409,3 @@
 
 <!-- Cancel Event Dialog -->
 <CancelEventDialog bind:open={showCancelEventDialog} eventId={event.id} />
-
-<style>
-	/* Ensure consistent focus states for accessibility */
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/events/[event_id]/waitlist/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/[event_id]/waitlist/+page.svelte
@@ -458,10 +458,3 @@
 	isPending={expiryDialogIsPending}
 	onConfirm={handleExpiryDialogConfirm}
 />
-
-<style>
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/events/new/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/events/new/+page.svelte
@@ -39,11 +39,3 @@
 		/>
 	</div>
 </div>
-
-<style>
-	/* Ensure consistent focus states for accessibility */
-	:global(button:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
@@ -701,12 +701,3 @@
 	bind:open={showEmailModal}
 	onClose={() => (showEmailModal = false)}
 />
-
-<style>
-	/* Ensure consistent focus states for accessibility */
-	:global(button:focus-visible),
-	:global(a:focus-visible) {
-		outline: 2px solid hsl(var(--ring));
-		outline-offset: 2px;
-	}
-</style>

--- a/src/routes/(public)/events/+page.svelte
+++ b/src/routes/(public)/events/+page.svelte
@@ -442,7 +442,7 @@
 	<button
 		type="button"
 		onclick={handleOpenMobileFilters}
-		class="fixed bottom-6 right-6 z-30 flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-lg transition-all hover:bg-primary/90 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:hidden"
+		class="fixed bottom-6 right-6 z-30 flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-lg transition-colors hover:bg-primary/90 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:hidden"
 		aria-label={m['common.filters_openFilters']()}
 	>
 		<Filter class="h-4 w-4" aria-hidden="true" />

--- a/src/routes/(public)/organizations/+page.svelte
+++ b/src/routes/(public)/organizations/+page.svelte
@@ -283,7 +283,7 @@
 	<button
 		type="button"
 		onclick={handleOpenMobileFilters}
-		class="fixed bottom-6 right-6 z-30 flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-lg transition-all hover:bg-primary/90 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:hidden"
+		class="fixed bottom-6 right-6 z-30 flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-lg transition-colors hover:bg-primary/90 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:hidden"
 		aria-label={m['common.filters_openFilters']()}
 	>
 		<Filter class="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
Closes #780.

## The floor

One zero-specificity rule in `@layer base`: `:where(:focus-visible)` gets a 2px `--ring` outline. Any element styling its own focus wins outright (every utility outranks specificity 0); anything with nothing gets a token-driven, AA-clearing ring (≥ 4.12:1 against every theme surface, worst case `--secondary`). Outline-based deliberately: it never collides with `shadow-poster` or ring-based selection states.

The differential is real, not assumed: with the rule commented out, **184 of 352 public-page tab stops** fall back to the UA ring that unconditional `outline` utilities silently kill. With it: **822 unique tab stops across both themes, zero without a visible indicator** — probed by a classifier that distinguishes token-outline / UA-auto / ring / none (a naive "is something there" probe was proven vacuously green first).

## What else it flushed out

- **Eleven redundant local `:global(button:focus-visible)` blocks removed** — ten were live double-ring bugs (their 0,1,1 specificity beat the utilities on every admin page that mounted them).
- **Four genuine double-rings fixed** (MarkdownEditor + its EditorToolbar ×3 — the toolbar trio was a review catch after the initial sweep was truncated by a `head -60`).
- **`transition-all` scoped on 22 focusable sites** so the focus ring never fades — the replacement property is chosen per ring mechanism (a box-shadow ring must exclude `box-shadow`; sites relying on the outline floor may keep `transition-shadow`), each non-obvious call documented inline.
- Structural guard test (4 assertions, each canary-proven able to fail — including brace-matched `@layer` membership and comment-blanking that survives backticked class names in prose).

Poster-panel shadcn Buttons keep their composite indicator (4.88:1/3.33:1 today) — a dedicated treatment is #796; app.css documents the exception honestly.

Review: independent opus review APPROVE WITH CHANGES → fix round → scoped re-review **ALL ADDRESSED** (the reviewer also performed the real merge against the destructive-token branch: zero conflicts, guard green on the merged tree — and this PR is rebased onto it, all gates re-run green).

`make check` green · vitest 2549 passed · brand audit 0 · `tests/e2e/**` and `messages/*.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>