### PR TITLE
fix(membership): remove the Stripe-return 303 hop from the org landing page

### DIFF
--- a/src/routes/(public)/org/[slug]/+page.server.ts
+++ b/src/routes/(public)/org/[slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { error, isHttpError, redirect } from '@sveltejs/kit';
+import { error, isHttpError } from '@sveltejs/kit';
 import { buildSeo } from '$lib/seo';
 import { resolveLang } from '$lib/seo/server';
 import {
@@ -21,20 +21,6 @@ import { canPerformAction } from '$lib/utils/permissions';
 
 export const load: PageServerLoad = async ({ params, locals, fetch, url, request }) => {
 	const { slug } = params;
-
-	// Stripe hands the member back to this URL — the success/cancel URLs are built
-	// server-side by the BACKEND (`subscription_stripe_service.py`, `/org/{slug}?
-	// membership_success=true`), so the frontend cannot re-point them. The card
-	// that explains the outcome now lives on the membership page, so forward the
-	// flag there. Outside the try below: a `redirect` is not an `HttpError`, and
-	// the catch would swallow it into a 500.
-	const isCheckoutReturn =
-		url.searchParams.has('membership_success') || url.searchParams.has('membership_cancelled');
-	if (isCheckoutReturn) {
-		// The whole query string travels: `?ot=` may be riding along on a private
-		// org, and the membership page reads it the same way this one does.
-		throw redirect(303, `/org/${encodeURIComponent(slug)}/membership${url.search}`);
-	}
 
 	try {
 		// Prepare headers with authentication if user is logged in

--- a/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
@@ -16,17 +16,14 @@ import { completeStripeCheckout } from '../../support/stripe';
 // the membership page, where CheckoutReturnCard polls until the `stripe listen`
 // webhook flips the subscription ACTIVE.
 //
-// MUST-COVER here and nowhere else, TWO server-side hops jsdom cannot exercise:
-//   * Stripe's return URLs are built by the BACKEND. Once backend #849
-//     deploys, they carry the org UUID
-//     (`/org/{org_uuid}/membership?membership_success=true`), and the
-//     `[org_id=uuid]` route resolves it and 303-redirects to
-//     `/org/{slug}/membership` (#756). Pre-#849 sessions — which today means
-//     ALL of them — carry the old slug LANDING-page URL
-//     (`/org/{slug}?membership_success=true`), which the landing page's own
-//     load 303-redirects the flag on from (#720/#726) — both hops land on the
-//     same membership page. This spec drives the real backend-built URL, so
-//     it is the only proof either hop happens.
+// MUST-COVER here and nowhere else, ONE server-side hop jsdom cannot exercise:
+//   * Stripe's return URLs are built by the BACKEND and carry the org UUID
+//     (`/org/{org_uuid}/membership?membership_success=true`, backend #849);
+//     the `[org_id=uuid]` route resolves it and 303-redirects to
+//     `/org/{slug}/membership` (#756). This spec drives the real
+//     backend-built URL, so it is the only proof the hop happens. (The old
+//     slug LANDING-page forward for pre-#849 sessions was removed in #745 —
+//     those sessions expired within a day of the backend deploy.)
 //   * the flag is then consumed in onMount with the RAW history API (see
 //     MembershipSection — $app/navigation's replaceState throws during
 //     hydration).
@@ -41,7 +38,7 @@ import { completeStripeCheckout } from '../../support/stripe';
 // backend refuses a second non-terminal subscription per user per org).
 
 const ORG_SLUG = 'revel-events-collective';
-/** The org landing page (backend-owned redirect target for pre-#849 sessions). */
+/** The org landing page (keeps the inline membership card). */
 const ORG_PATH = `/org/${ORG_SLUG}`;
 /** Where the plans live, and where the checkout return actually lands. */
 const MEMBERSHIP_PATH = membershipPath(ORG_SLUG);
@@ -126,12 +123,10 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await expect(welcome).toBeVisible({ timeout: 120_000 });
 		await expect(page.getByText('Your subscription is active.')).toBeVisible();
 
-		// MUST-COVER, both hops at once: Stripe returned to whichever URL this
-		// session was minted for — post-#849 the org-UUID membership route, or
-		// pre-#849 the slug LANDING page forwarded by its own load (#726/#756) —
-		// the server load resolved it to the canonical membership page, and the
-		// flag was then consumed in onMount via the raw history API — so a
-		// reload or a back-navigation cannot replay the card.
+		// MUST-COVER: Stripe returned to the backend-built org-UUID membership
+		// URL, the `[org_id=uuid]` route resolved it to the canonical membership
+		// page (#756), and the flag was then consumed in onMount via the raw
+		// history API — so a reload or a back-navigation cannot replay the card.
 		await expect(page).toHaveURL(new RegExp(`${MEMBERSHIP_PATH}(?:$|[?#])`));
 		expect(page.url()).not.toContain('membership_success');
 
@@ -232,14 +227,14 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await expect(inlineCard.getByText('Awaiting first payment')).toBeVisible();
 
 		// Abandon: walk away from the hosted page instead of paying, simulating
-		// the cancel URL as the slug LANDING page (still what pre-#849 Stripe
-		// sessions carry) rather than actually driving Stripe's cancel action.
+		// the cancel return rather than actually driving Stripe's cancel action.
 		// The PENDING subscription (and its open Checkout session) survives.
-		// That URL's own load 303-forwards the flag to the membership page where
-		// the card that reads it now lives (#726). Post-#849 sessions instead
-		// carry `/org/{org_uuid}/membership?membership_cancelled=true`, which the
-		// `[org_id=uuid]` route resolves to the same membership page (#756).
-		await gotoHydrated(page, `${ORG_PATH}?membership_cancelled=true`);
+		// The backend-built cancel URL carries the org UUID
+		// (`/org/{org_uuid}/membership?membership_cancelled=true`); the
+		// `[org_id=uuid]` hop it rides through is already proven by the success
+		// leg above, so this leg lands on the canonical path directly — what's
+		// under test here is the cancelled-card flow the flag switches on.
+		await gotoHydrated(page, `${MEMBERSHIP_PATH}?membership_cancelled=true`);
 		await expect(page).toHaveURL(new RegExp(`${MEMBERSHIP_PATH}(?:$|[?#])`));
 		await expect(page.getByRole('heading', { name: 'Checkout not completed' })).toBeVisible({
 			timeout: 20_000


### PR DESCRIPTION
Closes #745

## Why now

The issue's precondition is satisfied, verified against production:

- BE #838 (membership-route return URLs) merged 2026-07-31; BE #849 (org-UUID return URLs) merged 2026-08-03 20:43 UTC.
- The prod backend image was built 2026-08-03 22:12 UTC and `infra-web-2` has been running it since — well past the ~24h Stripe Checkout session lifetime, so no live session carries the old slug landing-page URL.

## Changes

- **`src/routes/(public)/org/[slug]/+page.server.ts`** — remove the `membership_success`/`membership_cancelled` 303 forward and its explanatory comment; drop the now-unused `redirect` import. The `?ot=` handling and everything else in the load is untouched.
- **`tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts`** — the abandon leg deliberately navigated to `${ORG_PATH}?membership_cancelled=true` to exercise the hop; it now lands on the canonical `${MEMBERSHIP_PATH}` directly. Header, `ORG_PATH` doc, and success-leg comments updated: the one surviving server-side hop is the `[org_id=uuid]` resolution (#756), still proven by the success leg which drives the real backend-built return URL. The flag-stripped assertions hold unchanged.

## Verification

- `make check` green (0 errors, warnings are the pre-existing baseline).
- `playwright test --list` compiles the spec — 4 tests listed (the e2e type-compile gap noted in #644 triage).
- Prod deploy state confirmed via the running container + image build dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDXmzqVQzDQTBwT98KL9Wf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription checkout return and cancellation handling.
  * Successful checkouts now resolve to the organization’s canonical membership page and display the appropriate success state.
  * Abandoned checkouts now return directly to the membership page with the cancellation status preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->