### PR TITLE
fix(a11y): poster-band focus recipe for shadcn Buttons on the SEO landing pages

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -231,8 +231,10 @@
 	 * hand-written outlines (amber on ink, ink on amber, ...), and for shadcn
 	 * Buttons the recipe in `LandingPageTemplate.svelte`'s `ctaButtonClass`
 	 * (#796): recolor BOTH halves of the Button base's composite —
-	 * `focus-visible:ring-poster-white` for the ring, `ring-offset-<band color>`
-	 * for the offset gap — so the indicator stays on the band's audited pair
+	 * `focus-visible:ring-poster-white` for the ring,
+	 * `focus-visible:ring-offset-<band color>` for the offset gap (scoped like
+	 * EventHeader's, winning over the base's unscoped `ring-offset-background`
+	 * by variant specificity) — so the indicator stays on the band's audited pair
 	 * instead of a theme-colored halo on a mode-inert panel. Any new poster-band
 	 * Button adopter needs the same pair for its own band color. Do not read
 	 * this rule as a guarantee for poster surfaces.

--- a/src/app.css
+++ b/src/app.css
@@ -225,17 +225,17 @@
 	 * WCAG 2.1 AA wants 3:1 for non-text UI, so every theme surface clears it.
 	 *
 	 * The fixed poster panels are the one place `--ring` does NOT clear it: a
-	 * purple ring on a purple panel is 1.27:1 light / 2.07:1 dark. Most
-	 * focusables that sit on a poster panel therefore declare their own explicit
-	 * focus outline (amber on ink, ink on amber, ...) and override this rule via
-	 * mechanism 1 — but NOT all of them. `LandingPageTemplate.svelte` (the SEO
-	 * landing pages) renders plain shadcn Buttons on poster panels, which keep
-	 * the Button base's `--ring` ring. Those are not invisible, because the same
-	 * base adds a `ring-offset-background` band between button and ring, and
-	 * that band measures 4.88:1 light / 3.33:1 dark against poster-purple — so
-	 * the COMPOSITE indicator clears 3:1 in both modes today. It is off-brand
-	 * rather than non-compliant; issue #796 tracks a proper poster-panel focus
-	 * treatment. Do not read this rule as a guarantee for poster surfaces.
+	 * purple ring on a purple panel is 1.27:1 light / 2.07:1 dark. Every
+	 * focusable that sits on a poster panel therefore declares its own explicit
+	 * poster-palette focus treatment and overrides this rule via mechanism 1 —
+	 * hand-written outlines (amber on ink, ink on amber, ...), and for shadcn
+	 * Buttons the recipe in `LandingPageTemplate.svelte`'s `ctaButtonClass`
+	 * (#796): recolor BOTH halves of the Button base's composite —
+	 * `focus-visible:ring-poster-white` for the ring, `ring-offset-<band color>`
+	 * for the offset gap — so the indicator stays on the band's audited pair
+	 * instead of a theme-colored halo on a mode-inert panel. Any new poster-band
+	 * Button adopter needs the same pair for its own band color. Do not read
+	 * this rule as a guarantee for poster surfaces.
 	 */
 	:where(:focus-visible) {
 		outline: 2px solid hsl(var(--ring));

--- a/src/lib/components/landing/LandingPageTemplate.svelte
+++ b/src/lib/components/landing/LandingPageTemplate.svelte
@@ -124,7 +124,7 @@
 	 * needs the same treatment with its own band color.
 	 */
 	function ctaButtonClass(variant: LandingPageCTA['variant']): string {
-		const posterFocus = 'ring-offset-poster-purple focus-visible:ring-poster-white';
+		const posterFocus = 'focus-visible:ring-offset-poster-purple focus-visible:ring-poster-white';
 		switch (variant) {
 			case 'primary':
 				return `${posterFocus} bg-poster-white text-poster-purple hover:bg-poster-paper`;

--- a/src/lib/components/landing/LandingPageTemplate.svelte
+++ b/src/lib/components/landing/LandingPageTemplate.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import type { LandingPageContent, LandingPageFeature } from '$lib/data/landing-pages';
+	import type {
+		LandingPageCTA,
+		LandingPageContent,
+		LandingPageFeature
+	} from '$lib/data/landing-pages';
 	import { landingPages } from '$lib/data/landing-pages';
 	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
@@ -105,19 +109,46 @@
 		const relatedContent = landingPages[content.locale]?.[slug];
 		return relatedContent?.hero.headline || slug;
 	}
+
+	/**
+	 * Shared CTA Button recipe for the poster-purple bands (hero + closing CTA).
+	 *
+	 * Focus (#796): the Button base pairs a `--ring` ring with a
+	 * `ring-offset-background` gap — a theme-colored halo on a mode-inert
+	 * poster panel (`--ring` measures 1.27:1 light / 2.07:1 dark against
+	 * poster-purple; only the offset band kept the composite legal). Recolor
+	 * both halves to the band instead: a poster-white ring (5.52:1 on
+	 * poster-purple — the band's audited pair, identical in both modes) over an
+	 * offset gap painted the band's own purple, so the indicator is on-brand
+	 * and independent of the theme axis. Any future poster-band Button adopter
+	 * needs the same treatment with its own band color.
+	 */
+	function ctaButtonClass(variant: LandingPageCTA['variant']): string {
+		const posterFocus = 'ring-offset-poster-purple focus-visible:ring-poster-white';
+		switch (variant) {
+			case 'primary':
+				return `${posterFocus} bg-poster-white text-poster-purple hover:bg-poster-paper`;
+			case 'secondary':
+				return `${posterFocus} border-2 border-poster-white bg-transparent text-poster-white hover:bg-poster-white/10`;
+			case 'outline':
+				return `${posterFocus} border-poster-white/65 bg-transparent text-poster-white hover:bg-poster-white/10 hover:text-poster-white`;
+		}
+	}
 </script>
 
 <!-- Hero Section. Fixed poster-purple background (imagery rule: decorative
      brand panel, identical in both themes, like the landing's own panels).
      text-poster-white on bg-poster-purple measures 5.52:1 (same pair
-     ClosePanel documents for this exact color). Button variants below avoid
-     any translucent-over-gradient wash so every pair stays a plain
-     opaque-or-bordered combination on this single audited number.
+     ClosePanel documents for this exact color). The Button variants
+     (ctaButtonClass in the script, shared with the closing CTA band — focus
+     recipe documented there) avoid any translucent-over-gradient wash so
+     every pair stays a plain opaque-or-bordered combination on this single
+     audited number.
 
      TRAP (guardrail 6, hit here in its INVERSE form): a Button with a custom
      bg-* class keeps the variant's default text unless you also set text-*
      — but a custom text-* class ALSO keeps the variant's default bg-* unless
-     you explicitly set bg-* too. The "outline" branch below previously set
+     you explicitly set bg-* too. The "outline" branch previously set
      only text-poster-white, so shadcn's `outline` variant's own
      `bg-background` (rest) and `hover:text-accent-foreground` (hover)
      survived cn()'s merge untouched → white text on a light bg-background at
@@ -148,16 +179,7 @@
 							: button.variant === 'secondary'
 								? 'secondary'
 								: 'outline'}
-					<Button
-						href={button.href}
-						{variant}
-						size="lg"
-						class={button.variant === 'primary'
-							? 'bg-poster-white text-poster-purple hover:bg-poster-paper'
-							: button.variant === 'secondary'
-								? 'border-2 border-poster-white bg-transparent text-poster-white hover:bg-poster-white/10'
-								: 'border-poster-white/65 bg-transparent text-poster-white hover:bg-poster-white/10 hover:text-poster-white'}
-					>
+					<Button href={button.href} {variant} size="lg" class={ctaButtonClass(button.variant)}>
 						{button.text}
 					</Button>
 				{/each}
@@ -366,11 +388,7 @@
 							? 'secondary'
 							: 'outline'}
 					size="lg"
-					class={button.variant === 'primary'
-						? 'bg-poster-white text-poster-purple hover:bg-poster-paper'
-						: button.variant === 'secondary'
-							? 'border-2 border-poster-white bg-transparent text-poster-white hover:bg-poster-white/10'
-							: 'border-poster-white/65 bg-transparent text-poster-white hover:bg-poster-white/10 hover:text-poster-white'}
+					class={ctaButtonClass(button.variant)}
 				>
 					{button.text}
 				</Button>

--- a/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
@@ -242,6 +242,10 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await expect(
 			page.getByText("Your payment wasn't completed. You can resume it whenever you're ready.")
 		).toBeVisible();
+		// Mirror of the success leg's stripped-flag check: the toHaveURL regex
+		// above deliberately tolerates a query string, so without this line the
+		// cancelled flag's onMount consumption would go unasserted.
+		expect(page.url()).not.toContain('membership_cancelled');
 
 		// Resume: the backend hands back a payable session for the same pending
 		// subscription, and the browser leaves for Stripe again.


### PR DESCRIPTION
Closes #796

## What

`LandingPageTemplate.svelte` rendered plain shadcn `Button`s on the poster-purple hero and closing-CTA bands with the default focus composite: a `--ring` ring (1.27:1 light / 2.07:1 dark against poster-purple) whose legality depended entirely on the `ring-offset-background` gap — a theme-colored halo on a mode-inert panel.

Per the issue's proposed fix, the recipe recolors **both halves** of the composite to the band:

- `focus-visible:ring-poster-white` — the ring lands on the band's audited **5.52:1** white-on-purple pair (same pair the hero text and ClosePanel document), identical in both modes per the imagery rule.
- `ring-offset-poster-purple` — the offset gap is painted the band's own purple, so the filled (white) variant keeps a visible separation between button and ring.

The two duplicated CTA class ternaries (hero + closing band) collapse into one `ctaButtonClass()` helper carrying the recipe, with the guardrail-6 trap comment preserved. The `app.css` focus-floor comment — the trap-list entry the issue asked for — now documents the recipe for any future poster-band Button adopter instead of pointing at the open issue.

## Verification

- `make check` green (0 errors); `svelte-autofixer` clean on the component.
- Live keyboard check (headless Chromium against `make dev`): all three CTA variants match `:focus-visible` with computed `box-shadow: rgb(140, 60, 221) 0 0 0 2px, rgb(255, 255, 255) 0 0 0 4px` — Hearty-Purple gap, white ring — and the screenshot shows a clearly visible on-brand indicator on the filled variant. Dark mode is identical by construction (poster tokens only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDXmzqVQzDQTBwT98KL9Wf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved keyboard focus indicators for landing-page call-to-action buttons with clear, branded ring and offset colors.

- **Style**
  - Standardized hero and closing call-to-action button styling across variants, including hover and outline states.
  - Updated accessibility guidance for focusable poster-panel elements.

- **Bug Fixes**
  - Ensured the `membership_cancelled` URL parameter is removed after the cancellation message appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->