### PR TITLE
fix(rebrand): create-org pull-up opacity + script-sourced contrast comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Landing page redesigned as a full-bleed color-block poster: brand-gradient hero with a rotating headline noun, amber pricing panel with direct fee comparison, dedicated panels for communities and for venues/theaters (premium seating), ticket-stub feature stubs, and an open-source panel. Replaces the card-grid landing page.
 
+### Fixed
+
+- On **Create organization**, the "you already own an organization" and "verify your email" notices no longer let the periwinkle header band bleed through their top edge — both now sit on an opaque card like the creation form does.
+
 ## [2.2.0] - 2026-08-03
 
 ### Added

--- a/scripts/audit-brand-themes.py
+++ b/scripts/audit-brand-themes.py
@@ -127,6 +127,7 @@ TEXT_PAIRS = [  # (fg, bg, min_ratio, note)
     ("primary-foreground", "primary", 4.5, "primary button label"),
     ("secondary-foreground", "secondary", 4.5, "secondary button label"),
     ("muted-foreground", "muted", 4.5, "muted text on muted bg"),
+    ("foreground", "muted", 4.5, "MarkdownEditor toolbar icons on the muted strip"),
     ("muted-foreground", "background", 4.5, "muted text on page"),
     ("muted-foreground", "card", 4.5, "muted text on card"),
     ("accent-foreground", "accent", 4.5, "accent label"),
@@ -223,6 +224,7 @@ COMPOSITED_PAIRS = [
     ("foreground", 1, "destructive", 0.20, "card", 4.5, BOTH, "DietarySummary allergen cell"),
     ("foreground", 1, "destructive", 0.10, "card", 4.5, BOTH, "DietarySummary restriction cell"),
     ("foreground", 1, "highlight", 0.10, "card", 4.5, BOTH, "DietarySummary / EventActionSidebar note"),
+    ("foreground", 1, "highlight", 0.20, "card", 4.5, BOTH, "create-org already-owner notice body"),
     ("highlight-foreground", 1, "highlight", 0.10, "card", 4.5, ("light",), "EventDetails highlight cell"),
     ("highlight", 1, "highlight", 0.10, "card", 4.5, ("dark",), "EventDetails highlight cell"),
     # Selected-option fills: the label stays --foreground, the BORDER carries the

--- a/src/lib/components/common/EmptyState.svelte
+++ b/src/lib/components/common/EmptyState.svelte
@@ -23,8 +23,8 @@
 		 *
 		 * Level 1 introduces NO new colour pair — it only changes size and
 		 * spacing, so every ratio is the one levels 2/3 already ship: title
-		 * (foreground on card) 17.46:1 light / 15.69:1 dark, body
-		 * (muted-foreground on card) 9.06:1 / 7.44:1, and the chip pairs listed
+		 * (foreground on card) 17.40:1 light / 15.64:1 dark, body
+		 * (muted-foreground on card) 9.05:1 / 7.41:1, and the chip pairs listed
 		 * below. Only the body's SIZE moves, 14px → 16px, which loosens the
 		 * requirement rather than tightening it.
 		 *

--- a/src/lib/components/forms/MarkdownEditor.svelte
+++ b/src/lib/components/forms/MarkdownEditor.svelte
@@ -203,7 +203,7 @@
 			class={cn(
 				'markdown-editor-surface prose prose-sm max-w-none rounded-md border-2 px-3 py-2 dark:prose-invert',
 				'focus-within:border-primary focus-within:ring-2 focus-within:ring-primary',
-				error ? 'border-destructive' : 'border-gray-300 dark:border-gray-600',
+				error ? 'border-destructive' : 'border-border',
 				disabled && 'cursor-not-allowed opacity-50'
 			)}
 			class:hidden={!editor || sourceMode}

--- a/src/lib/components/forms/editor/EditorToolbar.svelte
+++ b/src/lib/components/forms/editor/EditorToolbar.svelte
@@ -176,7 +176,7 @@
 	tabindex="-1"
 	bind:this={toolbarEl}
 	onkeydown={onKeydown}
-	class="flex flex-wrap items-center gap-1 rounded-md border border-gray-300 bg-gray-50 p-1.5 dark:border-gray-600 dark:bg-gray-800"
+	class="flex flex-wrap items-center gap-1 rounded-md border border-border bg-muted p-1.5"
 >
 	{#each commands as cmd, i (cmd.key)}
 		<button
@@ -188,7 +188,7 @@
 			title={cmd.label}
 			onclick={cmd.run}
 			onfocus={() => (focusIndex = i)}
-			class="rounded p-1.5 transition-colors hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 aria-pressed:bg-primary/15 dark:hover:bg-gray-700"
+			class="rounded p-1.5 transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 aria-pressed:bg-primary/15"
 		>
 			<cmd.icon class="h-4 w-4" aria-hidden="true" />
 		</button>
@@ -202,7 +202,7 @@
 		title={m['markdownEditor.insertLink']()}
 		onclick={onInsertLink}
 		onfocus={() => (focusIndex = linkIndex)}
-		class="rounded p-1.5 hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 dark:hover:bg-gray-700"
+		class="rounded p-1.5 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50"
 	>
 		<LinkIcon class="h-4 w-4" aria-hidden="true" />
 	</button>
@@ -215,7 +215,7 @@
 		title={m['markdownEditor.viewSource']()}
 		onclick={onToggleSource}
 		onfocus={() => (focusIndex = sourceIndex)}
-		class="ml-auto rounded p-1.5 hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50 dark:hover:bg-gray-700"
+		class="ml-auto rounded p-1.5 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50"
 	>
 		<SquareCode class="h-4 w-4" aria-hidden="true" />
 	</button>

--- a/src/lib/components/landing/LandingPageTemplate.svelte
+++ b/src/lib/components/landing/LandingPageTemplate.svelte
@@ -171,9 +171,9 @@
 	pairing: the hero is a mode-INERT poster-solid ribbon, so per the CLAUDE.md
 	rule it takes a theme-aware tinted wash below it — the same composite the
 	org-profile and event-detail pages use, so an SEO page and the product it
-	sells read as one surface. Composited alphas are invisible to
-	scripts/audit-brand-themes.py, so the honest numbers (computed, not
-	estimated):
+	sells read as one surface. The recipe IS registered in COMPOSITED_PAIRS
+	("public page secondary wash"); numbers pasted from
+	scripts/audit-brand-themes.py:
 	  light — secondary@55 over background ⇒ foreground 12.36:1 ·
 	          muted-foreground 6.43:1 · primary 4.97:1
 	  dark  — secondary@28 over background ⇒ foreground 15.68:1 ·

--- a/src/routes/(auth)/create-org/+page.svelte
+++ b/src/routes/(auth)/create-org/+page.svelte
@@ -123,9 +123,17 @@
 	<div class="container mx-auto -mt-12 max-w-2xl px-4 pb-16">
 		<!-- Check if user already owns an organization -->
 		{#if ownsOrganization}
-			<!-- Warning tint mirrors ToneTile's amber recipe (see security page). -->
-			<div class="rounded-lg border-2 border-highlight/40 bg-highlight/20 p-6 shadow-poster">
-				<div class="flex gap-3">
+			<!-- Warning tint mirrors ToneTile's amber recipe (see security page).
+			     Two layers, not one: this block is the first thing the -mt-12
+			     pull-up lands on, so the outer shell must be OPAQUE (pull-up
+			     opacity rule) or the band bleeds through its top 3rem and takes
+			     the composite under the copy with it. `bg-card` is that shell;
+			     the tint rides inside it, so the audited recipe is
+			     "highlight/20 over card" (already registered) rather than
+			     "over background". Inner radius is `rounded-md` =
+			     calc(--radius - 2px), concentric with the 2px border. -->
+			<div class="rounded-lg border-2 border-highlight/40 bg-card shadow-poster">
+				<div class="flex gap-3 rounded-md bg-highlight/20 p-6">
 					<AlertCircle
 						class="h-5 w-5 flex-shrink-0 text-highlight-foreground dark:text-highlight"
 						aria-hidden="true"
@@ -154,9 +162,12 @@
 		     --foreground (danger-framing rule: meaning is never color-only).
 		     `text-destructive` would now be safe here too — 6.05:1 in dark since
 		     the token split (#781), against 2.68:1 before it — but the framing
-		     rule stands on its own. -->
-			<div class="rounded-lg border-2 border-destructive/40 bg-destructive/10 p-6 shadow-poster">
-				<div class="flex gap-3">
+		     rule stands on its own.
+		     Same two-layer shell as the branch above: opaque `bg-card` outer so
+		     the -mt-12 pull-up never lands on a translucent block, tint inside,
+		     giving the already-registered "destructive/10 over card" recipe. -->
+			<div class="rounded-lg border-2 border-destructive/40 bg-card shadow-poster">
+				<div class="flex gap-3 rounded-md bg-destructive/10 p-6">
 					<AlertCircle class="h-5 w-5 flex-shrink-0 text-destructive" aria-hidden="true" />
 					<div>
 						<h3 class="font-bold text-foreground">

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -348,13 +348,14 @@
 		Tinted content panel (uplift prototype). The page body is no longer bare
 		`--background`: it is a periwinkle wash, so every card below reads as a
 		white sticker FLOATING on a colored surface rather than a rectangle on
-		paper. Composited alphas are invisible to scripts/audit-brand-themes.py,
-		so every text layer that lands directly on this panel (never inside a
-		card) is hand-verified against the composited colour:
+		paper. Every text layer that lands directly on this panel (never inside a
+		card) is covered by the "public page secondary wash" rows in
+		COMPOSITED_PAIRS, so these figures are pasted from
+		scripts/audit-brand-themes.py — never hand-computed:
 		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
-		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		          foreground 12.36:1 · muted-foreground 6.43:1 · primary 4.97:1
 		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
-		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		          foreground 15.68:1 · muted-foreground 7.44:1 · primary 6.30:1
 		(`primary` is the SectionHeader kicker; `foreground` the section headings.)
 	-->
 	<div class="bg-secondary/55 pt-8 dark:bg-secondary/[0.28]">

--- a/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/series/[series_slug]/+page.svelte
@@ -88,9 +88,9 @@
 		landing hero's mark-and-hearts chip — pinned to the far end.
 
 		Ribbon, strip and chip are mode-INERT by the imagery rule (a poster panel
-		is not a surface), so every pair on them is hand-verified against the
-		fixed values; a poster-palette pair is invisible to
-		scripts/audit-brand-themes.py (numbers are the audit script's own):
+		is not a surface), so every pair on them is measured against the fixed
+		values rather than per-mode. All three are registered in
+		scripts/audit-brand-themes.py; numbers pasted from its output:
 		  ink on white                   → 17.40:1
 		  Hearty Purple #8C3CDD on white →  5.52:1 (the text-xs kicker clears AA)
 		  white on crimson-DEEP          →  4.59:1 (the logo-less initial tile)
@@ -154,12 +154,13 @@
 	<!--
 		Tinted content panel — the event detail page's wash, so a series and the
 		events it contains read as the same surface. Composite and therefore
-		ratios are identical to that page's (a composited alpha is invisible to
-		scripts/audit-brand-themes.py):
+		ratios are identical to that page's. The recipe IS registered in
+		COMPOSITED_PAIRS ("public page secondary wash"), so these figures are
+		pasted from scripts/audit-brand-themes.py — never hand-computed:
 		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
-		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		          foreground 12.36:1 · muted-foreground 6.43:1 · primary 4.97:1
 		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
-		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		          foreground 15.68:1 · muted-foreground 7.44:1 · primary 6.30:1
 		Everything landing directly on it is covered: the h1 and section headings
 		(`foreground`), the back link, tallies and blurbs (`muted-foreground`),
 		and the SectionHeader kickers plus the org link (`primary`).

--- a/src/routes/(public)/org/[slug]/+page.svelte
+++ b/src/routes/(public)/org/[slug]/+page.svelte
@@ -203,9 +203,9 @@
 
 		Ribbon and sticker are mode-INERT by the imagery rule (a poster panel is
 		not a surface). No copy sits on the purple itself — the only text here is
-		the initial tile's letter, hand-verified against the fixed values because
-		a poster-palette pair is invisible to scripts/audit-brand-themes.py
-		(number is the audit script's own):
+		the initial tile's letter, measured against the fixed values rather than
+		per-mode. The pair is registered in scripts/audit-brand-themes.py;
+		number pasted from its output:
 		  white on crimson-DEEP →  4.59:1
 		The initial tile's gradient ends on `crimson-deep`, not raw
 		`poster-crimson`: white on raw Light Crimson is 4.33:1, which fails AA
@@ -240,12 +240,13 @@
 	<!--
 		Tinted content panel — the event detail page's wash, so an org profile and
 		the events it lists read as the same surface. Composite and therefore
-		ratios are identical to that page's (a composited alpha is invisible to
-		scripts/audit-brand-themes.py):
+		ratios are identical to that page's. The recipe IS registered in
+		COMPOSITED_PAIRS ("public page secondary wash"), so these figures are
+		pasted from scripts/audit-brand-themes.py — never hand-computed:
 		  light — secondary@55 over background ⇒ hsl(231 88% 90%);
-		          foreground 12.42:1 · muted-foreground 6.45:1 · primary 4.97:1
+		          foreground 12.36:1 · muted-foreground 6.43:1 · primary 4.97:1
 		  dark  — secondary@28 over background ⇒ hsl(246 33% 15%);
-		          foreground 15.75:1 · muted-foreground 7.47:1 · primary 6.30:1
+		          foreground 15.68:1 · muted-foreground 7.44:1 · primary 6.30:1
 		Everything that lands directly on it here is covered: the h1 and section
 		headings (`foreground`), the metadata/social row and section blurbs
 		(`muted-foreground`), and the SectionHeader kickers plus the inline


### PR DESCRIPTION
Follow-up to the code review on #764, which merged before the findings landed. Addresses all three reported issues plus two of the sub-threshold ones from the same review.

### 1. Pull-up opacity rule — `create-org`

#764 gave `create-org` a `bg-secondary` band with a `-mt-12` pull-up, but two of the three branches below it opened with a **translucent** block, so the band bled through their top 3rem and took the composite under the copy with it:

- `ownsOrganization` → `bg-highlight/20`
- `!user?.email_verified` → `bg-destructive/10`

The `{:else}` form branch already did the right thing with `bg-card`. Both notices now use the same two-layer shell — an opaque `bg-card` outer carrying the border, radius and shadow, with the tint riding inside on a concentric `rounded-md` (`= calc(--radius - 2px)`, exact for the 2px border). The tint reads identically; it just composites over `--card` instead of over whatever is behind.

That shifts both recipes from "tint over background" to "tint over card". `destructive/10 over card` was already registered; the one gap, `foreground` on `highlight/0.20 over card`, is now registered too and passes at **10.14:1** light / **15.24:1** dark.

### 2. Contrast comments claiming the audit script can't see them

Six comments said a pair was *"invisible to `scripts/audit-brand-themes.py`"* and quoted hand-computed ratios. Every one of those pairs **is** registered — the wash as `"public page secondary wash"` in `COMPOSITED_PAIRS`, the poster-palette pairs in the opaque list — and two of them even said *"numbers are the audit script's own"* in the same breath. Claims corrected, figures replaced with the script's actual output:

| Pair | Was | Now (script) |
| --- | --- | --- |
| secondary wash, light (`foreground` · `muted-foreground`) | 12.42 · 6.45 | **12.36 · 6.43** |
| secondary wash, dark (`foreground` · `muted-foreground`) | 15.75 · 7.47 | **15.68 · 7.44** |
| EmptyState title (`foreground on card`) | 17.46 / 15.69 | **17.40 / 15.64** |
| EmptyState body (`muted-foreground on card`) | 9.06 / 7.44 | **9.05 / 7.41** |

`LandingPageTemplate.svelte` already carried the correct wash numbers — only its "invisible to the script" premise needed fixing.

This is the failure mode CLAUDE.md calls out by name: *"Let the script print the ratio and paste **that** into the code comment, never the reverse: hand-written ratios were wrong repeatedly during the 2026-08 rebrand (#783)."*

### 3. Raw-hue sweep — MarkdownEditor toolbar

The toolbar kept `bg-gray-50` / `hover:bg-gray-200` / `border-gray-300` and their `dark:` variants on the exact lines #798 had already touched. Swept to `bg-muted` / `hover:bg-background` / `border-border`, plus the editor surface's border on the sibling component.

Note: **not** `hover:bg-accent` — `--accent` is crimson (the "heart" pop) in this theme, so the shadcn ghost-button idiom would have turned the toolbar red on hover. Registered `foreground` on `muted` for the toolbar icons: **13.96:1 / 13.81:1**.

### Not addressed (deliberately)

The review's two lowest-confidence findings — the `destructive-text`-on-`secondary` note in `app.css:135` and the `4.12:1 / 4.60:1` figure in `PageHeader.svelte` — are **opaque** pairs, and CLAUDE.md's registration rule binds translucent recipes only. Both are numerically fine today and neither pair is ever actually rendered (`PageHeader`'s `onBand` exists precisely to avoid it). Registering them properly is a reasonable tidy-up but wants its own change.

### Verification

- `python3 scripts/audit-brand-themes.py` — **0 WCAG failures, 0 colorblind confusables**
- `make check` — **0 errors**, type gate armed, i18n clean, file lengths clean, no SSR token leaks, image-alt clean
- `make test` — **221 files, 2573 passed**, 1 todo

E2E not run; no copy or selector changes in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the “already own an organization” and “verify your email” notices so their backgrounds remain opaque and the header no longer shows through.
  - Improved theme-aware borders, colors, and hover states in the Markdown editor and toolbar.
  - Updated contrast handling across notices and content panels for clearer, more accessible text and surfaces.

- **Documentation**
  - Updated accessibility contrast references and audit documentation for key interface components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->