### PR TITLE
fix(a11y): StatusBadge is named by its content, not by an aria-label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,22 @@ PR 7, mirrors `StatusBadge`) so routed adopters can attach `id`/`aria-label`/etc
 instead. `PageHeader`'s `decoration` slot is aria-hidden ornament only — status
 text goes through `actions` or `StatusBadge`, never `decoration`.
 
+**A badge is named by its content** (#795). `StatusBadge` renders a role-less
+`<span>`, whose implicit `generic` role does not support name-from-author, so
+`aria-label` on it is ARIA-prohibited and ignored by conforming AT — it is
+`Omit`ted from the component's props, and passing one is a type error. Do not
+"fix" that by adding a role: `status` is a live region (wrong for a static pill)
+and `img`/`note`/`group` all buy validity with per-badge screen-reader verbosity.
+When a badge genuinely needs a richer announcement than its visible text
+("Membership status: Active"), pass the whole already-translated sentence as
+**`srLabel`** — it renders as real `sr-only` content with the visible label
+`aria-hidden`, so nothing is read twice. Never compose it from a prefix plus
+`label`; word order and agreement differ across the six locales. Tests locate
+badges by the **`data-testid="status-badge"`** the primitive always emits
+(overridable — `account/MembershipCard` uses `membership-subscription-status` so
+a pending subscription and a pending payment stay addressable apart), never by
+accessible name.
+
 **Band/wash pairing:** a mode-inert poster-solid ribbon pairs with a theme-aware
 tinted wash below it, and a theme `bg-secondary` band pairs with a plain
 `--background` body — never pair a band with a wash from the same token family.

--- a/src/lib/components/account/MembershipCard.svelte
+++ b/src/lib/components/account/MembershipCard.svelte
@@ -264,7 +264,14 @@
 					{/if}
 				</div>
 				{#if sub}
-					<SubscriptionStatusBadge status={sub.status} />
+					<!-- Its own testid, not the primitive's generic `status-badge`: the
+					     payment-history table further down this card renders status pills
+					     too, and a pending PAYMENT would otherwise answer a lookup meant for
+					     a pending SUBSCRIPTION (j23 revival.spec.ts). #795 -->
+					<SubscriptionStatusBadge
+						status={sub.status}
+						data-testid="membership-subscription-status"
+					/>
 				{:else}
 					<Badge variant="secondary" class="capitalize">{membership.status}</Badge>
 				{/if}

--- a/src/lib/components/account/MembershipPaymentHistory.svelte
+++ b/src/lib/components/account/MembershipPaymentHistory.svelte
@@ -211,19 +211,18 @@
 										{/if}
 									</td>
 									<td class="py-2">
-										<!-- Deliberately opted OUT of the primitive's default accessible name
-										     (#788). This table renders INSIDE the account hub's membership
-										     <article>, next to the subscription-status pill — and that pill's
-										     name is the cross-surface contract the e2e suite addresses the card
-										     by (`card.getByLabel('Pending')`, j23 revival.spec.ts). A pending
-										     PAYMENT row would answer the same lookup and trip Playwright strict
-										     mode, so this cell keeps the name it has always had: none. The
-										     status is still announced as the cell's text content. -->
+										<!-- Plain `status-badge` testid. This table renders INSIDE the account
+										     hub's membership <article>, next to the subscription-status pill, and
+										     a pending PAYMENT row would answer the same lookup as a pending
+										     SUBSCRIPTION and trip Playwright strict mode (j23 revival.spec.ts).
+										     That is why the pill above carries its own
+										     `membership-subscription-status` testid — the two are addressable
+										     apart, and this cell needs no opt-out of its own (#795, replacing the
+										     `aria-label={undefined}` hatch #788 needed). -->
 										<StatusBadge
 											tone={statusTone(p.status)}
 											label={statusLabel(p.status)}
 											size="sm"
-											aria-label={undefined}
 										/>
 									</td>
 								</tr>

--- a/src/lib/components/account/OrgMembershipInline.svelte
+++ b/src/lib/components/account/OrgMembershipInline.svelte
@@ -58,7 +58,7 @@
 			<div class="mt-1 font-medium">{sub.plan.name}</div>
 			<div class="text-sm text-muted-foreground">{formatPlanPrice(sub.plan)}</div>
 			<div class="mt-2 flex items-center gap-2">
-				<SubscriptionStatusBadge status={sub.status} />
+				<SubscriptionStatusBadge status={sub.status} data-testid="membership-subscription-status" />
 				<span class="text-xs text-muted-foreground">
 					{#if line.kind === 'renewal'}
 						{m['subscriptions.dateLine.renewal']({ date: fmtDate(line.date) })}

--- a/src/lib/components/account/applications/ApplicationRow.svelte
+++ b/src/lib/components/account/applications/ApplicationRow.svelte
@@ -281,7 +281,7 @@
 			label={statusLabel}
 			size="sm"
 			class="shrink-0"
-			aria-label={m['applications.statusAriaLabel']({ status: statusLabel })}
+			srLabel={m['applications.statusAriaLabel']({ status: statusLabel })}
 		/>
 	</div>
 

--- a/src/lib/components/account/applications/ApplicationRow.test.ts
+++ b/src/lib/components/account/applications/ApplicationRow.test.ts
@@ -198,7 +198,11 @@ describe('ApplicationRow', () => {
 	it('labels the status chip for assistive tech', () => {
 		renderRow(makeApplication({ status: 'rejected' }));
 
-		expect(screen.getByLabelText('Application status: Rejected')).toHaveTextContent('Rejected');
+		// `srLabel` renders the context as real sr-only content, so the chip reads
+		// "Application status: Rejected" and the visible word is hidden from AT.
+		const chip = screen.getByTestId('status-badge');
+		expect(chip).toHaveTextContent('Application status: Rejected');
+		expect(screen.getByText('Rejected')).toHaveAttribute('aria-hidden', 'true');
 	});
 
 	describe('actions', () => {

--- a/src/lib/components/announcements/AnnouncementStatusBadge.svelte
+++ b/src/lib/components/announcements/AnnouncementStatusBadge.svelte
@@ -30,4 +30,4 @@
 	);
 </script>
 
-<StatusBadge {tone} {label} size="sm" aria-label={label} />
+<StatusBadge {tone} {label} size="sm" />

--- a/src/lib/components/announcements/AnnouncementStatusBadge.test.ts
+++ b/src/lib/components/announcements/AnnouncementStatusBadge.test.ts
@@ -12,19 +12,17 @@ const LABELS: Record<AnnouncementStatus, string> = {
 };
 
 /**
- * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts`: this mapper
- * wraps `common/StatusBadge`. The accessible NAME is what lets callers (and
- * any future e2e lookup) address the pill via `getByLabelText` — passed here
- * explicitly and, since #788, defaulted by the primitive as well. Assert it
- * for every enum value, not a
- * sample, so a status silently losing its name doesn't slip through.
+ * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts`:
+ * this mapper wraps `common/StatusBadge`. Its status text is what lets callers
+ * (and any e2e lookup) address the pill, and since #795 it is the accessible
+ * name too. Assert it for every enum value, not a sample, so a status silently
+ * losing its label doesn't slip through.
  */
 describe('announcements/AnnouncementStatusBadge', () => {
-	it.each(STATUSES)('exposes the %s label as the pill accessible name', (status) => {
+	it.each(STATUSES)('renders the %s label on the pill', (status) => {
 		render(AnnouncementStatusBadge, { props: { status } });
 		const label = LABELS[status];
-		expect(screen.getByLabelText(label)).toBeInTheDocument();
-		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 	});
 
 	it('maps status to the primitive tone (draft → neutral, scheduled → info, sent → success)', () => {

--- a/src/lib/components/blacklist/WhitelistRequestStatusBadge.svelte
+++ b/src/lib/components/blacklist/WhitelistRequestStatusBadge.svelte
@@ -38,6 +38,7 @@
 	const icon = $derived(ICON_MAP[status] ?? Clock);
 </script>
 
-<!-- aria-label mirrors the visible (unlocalized) status text, per the house
-     `common/StatusBadge` mapper pattern (see `members/SubscriptionStatusBadge.svelte`). -->
-<CommonStatusBadge {tone} label={status} {icon} size="sm" class={extraClass} aria-label={status} />
+<!-- House `common/StatusBadge` mapper pattern (see
+     `members/SubscriptionStatusBadge.svelte`); the raw (unlocalized) status text
+     is both the visible label and the accessible name (#795). -->
+<CommonStatusBadge {tone} label={status} {icon} size="sm" class={extraClass} />

--- a/src/lib/components/blacklist/WhitelistRequestStatusBadge.test.ts
+++ b/src/lib/components/blacklist/WhitelistRequestStatusBadge.test.ts
@@ -3,19 +3,18 @@ import { describe, it, expect } from 'vitest';
 import WhitelistRequestStatusBadge from './WhitelistRequestStatusBadge.svelte';
 
 /**
- * REGRESSION GUARD, mirroring `members/SubscriptionStatusBadge.test.ts`: this pill's
- * accessible NAME is what locates it on `WhitelistRequestCard`. The status
- * text itself is intentionally unlocalized (matches the pre-rebrand
- * behaviour) — this guard is about the aria-label surviving the move to the
- * shared `common/StatusBadge` primitive, not about translation.
+ * REGRESSION GUARD, mirroring `members/SubscriptionStatusBadge.test.ts`: this
+ * pill's status text is what locates it on `WhitelistRequestCard`, and since
+ * #795 it is the accessible name too. The text itself is intentionally
+ * unlocalized (matches the pre-rebrand behaviour) — this guard is about the
+ * label surviving the move to the shared primitive, not about translation.
  */
 describe('blacklist/WhitelistRequestStatusBadge', () => {
 	it.each(['pending', 'approved', 'rejected'])(
-		'exposes the raw "%s" status as the pill accessible name',
+		'renders the raw "%s" status on the pill',
 		(status) => {
 			render(WhitelistRequestStatusBadge, { props: { status } });
-			expect(screen.getByLabelText(status)).toBeInTheDocument();
-			expect(screen.getByLabelText(status)).toHaveTextContent(status);
+			expect(screen.getByTestId('status-badge')).toHaveTextContent(status);
 		}
 	);
 
@@ -23,7 +22,7 @@ describe('blacklist/WhitelistRequestStatusBadge', () => {
 		const { container } = render(WhitelistRequestStatusBadge, {
 			props: { status: 'some_future_status' }
 		});
-		expect(screen.getByLabelText('some_future_status')).toBeInTheDocument();
+		expect(screen.getByTestId('status-badge')).toHaveTextContent('some_future_status');
 		expect(container.querySelector('span')?.className).toContain('bg-highlight');
 	});
 

--- a/src/lib/components/common/StatusBadge.svelte
+++ b/src/lib/components/common/StatusBadge.svelte
@@ -4,10 +4,39 @@
 	import { cn } from '$lib/utils';
 	import type { Tone } from './tones';
 
-	interface Props extends HTMLAttributes<HTMLSpanElement> {
+	// RULING (#795): a badge is text, and its accessible name is its content.
+	//
+	// `aria-label` is deliberately OMITTED from the public type. On a role-less
+	// <span> the implicit role is `generic`, which does not support name-from-
+	// author, so conforming AT ignores the attribute outright (axe reports it as
+	// `aria-prohibited-attr` — `incomplete` rather than a violation only because
+	// there is text content to fall back on). Every name the primitive used to
+	// emit was therefore reaching Playwright and nobody else.
+	//
+	// The `Omit` is doing the job #788's runtime default was doing. That default
+	// existed because forgetting the prop in ONE mapper un-named every
+	// subscription pill and took 19 e2e specs down with it (#772). A compile
+	// error retires that failure class more decisively — and without the
+	// prohibited attribute. Automation locates badges by `data-testid` below.
+	interface Props extends Omit<HTMLAttributes<HTMLSpanElement>, 'aria-label'> {
 		tone: Tone;
 		/** Already-translated label — i18n stays at the call site. */
 		label: string;
+		/**
+		 * Screen-reader name for the ~7 badges whose intended announcement is
+		 * genuinely richer than the visible text ("Membership status: Active",
+		 * "Email is verified"). Rendered as real sr-only CONTENT, with the visible
+		 * label hidden from AT so it is not read twice — the name still comes from
+		 * content, it is just content the sighted reader gets from context instead.
+		 *
+		 * Pass the whole sentence, already translated. Do NOT compose it from a
+		 * prefix plus `label`: word order and agreement differ across the six
+		 * locales.
+		 *
+		 * Leave unset unless the visible text is genuinely ambiguous on its own —
+		 * for the other ~70 badges the label IS the name and needs no help.
+		 */
+		srLabel?: string;
 		icon?: Component;
 		size?: 'sm' | 'md' | 'lg';
 		class?: string;
@@ -15,31 +44,12 @@
 	const {
 		tone,
 		label,
+		srLabel,
 		icon: Icon,
 		size = 'md',
 		class: className = '',
 		...restProps
 	}: Props = $props();
-
-	// The accessible name defaults to the visible label (#788). Every mapper used
-	// to have to remember to pass one; forgetting it in a single mapper un-named
-	// every subscription pill and took 19 e2e specs down with it (fixed in #772).
-	// Defaulting here retires that whole failure class.
-	//
-	// Presence-tested with `in` rather than `restProps['aria-label'] ?? label`, so
-	// that passing `aria-label={undefined}` is a real OPT-OUT and not just another
-	// way to spell "use the default". One call site needs that escape hatch —
-	// see `account/MembershipPaymentHistory.svelte`.
-	//
-	// An EMPTY label emits no attribute at all. Measured against axe-core 4.12.1
-	// (the version the e2e a11y smoke runs): on a role-less <span> WITH text
-	// content, `aria-label` lands in `incomplete` under aria-prohibited-attr —
-	// needs-review, not a violation, so the smoke stays green. On a span with NO
-	// text content the same rule fires as a SERIOUS violation. `label || undefined`
-	// keeps every badge on the safe side of that line.
-	const ariaLabel = $derived(
-		'aria-label' in restProps ? restProps['aria-label'] : label || undefined
-	);
 
 	// Solid fills only: every fg/bg pair below is a token pair enforced at
 	// >= 4.5:1 by scripts/audit-brand-themes.py in BOTH modes. No alpha here —
@@ -60,18 +70,27 @@
 	const iconSizes = { sm: 'h-3 w-3', md: 'h-3 w-3', lg: 'h-3.5 w-3.5' };
 </script>
 
+<!--
+  `data-testid` is the automation contract that #772/#788 were really protecting,
+  now labelled honestly as automation instead of dressed as accessibility. It is
+  emitted by the primitive so no mapper can forget it, and sits in restProps'
+  spread path so a call site can still override it.
+-->
 <span
+	data-testid="status-badge"
+	{...restProps}
 	class={cn(
 		'inline-flex items-center gap-1 rounded-full font-bold',
 		sizeClasses[size],
 		toneClasses[tone],
 		className
 	)}
-	{...restProps}
-	aria-label={ariaLabel}
 >
+	{#if srLabel}
+		<span class="sr-only">{srLabel}</span>
+	{/if}
 	{#if Icon}
 		<Icon class={iconSizes[size]} aria-hidden="true" />
 	{/if}
-	{label}
+	<span aria-hidden={srLabel ? 'true' : undefined}>{label}</span>
 </span>

--- a/src/lib/components/common/StatusBadge.test.ts
+++ b/src/lib/components/common/StatusBadge.test.ts
@@ -34,50 +34,73 @@ describe('StatusBadge', () => {
 		expect(el.getAttribute('role')).toBe('status');
 	});
 
-	// --- accessible name (#788) ---
-	// The mappers each pass `aria-label={label}` and each pin it with an
-	// enum-driven guard test. Those guards exist because forgetting the prop in
-	// ONE mapper un-named every subscription pill and took 19 e2e specs with it
-	// (#772). The default below is what makes forgetting it harmless; these four
-	// cases are its contract.
+	// --- the accessible name (#795) ---
+	// The ruling: a badge is text, so its name is its content. `aria-label` is
+	// gone from the public type — on a role-less <span> the implicit `generic`
+	// role does not support name-from-author, so every name the primitive used to
+	// emit was reaching Playwright and no assistive technology at all.
 
-	it('defaults the accessible name to the visible label', () => {
+	it('emits no ARIA at all for the ordinary case', () => {
 		const { container } = render(StatusBadge, { props: { tone: 'success', label: 'Active' } });
 		const el = container.querySelector('span') as HTMLElement;
-		expect(el.getAttribute('aria-label')).toBe('Active');
-		expect(screen.getByLabelText('Active')).toBeInTheDocument();
-		// The name is an alias for what is on screen, never a substitute for it.
-		expect(screen.getByLabelText('Active')).toHaveTextContent('Active');
+		expect(el.hasAttribute('aria-label')).toBe(false);
+		expect(el.hasAttribute('role')).toBe(false);
+		expect(container.querySelector('[aria-hidden]')).toBeNull();
+		expect(el).toHaveTextContent('Active');
 	});
 
-	it('lets an explicit aria-label from the caller win over the default', () => {
+	it('exposes the data-testid automation hook', () => {
+		const { container } = render(StatusBadge, { props: { tone: 'success', label: 'Active' } });
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.getAttribute('data-testid')).toBe('status-badge');
+	});
+
+	// The dedicated hook `account/MembershipCard` uses so a pending SUBSCRIPTION
+	// and a pending PAYMENT in the same card stay addressable apart.
+	it('lets a call site override the data-testid', () => {
 		const { container } = render(StatusBadge, {
-			props: { tone: 'success', label: 'Active', 'aria-label': 'Membership status: Active' }
+			props: { tone: 'warning', label: 'Pending', 'data-testid': 'membership-subscription-status' }
 		});
 		const el = container.querySelector('span') as HTMLElement;
-		expect(el.getAttribute('aria-label')).toBe('Membership status: Active');
-		expect(screen.queryByLabelText('Active')).toBeNull();
+		expect(el.getAttribute('data-testid')).toBe('membership-subscription-status');
 	});
 
-	// The escape hatch. `aria-label={undefined}` is an explicit OPT-OUT, not a
-	// request for the default — `account/MembershipPaymentHistory` relies on it to
-	// stay out of the way of a `getByLabel` lookup scoped to the same card.
-	it('emits no aria-label when the caller passes undefined explicitly', () => {
+	// --- srLabel ---
+
+	it('renders srLabel as sr-only content and hides the duplicated visible label', () => {
 		const { container } = render(StatusBadge, {
-			props: { tone: 'warning', label: 'Pending', 'aria-label': undefined }
+			props: { tone: 'success', label: 'Verified', srLabel: 'Email is verified' }
+		});
+		const srOnly = container.querySelector('.sr-only') as HTMLElement;
+		expect(srOnly).not.toBeNull();
+		expect(srOnly).toHaveTextContent('Email is verified');
+
+		// The visible text stays on screen, and stays out of the announcement, so
+		// the badge reads "Email is verified" rather than "Email is verified
+		// Verified".
+		const visible = screen.getByText('Verified');
+		expect(visible).toBeInTheDocument();
+		expect(visible.getAttribute('aria-hidden')).toBe('true');
+
+		// Still no prohibited attribute: the name comes from content either way.
+		const el = container.querySelector('span') as HTMLElement;
+		expect(el.hasAttribute('aria-label')).toBe(false);
+	});
+
+	it('leaves the visible label exposed when there is no srLabel', () => {
+		render(StatusBadge, { props: { tone: 'neutral', label: 'Draft' } });
+		expect(screen.getByText('Draft').hasAttribute('aria-hidden')).toBe(false);
+	});
+
+	// `filter({ hasText })` in the e2e suite matches on textContent, which is a
+	// superset of both strings — this pins that.
+	it('keeps textContent a superset of both label and srLabel', () => {
+		const { container } = render(StatusBadge, {
+			props: { tone: 'success', label: 'Active', srLabel: 'Membership status: Active' }
 		});
 		const el = container.querySelector('span') as HTMLElement;
-		expect(el.hasAttribute('aria-label')).toBe(false);
-		expect(el).toHaveTextContent('Pending');
-	});
-
-	// An empty name would turn axe's `aria-prohibited-attr` from `incomplete`
-	// (needs-review, which the e2e a11y smoke ignores) into a SERIOUS violation,
-	// because the span would then carry a prohibited attribute and no text.
-	it('emits no aria-label for an empty label', () => {
-		const { container } = render(StatusBadge, { props: { tone: 'neutral', label: '' } });
-		const el = container.querySelector('span') as HTMLElement;
-		expect(el.hasAttribute('aria-label')).toBe(false);
+		expect(el.textContent).toContain('Membership status: Active');
+		expect(el.textContent).toContain('Active');
 	});
 
 	it('lg size applies the larger padding classes', () => {

--- a/src/lib/components/dashboard/DashboardOrganizationsSection.svelte
+++ b/src/lib/components/dashboard/DashboardOrganizationsSection.svelte
@@ -102,7 +102,7 @@
 										label={m['dashboardPage.ownerBadge']()}
 										icon={Crown}
 										size="sm"
-										aria-label={m['dashboardPage.ownerBadgeLabel']()}
+										srLabel={m['dashboardPage.ownerBadgeLabel']()}
 									/>
 								{:else if isStaff(permissions, org.id)}
 									<!-- Staff Badge -->
@@ -111,7 +111,7 @@
 										label={m['dashboardPage.staffBadge']()}
 										icon={Shield}
 										size="sm"
-										aria-label={m['dashboardPage.staffBadgeLabel']()}
+										srLabel={m['dashboardPage.staffBadgeLabel']()}
 									/>
 								{/if}
 							</div>
@@ -134,8 +134,8 @@
 											label={m[`memberStatus.${membershipStatus}`]()}
 											icon={Check}
 											size="sm"
-											aria-label={m['dashboardPage.membershipStatusLabel']({
-												status: membershipStatus
+											srLabel={m['dashboardPage.membershipStatusLabel']({
+												status: m[`memberStatus.${membershipStatus}`]()
 											})}
 										/>
 									{/if}
@@ -147,7 +147,7 @@
 											label={membershipTier.name}
 											icon={Award}
 											size="sm"
-											aria-label={m['dashboardPage.membershipTierLabel']({
+											srLabel={m['dashboardPage.membershipTierLabel']({
 												tier: membershipTier.name
 											})}
 										/>

--- a/src/lib/components/discount-codes/DiscountCodeStatusBadge.svelte
+++ b/src/lib/components/discount-codes/DiscountCodeStatusBadge.svelte
@@ -16,6 +16,6 @@
 	);
 </script>
 
-<!-- aria-label explicit per the house `common/StatusBadge` mapper pattern
-     (see `members/SubscriptionStatusBadge.svelte`). -->
-<CommonStatusBadge {tone} {label} size="sm" class={extraClass} aria-label={label} />
+<!-- House `common/StatusBadge` mapper pattern (see
+     `members/SubscriptionStatusBadge.svelte`). -->
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} />

--- a/src/lib/components/discount-codes/DiscountCodeStatusBadge.test.ts
+++ b/src/lib/components/discount-codes/DiscountCodeStatusBadge.test.ts
@@ -8,16 +8,14 @@ import DiscountCodeStatusBadge from './DiscountCodeStatusBadge.svelte';
  * discount-codes admin table and its mobile card twin.
  */
 describe('discount-codes/DiscountCodeStatusBadge', () => {
-	it('exposes "Active" as the accessible name when active', () => {
+	it('renders "Active" on the pill when active', () => {
 		render(DiscountCodeStatusBadge, { props: { isActive: true } });
-		expect(screen.getByLabelText('Active')).toBeInTheDocument();
-		expect(screen.getByLabelText('Active')).toHaveTextContent('Active');
+		expect(screen.getByTestId('status-badge')).toHaveTextContent('Active');
 	});
 
-	it('exposes "Inactive" as the accessible name when inactive', () => {
+	it('renders "Inactive" on the pill when inactive', () => {
 		render(DiscountCodeStatusBadge, { props: { isActive: false } });
-		expect(screen.getByLabelText('Inactive')).toBeInTheDocument();
-		expect(screen.getByLabelText('Inactive')).toHaveTextContent('Inactive');
+		expect(screen.getByTestId('status-badge')).toHaveTextContent('Inactive');
 	});
 
 	it('maps active to the success tone and inactive to the neutral tone', () => {

--- a/src/lib/components/event-series/admin/SeriesHeaderCard.svelte
+++ b/src/lib/components/event-series/admin/SeriesHeaderCard.svelte
@@ -80,14 +80,12 @@
 				tone="neutral"
 				icon={Pause}
 				label={m['recurringEvents.dashboard.statusPaused']()}
-				aria-label={m['recurringEvents.dashboard.statusPaused']()}
 			/>
 		{:else}
 			<StatusBadge
 				tone="success"
 				icon={Play}
 				label={m['recurringEvents.dashboard.statusActive']()}
-				aria-label={m['recurringEvents.dashboard.statusActive']()}
 			/>
 		{/if}
 		<span

--- a/src/lib/components/event-series/admin/SeriesHeaderCard.test.ts
+++ b/src/lib/components/event-series/admin/SeriesHeaderCard.test.ts
@@ -79,15 +79,14 @@ describe('SeriesHeaderCard', () => {
 
 	it('shows the Active status pill when series is_active=true', () => {
 		render(SeriesHeaderCard, { props: { series: makeSeries() } });
-		// The pill uses aria-label to carry the status string.
-		expect(screen.getByLabelText(/active/i)).toBeInTheDocument();
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(/active/i);
 	});
 
 	it('shows the Paused status pill when series is_active=false', () => {
 		render(SeriesHeaderCard, {
 			props: { series: makeSeries({ is_active: false }) }
 		});
-		expect(screen.getByLabelText(/paused/i)).toBeInTheDocument();
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(/paused/i);
 	});
 
 	it('renders the recurrence summary when a rule is present', () => {

--- a/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte
+++ b/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.svelte
@@ -46,9 +46,7 @@
 </script>
 
 <!--
-	aria-label is deliberate, not redundant with the visible text: this badge
-	is a `common/StatusBadge` consumer (see CLAUDE.md primitive contract) and
-	every domain mapper attaches its own aria-label explicitly — the primitive
-	defaults the same value since #788, so the two agree by construction.
+	A `common/StatusBadge` consumer (see CLAUDE.md primitive contract). No
+	`aria-label`: the visible status text is the accessible name (#795).
 -->
-<StatusBadge {tone} {label} {icon} size="sm" class={className} aria-label={label} />
+<StatusBadge {tone} {label} {icon} size="sm" class={className} />

--- a/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.test.ts
+++ b/src/lib/components/events/waitlist/WaitlistOfferStatusBadge.test.ts
@@ -14,22 +14,17 @@ const LABELS: Record<WaitlistOfferStatus, string> = {
 };
 
 /**
- * REGRESSION GUARD (see members/SubscriptionStatusBadge.test.ts for the incident this
- * pattern guards against). `common/StatusBadge` named itself from its text
- * content only until #788, so every domain mapper had to pass `aria-label`
- * explicitly or `getByLabel` lookups against the badge silently stopped
- * resolving. The primitive defaults it now; pin every enum value regardless.
+ * REGRESSION GUARD (see members/SubscriptionStatusBadge.test.ts for the incident
+ * this pattern guards against). The badge is addressed by `status-badge` plus its
+ * status text, which since #795 is also its accessible name — pin every enum
+ * value, since the failure mode drops all of them at once.
  */
 describe('events/waitlist/WaitlistOfferStatusBadge', () => {
-	it.each(WAITLIST_OFFER_STATUS_ORDER)(
-		'exposes the %s label as the pill accessible name',
-		(status) => {
-			render(WaitlistOfferStatusBadge, { props: { status } });
-			const label = LABELS[status];
-			expect(screen.getByLabelText(label)).toBeInTheDocument();
-			expect(screen.getByLabelText(label)).toHaveTextContent(label);
-		}
-	);
+	it.each(WAITLIST_OFFER_STATUS_ORDER)('renders the %s label on the pill', (status) => {
+		render(WaitlistOfferStatusBadge, { props: { status } });
+		const label = LABELS[status];
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
+	});
 
 	it('maps status to the primitive tone (claimed → success, revoked → danger)', () => {
 		const claimed = render(WaitlistOfferStatusBadge, { props: { status: 'claimed' } });

--- a/src/lib/components/members/MemberStatusBadge.svelte
+++ b/src/lib/components/members/MemberStatusBadge.svelte
@@ -15,10 +15,9 @@
 </script>
 
 <!--
-	`aria-label` is deliberate, not redundant with the visible text: this is the
-	canonical `common/StatusBadge` mapper pattern (see `members/SubscriptionStatusBadge.svelte`
-	for the subscription-status sibling). The primitive has defaulted this name
-	from the visible label since #788; the mapper still supplies it explicitly,
-	and the enum-driven test pins it whichever side provides it.
+	The canonical `common/StatusBadge` mapper pattern (see
+	`members/SubscriptionStatusBadge.svelte` for the subscription-status sibling):
+	enum in, tone + already-translated label out, no ARIA of its own — the badge
+	is named by the text it renders (#795). The enum-driven test pins the label.
 -->
-<CommonStatusBadge {tone} {label} size="sm" class={extraClass} aria-label={label} />
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} />

--- a/src/lib/components/members/MemberStatusBadge.test.ts
+++ b/src/lib/components/members/MemberStatusBadge.test.ts
@@ -5,21 +5,18 @@ import { getMemberStatusLabel, MEMBER_STATUS_ORDER } from '$lib/utils/member-sta
 import MemberStatusBadge from './MemberStatusBadge.svelte';
 
 /**
- * REGRESSION GUARD, mirroring `members/SubscriptionStatusBadge.test.ts`: this pill's
- * accessible NAME is what locates it in `MemberCard` (roster) — a mapper over
- * `common/StatusBadge` that dropped its `aria-label` would still render the
- * right text on screen while `getByLabelText` stopped finding it. Every enum
- * value is asserted, not a sample, since the failure mode drops all of them
- * at once.
+ * REGRESSION GUARD, mirroring `members/SubscriptionStatusBadge.test.ts`: this
+ * pill's status text is what locates it in `MemberCard` (roster), and since #795
+ * it is the accessible name too. Every enum value is asserted, not a sample,
+ * since the failure mode drops all of them at once.
  */
 describe('members/MemberStatusBadge', () => {
 	it.each(MEMBER_STATUS_ORDER as MembershipStatus[])(
-		'exposes the %s label as the pill accessible name',
+		'renders the %s label on the pill',
 		(status) => {
 			render(MemberStatusBadge, { props: { status } });
 			const label = getMemberStatusLabel(status);
-			expect(screen.getByLabelText(label)).toBeInTheDocument();
-			expect(screen.getByLabelText(label)).toHaveTextContent(label);
+			expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 		}
 	);
 

--- a/src/lib/components/members/MembershipRequestStatusBadge.svelte
+++ b/src/lib/components/members/MembershipRequestStatusBadge.svelte
@@ -17,7 +17,7 @@
 	const label = $derived(getMembershipRequestStatusLabel(status));
 </script>
 
-<!-- aria-label is explicit per the house `common/StatusBadge` mapper pattern
-     (see `members/SubscriptionStatusBadge.svelte`). The primitive also defaults
-     it from the visible label since #788. -->
-<CommonStatusBadge {tone} {label} size="sm" class={extraClass} aria-label={label} />
+<!-- House `common/StatusBadge` mapper pattern (see
+     `members/SubscriptionStatusBadge.svelte`): no ARIA of its own — the badge is
+     named by its visible text (#795). -->
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} />

--- a/src/lib/components/members/MembershipRequestStatusBadge.test.ts
+++ b/src/lib/components/members/MembershipRequestStatusBadge.test.ts
@@ -15,12 +15,11 @@ import MembershipRequestStatusBadge from './MembershipRequestStatusBadge.svelte'
  */
 describe('members/MembershipRequestStatusBadge', () => {
 	it.each(MEMBERSHIP_REQUEST_STATUS_ORDER as MembershipRequestStatus[])(
-		'exposes the %s label as the pill accessible name',
+		'renders the %s label on the pill',
 		(status) => {
 			render(MembershipRequestStatusBadge, { props: { status } });
 			const label = getMembershipRequestStatusLabel(status);
-			expect(screen.getByLabelText(label)).toBeInTheDocument();
-			expect(screen.getByLabelText(label)).toHaveTextContent(label);
+			expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 		}
 	);
 

--- a/src/lib/components/members/SubscriptionPaymentsStatusBadge.svelte
+++ b/src/lib/components/members/SubscriptionPaymentsStatusBadge.svelte
@@ -41,9 +41,8 @@
 </script>
 
 <!--
-	`aria-label` is deliberate, not redundant: this pill is how the org-wide
-	payments ledger row/card is addressed by tests. `common/StatusBadge` defaults
-	it from the visible label since #788; passing it here keeps the contract
-	explicit at the mapper.
+	The org-wide payments ledger row/card is addressed by this pill's status text
+	plus the primitive's `data-testid` — no `aria-label`, per the #795 ruling that
+	a badge is named by its content.
 -->
-<CommonStatusBadge {tone} {label} icon={Icon} size="sm" aria-label={label} />
+<CommonStatusBadge {tone} {label} icon={Icon} size="sm" />

--- a/src/lib/components/members/SubscriptionPaymentsStatusBadge.test.ts
+++ b/src/lib/components/members/SubscriptionPaymentsStatusBadge.test.ts
@@ -5,13 +5,11 @@ import type { PaymentStatus } from '$lib/api/generated/types.gen';
 import SubscriptionPaymentsStatusBadge from './SubscriptionPaymentsStatusBadge.svelte';
 
 /**
- * REGRESSION GUARD. Before #788 `common/StatusBadge` named itself from its
- * text content alone, so a mapper that forgot `aria-label` silently un-named
- * its pill for every `getByLabel` lookup on the org-wide payments ledger
- * row/card. The primitive defaults the name now; this test pins it either
- * way. See `src/lib/components/members/SubscriptionStatusBadge.test.ts` for
- * the incident this pattern guards against (19 e2e specs broke on exactly
- * this omission).
+ * REGRESSION GUARD. The org-wide payments ledger row/card locates this pill by
+ * its status text, which since #795 is also its accessible name. Every enum
+ * value is pinned, not a sample. See
+ * `src/lib/components/members/SubscriptionStatusBadge.test.ts` for the incident
+ * this pattern guards against (19 e2e specs broke on one dropped label).
  */
 const PAYMENT_STATUS_ORDER: PaymentStatus[] = ['pending', 'succeeded', 'failed', 'refunded'];
 
@@ -23,11 +21,10 @@ const LABELS: Record<PaymentStatus, string> = {
 };
 
 describe('members/SubscriptionPaymentsStatusBadge', () => {
-	it.each(PAYMENT_STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+	it.each(PAYMENT_STATUS_ORDER)('renders the %s label on the pill', (status) => {
 		render(SubscriptionPaymentsStatusBadge, { props: { status } });
 		const label = LABELS[status];
-		expect(screen.getByLabelText(label)).toBeInTheDocument();
-		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 	});
 
 	it('maps status to the primitive tone (succeeded -> success, failed -> danger, refunded -> neutral)', () => {

--- a/src/lib/components/members/SubscriptionStatusBadge.svelte
+++ b/src/lib/components/members/SubscriptionStatusBadge.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { getStatusLabel, getStatusTone, type SubscriptionStatus } from '$lib/utils/subscriptions';
+	import type { HTMLAttributes } from 'svelte/elements';
 	import CommonStatusBadge from '$lib/components/common/StatusBadge.svelte';
 
-	interface Props {
+	interface Props extends Omit<HTMLAttributes<HTMLSpanElement>, 'aria-label'> {
 		status: SubscriptionStatus;
 		class?: string;
 	}
 
-	const { status, class: extraClass = '' }: Props = $props();
+	const { status, class: extraClass = '', ...restProps }: Props = $props();
 
 	// Tone mapping lives in `utils/subscription-status.ts::getStatusTone` — the
 	// single source this badge and `members/SubscriptionMetrics`'s chip strip
@@ -18,15 +19,11 @@
 </script>
 
 <!--
-	`aria-label` is deliberate and load-bearing, not redundant with the visible
-	text: the subscription status is the one bit of this pill that other surfaces
-	address it by, and the status word alone ("Active", "Past due") is what names
-	it. It predates the shared primitive — every subscription surface (account
-	hub card, org landing inline card, admin subs table/drawer) is located by it,
-	so dropping it when this became a mapper silently un-named every one of them.
-	#788 since baked the same default into `common/StatusBadge` itself, so this
-	pass is now belt-and-suspenders rather than the only thing supplying the name.
-	It stays because the enum-driven test above it is the contract, and a mapper
-	that states its own accessible name cannot lose it to a primitive refactor.
+	No `aria-label` here, or in any other mapper: per the #795 ruling the badge's
+	accessible name is its visible text, and `common/StatusBadge` omits the
+	attribute from its public type. Every subscription surface (account hub card,
+	org landing inline card, admin subs table/drawer) that used to be located by
+	that name is located by the primitive's `data-testid` plus this status text
+	instead; the enum-driven test above is still the contract for the text.
 -->
-<CommonStatusBadge {tone} {label} size="sm" class={extraClass} aria-label={label} />
+<CommonStatusBadge {tone} {label} size="sm" class={extraClass} {...restProps} />

--- a/src/lib/components/members/SubscriptionStatusBadge.test.ts
+++ b/src/lib/components/members/SubscriptionStatusBadge.test.ts
@@ -5,39 +5,33 @@ import { getStatusLabel, STATUS_ORDER } from '$lib/utils/subscriptions';
 import SubscriptionStatusBadge from './SubscriptionStatusBadge.svelte';
 
 /**
- * REGRESSION GUARD. This badge's accessible NAME is a cross-surface contract,
- * not decoration: the e2e suite addresses every subscription pill by
- * `getByLabel('Active' | 'Pending' | 'Past due' | …)` — on the account hub
+ * REGRESSION GUARD. This badge's status LABEL is a cross-surface contract, not
+ * decoration: the e2e suite addresses every subscription pill by
+ * `status-badge` + 'Active' | 'Pending' | 'Past due' | … — on the account hub
  * card, the org landing page's inline card, the admin subs table/mobile card
- * and the admin subscription drawer — and the admin metrics strip deliberately
- * leaves its own chips unlabelled so those lookups resolve to badges ONLY.
+ * and the admin subscription drawer.
  *
  * The 2026-08 rebrand wave turned this component into a thin mapper over
- * `common/StatusBadge` and dropped its `aria-label` in the process. The
- * primitive named itself from its text content only, `getByLabel` never matches
- * text content, and 19 e2e tests went red while every unit test stayed green —
- * because nothing here asserted the name. Hence this file. #788 later made the
- * primitive default the name; this file is why that default is safe to trust.
+ * `common/StatusBadge` and dropped the pill's `aria-label` in the process; 19
+ * e2e tests went red while every unit test stayed green, because nothing here
+ * asserted it. Hence this file. #795 has since removed the ARIA name entirely —
+ * on a role-less <span> it never reached assistive technology anyway — so the
+ * visible text is now the whole contract, and this file is what pins it.
  */
 describe('members/SubscriptionStatusBadge', () => {
 	// Every status, not just a sample: the whole failure mode was a name that
 	// vanished for all six at once, and a spot-check of one would have caught
 	// that only by luck.
-	it.each(STATUS_ORDER as SubscriptionStatus[])(
-		'exposes the %s label as the pill accessible name',
-		(status) => {
-			render(SubscriptionStatusBadge, { props: { status } });
-			const label = getStatusLabel(status);
-			expect(screen.getByLabelText(label)).toBeInTheDocument();
-			// The name is an alias for what is on screen, never a substitute for it.
-			expect(screen.getByLabelText(label)).toHaveTextContent(label);
-		}
-	);
+	it.each(STATUS_ORDER as SubscriptionStatus[])('renders the %s label on the pill', (status) => {
+		render(SubscriptionStatusBadge, { props: { status } });
+		const label = getStatusLabel(status);
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
+	});
 
 	it('names past_due "Past due" — the label carries the distinction the tone cannot', () => {
 		render(SubscriptionStatusBadge, { props: { status: 'past_due' } });
-		expect(screen.getByLabelText('Past due')).toBeInTheDocument();
-		expect(screen.queryByLabelText('Active')).toBeNull();
+		expect(screen.getByTestId('status-badge')).toHaveTextContent('Past due');
+		expect(screen.queryByText('Active')).toBeNull();
 	});
 
 	it('maps status to the primitive tone (active → success, past_due → danger)', () => {

--- a/src/lib/components/organization/membership/MembershipCta.svelte
+++ b/src/lib/components/organization/membership/MembershipCta.svelte
@@ -23,6 +23,8 @@
 		UserPlus
 	} from '@lucide/svelte';
 	import { cn } from '$lib/utils/cn';
+	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
+	import type { Tone } from '$lib/components/common/tones';
 	import { resolve } from '$app/paths';
 
 	interface Props {
@@ -112,14 +114,17 @@
 		return plan && inline;
 	});
 
-	// Status badge styling, on the semantic tone tokens rather than a
-	// hand-picked green/yellow/grey/red ramp — each pill still carries its own
-	// translated label (`memberStatus.*`), so the fill never says it alone.
-	const statusStyles: Record<MembershipStatus, string> = {
-		active: 'bg-success text-success-foreground',
-		paused: 'bg-highlight text-highlight-foreground',
-		cancelled: 'bg-muted text-muted-foreground',
-		banned: 'bg-destructive text-destructive-foreground'
+	// Status badge styling on the semantic tone tokens rather than a hand-picked
+	// green/yellow/grey/red ramp — each pill still carries its own translated
+	// label (`memberStatus.*`), so the fill never says it alone. These are the
+	// same four pairs the pills used to spell out as class strings, now handed to
+	// `common/StatusBadge` as tones (#795): success/highlight/muted/destructive
+	// are exactly what tones success/warning/neutral/danger render.
+	const statusTones: Record<MembershipStatus, Tone> = {
+		active: 'success',
+		paused: 'warning',
+		cancelled: 'neutral',
+		banned: 'danger'
 	};
 
 	const accessToken = $derived(authStore.accessToken);
@@ -225,39 +230,43 @@
 
 {#snippet memberBadge()}
 	<!-- Ported from the legacy RequestMembershipButton: status pill + tier pill,
-	     each labelled by its own text so nothing is conveyed by colour alone. -->
+	     each labelled by its own text so nothing is conveyed by colour alone.
+	     Hand-rolled spans until #795 — they carried `aria-label` on a role-less
+	     <span>, the exact pattern that issue rules against, and their class
+	     strings were `common/StatusBadge`'s tone map spelled out by hand. Now they
+	     ARE StatusBadges: the tone map replaces `statusStyles`, `srLabel` turns
+	     each name into real sr-only content, and `class` pins the slightly roomier
+	     legacy geometry (gap-1.5 px-3 py-1.5) so nothing moves on screen. -->
 	<div class={cn('inline-flex flex-wrap items-center gap-2', className)} role="status">
 		{#if membershipStatus}
-			<span
-				class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-bold {statusStyles[
-					membershipStatus
-				]}"
-				aria-label={m['membershipEligibility.memberStatusAriaLabel']({
+			<StatusBadge
+				tone={statusTones[membershipStatus]}
+				label={m[`memberStatus.${membershipStatus}`]()}
+				icon={Check}
+				class="gap-1.5 px-3 py-1.5"
+				srLabel={m['membershipEligibility.memberStatusAriaLabel']({
 					status: m[`memberStatus.${membershipStatus}`]()
 				})}
-			>
-				<Check class="h-3 w-3" aria-hidden="true" />
-				{m[`memberStatus.${membershipStatus}`]()}
-			</span>
+			/>
 		{/if}
 
 		{#if membershipTier}
-			<span
-				class="inline-flex items-center gap-1.5 rounded-full bg-info px-3 py-1.5 text-xs font-bold text-info-foreground"
-				aria-label={m['membershipEligibility.memberTierAriaLabel']({ tier: membershipTier.name })}
-			>
-				<Award class="h-3 w-3" aria-hidden="true" />
-				{membershipTier.name}
-			</span>
+			<StatusBadge
+				tone="info"
+				label={membershipTier.name}
+				icon={Award}
+				class="gap-1.5 px-3 py-1.5"
+				srLabel={m['membershipEligibility.memberTierAriaLabel']({ tier: membershipTier.name })}
+			/>
 		{:else if !membershipStatus}
 			<!-- Eligibility-derived membership: no server props to describe it. -->
-			<span
-				class="inline-flex items-center gap-1.5 rounded-full bg-success px-3 py-1.5 text-xs font-bold text-success-foreground"
-				aria-label={m['membershipEligibility.memberBadgeAriaLabel']()}
-			>
-				<Check class="h-3 w-3" aria-hidden="true" />
-				{m['membershipEligibility.memberBadge']()}
-			</span>
+			<StatusBadge
+				tone="success"
+				label={m['membershipEligibility.memberBadge']()}
+				icon={Check}
+				class="gap-1.5 px-3 py-1.5"
+				srLabel={m['membershipEligibility.memberBadgeAriaLabel']()}
+			/>
 		{/if}
 	</div>
 {/snippet}

--- a/src/lib/components/polls/PollStatusBadge.svelte
+++ b/src/lib/components/polls/PollStatusBadge.svelte
@@ -28,9 +28,8 @@
 </script>
 
 <!--
-	`aria-label` is explicit even though `common/StatusBadge` has defaulted one
-	since #788: every poll surface (admin list/detail cards) locates this pill
-	by its status text — closing the same contract hole the other 11 mappers in
-	this program already guard against (see `members/SubscriptionStatusBadge.test.ts`).
+	Every poll surface (admin list/detail cards) locates this pill by its status
+	text, which is also its accessible name (#795) — pinned by the enum-driven
+	test, as in the other mappers (see `members/SubscriptionStatusBadge.test.ts`).
 -->
-<StatusBadge {tone} {label} size="sm" aria-label={label} />
+<StatusBadge {tone} {label} size="sm" />

--- a/src/lib/components/polls/PollStatusBadge.test.ts
+++ b/src/lib/components/polls/PollStatusBadge.test.ts
@@ -4,13 +4,10 @@ import type { PollStatus } from '$lib/api/generated/types.gen';
 import PollStatusBadge from './PollStatusBadge.svelte';
 
 /**
- * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts`: this pill's
- * accessible NAME is a cross-surface contract (admin poll list/detail cards
- * locate it by its status text), not decoration. `PollStatusBadge` shipped in
- * an earlier wave as a `common/StatusBadge` mapper WITHOUT an `aria-label`,
- * back when the primitive defaulted nothing (it defaults one since #788) — so
- * this guards every status, not just a sample, against that name being
- * silently absent.
+ * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts`:
+ * this pill's status text is a cross-surface contract (admin poll list/detail
+ * cards locate it by that text, which since #795 is also its accessible name),
+ * not decoration. Every status is pinned, not a sample.
  */
 const STATUS_ORDER: PollStatus[] = ['draft', 'open', 'closed'];
 
@@ -27,11 +24,10 @@ const EXPECTED_TONE_CLASS: Record<PollStatus, string> = {
 };
 
 describe('polls/PollStatusBadge', () => {
-	it.each(STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+	it.each(STATUS_ORDER)('renders the %s label on the pill', (status) => {
 		render(PollStatusBadge, { props: { status } });
 		const label = LABELS[status];
-		expect(screen.getByLabelText(label)).toBeInTheDocument();
-		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 	});
 
 	it.each(STATUS_ORDER)('maps %s to its tone class', (status) => {

--- a/src/lib/components/questionnaires/QuestionTypeBadge.svelte
+++ b/src/lib/components/questionnaires/QuestionTypeBadge.svelte
@@ -34,4 +34,4 @@
 	const tone = $derived(TONE_MAP[type]);
 </script>
 
-<StatusBadge {tone} {label} {size} class={className} aria-label={label} />
+<StatusBadge {tone} {label} {size} class={className} />

--- a/src/lib/components/questionnaires/QuestionTypeBadge.test.ts
+++ b/src/lib/components/questionnaires/QuestionTypeBadge.test.ts
@@ -24,11 +24,10 @@ const EXPECTED_TONE_CLASS: Record<QuestionType, string> = {
 };
 
 describe('questionnaires/QuestionTypeBadge', () => {
-	it.each(TYPE_ORDER)('exposes the %s label as the pill accessible name', (type) => {
+	it.each(TYPE_ORDER)('renders the %s label on the pill', (type) => {
 		const label = LABELS[type];
 		render(QuestionTypeBadge, { props: { type, label } });
-		expect(screen.getByLabelText(label)).toBeInTheDocument();
-		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 	});
 
 	it.each(TYPE_ORDER)('maps %s to its tone class', (type) => {

--- a/src/lib/components/questionnaires/QuestionnaireStatusBadge.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireStatusBadge.svelte
@@ -33,4 +33,4 @@
 	const tone = $derived(TONE_MAP[status]);
 </script>
 
-<StatusBadge {tone} {label} {size} class={className} aria-label={label} />
+<StatusBadge {tone} {label} {size} class={className} />

--- a/src/lib/components/questionnaires/QuestionnaireStatusBadge.test.ts
+++ b/src/lib/components/questionnaires/QuestionnaireStatusBadge.test.ts
@@ -5,11 +5,9 @@ import QuestionnaireStatusBadge from './QuestionnaireStatusBadge.svelte';
 
 /**
  * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts` and
- * `polls/PollStatusBadge`'s sibling `SubmissionStatusBadge.test.ts`: this
- * pill's accessible NAME is not decoration. `common/StatusBadge` now defaults
- * the `aria-label` to its label text (#788), but the mapper still passes it
- * explicitly (defense in depth) — this guards every status, not just a
- * sample, against that name silently vanishing.
+ * its sibling `SubmissionStatusBadge.test.ts`: this pill's status text is not
+ * decoration — it is what locates the badge, and since #795 it is the accessible
+ * name too. Every status is pinned, not a sample.
  */
 const STATUS_ORDER: QuestionnaireStatus[] = ['draft', 'ready', 'published'];
 const LABELS: Record<QuestionnaireStatus, string> = {
@@ -24,11 +22,10 @@ const EXPECTED_TONE_CLASS: Record<QuestionnaireStatus, string> = {
 };
 
 describe('questionnaires/QuestionnaireStatusBadge', () => {
-	it.each(STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+	it.each(STATUS_ORDER)('renders the %s label on the pill', (status) => {
 		const label = LABELS[status];
 		render(QuestionnaireStatusBadge, { props: { status, label } });
-		expect(screen.getByLabelText(label)).toBeInTheDocument();
-		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 	});
 
 	it.each(STATUS_ORDER)('maps %s to its tone class', (status) => {

--- a/src/lib/components/questionnaires/SubmissionStatusBadge.svelte
+++ b/src/lib/components/questionnaires/SubmissionStatusBadge.svelte
@@ -53,11 +53,9 @@
 <!--
 	Submission Status Badge Component
 
-	Displays the evaluation status of a questionnaire submission with an
-	`aria-label`-carrying pill (thin mapper over `common/StatusBadge`). The
-	label is passed explicitly even though the primitive has defaulted one since
-	#788, and the submissions table/detail page locate this pill by its status
-	text.
+	Displays the evaluation status of a questionnaire submission as a thin mapper
+	over `common/StatusBadge`. The submissions table/detail page locate this pill
+	by its status text, which is also its accessible name (#795).
 
 	@component
 	@example
@@ -65,4 +63,4 @@
 	<SubmissionStatusBadge status="pending review" />
 	<SubmissionStatusBadge status="auto_accepted" />
 -->
-<CommonStatusBadge {tone} {label} {icon} size="sm" class={className} aria-label={label} />
+<CommonStatusBadge {tone} {label} {icon} size="sm" class={className} />

--- a/src/lib/components/questionnaires/SubmissionStatusBadge.test.ts
+++ b/src/lib/components/questionnaires/SubmissionStatusBadge.test.ts
@@ -4,13 +4,11 @@ import { SUBMISSION_BADGE_STATUS_ORDER } from '$lib/utils/questionnaire-types';
 import SubmissionStatusBadge from './SubmissionStatusBadge.svelte';
 
 /**
- * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts`: this pill's
- * accessible NAME is a cross-surface contract (the submissions table and the
- * submission detail page locate it by its status text), not decoration. The
- * rebrand turned this into a thin mapper over `common/StatusBadge`; the
- * primitive now defaults the `aria-label` to its label text (#788), and the
- * mapper still passes it explicitly (defense in depth) — this guards every
- * status, not just a sample, against that name silently vanishing again.
+ * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts`:
+ * this pill's status TEXT is a cross-surface contract (the submissions table and
+ * the submission detail page locate it by that text, which since #795 is also
+ * its accessible name), not decoration. Every status is pinned, not a sample —
+ * the failure mode drops all of them at once.
  */
 const LABELS: Record<(typeof SUBMISSION_BADGE_STATUS_ORDER)[number], string> = {
 	draft: 'Draft',
@@ -21,15 +19,11 @@ const LABELS: Record<(typeof SUBMISSION_BADGE_STATUS_ORDER)[number], string> = {
 };
 
 describe('questionnaires/SubmissionStatusBadge', () => {
-	it.each(SUBMISSION_BADGE_STATUS_ORDER)(
-		'exposes the %s label as the pill accessible name',
-		(status) => {
-			render(SubmissionStatusBadge, { props: { status } });
-			const label = LABELS[status];
-			expect(screen.getByLabelText(label)).toBeInTheDocument();
-			expect(screen.getByLabelText(label)).toHaveTextContent(label);
-		}
-	);
+	it.each(SUBMISSION_BADGE_STATUS_ORDER)('renders the %s label on the pill', (status) => {
+		render(SubmissionStatusBadge, { props: { status } });
+		const label = LABELS[status];
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
+	});
 
 	it('collapses approved and auto_accepted onto the same tone, distinguished by label', () => {
 		const approved = render(SubmissionStatusBadge, { props: { status: 'approved' } });
@@ -40,8 +34,8 @@ describe('questionnaires/SubmissionStatusBadge', () => {
 		const autoEl = auto.container.querySelector('span') as HTMLElement;
 		expect(autoEl.className).toContain('bg-success');
 
-		expect(screen.getByLabelText('Approved')).toBeInTheDocument();
-		expect(screen.getByLabelText('Auto-accepted')).toBeInTheDocument();
+		expect(screen.getByText('Approved')).toBeInTheDocument();
+		expect(screen.getByText('Auto-accepted')).toBeInTheDocument();
 	});
 
 	it('maps rejected to danger', () => {

--- a/src/lib/components/tickets/RefundStatusBadge.svelte
+++ b/src/lib/components/tickets/RefundStatusBadge.svelte
@@ -48,14 +48,13 @@
 </script>
 
 <!--
-	`aria-label` is deliberate, not redundant: this pill's accessible name is how
-	the ticket table/card list surfaces are addressed by tests. Since #788 the
-	`common/StatusBadge` primitive defaults that name to the visible label, so
-	this pass is belt-and-suspenders that the enum-driven test pins either way.
-	`title` carries the optional amount+currency tooltip via restProps.
+	The ticket table/card list surfaces are addressed by this pill's status text,
+	which is also its accessible name (#795) — pinned by the enum-driven test.
+	`title` carries the optional amount+currency tooltip via restProps; that is a
+	description, not a name, and stays valid on a role-less span.
 -->
 {#if known}
 	<!-- w-fit: this sits in TicketTable/TicketCardList's flex flex-col cell, which
 	     would otherwise stretch the pill to the cell's full width. -->
-	<CommonStatusBadge {tone} {label} size="sm" title={tooltip} aria-label={label} class="w-fit" />
+	<CommonStatusBadge {tone} {label} size="sm" title={tooltip} class="w-fit" />
 {/if}

--- a/src/lib/components/tickets/RefundStatusBadge.test.ts
+++ b/src/lib/components/tickets/RefundStatusBadge.test.ts
@@ -7,13 +7,12 @@ import RefundStatusBadge, {
 } from './RefundStatusBadge.svelte';
 
 /**
- * REGRESSION GUARD. Before #788 `common/StatusBadge` named itself from its
- * text content alone, so a mapper that forgot `aria-label` silently un-named
- * its pill for every `getByLabel` lookup in the ticket table / card list, even
- * though its own unit tests (which query by text) stayed green. The primitive
- * defaults the name now; this test is what keeps it true either way. See
- * `src/lib/components/members/SubscriptionStatusBadge.test.ts` for the incident this
- * pattern guards against (19 e2e specs broke on exactly this omission).
+ * REGRESSION GUARD. The ticket table / card list locate this pill by its
+ * status text, which since #795 is also its accessible name — the badge is
+ * addressed as `status-badge` + that text, and nothing hidden supplies it. Every
+ * enum value is pinned, not a sample. See
+ * `src/lib/components/members/SubscriptionStatusBadge.test.ts` for the incident
+ * this pattern guards against (19 e2e specs broke on one dropped label).
  */
 const LABELS: Record<KnownRefundStatus, string> = {
 	succeeded: m['adminTicketTable.refundStatus.succeeded'](),
@@ -22,11 +21,10 @@ const LABELS: Record<KnownRefundStatus, string> = {
 };
 
 describe('tickets/RefundStatusBadge', () => {
-	it.each(REFUND_STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+	it.each(REFUND_STATUS_ORDER)('renders the %s label on the pill', (status) => {
 		render(RefundStatusBadge, { props: { status } });
 		const label = LABELS[status];
-		expect(screen.getByLabelText(label)).toBeInTheDocument();
-		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 	});
 
 	it('renders nothing for an unknown/null status — never mislabels as "failed"', () => {
@@ -46,6 +44,6 @@ describe('tickets/RefundStatusBadge', () => {
 		render(RefundStatusBadge, {
 			props: { status: 'succeeded', amount: '12.00', currency: 'EUR' }
 		});
-		expect(screen.getByLabelText(LABELS.succeeded)).toHaveAttribute('title', '12.00 EUR');
+		expect(screen.getByTestId('status-badge')).toHaveAttribute('title', '12.00 EUR');
 	});
 });

--- a/src/lib/components/tokens/TokenStatusBadge.svelte
+++ b/src/lib/components/tokens/TokenStatusBadge.svelte
@@ -39,9 +39,8 @@
 </script>
 
 <!--
-	`aria-label` is explicit (the primitive also defaults one since #788), and
-	every token surface (event admin card, org admin card) is located by its
-	status pill through this text — dropping it here silently un-names them
-	the same way it did for `members/SubscriptionStatusBadge` (see that component's test).
+	Every token surface (event admin card, org admin card) is located by this
+	pill's status text; since #795 that text is also the badge's accessible name,
+	so there is no `aria-label` to keep in sync with it.
 -->
-<CommonStatusBadge {tone} {label} size="sm" class={className} aria-label={label} />
+<CommonStatusBadge {tone} {label} size="sm" class={className} />

--- a/src/lib/components/tokens/TokenStatusBadge.test.ts
+++ b/src/lib/components/tokens/TokenStatusBadge.test.ts
@@ -3,12 +3,10 @@ import { describe, it, expect } from 'vitest';
 import TokenStatusBadge from './TokenStatusBadge.svelte';
 
 /**
- * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts`: this pill's
- * accessible NAME is a cross-surface contract (event admin + org admin token
- * cards locate their status pill by it), not decoration. The rebrand turned
- * this into a thin mapper over `common/StatusBadge`, which back then defaulted
- * no `aria-label` from its content (#788 changed that) — so this guards every
- * status, not just a sample, against that name silently vanishing again.
+ * REGRESSION GUARD, same shape as `members/SubscriptionStatusBadge.test.ts`:
+ * this pill's status text is a cross-surface contract (event admin + org admin
+ * token cards locate their status pill by it, and since #795 it is the
+ * accessible name too), not decoration. Every status is pinned, not a sample.
  */
 const STATUS_ORDER = ['active', 'expired', 'limit-reached', 'staff'] as const;
 
@@ -20,11 +18,10 @@ const LABELS: Record<(typeof STATUS_ORDER)[number], string> = {
 };
 
 describe('tokens/TokenStatusBadge', () => {
-	it.each(STATUS_ORDER)('exposes the %s label as the pill accessible name', (status) => {
+	it.each(STATUS_ORDER)('renders the %s label on the pill', (status) => {
 		render(TokenStatusBadge, { props: { status } });
 		const label = LABELS[status];
-		expect(screen.getByLabelText(label)).toBeInTheDocument();
-		expect(screen.getByLabelText(label)).toHaveTextContent(label);
+		expect(screen.getByTestId('status-badge')).toHaveTextContent(label);
 	});
 
 	it('maps status to the primitive tone (active → success, expired → danger)', () => {

--- a/src/routes/(auth)/account/profile/+page.svelte
+++ b/src/routes/(auth)/account/profile/+page.svelte
@@ -335,7 +335,7 @@
 							icon={ShieldCheck}
 							label={m['profile.email_verified']()}
 							role="status"
-							aria-label={m['profile.email_verified_label']()}
+							srLabel={m['profile.email_verified_label']()}
 						/>
 					{:else}
 						<StatusBadge
@@ -343,7 +343,7 @@
 							icon={ShieldAlert}
 							label={m['profile.email_unverified']()}
 							role="status"
-							aria-label={m['profile.email_unverified_label']()}
+							srLabel={m['profile.email_unverified_label']()}
 						/>
 					{/if}
 				</div>

--- a/src/routes/(auth)/org/[slug]/admin/billing/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/+page.svelte
@@ -582,7 +582,6 @@
 				<StatusBadge
 					tone={VAT_STATUS_TONE[vatStatus.type]}
 					label={vatStatus.label}
-					aria-label={vatStatus.label}
 					icon={vatStatus.type === 'validated'
 						? Check
 						: vatStatus.type === 'pending'

--- a/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/attendee-invoices/+page.svelte
@@ -350,7 +350,6 @@
 								<StatusBadge
 									tone={statusTone(invoice.status)}
 									label={statusLabel(invoice.status)}
-									aria-label={statusLabel(invoice.status)}
 								/>
 							</td>
 							<td class="px-4 py-3 text-right font-mono"
@@ -470,12 +469,7 @@
 						</p>
 						<p class="text-lg font-semibold">{inv.invoice_number}</p>
 					</div>
-					<StatusBadge
-						tone={statusTone(inv.status)}
-						label={statusLabel(inv.status)}
-						aria-label={statusLabel(inv.status)}
-						class="mt-1"
-					/>
+					<StatusBadge tone={statusTone(inv.status)} label={statusLabel(inv.status)} class="mt-1" />
 				</div>
 
 				{#if isEditing}

--- a/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/billing/invoices/+page.svelte
@@ -239,7 +239,6 @@
 								<StatusBadge
 									tone={statusTone(invoice.status)}
 									label={statusLabel(invoice.status)}
-									aria-label={statusLabel(invoice.status)}
 								/>
 							</td>
 							<td class="px-4 py-3 text-right font-mono">
@@ -354,11 +353,7 @@
 						</p>
 						<p class="text-lg font-semibold">{inv.invoice_number}</p>
 					</div>
-					<StatusBadge
-						tone={statusTone(inv.status)}
-						label={statusLabel(inv.status)}
-						aria-label={statusLabel(inv.status)}
-					/>
+					<StatusBadge tone={statusTone(inv.status)} label={statusLabel(inv.status)} />
 				</div>
 
 				<!-- Period -->

--- a/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/settings/+page.svelte
@@ -537,7 +537,6 @@
 					<StatusBadge
 						tone="success"
 						label={m['orgAdmin.settings.membership.emailVerified']()}
-						aria-label={m['orgAdmin.settings.membership.emailVerified']()}
 						size="sm"
 						class="mt-1"
 					/>
@@ -546,7 +545,6 @@
 						tone="warning"
 						icon={AlertCircle}
 						label={m['orgAdmin.settings.membership.emailNotVerified']()}
-						aria-label={m['orgAdmin.settings.membership.emailNotVerified']()}
 						size="sm"
 						class="mt-1"
 					/>

--- a/tests/e2e/journeys/j03-account/follow-org.spec.ts
+++ b/tests/e2e/journeys/j03-account/follow-org.spec.ts
@@ -150,8 +150,12 @@ test.describe('J3 follow org & request membership @p1', () => {
 		// The member-side CTA is now the membership badge, tier and all.
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
-		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel('Membership tier: General membership')).toBeVisible();
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Membership status: Active' })
+		).toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Membership tier: General membership' })
+		).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Application pending' })).toBeHidden();
 
 		// Unfollow via the dropdown; the plain Follow button returns.

--- a/tests/e2e/journeys/j18-series/recurring-admin.spec.ts
+++ b/tests/e2e/journeys/j18-series/recurring-admin.spec.ts
@@ -120,11 +120,15 @@ test.describe('J18 recurring series admin @p2', () => {
 		await seriesAction(page, 'action-pause-resume');
 		await page.getByTestId('pause-resume-confirm').click();
 		await expect(page.getByText('Series paused.')).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel('Paused').first()).toBeVisible();
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Paused' }).first()
+		).toBeVisible();
 
 		await seriesAction(page, 'action-pause-resume');
 		await expect(page.getByText('Series resumed.')).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel('Active').first()).toBeVisible();
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Active' }).first()
+		).toBeVisible();
 
 		await context.close();
 	});

--- a/tests/e2e/journeys/j23-subscriptions/manage-subscription.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/manage-subscription.spec.ts
@@ -146,7 +146,9 @@ async function subscribeAndPay(
 		page,
 		async (card) => {
 			await expect(card).toBeVisible({ timeout: 15_000 });
-			await expect(card.getByLabel('Active')).toBeVisible({ timeout: 10_000 });
+			await expect(
+				card.getByTestId('membership-subscription-status').filter({ hasText: 'Active' })
+			).toBeVisible({ timeout: 10_000 });
 			await expect(card.getByText(plan.name)).toBeVisible({ timeout: 5_000 });
 		},
 		150_000
@@ -210,7 +212,9 @@ test.describe('J23 manage subscription @p2', () => {
 		});
 		// …while the paid plan keeps billing until then.
 		await expect(card.getByText(standard.name)).toBeVisible();
-		await expect(card.getByLabel('Active')).toBeVisible();
+		await expect(
+			card.getByTestId('membership-subscription-status').filter({ hasText: 'Active' })
+		).toBeVisible();
 		// A second change would only 400 while one is pending (getMemberActions).
 		await expect(card.getByRole('button', { name: 'Change plan' })).toBeHidden();
 
@@ -244,7 +248,9 @@ test.describe('J23 manage subscription @p2', () => {
 		await expect(
 			card.getByText('Renewal is off. Resume it any time before this date to keep your membership.')
 		).toBeVisible();
-		await expect(card.getByLabel('Active')).toBeVisible();
+		await expect(
+			card.getByTestId('membership-subscription-status').filter({ hasText: 'Active' })
+		).toBeVisible();
 		await expect(card.getByRole('button', { name: 'Cancel membership' })).toBeHidden();
 		await expect(card.getByRole('button', { name: 'Change plan' })).toBeHidden();
 		await expect(card.getByRole('button', { name: 'Manage billing' })).toBeVisible();
@@ -302,7 +308,9 @@ test.describe('J23 manage subscription @p2', () => {
 			await expect(settled.getByText('€15.00 / month')).toBeVisible({ timeout: 5_000 });
 		});
 		await expect(card.getByText(/^Switching to /)).toBeHidden();
-		await expect(card.getByLabel('Active')).toBeVisible();
+		await expect(
+			card.getByTestId('membership-subscription-status').filter({ hasText: 'Active' })
+		).toBeVisible();
 
 		// --- Immediate cancel ---------------------------------------------------
 		await card.getByRole('button', { name: 'Cancel membership' }).click();
@@ -350,7 +358,9 @@ test.describe('J23 manage subscription @p2', () => {
 		// memberships dict, which keeps cancelled rows).
 		await gotoHydrated(page, ORG_PATH);
 		await waitForClientAuth(page);
-		await expect(page.getByLabel('Membership status: Cancelled')).toBeVisible({ timeout: 20_000 });
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Membership status: Cancelled' })
+		).toBeVisible({ timeout: 20_000 });
 
 		await context.close();
 	});

--- a/tests/e2e/journeys/j23-subscriptions/metrics.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/metrics.spec.ts
@@ -95,16 +95,20 @@ test.describe('J23 subscription metrics @p2', () => {
 
 		// The one subscription row behind those figures — a different claim from
 		// the strip above, and still worth making: it pins the row-level state, not
-		// the aggregate. StatusBadge exposes the status as its accessible NAME,
-		// while the strip's chips are plain <span>s with no aria-label, so
-		// getByLabel('Active') keeps resolving to badges only.
+		// the aggregate. The strip's chips are plain <span>s that never go through
+		// `common/StatusBadge`, so the `status-badge` testid resolves to badges
+		// only — a structural guarantee since #795, where it used to rest on the
+		// chips happening to carry no aria-label.
 		//
 		// Scoped twice over. To the open tab panel, because the Members tab stays
 		// mounted behind it and its membership rows carry an "Active" badge of
 		// their own; and to VISIBLE nodes, because each subscription renders both a
 		// desktop table row and a mobile card (one of which is always display:none)
 		// — so an unfiltered count is 2 per subscription and layout-dependent.
-		const activeBadges = subsPanel.getByLabel('Active').filter({ visible: true });
+		const activeBadges = subsPanel
+			.getByTestId('status-badge')
+			.filter({ hasText: 'Active' })
+			.filter({ visible: true });
 		await expect(activeBadges).toHaveCount(1);
 		await expect(subsPanel.getByText(member.email).filter({ visible: true })).toHaveCount(1);
 

--- a/tests/e2e/journeys/j23-subscriptions/revival.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/revival.spec.ts
@@ -297,7 +297,9 @@ test.describe('J23 revival window + past due @p2', () => {
 		// Grace semantics, PROBED: the member row stays ACTIVE and the past-due
 		// subscription is still inlined, so this is a full membership card
 		// carrying a warning — not a stripped terminal one.
-		await expect(card.getByLabel('Past due')).toBeVisible();
+		await expect(
+			card.getByTestId('membership-subscription-status').filter({ hasText: 'Past due' })
+		).toBeVisible();
 		await expect(card.getByText(`${PLAN_NAME} · ${PLAN_PRICE}`)).toBeVisible();
 
 		// The banner is the failure's only announcement, so it must reach a screen
@@ -387,7 +389,9 @@ test.describe('J23 revival window + past due @p2', () => {
 			// out-of-window test. The rejoin offer is gone with it: the offer is
 			// gated on an EXPIRED row, and the row is PENDING now.
 			await expect(card).toBeVisible({ timeout: 20_000 });
-			await expect(card.getByLabel('Pending')).toBeVisible();
+			await expect(
+				card.getByTestId('membership-subscription-status').filter({ hasText: 'Pending' })
+			).toBeVisible();
 			await expect(card.getByText(`${PLAN_NAME} · ${PLAN_PRICE}`)).toBeVisible();
 			await expect(card.getByText('Awaiting first payment')).toBeVisible();
 			await expect(page.getByRole('button', { name: 'Rejoin' })).toBeHidden();

--- a/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
@@ -138,7 +138,9 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await expect(boughtPlan.getByText("You're subscribed to this plan.")).toBeVisible();
 		// …and the grid's join CTAs are replaced by the member status pill (this
 		// one rides on invalidateAll() re-running the server load).
-		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 30_000 });
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Membership status: Active' })
+		).toBeVisible({ timeout: 30_000 });
 
 		// The org landing page — which keeps the inline membership card — tells the
 		// same story on a fresh server load.
@@ -146,7 +148,9 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await waitForClientAuth(page);
 		const inlineCard = page.locator('.bg-card').filter({ hasText: 'Your membership' });
 		await expect(inlineCard.getByText(plan.name)).toBeVisible({ timeout: 30_000 });
-		await expect(inlineCard.getByLabel('Active')).toBeVisible();
+		await expect(
+			inlineCard.getByTestId('membership-subscription-status').filter({ hasText: 'Active' })
+		).toBeVisible();
 
 		// The account hub tells the same story.
 		await gotoHydrated(page, '/account/memberships');
@@ -154,7 +158,9 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		const card = membershipCard(page, 'Revel Events Collective');
 		await expect(card).toBeVisible({ timeout: 20_000 });
 		await expect(card.getByText(plan.name)).toBeVisible();
-		await expect(card.getByLabel('Active')).toBeVisible();
+		await expect(
+			card.getByTestId('membership-subscription-status').filter({ hasText: 'Active' })
+		).toBeVisible();
 
 		// BE #774 follow-up, ONLINE side. This is the only place the real Stripe
 		// handles exist, so it is the only place that can prove the admin schema's
@@ -223,7 +229,9 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await gotoHydrated(page, ORG_PATH);
 		await waitForClientAuth(page);
 		const inlineCard = page.locator('.bg-card').filter({ hasText: 'Your membership' });
-		await expect(inlineCard.getByLabel('Pending')).toBeVisible({ timeout: 20_000 });
+		await expect(
+			inlineCard.getByTestId('membership-subscription-status').filter({ hasText: 'Pending' })
+		).toBeVisible({ timeout: 20_000 });
 		await expect(inlineCard.getByText('Awaiting first payment')).toBeVisible();
 
 		// Abandon: walk away from the hosted page instead of paying, simulating

--- a/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscription-lifecycle.spec.ts
@@ -76,7 +76,9 @@ test.describe('J23 subscription lifecycle @p2', () => {
 		}
 
 		// Succeeded initial payment → ACTIVE, and the payment row is recorded.
-		await expect(drawer.getByLabel('Active')).toBeVisible({ timeout: 15_000 });
+		await expect(drawer.getByTestId('status-badge').filter({ hasText: 'Active' })).toBeVisible({
+			timeout: 15_000
+		});
 		await expect(drawer.getByText('Payments')).toBeVisible();
 		// Currency-formatted since b163f3eb ("€15.00", not the raw "15.00 EUR" the
 		// cell rendered before the platform-fee work reused `formatMoney` here).
@@ -103,7 +105,9 @@ test.describe('J23 subscription lifecycle @p2', () => {
 		await expect(card).toBeVisible({ timeout: 15_000 });
 		await expect(card.getByText(plan.name)).toBeVisible();
 		await expect(card.getByText('€15.00 / month')).toBeVisible();
-		await expect(card.getByLabel('Active')).toBeVisible();
+		await expect(
+			card.getByTestId('membership-subscription-status').filter({ hasText: 'Active' })
+		).toBeVisible();
 
 		// An OFFLINE row is organization-managed, and the backend now says so
 		// itself: `me_subscriptions.change_plan` refuses one with a 400 (an offline
@@ -130,15 +134,21 @@ test.describe('J23 subscription lifecycle @p2', () => {
 		).toBeVisible();
 		await pauseDialog.getByRole('button', { name: 'Pause subscription' }).click();
 		await expect(pauseDialog).toBeHidden({ timeout: 15_000 });
-		await expect(drawer.getByLabel('Paused')).toBeVisible({ timeout: 15_000 });
+		await expect(drawer.getByTestId('status-badge').filter({ hasText: 'Paused' })).toBeVisible({
+			timeout: 15_000
+		});
 		await gotoHydrated(memberPage, '/account/memberships');
 		await waitForClientAuth(memberPage);
-		await expect(card.getByLabel('Paused')).toBeVisible({ timeout: 15_000 });
+		await expect(
+			card.getByTestId('membership-subscription-status').filter({ hasText: 'Paused' })
+		).toBeVisible({ timeout: 15_000 });
 		await memberContext.close();
 
 		// Resume → ACTIVE again.
 		await drawer.getByRole('button', { name: 'Resume', exact: true }).click();
-		await expect(drawer.getByLabel('Active')).toBeVisible({ timeout: 15_000 });
+		await expect(drawer.getByTestId('status-badge').filter({ hasText: 'Active' })).toBeVisible({
+			timeout: 15_000
+		});
 
 		// Immediate cancel needs the explicit acknowledgement.
 		await drawer.getByRole('button', { name: 'Cancel', exact: true }).click();
@@ -151,7 +161,9 @@ test.describe('J23 subscription lifecycle @p2', () => {
 			.click();
 		await confirmButton.click();
 		await expect(cancelDialog).toBeHidden({ timeout: 15_000 });
-		await expect(drawer.getByLabel('Cancelled')).toBeVisible({ timeout: 15_000 });
+		await expect(drawer.getByTestId('status-badge').filter({ hasText: 'Cancelled' })).toBeVisible({
+			timeout: 15_000
+		});
 		// Terminal state: no lifecycle actions remain.
 		await expect(drawer.getByRole('button', { name: 'Pause', exact: true })).toBeHidden();
 

--- a/tests/e2e/journeys/j23-subscriptions/uncancel-gating.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/uncancel-gating.spec.ts
@@ -119,7 +119,9 @@ test.describe('J23 uncancel gating @p2', () => {
 
 		// --- CONTROL: member row ACTIVE → the button is there --------------------
 		const okDrawer = await openDrawerFor(page, activeMember);
-		await expect(okDrawer.getByLabel('Active')).toBeVisible({ timeout: 15_000 });
+		await expect(okDrawer.getByTestId('status-badge').filter({ hasText: 'Active' })).toBeVisible({
+			timeout: 15_000
+		});
 		await expect(okDrawer.getByText(new RegExp(`^Cancels on .*(${MONTH})`))).toBeVisible();
 		await expect(okDrawer.getByRole('button', { name: 'Undo cancellation' })).toBeVisible();
 		// Corroborates that the row really is scheduled to cancel: Pause is refused
@@ -136,7 +138,9 @@ test.describe('J23 uncancel gating @p2', () => {
 		// was not mirrored onto it), and the cancellation is still booked — so the
 		// only thing that differs from the control above is `member_status`.
 		// Without these, the absence below could just be an unloaded drawer.
-		await expect(gatedDrawer.getByLabel('Active')).toBeVisible({ timeout: 15_000 });
+		await expect(gatedDrawer.getByTestId('status-badge').filter({ hasText: 'Active' })).toBeVisible(
+			{ timeout: 15_000 }
+		);
 		await expect(gatedDrawer.getByText(new RegExp(`^Cancels on .*(${MONTH})`))).toBeVisible();
 
 		// THE NEGATIVE: the backend would answer 403, so the drawer never offers it.

--- a/tests/e2e/journeys/j27-applications/apply-flows.spec.ts
+++ b/tests/e2e/journeys/j27-applications/apply-flows.spec.ts
@@ -89,8 +89,12 @@ test.describe('j27 application flows @p2', () => {
 		// The org page reports it server-side: status + tier badges, not a CTA.
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
-		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel(`Membership tier: ${DEFAULT_TIER}`)).toBeVisible();
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Membership status: Active' })
+		).toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: `Membership tier: ${DEFAULT_TIER}` })
+		).toBeVisible();
 
 		// The membership grid withdraws the offer tier by tier. The per-tier member
 		// badge is the settle signal: those CTAs resolve asynchronously, so
@@ -99,7 +103,9 @@ test.describe('j27 application flows @p2', () => {
 		await gotoHydrated(page, membershipPath(org.slug));
 		await waitForClientAuth(page);
 		await expect(
-			tierCard(page, DEFAULT_TIER).getByLabel('You are a member of this organization')
+			tierCard(page, DEFAULT_TIER)
+				.getByTestId('status-badge')
+				.filter({ hasText: 'You are a member of this organization' })
 		).toBeVisible({ timeout: 15_000 });
 		await expect(page.getByRole('button', { name: /^Join / })).toHaveCount(0);
 
@@ -113,7 +119,9 @@ test.describe('j27 application flows @p2', () => {
 		// message (CSS-capitalized, so the DOM string is lowercase).
 		await expect(card.getByText('active', { exact: true })).toBeVisible();
 		await expect(
-			applicationRow(page, 'Closed', org.name).getByLabel('Application status: Completed')
+			applicationRow(page, 'Closed', org.name)
+				.getByTestId('status-badge')
+				.filter({ hasText: 'Application status: Completed' })
 		).toBeVisible();
 		await expect(page.getByRole('list', { name: 'In progress' })).toBeHidden();
 
@@ -161,7 +169,9 @@ test.describe('j27 application flows @p2', () => {
 		await gotoHydrated(page, '/account/memberships');
 		await waitForClientAuth(page);
 		await expect(
-			applicationRow(page, 'In progress', org.name).getByLabel('Application status: Pending')
+			applicationRow(page, 'In progress', org.name)
+				.getByTestId('status-badge')
+				.filter({ hasText: 'Application status: Pending' })
 		).toBeVisible({ timeout: 15_000 });
 		await expect(membershipCard(page, org.name)).toBeHidden();
 
@@ -181,7 +191,9 @@ test.describe('j27 application flows @p2', () => {
 			await waitForClientAuth(page);
 			await expect(membershipCard(page, org.name)).toBeVisible({ timeout: 10_000 });
 			await expect(
-				applicationRow(page, 'Closed', org.name).getByLabel('Application status: Completed')
+				applicationRow(page, 'Closed', org.name)
+					.getByTestId('status-badge')
+					.filter({ hasText: 'Application status: Completed' })
 			).toBeVisible({ timeout: 10_000 });
 		}).toPass({ timeout: 30_000 });
 
@@ -245,10 +257,14 @@ test.describe('j27 application flows @p2', () => {
 		await gotoHydrated(page, '/account/memberships');
 		await waitForClientAuth(page);
 		await expect(
-			applicationRow(page, 'Closed', org.name).getByLabel('Application status: Rejected')
+			applicationRow(page, 'Closed', org.name)
+				.getByTestId('status-badge')
+				.filter({ hasText: 'Application status: Rejected' })
 		).toBeVisible({ timeout: 15_000 });
 		await expect(
-			applicationRow(page, 'In progress', org.name).getByLabel('Application status: Pending')
+			applicationRow(page, 'In progress', org.name)
+				.getByTestId('status-badge')
+				.filter({ hasText: 'Application status: Pending' })
 		).toBeVisible();
 
 		await page.context().close();
@@ -284,7 +300,9 @@ test.describe('j27 application flows @p2', () => {
 
 		// The row settles into "Closed", and nothing is left in progress.
 		await expect(
-			applicationRow(page, 'Closed', org.name).getByLabel('Application status: Cancelled')
+			applicationRow(page, 'Closed', org.name)
+				.getByTestId('status-badge')
+				.filter({ hasText: 'Application status: Cancelled' })
 		).toBeVisible({ timeout: 15_000 });
 		await expect(page.getByRole('list', { name: 'In progress' })).toBeHidden();
 

--- a/tests/e2e/journeys/j27-applications/eligibility-states.spec.ts
+++ b/tests/e2e/journeys/j27-applications/eligibility-states.spec.ts
@@ -93,8 +93,12 @@ test.describe('j27 membership eligibility states @p2', () => {
 
 		// Both pills are labelled, so neither status nor tier is conveyed by
 		// colour alone.
-		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel('Membership tier: General membership')).toBeVisible();
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Membership status: Active' })
+		).toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Membership tier: General membership' })
+		).toBeVisible();
 		// A member has nothing to apply for — whatever the org's join policy is.
 		await expect(page.getByRole('button', { name: /^Join / })).toBeHidden();
 		await expect(page.getByRole('button', { name: 'Application pending' })).toBeHidden();
@@ -169,7 +173,9 @@ test.describe('j27 membership eligibility states @p2', () => {
 		await gotoHydrated(gatedPage, '/account/memberships');
 		await waitForClientAuth(gatedPage);
 		await expect(
-			applicationRow(gatedPage, 'In progress', lax.name).getByLabel('Application status: Pending')
+			applicationRow(gatedPage, 'In progress', lax.name)
+				.getByTestId('status-badge')
+				.filter({ hasText: 'Application status: Pending' })
 		).toBeVisible({ timeout: 15_000 });
 		await expect(membershipCard(gatedPage, lax.name)).toBeHidden();
 		await gatedPage.context().close();
@@ -181,7 +187,9 @@ test.describe('j27 membership eligibility states @p2', () => {
 		await expect(card).toBeVisible({ timeout: 15_000 });
 		await expect(card.getByText('active', { exact: true })).toBeVisible();
 		await expect(
-			applicationRow(openPage, 'Closed', lax.name).getByLabel('Application status: Completed')
+			applicationRow(openPage, 'Closed', lax.name)
+				.getByTestId('status-badge')
+				.filter({ hasText: 'Application status: Completed' })
 		).toBeVisible();
 		await openPage.context().close();
 	});

--- a/tests/e2e/journeys/j27-applications/gated-paid-tier.spec.ts
+++ b/tests/e2e/journeys/j27-applications/gated-paid-tier.spec.ts
@@ -251,7 +251,9 @@ test.describe('j27 gated + paid tier @p2', () => {
 		// — and not on the ungated neighbour or the org's default tier.
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
-		await expect(page.getByLabel(`Membership tier: ${gatedTierName}`)).toBeVisible({
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: `Membership tier: ${gatedTierName}` })
+		).toBeVisible({
 			timeout: 20_000
 		});
 
@@ -399,7 +401,9 @@ test.describe('j27 gated + paid tier @p2', () => {
 		// ungated default one.
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
-		await expect(page.getByLabel(`Membership tier: ${tierName}`)).toBeVisible({ timeout: 20_000 });
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: `Membership tier: ${tierName}` })
+		).toBeVisible({ timeout: 20_000 });
 
 		await page.context().close();
 	});

--- a/tests/e2e/journeys/j27-applications/questionnaire-flow.spec.ts
+++ b/tests/e2e/journeys/j27-applications/questionnaire-flow.spec.ts
@@ -134,8 +134,12 @@ test.describe('j27 membership questionnaire @p2', () => {
 
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
-		await expect(page.getByLabel('Membership status: Active')).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel(`Membership tier: ${DEFAULT_TIER}`)).toBeVisible();
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: 'Membership status: Active' })
+		).toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: `Membership tier: ${DEFAULT_TIER}` })
+		).toBeVisible();
 
 		await gotoHydrated(page, '/account/memberships');
 		await waitForClientAuth(page);

--- a/tests/e2e/journeys/j27-applications/tier-selection.spec.ts
+++ b/tests/e2e/journeys/j27-applications/tier-selection.spec.ts
@@ -99,8 +99,12 @@ test.describe('j27 tier selection @p2', () => {
 		// backend would have fallen back to.
 		await gotoHydrated(page, `/org/${org.slug}`);
 		await waitForClientAuth(page);
-		await expect(page.getByLabel(`Membership tier: ${goldName}`)).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByLabel(`Membership tier: ${DEFAULT_TIER}`)).toHaveCount(0);
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: `Membership tier: ${goldName}` })
+		).toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.getByTestId('status-badge').filter({ hasText: `Membership tier: ${DEFAULT_TIER}` })
+		).toHaveCount(0);
 
 		await page.context().close();
 	});


### PR DESCRIPTION
Closes #795.

## The ruling

`common/StatusBadge` rendered a role-less `<span>` carrying both visible text and an `aria-label`. On an element whose implicit role is `generic`, ARIA prohibits name-from-author, so conforming AT ignores the attribute outright — axe reports `aria-prohibited-attr` as **incomplete** (needs-review) rather than a violation only because there is text content to fall back on. Nothing was red, and nothing was ever going to be.

The survey made the ruling easy. Of the 31 call sites passing an explicit name:

- **24** passed a string byte-identical to the visible label — pure duplication.
- **7** passed something richer (`"Membership status: Active"`, `"You are the owner"`, `"Email is verified"`).
- **1** passed `aria-label={undefined}` as an escape hatch to dodge a Playwright collision.

The decisive finding: **those 7 richer names reach nobody.** On a role-less span they are ignored by AT. They exist so `getByLabel` can find the badge. ARIA was serving test automation.

**A badge is text. Its accessible name is its content.**

### Rejected alternatives

| Option | Why not |
| --- | --- |
| `role="img"` + `aria-label` | ARIA-valid and nearly free (names stay byte-identical, e2e barely moves), but screen readers announce "graphic" on ~80 badges and the inner text goes presentational. A real verbosity regression for real users, traded for a needs-review finding. |
| `role="status"` | A live region. Every table of pills would chatter. Rejected by the issue itself. |
| `role="note"` / `role="group"` | Nameable, equally verbose ("note", "grouping"). **No quiet role supporting name-from-author exists** — which is itself the argument that the fix is to remove the name, not bolt on a role. |
| Document and close | Leaves the codebase with a canonical example of the pattern, and leaves the 7 broken promises in place. |

Primer `Label`, MUI `Chip`, Carbon `Tag` and Bootstrap `badge` are all plain spans with no role and no `aria-label`.

## What changed

**The primitive** `Omit`s `aria-label` from its public type — passing one is now a type error. That does the job #788's runtime default was doing (a mapper forgetting the prop un-named every subscription pill and took 19 e2e specs down, #772) more decisively, and without the prohibited attribute. It caught two call sites my own survey had missed.

**New `srLabel` prop** for the 7 genuinely-richer names: renders the whole already-translated sentence as real `sr-only` content with the visible label `aria-hidden`, so nothing is read twice. This delivers those names to a screen reader **for the first time**. It reuses the existing message strings verbatim — no prefix-shaped rewrite, so no new keys across the six locales and no sentence composed from an interpolated fragment (which does not survive translation).

**`data-testid="status-badge"`** (overridable) is the automation contract, now labelled honestly instead of dressed as accessibility, and emitted by the primitive so no mapper can forget it. `account/MembershipCard` overrides it with `membership-subscription-status` so a pending SUBSCRIPTION and a pending PAYMENT in the same card stay addressable apart — structurally retiring the collision that needed `aria-label={undefined}` under #788.

**`MembershipCta`'s three hand-rolled pills** carried the same `aria-label`-on-a-span pattern, and their class strings were `common/StatusBadge`'s tone map spelled out by hand. They are StatusBadges now (`statusStyles` → `statusTones`), with `class` pinning the slightly roomier legacy geometry so nothing moves on screen.

**Fixed in passing:** the dashboard membership pill built its name from the raw enum (`"Membership status: active"`), not the translated label. Harmless while nothing read it; a real defect once it is announced.

`EventStatusBadge` keeps `role="status"`/`aria-live` — that is a live region by intent, not a naming workaround.

## Test migration

- **34 e2e assertions** across 12 specs translate 1:1, preserving today's substring semantics:
  ```diff
  - card.getByLabel('Active')
  + card.getByTestId('status-badge').filter({ hasText: 'Active' })
  ```
- Plus **8 `Membership tier: …`** locators and one member-badge lookup, found by sweeping **every distinct `getByLabel` literal in the suite** rather than a keyword filter — the keyword pass missed the tier pills.
- **~44 component assertions** move off `getByLabelText`. The 12 enum-driven mapper guards now pin the label text via the testid; their docblocks are rewritten (they described the #788 contract this PR retires).

## Verification

- `make check` — **exit 0**, 0 type errors (gate self-armed check passed)
- `pnpm vitest run` — **2575 passed**, 1 todo, 0 failed
- `python3 scripts/audit-brand-themes.py` — **0 WCAG failures, 0 colorblind confusables**
- `playwright test --list` — all **545 tests** compile
- `svelte-autofixer` clean on `StatusBadge`, `MembershipCta`, `SubscriptionStatusBadge`
- Zero residual `aria-label` on any `StatusBadge` call site (scripted check)

⚠️ **The e2e suite has NOT been run** — per the house rule, that is yours. The at-risk journeys are `j23-subscriptions`, `j27-applications`, `j18-series` and `j03-account`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved status badge announcements for screen readers using optional translated context.
  * Standardized visible status text as the accessible name while preventing duplicate announcements.
  * Added consistent, customizable badge identifiers for reliable status tracking.

* **Consistency**
  * Replaced custom membership status indicators with consistent status badges and semantic tones.

* **Tests**
  * Updated component and end-to-end coverage to verify badge identifiers and visible status text across membership, billing, applications, and other workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->