### PR TITLE
fix(rebrand): drop LogoChip hearts and event-page duplicate logo

### DIFF
--- a/src/lib/components/brand/LogoChip.svelte
+++ b/src/lib/components/brand/LogoChip.svelte
@@ -44,7 +44,5 @@
 		style="transform: rotate({clamped}deg)"
 	>
 		<img {src} alt="" class="h-12 w-12 rounded-[14px] object-cover" />
-		<span class="absolute -left-3 -top-2 text-xl">❤️</span>
-		<span class="absolute -bottom-1.5 -right-2 text-sm">❤️</span>
 	</div>
 {/if}

--- a/src/lib/components/events/EventHeader.svelte
+++ b/src/lib/components/events/EventHeader.svelte
@@ -9,7 +9,6 @@
 	import { MapPin, Calendar, Share2, ExternalLink } from '@lucide/svelte';
 	import { cn } from '$lib/utils/cn';
 	import { toast } from 'svelte-sonner';
-	import LogoChip from '$lib/components/brand/LogoChip.svelte';
 
 	interface Props {
 		event: EventDetailSchema;
@@ -224,20 +223,6 @@
 					</span>
 				</div>
 			</a>
-			<!-- Positioning lives on the wrapper: LogoChip owns its own `transform`
-			     (the tilt), so a translate utility on the chip itself would be
-			     overwritten. Anchored to the ribbon's BOTTOM so the chip grows
-			     UPWARD over the cover — a sticker straddling the cut — instead of
-			     past the header's `overflow-hidden` bottom edge. Renders nothing
-			     for a logo-less org (sticker-chip rule) — the strip's initial
-			     tile is the only identity mark then, which is the point. -->
-			<div class="absolute bottom-3 right-8 hidden md:block">
-				<LogoChip
-					rotate={-8}
-					logo={event.organization.logo}
-					logoThumbnail={event.organization.logo_thumbnail_url}
-				/>
-			</div>
 		</div>
 	</div>
 </header>


### PR DESCRIPTION
## Summary

Two small visual cleanups to the rebrand's `LogoChip` sticker:

- **Remove the two ❤️ emoji** that wrapped organization logos in `brand/LogoChip.svelte`. The chip is shared, so the hearts disappear from every surface that renders it (join pages, series page, questionnaire bands).
- **Drop the extra tilted `LogoChip`** from the event page header ribbon (`events/EventHeader.svelte`). The "organized by" white sticker already shows the organization's logo there, so the second chip was a duplicate identity mark.

No behavior change otherwise — the sticker-chip rule (render nothing for a logo-less org), rotation clamp, and decorative `aria-hidden`/empty-`alt` semantics are untouched, and the existing `LogoChip` unit tests pass unchanged.

## Test plan

- [x] `make check` green (format, lint, types + armed canary, i18n, file-length, SSR-token, image-alt)
- [ ] Visual spot-check: event page, `/join/org/[token]`, series page, questionnaire bands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDXmzqVQzDQTBwT98KL9Wf