### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-08-05
+
 ### Changed
 
 - Landing page redesigned as a full-bleed color-block poster: brand-gradient hero with a rotating headline noun, amber pricing panel with direct fee comparison, dedicated panels for communities and for venues/theaters (premium seating), ticket-stub feature stubs, and an open-source panel. Replaces the card-grid landing page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## [2.3.0] - 2026-08-05

### Changed

- Landing page redesigned as a full-bleed color-block poster: brand-gradient hero with a rotating headline noun, amber pricing panel with direct fee comparison, dedicated panels for communities and for venues/theaters (premium seating), ticket-stub feature stubs, and an open-source panel. Replaces the card-grid landing page.

### Fixed

- On **Create organization**, the "you already own an organization" and "verify your email" notices no longer let the periwinkle header band bleed through their top edge — both now sit on an opaque card like the creation form does.

