### PR TITLE
Localize date and time formatting via Intl

### DIFF
--- a/scripts/check-file-length.sh
+++ b/scripts/check-file-length.sh
@@ -33,10 +33,17 @@ FAILED=0
 #   handlers from that state threads it through closures and breaks single
 #   ownership (same rationale as auth.svelte.ts). Raised to fit the snap-on-drop
 #   drag fix (blocks were trailing the cursor when snap was on).
+#   utils/date.ts → 570: CLAUDE.md + the ESLint toLocale* ban route ALL
+#   human-facing date formatting through this one file, so every formatter must
+#   live here — splitting it would weaken that single-entry-point contract.
+#   Roughly half the length is JSDoc documenting non-obvious CLDR/Intl behavior
+#   (#812: interval-pattern suffix probe, pt-BR pattern selection, DST range
+#   branches) that must stay next to the code it explains.
 max_for() {
     case "$1" in
         src/lib/stores/auth.svelte.ts) echo 620 ;;
         src/lib/components/venues/designer/designer-controller.svelte.ts) echo 540 ;;
+        src/lib/utils/date.ts) echo 570 ;;
         *) echo "$2" ;;
     esac
 }

--- a/src/lib/components/events/EventDetails.svelte
+++ b/src/lib/components/events/EventDetails.svelte
@@ -15,10 +15,12 @@
 
 	const { event, class: className }: Props = $props();
 
-	// Compute RSVP deadline info
+	// Compute RSVP deadline info. A null from getRSVPDeadlineRelative means the
+	// deadline has passed (not "no deadline") — keep showing the tile with the
+	// translated closed copy rather than hiding it.
 	const rsvpDeadlineText = $derived.by(() => {
 		if (!event.rsvp_before) return null;
-		return getRSVPDeadlineRelative(event.rsvp_before);
+		return getRSVPDeadlineRelative(event.rsvp_before) ?? m['eventQuickInfo.rsvpClosed']();
 	});
 
 	const isDeadlineSoon = $derived.by(() => {

--- a/src/lib/components/events/EventDetails.test.ts
+++ b/src/lib/components/events/EventDetails.test.ts
@@ -105,3 +105,19 @@ describe('EventDetails — capacity disclosure', () => {
 		expect(screen.queryByText(/Attendance/i)).not.toBeInTheDocument();
 	});
 });
+
+describe('EventDetails — RSVP deadline', () => {
+	// PR #812 regression guard: getRSVPDeadlineRelative returns null for a passed
+	// deadline; the tile must keep showing the translated closed copy, not vanish
+	// (null here means "closed", not "no deadline set").
+	it('shows "RSVP closed" when the deadline has passed', () => {
+		const event = createMockEvent({ rsvp_before: '2020-01-01T00:00:00Z' });
+		render(EventDetails, { props: { event } });
+		expect(screen.getByText(/RSVP closed/i)).toBeInTheDocument();
+	});
+
+	it('omits the deadline tile when no deadline is set', () => {
+		render(EventDetails, { props: { event: createMockEvent({ rsvp_before: null }) } });
+		expect(screen.queryByText(/RSVP Deadline/i)).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/components/events/EventQuickInfo.svelte
+++ b/src/lib/components/events/EventQuickInfo.svelte
@@ -158,7 +158,7 @@
 	const rsvpDeadlineDisplay = $derived.by(() => {
 		if (!event.rsvp_before) return null;
 		const relative = getRSVPDeadlineRelative(event.rsvp_before);
-		return relative === 'closed'
+		return relative === null
 			? m['eventQuickInfo.rsvpClosed']()
 			: m['eventQuickInfo.rsvpBy']({ deadline: relative });
 	});

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -14,6 +14,7 @@ vi.mock('$lib/paraglide/runtime.js', () => ({
 }));
 
 import {
+	getDateLocale,
 	formatEventDate,
 	formatEventDateRange,
 	formatEventDateForScreenReader,
@@ -399,5 +400,52 @@ describe('isRSVPClosingSoon', () => {
 		expect(isRSVPClosingSoon('2026-06-15T12:00:00.000Z')).toBe(true); // in 2h
 		expect(isRSVPClosingSoon('2026-06-17T10:00:00.000Z')).toBe(false); // in 48h
 		expect(isRSVPClosingSoon('2026-06-15T09:00:00.000Z')).toBe(false); // passed
+	});
+});
+
+describe('every supported UI language uses a textual month in the short forms', () => {
+	// Mirrors the keys of LOCALE_MAP in date.ts. If a language is added there,
+	// add it here so the invariant below covers it.
+	const SUPPORTED_UI_LANGUAGES = ['en', 'de', 'it', 'fr', 'es', 'pt'];
+
+	// The invariant guarded here: the `month: 'short'` skeletons used across
+	// this file (MMMd in formatEventDate/formatEventDateRange, yMMMd in
+	// formatDateTime/formatDate/formatDateTimeReadback) must resolve to a
+	// *textual* month in every mapped locale. This is a property of the
+	// locale's CLDR pattern data, not of the requested options: a locale may
+	// have abbreviated month names yet map these skeletons to numeric
+	// patterns — pt-PT does exactly that ("sexta, 24/10"), which is why
+	// LOCALE_MAP maps pt to pt-BR ("sex., 24 de out.").
+	it.each(SUPPORTED_UI_LANGUAGES)(
+		'%s resolves the short-month-with-day skeletons to a month word',
+		(lang) => {
+			mockLocale.value = lang;
+			const locale = getDateLocale();
+
+			for (const options of [
+				{ month: 'short', day: 'numeric' }, // MMMd (formatEventDate)
+				{ year: 'numeric', month: 'short', day: 'numeric' } // yMMMd (formatDateTime, formatDate)
+			] as Intl.DateTimeFormatOptions[]) {
+				const month = new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' })
+					.formatToParts(new Date(WINTER_UTC))
+					.find((p) => p.type === 'month')?.value;
+
+				expect(month, `${lang} → ${locale} ${JSON.stringify(options)}`).toMatch(/\p{L}/u);
+			}
+		}
+	);
+
+	it.each(SUPPORTED_UI_LANGUAGES)('%s end-to-end: formatEventDate contains no numeric d/M', (lang) => {
+		mockLocale.value = lang;
+		// A numeric month pattern surfaces as slash-separated digits
+		// (pt-PT would render "sexta, 24/10 • …").
+		expect(formatEventDate(WINTER_UTC, 'Europe/Vienna')).not.toMatch(/\d+\/\d+/);
+	});
+
+	it('pt renders the Brazilian textual short date, not the pt-PT numeric one', () => {
+		mockLocale.value = 'pt';
+		const out = formatEventDate(WINTER_UTC, 'Europe/Vienna');
+		expect(out).toContain('fev.'); // "sex., 6 de fev. • 20:00 …"
+		expect(out).not.toContain('06/02');
 	});
 });

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -236,6 +236,17 @@ describe('getRSVPDeadlineRelative', () => {
 		expect(getRSVPDeadlineRelative(new Date(Date.now() - 60_000).toISOString())).toBeNull();
 	});
 
+	it('treats the exact deadline instant as closed', () => {
+		vi.useFakeTimers();
+		try {
+			const deadline = '2026-06-15T18:00:00.000Z';
+			vi.setSystemTime(new Date(deadline));
+			expect(getRSVPDeadlineRelative(deadline)).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it('returns a localized relative phrase for a future deadline', () => {
 		const out = getRSVPDeadlineRelative(new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString());
 		// en locale via the runtime mock; Intl.RelativeTimeFormat wording.

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-// Force a stable locale so 12-hour formatting (gated on en-US) is deterministic
+// Force a stable locale so hour-cycle and month names are deterministic
 // regardless of the machine running the tests.
 vi.mock('$lib/paraglide/runtime.js', () => ({
 	getLocale: () => 'en'
@@ -16,7 +16,8 @@ import {
 	formatEventTimezoneLabel,
 	formatDateLongMonth,
 	formatDateTimeVerbose,
-	formatMonthYearLabel
+	formatMonthYearLabel,
+	getRSVPDeadlineRelative
 } from './date';
 
 // A fixed winter instant (no DST ambiguity):
@@ -69,7 +70,10 @@ describe('formatEventDateRange same-day detection is timezone-aware', () => {
 
 	it('collapses to a single date when both ends fall on the same local day', () => {
 		const ny = formatEventDateRange(start, end, 'America/New_York');
-		expect(ny).toContain('5:00 PM - 10:00 PM');
+		// formatRange output: locale range dash, shared day-period collapsed.
+		// (\s also matches the narrow no-break space ICU puts before "PM".)
+		expect(ny).toMatch(/5:00\s*[–-]\s*10:00\sPM/);
+		expect(ny.match(/•/g)?.length).toBe(1);
 	});
 
 	it('shows two dates when the local days differ', () => {
@@ -88,6 +92,22 @@ describe('formatEventDateRange same-day detection is timezone-aware', () => {
 		);
 		expect(out).toContain('11:00 PM GMT+1');
 		expect(out).toContain('1:00 PM GMT+2');
+	});
+
+	it('labels each end with its own offset when a DST transition falls within a single local day', () => {
+		// Europe/Vienna falls back on 2026-10-25: 03:00 GMT+2 → 02:00 GMT+1.
+		// 23:00 UTC Oct 24 → 01:00 Oct 25 (GMT+2); 11:00 UTC Oct 25 → 12:00 Oct 25 (GMT+1).
+		// Same local calendar day, but the offsets differ — the range must not
+		// label the end time with the start's offset.
+		const out = formatEventDateRange(
+			'2026-10-24T23:00:00Z',
+			'2026-10-25T11:00:00Z',
+			'Europe/Vienna'
+		);
+		expect(out).toContain('1:00 AM GMT+2');
+		expect(out).toContain('12:00 PM GMT+1');
+		// Date still shown only once (same-day collapse preserved).
+		expect(out.match(/•/g)?.length).toBe(1);
 	});
 });
 
@@ -208,5 +228,22 @@ describe('formatMonthYearLabel (#510)', () => {
 	it('does not contain a time component', () => {
 		const out = formatMonthYearLabel('2026-06-07T12:00:00Z');
 		expect(out).not.toMatch(/\d+:\d+/);
+	});
+});
+
+describe('getRSVPDeadlineRelative', () => {
+	it('returns null for a passed deadline (caller supplies the "closed" copy)', () => {
+		expect(getRSVPDeadlineRelative(new Date(Date.now() - 60_000).toISOString())).toBeNull();
+	});
+
+	it('returns a localized relative phrase for a future deadline', () => {
+		const out = getRSVPDeadlineRelative(new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString());
+		// en locale via the runtime mock; Intl.RelativeTimeFormat wording.
+		expect(out).toMatch(/^in 2 hours$/);
+	});
+
+	it('uses minutes below one hour', () => {
+		const out = getRSVPDeadlineRelative(new Date(Date.now() + 30 * 60 * 1000).toISOString());
+		expect(out).toMatch(/^in (29|30) minutes$/);
 	});
 });

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -187,6 +187,21 @@ describe('formatDateTime and screen-reader format carry the timezone', () => {
 		expect(out).toContain('2:00 PM');
 		expect(out).toContain('EST');
 	});
+
+	it('screen-reader format appends the spoken "Uhr" after the minutes in German', () => {
+		mockLocale.value = 'de';
+		const out = formatEventDateForScreenReader(WINTER_UTC, 'Europe/Vienna');
+		// "Freitag, 6. Februar 2026 um 20:00 Uhr MEZ" — Uhr sits between the
+		// time and the tz abbreviation, not at the end of the string.
+		expect(out).toContain('Februar');
+		expect(out).toContain('20:00 Uhr');
+		expect(out).toMatch(/20:00 Uhr MEZ$/);
+	});
+
+	it('screen-reader format adds no time word for locales without one (en unchanged)', () => {
+		const out = formatEventDateForScreenReader(WINTER_UTC, 'Europe/Vienna');
+		expect(out).not.toContain('Uhr');
+	});
 });
 
 describe('formatTimeOfDay', () => {

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -435,12 +435,15 @@ describe('every supported UI language uses a textual month in the short forms', 
 		}
 	);
 
-	it.each(SUPPORTED_UI_LANGUAGES)('%s end-to-end: formatEventDate contains no numeric d/M', (lang) => {
-		mockLocale.value = lang;
-		// A numeric month pattern surfaces as slash-separated digits
-		// (pt-PT would render "sexta, 24/10 • …").
-		expect(formatEventDate(WINTER_UTC, 'Europe/Vienna')).not.toMatch(/\d+\/\d+/);
-	});
+	it.each(SUPPORTED_UI_LANGUAGES)(
+		'%s end-to-end: formatEventDate contains no numeric d/M',
+		(lang) => {
+			mockLocale.value = lang;
+			// A numeric month pattern surfaces as slash-separated digits
+			// (pt-PT would render "sexta, 24/10 • …").
+			expect(formatEventDate(WINTER_UTC, 'Europe/Vienna')).not.toMatch(/\d+\/\d+/);
+		}
+	);
 
 	it('pt renders the Brazilian textual short date, not the pt-PT numeric one', () => {
 		mockLocale.value = 'pt';

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Force a stable locale so hour-cycle and month names are deterministic
-// regardless of the machine running the tests.
+// regardless of the machine running the tests. The mock is mutable so the
+// getDateLocale fallback (unknown UI language → en-US) can be exercised.
+//
+// NOTE: for full determinism, also pin TZ=UTC for the test run (vitest.config
+// `test.env: { TZ: 'UTC' }` or `TZ=UTC vitest` in the npm script) — the
+// no-timezone code paths render in the machine's local zone. The assertions
+// below are written to hold either way, but pinning removes the ambiguity.
+const mockLocale = vi.hoisted(() => ({ value: 'en' }));
 vi.mock('$lib/paraglide/runtime.js', () => ({
-	getLocale: () => 'en'
+	getLocale: () => mockLocale.value
 }));
 
 import {
@@ -17,12 +24,33 @@ import {
 	formatDateLongMonth,
 	formatDateTimeVerbose,
 	formatMonthYearLabel,
-	getRSVPDeadlineRelative
+	formatRelativeTime,
+	formatTimeOfDay,
+	getRSVPDeadlineRelative,
+	isEventPast,
+	isRSVPClosed,
+	isRSVPClosingSoon
 } from './date';
+
+afterEach(() => {
+	mockLocale.value = 'en';
+	vi.useRealTimers();
+});
 
 // A fixed winter instant (no DST ambiguity):
 //   19:00 UTC  →  14:00 (2:00 PM) EST in New York,  20:00 (8:00 PM) CET in Vienna.
 const WINTER_UTC = '2026-02-06T19:00:00Z';
+
+// Fixed "now" for every wall-clock-dependent test. Freezing time makes the
+// relative-time assertions exact instead of racing the real clock (a deadline
+// built as `now + 2h` and floored inside the function lands on "in 1 hour"
+// whenever any real time elapses in between).
+const FROZEN_NOW = '2026-06-15T10:00:00.000Z';
+
+function freezeTime(iso: string = FROZEN_NOW) {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(iso));
+}
 
 describe('formatEventDate with an explicit timezone (#474)', () => {
 	it('renders the instant in the given timezone, not the viewer’s', () => {
@@ -36,6 +64,8 @@ describe('formatEventDate with an explicit timezone (#474)', () => {
 
 	it('appends a timezone abbreviation when a timezone is supplied', () => {
 		// New York's short name is reliably "EST" in winter across ICU versions.
+		// (Vienna renders as "GMT+1"/"GMT+2" in en-US on current full-ICU Node —
+		// the most ICU-version-sensitive assumption in this file.)
 		expect(formatEventDate(WINTER_UTC, 'America/New_York')).toContain('EST');
 	});
 
@@ -72,7 +102,7 @@ describe('formatEventDateRange same-day detection is timezone-aware', () => {
 		const ny = formatEventDateRange(start, end, 'America/New_York');
 		// formatRange output: locale range dash, shared day-period collapsed.
 		// (\s also matches the narrow no-break space ICU puts before "PM".)
-		expect(ny).toMatch(/5:00\s*[–-]\s*10:00\sPM/);
+		expect(ny).toMatch(/5:00\s*–\s*10:00\sPM/);
 		expect(ny.match(/•/g)?.length).toBe(1);
 	});
 
@@ -80,6 +110,12 @@ describe('formatEventDateRange same-day detection is timezone-aware', () => {
 		const vienna = formatEventDateRange(start, end, 'Europe/Vienna');
 		// A cross-day range repeats the bullet separator for the end date.
 		expect(vienna.match(/•/g)?.length).toBe(2);
+	});
+
+	it('uses the en dash separator in the hand-built cross-day branch (consistent with formatRange)', () => {
+		const vienna = formatEventDateRange(start, end, 'Europe/Vienna');
+		expect(vienna).toContain(' – ');
+		expect(vienna).not.toContain(' - ');
 	});
 
 	it('labels each end with its own offset across a DST transition', () => {
@@ -125,9 +161,22 @@ describe('formatDate applies the timezone to the calendar day without an abbrevi
 	});
 });
 
+describe('getDateLocale falls back to en-US for an unmapped UI language', () => {
+	it('renders English month names when the UI language is unknown', () => {
+		mockLocale.value = 'xx';
+		expect(formatDate(WINTER_UTC, 'America/New_York')).toContain('Feb');
+	});
+});
+
 describe('formatDateTime and screen-reader format carry the timezone', () => {
 	it('formatDateTime includes the localized time and abbreviation', () => {
 		const out = formatDateTime(WINTER_UTC, 'America/New_York');
+		expect(out).toContain('2:00 PM');
+		expect(out).toContain('EST');
+	});
+
+	it('formatDateTime also accepts an already-parsed Date', () => {
+		const out = formatDateTime(new Date(WINTER_UTC), 'America/New_York');
 		expect(out).toContain('2:00 PM');
 		expect(out).toContain('EST');
 	});
@@ -137,6 +186,15 @@ describe('formatDateTime and screen-reader format carry the timezone', () => {
 		expect(out).toContain('February');
 		expect(out).toContain('2:00 PM');
 		expect(out).toContain('EST');
+	});
+});
+
+describe('formatTimeOfDay', () => {
+	it('renders only the clock time in the supplied timezone, no abbreviation', () => {
+		const out = formatTimeOfDay(WINTER_UTC, 'America/New_York');
+		expect(out).toContain('2:00 PM');
+		expect(out).not.toContain('EST');
+		expect(out).not.toContain('February');
 	});
 });
 
@@ -233,28 +291,98 @@ describe('formatMonthYearLabel (#510)', () => {
 
 describe('getRSVPDeadlineRelative', () => {
 	it('returns null for a passed deadline (caller supplies the "closed" copy)', () => {
-		expect(getRSVPDeadlineRelative(new Date(Date.now() - 60_000).toISOString())).toBeNull();
+		freezeTime();
+		expect(getRSVPDeadlineRelative('2026-06-15T09:59:00.000Z')).toBeNull();
 	});
 
 	it('treats the exact deadline instant as closed', () => {
-		vi.useFakeTimers();
-		try {
-			const deadline = '2026-06-15T18:00:00.000Z';
-			vi.setSystemTime(new Date(deadline));
-			expect(getRSVPDeadlineRelative(deadline)).toBeNull();
-		} finally {
-			vi.useRealTimers();
-		}
+		freezeTime(FROZEN_NOW);
+		expect(getRSVPDeadlineRelative(FROZEN_NOW)).toBeNull();
 	});
 
 	it('returns a localized relative phrase for a future deadline', () => {
-		const out = getRSVPDeadlineRelative(new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString());
-		// en locale via the runtime mock; Intl.RelativeTimeFormat wording.
-		expect(out).toMatch(/^in 2 hours$/);
+		freezeTime(); // 10:00Z — deadline exactly 2h later
+		expect(getRSVPDeadlineRelative('2026-06-15T12:00:00.000Z')).toBe('in 2 hours');
 	});
 
 	it('uses minutes below one hour', () => {
-		const out = getRSVPDeadlineRelative(new Date(Date.now() + 30 * 60 * 1000).toISOString());
-		expect(out).toMatch(/^in (29|30) minutes$/);
+		freezeTime();
+		expect(getRSVPDeadlineRelative('2026-06-15T10:30:00.000Z')).toBe('in 30 minutes');
+	});
+
+	it('uses days at 24 hours and beyond', () => {
+		freezeTime();
+		expect(getRSVPDeadlineRelative('2026-06-18T10:00:00.000Z')).toBe('in 3 days');
+	});
+
+	it('never says "in 0 minutes" for a deadline seconds away', () => {
+		freezeTime();
+		expect(getRSVPDeadlineRelative('2026-06-15T10:00:30.000Z')).toBe('in 1 minute');
+	});
+});
+
+describe('formatRelativeTime', () => {
+	it('phrases future instants with "in …"', () => {
+		freezeTime();
+		expect(formatRelativeTime('2026-06-18T10:00:00.000Z')).toBe('in 3 days');
+		expect(formatRelativeTime('2026-06-15T12:00:00.000Z')).toBe('in 2 hours');
+	});
+
+	it('phrases past instants with "… ago" (or the locale idiom via numeric:auto)', () => {
+		freezeTime();
+		expect(formatRelativeTime('2026-06-15T08:00:00.000Z')).toBe('2 hours ago');
+		// numeric: 'auto' — exactly one day back becomes the idiom, not "1 day ago".
+		expect(formatRelativeTime('2026-06-14T10:00:00.000Z')).toBe('yesterday');
+	});
+
+	it('falls through to seconds below one minute', () => {
+		freezeTime();
+		expect(formatRelativeTime('2026-06-15T10:00:30.000Z')).toBe('in 30 seconds');
+	});
+});
+
+describe('isEventPast', () => {
+	it('is false while the event is still running', () => {
+		freezeTime();
+		expect(isEventPast('2026-06-15T11:00:00.000Z')).toBe(false);
+	});
+
+	it('is true once the end has passed', () => {
+		freezeTime();
+		expect(isEventPast('2026-06-15T09:00:00.000Z')).toBe(true);
+	});
+});
+
+describe('isRSVPClosed', () => {
+	it('is false for a nullish deadline (no deadline set)', () => {
+		expect(isRSVPClosed(null)).toBe(false);
+		expect(isRSVPClosed(undefined)).toBe(false);
+		expect(isRSVPClosed('')).toBe(false);
+	});
+
+	it('is false before the deadline and true after it', () => {
+		freezeTime();
+		expect(isRSVPClosed('2026-06-15T12:00:00.000Z')).toBe(false);
+		expect(isRSVPClosed('2026-06-15T09:00:00.000Z')).toBe(true);
+	});
+
+	it('treats the exact deadline instant as closed (consistent with getRSVPDeadlineRelative)', () => {
+		freezeTime(FROZEN_NOW);
+		expect(isRSVPClosed(FROZEN_NOW)).toBe(true);
+		// The two must never disagree at the boundary.
+		expect(getRSVPDeadlineRelative(FROZEN_NOW)).toBeNull();
+	});
+});
+
+describe('isRSVPClosingSoon', () => {
+	it('is false for a nullish deadline', () => {
+		expect(isRSVPClosingSoon(null)).toBe(false);
+	});
+
+	it('is true within 24 hours, false beyond, false once passed', () => {
+		freezeTime();
+		expect(isRSVPClosingSoon('2026-06-15T12:00:00.000Z')).toBe(true); // in 2h
+		expect(isRSVPClosingSoon('2026-06-17T10:00:00.000Z')).toBe(false); // in 48h
+		expect(isRSVPClosingSoon('2026-06-15T09:00:00.000Z')).toBe(false); // passed
 	});
 });

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -3,6 +3,7 @@
  */
 
 import { getLocale } from '$lib/paraglide/runtime.js';
+import * as m from '$lib/paraglide/messages.js';
 
 /** Maps the active Paraglide UI language to a BCP 47 date locale. */
 const LOCALE_MAP: Record<string, string> = {
@@ -170,19 +171,18 @@ export function formatEventDateRange(
  * Get a relative time description for an RSVP deadline, localized via
  * Intl.RelativeTimeFormat so the directional word and pluralization come
  * from the active locale ("in 2 days" / "in 2 Tagen" / "dans 2 jours").
+ * A passed deadline returns the translated "RSVP closed" message.
  * @param deadlineString ISO 8601 date-time string
- * @returns Relative time description (e.g., "in 2 days", "in 3 hours", "closed")
+ * @returns Relative time description (e.g., "in 2 days", "in 3 hours", "RSVP closed")
  */
 export function getRSVPDeadlineRelative(deadlineString: string): string {
 	const deadline = new Date(deadlineString);
 	const now = new Date();
 	const diffMs = deadline.getTime() - now.getTime();
 
-	// Already passed. NOTE: this status word is still English — it should be
-	// replaced with a Paraglide message (e.g. m.rsvp_closed()) at the call
-	// site or here once one exists, since Intl cannot translate it.
+	// Already passed
 	if (diffMs < 0) {
-		return 'closed';
+		return m['eventQuickInfo.rsvpClosed']();
 	}
 
 	const rtf = new Intl.RelativeTimeFormat(getDateLocale(), { numeric: 'always' });

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -51,15 +51,6 @@ function getTimeZoneAbbreviation(date: Date, locale: string, timeZone?: string):
 }
 
 /**
- * The day-of-month as computed in the given timezone (falls back to the
- * viewer's zone when none is supplied). Used instead of `Date.getDate()`,
- * which is always viewer-local.
- */
-function dayOfMonthInZone(date: Date, locale: string, timeZone?: string): string {
-	return date.toLocaleDateString(locale, { day: 'numeric', ...tzOpt(timeZone) });
-}
-
-/**
  * Whether two instants land on the same calendar day in the given timezone.
  * Uses en-CA (ISO-like YYYY-MM-DD) for a stable, locale-independent compare.
  */
@@ -81,7 +72,10 @@ function withTz(formatted: string, abbreviation: string): string {
 }
 
 /**
- * Format a date-time string for event display
+ * Format a date-time string for event display with locale-aware date ordering,
+ * punctuation, and time formats (e.g. "Fri, Oct 20 • 8:00 PM GMT+1" in en-US,
+ * "Fr., 20. Okt. • 20:00 MEZ" in de-DE). Hour cycle (12h/24h) is decided by
+ * the locale, not hardcoded.
  * @param dateString ISO 8601 date-time string
  * @param timeZone Optional IANA timezone to render in (e.g. the event's timezone)
  * @param withAbbreviation Append the tz abbreviation/offset (default true). Pass
@@ -96,17 +90,19 @@ export function formatEventDate(
 	const date = new Date(dateString);
 	const locale = getDateLocale();
 
-	const dayOfWeek = date.toLocaleDateString(locale, { weekday: 'short', ...tzOpt(timeZone) });
-	const month = date.toLocaleDateString(locale, { month: 'short', ...tzOpt(timeZone) });
-	const day = dayOfMonthInZone(date, locale, timeZone);
-	const time = date.toLocaleTimeString(locale, {
+	const dateFormatter = new Intl.DateTimeFormat(locale, {
+		weekday: 'short',
+		month: 'short',
+		day: 'numeric',
+		...tzOpt(timeZone)
+	});
+	const timeFormatter = new Intl.DateTimeFormat(locale, {
 		hour: 'numeric',
 		minute: '2-digit',
-		hour12: locale === 'en-US', // Only use 12-hour format for English
 		...tzOpt(timeZone)
 	});
 
-	const base = `${dayOfWeek}, ${month} ${day} • ${time}`;
+	const base = `${dateFormatter.format(date)} • ${timeFormatter.format(date)}`;
 	return withAbbreviation ? withTz(base, getTimeZoneAbbreviation(date, locale, timeZone)) : base;
 }
 
@@ -129,34 +125,31 @@ export function formatEventDateRange(
 	const end = new Date(endString);
 	const locale = getDateLocale();
 
-	const dayOfWeek = start.toLocaleDateString(locale, { weekday: 'short', ...tzOpt(timeZone) });
-	const month = start.toLocaleDateString(locale, { month: 'short', ...tzOpt(timeZone) });
-	const day = dayOfMonthInZone(start, locale, timeZone);
-
-	const startTime = start.toLocaleTimeString(locale, {
-		hour: 'numeric',
-		minute: '2-digit',
-		hour12: locale === 'en-US',
+	const dateFormatter = new Intl.DateTimeFormat(locale, {
+		weekday: 'short',
+		month: 'short',
+		day: 'numeric',
 		...tzOpt(timeZone)
 	});
-	const endTime = end.toLocaleTimeString(locale, {
+	const timeFormatter = new Intl.DateTimeFormat(locale, {
 		hour: 'numeric',
 		minute: '2-digit',
-		hour12: locale === 'en-US',
 		...tzOpt(timeZone)
 	});
 
 	const startTz = withAbbreviation ? getTimeZoneAbbreviation(start, locale, timeZone) : '';
 
-	// If same day, show date once.
+	// If same day, show date once. formatRange renders the time span with
+	// locale-appropriate punctuation and collapsing (e.g. "8:00 – 11:00 PM"
+	// in en-US, "20:00–23:00" in de-DE).
 	if (isSameDayInZone(start, end, timeZone)) {
-		return withTz(`${dayOfWeek}, ${month} ${day} • ${startTime} - ${endTime}`, startTz);
+		return withTz(
+			`${dateFormatter.format(start)} • ${timeFormatter.formatRange(start, end)}`,
+			startTz
+		);
 	}
 
 	// Different days
-	const endDayOfWeek = end.toLocaleDateString(locale, { weekday: 'short', ...tzOpt(timeZone) });
-	const endMonth = end.toLocaleDateString(locale, { month: 'short', ...tzOpt(timeZone) });
-	const endDay = dayOfMonthInZone(end, locale, timeZone);
 	const endTz = withAbbreviation ? getTimeZoneAbbreviation(end, locale, timeZone) : '';
 
 	// A multi-day range can straddle a DST transition, in which case start and
@@ -164,17 +157,19 @@ export function formatEventDateRange(
 	// to its own time so the end isn't mislabelled with the start's offset; when
 	// they match, append once at the end as before.
 	if (startTz !== endTz) {
-		return `${dayOfWeek}, ${month} ${day} • ${withTz(startTime, startTz)} - ${endDayOfWeek}, ${endMonth} ${endDay} • ${withTz(endTime, endTz)}`;
+		return `${dateFormatter.format(start)} • ${withTz(timeFormatter.format(start), startTz)} - ${dateFormatter.format(end)} • ${withTz(timeFormatter.format(end), endTz)}`;
 	}
 
 	return withTz(
-		`${dayOfWeek}, ${month} ${day} • ${startTime} - ${endDayOfWeek}, ${endMonth} ${endDay} • ${endTime}`,
+		`${dateFormatter.format(start)} • ${timeFormatter.format(start)} - ${dateFormatter.format(end)} • ${timeFormatter.format(end)}`,
 		startTz
 	);
 }
 
 /**
- * Get a relative time description for an RSVP deadline
+ * Get a relative time description for an RSVP deadline, localized via
+ * Intl.RelativeTimeFormat so the directional word and pluralization come
+ * from the active locale ("in 2 days" / "in 2 Tagen" / "dans 2 jours").
  * @param deadlineString ISO 8601 date-time string
  * @returns Relative time description (e.g., "in 2 days", "in 3 hours", "closed")
  */
@@ -183,24 +178,28 @@ export function getRSVPDeadlineRelative(deadlineString: string): string {
 	const now = new Date();
 	const diffMs = deadline.getTime() - now.getTime();
 
-	// Already passed
+	// Already passed. NOTE: this status word is still English — it should be
+	// replaced with a Paraglide message (e.g. m.rsvp_closed()) at the call
+	// site or here once one exists, since Intl cannot translate it.
 	if (diffMs < 0) {
 		return 'closed';
 	}
+
+	const rtf = new Intl.RelativeTimeFormat(getDateLocale(), { numeric: 'always' });
 
 	const diffMinutes = Math.floor(diffMs / (1000 * 60));
 	const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
 	const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
 	if (diffMinutes < 60) {
-		return `in ${diffMinutes} minute${diffMinutes !== 1 ? 's' : ''}`;
+		return rtf.format(diffMinutes, 'minute');
 	}
 
 	if (diffHours < 24) {
-		return `in ${diffHours} hour${diffHours !== 1 ? 's' : ''}`;
+		return rtf.format(diffHours, 'hour');
 	}
 
-	return `in ${diffDays} day${diffDays !== 1 ? 's' : ''}`;
+	return rtf.format(diffDays, 'day');
 }
 
 /**
@@ -285,45 +284,17 @@ export function formatEventDateForScreenReader(dateString: string, timeZone?: st
 	const date = new Date(dateString);
 	const locale = getDateLocale();
 
-	const dayOfWeek = date.toLocaleDateString(locale, { weekday: 'long', ...tzOpt(timeZone) });
-	const month = date.toLocaleDateString(locale, { month: 'long', ...tzOpt(timeZone) });
-	const day = Number(date.toLocaleDateString('en-US', { day: 'numeric', ...tzOpt(timeZone) }));
-	const year = date.toLocaleDateString('en-US', { year: 'numeric', ...tzOpt(timeZone) });
-	const time = date.toLocaleTimeString(locale, {
-		hour: 'numeric',
-		minute: '2-digit',
-		hour12: locale === 'en-US',
+	// dateStyle/timeStyle produce the fully localized verbose form, including
+	// the locale's own connector word ("Friday, October 20, 2025 at 8:00 PM" in
+	// en-US, "Freitag, 20. Oktober 2025 um 20:00" in de-DE) — replacing the
+	// previous hand-built string with an English-only ordinal suffix.
+	const formatted = date.toLocaleString(locale, {
+		dateStyle: 'full',
+		timeStyle: 'short',
 		...tzOpt(timeZone)
 	});
-	const tz = getTimeZoneAbbreviation(date, locale, timeZone);
 
-	// Add ordinal suffix (st, nd, rd, th) - only for English
-	if (locale === 'en-US') {
-		const ordinal = getOrdinalSuffix(day);
-		return withTz(`${dayOfWeek}, ${month} ${day}${ordinal}, ${year} at ${time}`, tz);
-	}
-
-	// For other locales, use standard format
-	return withTz(`${dayOfWeek}, ${day} ${month} ${year} ${time}`, tz);
-}
-
-/**
- * Get ordinal suffix for a day number
- * @param day Day of month (1-31)
- * @returns Ordinal suffix ("st", "nd", "rd", "th")
- */
-function getOrdinalSuffix(day: number): string {
-	if (day > 3 && day < 21) return 'th';
-	switch (day % 10) {
-		case 1:
-			return 'st';
-		case 2:
-			return 'nd';
-		case 3:
-			return 'rd';
-		default:
-			return 'th';
-	}
+	return withTz(formatted, getTimeZoneAbbreviation(date, locale, timeZone));
 }
 
 /**
@@ -344,7 +315,6 @@ export function formatTimeOfDay(dateString: string, timeZone?: string): string {
 	return date.toLocaleTimeString(locale, {
 		hour: 'numeric',
 		minute: '2-digit',
-		hour12: locale === 'en-US',
 		...tzOpt(timeZone)
 	});
 }
@@ -365,7 +335,6 @@ export function formatDateTime(dateString: string, timeZone?: string): string {
 		day: 'numeric',
 		hour: 'numeric',
 		minute: '2-digit',
-		hour12: locale === 'en-US',
 		...tzOpt(timeZone)
 	});
 
@@ -429,7 +398,6 @@ export function formatDateTimeVerbose(dateString: string, timeZone?: string): st
 		day: 'numeric',
 		hour: 'numeric',
 		minute: '2-digit',
-		hour12: locale === 'en-US',
 		...tzOpt(timeZone)
 	});
 }

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -3,7 +3,6 @@
  */
 
 import { getLocale } from '$lib/paraglide/runtime.js';
-import * as m from '$lib/paraglide/messages.js';
 
 /** Maps the active Paraglide UI language to a BCP 47 date locale. */
 const LOCALE_MAP: Record<string, string> = {
@@ -139,11 +138,17 @@ export function formatEventDateRange(
 	});
 
 	const startTz = withAbbreviation ? getTimeZoneAbbreviation(start, locale, timeZone) : '';
+	const endTz = withAbbreviation ? getTimeZoneAbbreviation(end, locale, timeZone) : '';
 
-	// If same day, show date once. formatRange renders the time span with
-	// locale-appropriate punctuation and collapsing (e.g. "8:00 – 11:00 PM"
-	// in en-US, "20:00–23:00" in de-DE).
+	// If same day, show date once. A same-local-day range can still straddle a
+	// DST transition (fall-back: e.g. 01:00 GMT+2 → 12:00 GMT+1 on the same
+	// calendar day), in which case each time carries its own offset. Otherwise
+	// formatRange renders the span with locale-appropriate punctuation and
+	// collapsing (e.g. "8:00 – 11:00 PM" in en-US, "20:00–23:00" in de-DE).
 	if (isSameDayInZone(start, end, timeZone)) {
+		if (startTz !== endTz) {
+			return `${dateFormatter.format(start)} • ${withTz(timeFormatter.format(start), startTz)} - ${withTz(timeFormatter.format(end), endTz)}`;
+		}
 		return withTz(
 			`${dateFormatter.format(start)} • ${timeFormatter.formatRange(start, end)}`,
 			startTz
@@ -151,7 +156,6 @@ export function formatEventDateRange(
 	}
 
 	// Different days
-	const endTz = withAbbreviation ? getTimeZoneAbbreviation(end, locale, timeZone) : '';
 
 	// A multi-day range can straddle a DST transition, in which case start and
 	// end have different abbreviations/offsets (e.g. GMT+1 → GMT+2). Append each
@@ -171,18 +175,20 @@ export function formatEventDateRange(
  * Get a relative time description for an RSVP deadline, localized via
  * Intl.RelativeTimeFormat so the directional word and pluralization come
  * from the active locale ("in 2 days" / "in 2 Tagen" / "dans 2 jours").
- * A passed deadline returns the translated "RSVP closed" message.
  * @param deadlineString ISO 8601 date-time string
- * @returns Relative time description (e.g., "in 2 days", "in 3 hours", "RSVP closed")
+ * @returns Relative time description (e.g., "in 2 days", "in 3 hours"), or
+ *   null when the deadline has passed — the caller decides the "closed" copy
+ *   for its surface (e.g. eventQuickInfo.rsvpClosed), keeping UI messages out
+ *   of this utility.
  */
-export function getRSVPDeadlineRelative(deadlineString: string): string {
+export function getRSVPDeadlineRelative(deadlineString: string): string | null {
 	const deadline = new Date(deadlineString);
 	const now = new Date();
 	const diffMs = deadline.getTime() - now.getTime();
 
 	// Already passed
 	if (diffMs < 0) {
-		return m['eventQuickInfo.rsvpClosed']();
+		return null;
 	}
 
 	const rtf = new Intl.RelativeTimeFormat(getDateLocale(), { numeric: 'always' });

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -32,6 +32,49 @@ export function getDateLocale(): string {
 const RANGE_SEPARATOR = ' \u2013 ';
 
 /**
+ * CLDR-derived spoken time suffix (de: " Uhr"), used by the screen-reader
+ * format.
+ *
+ * CLDR's single-instant time patterns carry no time word (de renders bare
+ * "20:00"), but its *interval* patterns do: de formats a range as
+ * "20:00–23:00 Uhr". Probe the locale's interval pattern once and reuse its
+ * trailing shared suffix for single times — but only when that tail is purely
+ * literal. A tail containing a real field is a collapsed shared component,
+ * not a time word (en collapses the day period: "8:00 – 11:00 PM"), and the
+ * single format already renders that field itself.
+ *
+ * Probed with two same-day-period instants pinned to UTC so the result
+ * depends on locale data only, never on the viewer's timezone. Cached per
+ * locale. Hardcodes no language: any locale whose CLDR interval data carries
+ * a literal time word gets it automatically.
+ */
+const spokenTimeSuffixCache = new Map<string, string>();
+
+function getSpokenTimeSuffix(locale: string): string {
+	const cached = spokenTimeSuffixCache.get(locale);
+	if (cached !== undefined) return cached;
+
+	const parts = getFormatter(locale, {
+		hour: 'numeric',
+		minute: '2-digit',
+		timeZone: 'UTC'
+	}).formatRangeToParts(
+		new Date(Date.UTC(2024, 0, 1, 13, 0)),
+		new Date(Date.UTC(2024, 0, 1, 14, 0))
+	);
+
+	const lastEnd = parts.map((p) => p.source).lastIndexOf('endRange');
+	const tail = parts.slice(lastEnd + 1);
+	const suffix =
+		tail.length > 0 && tail.every((p) => p.type === 'literal')
+			? tail.map((p) => p.value).join('')
+			: '';
+
+	spokenTimeSuffixCache.set(locale, suffix);
+	return suffix;
+}
+
+/**
  * Memoized Intl.DateTimeFormat instances. Constructing a formatter is
  * expensive (ICU data lookup); event lists render dozens of dates with the
  * same locale/timezone/options, so cache by a stable key. Option objects
@@ -328,11 +371,30 @@ export function formatEventDateForScreenReader(dateString: string, timeZone?: st
 	// the locale's own connector word ("Friday, October 20, 2025 at 8:00 PM" in
 	// en-US, "Freitag, 20. Oktober 2025 um 20:00" in de-DE) — replacing the
 	// previous hand-built string with an English-only ordinal suffix.
-	const formatted = getFormatter(locale, {
+	//
+	// CLDR's single-instant pattern omits the spoken time word ("20:00", never
+	// "20:00 Uhr" — only the *interval* pattern carries it). That's fine
+	// visually, but this string exists to be read aloud, and German times are
+	// spoken "zwanzig Uhr". getSpokenTimeSuffix derives the word from the
+	// locale's own CLDR interval data; when present, insert it after the
+	// minute via formatToParts so it lands correctly regardless of where the
+	// time sits in the locale's pattern. Locales without one take the plain
+	// format() path — deliberately, since format() and joined formatToParts
+	// output are not byte-identical on V8 (its NNBSP→space compatibility
+	// patch applies only to format()).
+	const suffix = getSpokenTimeSuffix(locale);
+	const formatter = getFormatter(locale, {
 		dateStyle: 'full',
 		timeStyle: 'short',
 		...tzOpt(timeZone)
-	}).format(date);
+	});
+
+	const formatted = suffix
+		? formatter
+				.formatToParts(date)
+				.map((p) => (p.type === 'minute' ? p.value + suffix : p.value))
+				.join('')
+		: formatter.format(date);
 
 	return withTz(formatted, getTimeZoneAbbreviation(date, locale, timeZone));
 }

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -113,7 +113,7 @@ export function formatEventDate(
  * @param timeZone Optional IANA timezone to render in (e.g. the event's timezone)
  * @param withAbbreviation Append the tz abbreviation/offset (default true). Pass
  *   false on surfaces that show a separate "Times shown in …" label instead.
- * @returns Formatted date range (e.g., "Fri, Oct 20 • 8:00 PM - 11:00 PM GMT+1")
+ * @returns Formatted date range (e.g., "Fri, Oct 20 • 8:00 – 11:00 PM GMT+1")
  */
 export function formatEventDateRange(
 	startString: string,
@@ -186,8 +186,8 @@ export function getRSVPDeadlineRelative(deadlineString: string): string | null {
 	const now = new Date();
 	const diffMs = deadline.getTime() - now.getTime();
 
-	// Already passed
-	if (diffMs < 0) {
+	// Passed, or exactly at the deadline — "RSVP by X" means X itself is too late.
+	if (diffMs <= 0) {
 		return null;
 	}
 
@@ -284,7 +284,7 @@ export function isRSVPClosingSoon(deadlineString: string | null): boolean {
  * @param dateString ISO 8601 date-time string
  * @param timeZone Optional IANA timezone to render in (e.g. the event's timezone);
  *   when supplied, the tz abbreviation is appended (e.g. "… at 8:00 PM CET")
- * @returns Verbose date string (e.g., "Friday, October 20th, 2025 at 8:00 PM CET")
+ * @returns Verbose date string (e.g., "Friday, October 20, 2025 at 8:00 PM CET")
  */
 export function formatEventDateForScreenReader(dateString: string, timeZone?: string): string {
 	const date = new Date(dateString);

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -4,14 +4,31 @@
 
 import { getLocale } from '$lib/paraglide/runtime.js';
 
-/** Maps the active Paraglide UI language to a BCP 47 date locale. */
+/**
+ * Maps the active Paraglide UI language to a BCP 47 date locale.
+ *
+ * Invariant: every mapped locale renders a *textual* month for the
+ * `month: 'short'` skeletons used throughout this file (guarded by a test).
+ *
+ * pt deliberately maps to pt-BR, not pt-PT: pt-PT's CLDR data resolves the
+ * short-month-with-day skeletons (MMMd → "d/MM", yMMMd → "dd/MM/y") to
+ * *numeric* patterns — Portugal's editorial convention for medium-length
+ * dates — so `formatEventDate` would render "sexta, 24/10" where every other
+ * locale shows a month word. The language material is identical between the
+ * two (same month/weekday names, same "de … de …" construction, same "às"
+ * connector); pt-BR differs only in preferring textual medium dates
+ * ("sex., 24 de out.") and three-letter weekday abbreviations ("sex." vs
+ * pt-PT "sexta") — natural, fully intelligible Portuguese for either
+ * audience, and consistent with the app-wide "month is always a word" intent
+ * (cf. formatDateTimeReadback).
+ */
 const LOCALE_MAP: Record<string, string> = {
 	en: 'en-US',
 	de: 'de-DE',
 	it: 'it-IT',
 	fr: 'fr-FR',
 	es: 'es-ES',
-	pt: 'pt-PT'
+	pt: 'pt-BR'
 };
 
 /**

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -24,6 +24,33 @@ export function getDateLocale(): string {
 }
 
 /**
+ * Locale-appropriate range separator for the hand-built range branches (the
+ * DST-straddling cases where formatRange can't be used because each end
+ * carries its own offset). En dash with spaces matches what formatRange
+ * produces for the supported locales, so normal and DST ranges read alike.
+ */
+const RANGE_SEPARATOR = ' \u2013 ';
+
+/**
+ * Memoized Intl.DateTimeFormat instances. Constructing a formatter is
+ * expensive (ICU data lookup); event lists render dozens of dates with the
+ * same locale/timezone/options, so cache by a stable key. Option objects
+ * below are built with literal, fixed key order, so JSON.stringify is a
+ * stable cache key.
+ */
+const dtfCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(locale: string, options: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+	const key = `${locale}|${JSON.stringify(options)}`;
+	let formatter = dtfCache.get(key);
+	if (!formatter) {
+		formatter = new Intl.DateTimeFormat(locale, options);
+		dtfCache.set(key, formatter);
+	}
+	return formatter;
+}
+
+/**
  * Build the `timeZone` slice of an Intl options object.
  *
  * When a `timeZone` (IANA name, e.g. "Europe/Vienna") is supplied, all date
@@ -43,7 +70,7 @@ function tzOpt(timeZone?: string): { timeZone?: string } {
  */
 function getTimeZoneAbbreviation(date: Date, locale: string, timeZone?: string): string {
 	if (!timeZone) return '';
-	const parts = new Intl.DateTimeFormat(locale, {
+	const parts = getFormatter(locale, {
 		timeZone,
 		timeZoneName: 'short'
 	}).formatToParts(date);
@@ -55,13 +82,13 @@ function getTimeZoneAbbreviation(date: Date, locale: string, timeZone?: string):
  * Uses en-CA (ISO-like YYYY-MM-DD) for a stable, locale-independent compare.
  */
 function isSameDayInZone(a: Date, b: Date, timeZone?: string): boolean {
-	const opts: Intl.DateTimeFormatOptions = {
+	const formatter = getFormatter('en-CA', {
 		year: 'numeric',
 		month: '2-digit',
 		day: '2-digit',
 		...tzOpt(timeZone)
-	};
-	return a.toLocaleDateString('en-CA', opts) === b.toLocaleDateString('en-CA', opts);
+	});
+	return formatter.format(a) === formatter.format(b);
 }
 
 /**
@@ -90,13 +117,13 @@ export function formatEventDate(
 	const date = new Date(dateString);
 	const locale = getDateLocale();
 
-	const dateFormatter = new Intl.DateTimeFormat(locale, {
+	const dateFormatter = getFormatter(locale, {
 		weekday: 'short',
 		month: 'short',
 		day: 'numeric',
 		...tzOpt(timeZone)
 	});
-	const timeFormatter = new Intl.DateTimeFormat(locale, {
+	const timeFormatter = getFormatter(locale, {
 		hour: 'numeric',
 		minute: '2-digit',
 		...tzOpt(timeZone)
@@ -125,13 +152,13 @@ export function formatEventDateRange(
 	const end = new Date(endString);
 	const locale = getDateLocale();
 
-	const dateFormatter = new Intl.DateTimeFormat(locale, {
+	const dateFormatter = getFormatter(locale, {
 		weekday: 'short',
 		month: 'short',
 		day: 'numeric',
 		...tzOpt(timeZone)
 	});
-	const timeFormatter = new Intl.DateTimeFormat(locale, {
+	const timeFormatter = getFormatter(locale, {
 		hour: 'numeric',
 		minute: '2-digit',
 		...tzOpt(timeZone)
@@ -147,7 +174,7 @@ export function formatEventDateRange(
 	// collapsing (e.g. "8:00 – 11:00 PM" in en-US, "20:00–23:00" in de-DE).
 	if (isSameDayInZone(start, end, timeZone)) {
 		if (startTz !== endTz) {
-			return `${dateFormatter.format(start)} • ${withTz(timeFormatter.format(start), startTz)} - ${withTz(timeFormatter.format(end), endTz)}`;
+			return `${dateFormatter.format(start)} • ${withTz(timeFormatter.format(start), startTz)}${RANGE_SEPARATOR}${withTz(timeFormatter.format(end), endTz)}`;
 		}
 		return withTz(
 			`${dateFormatter.format(start)} • ${timeFormatter.formatRange(start, end)}`,
@@ -162,11 +189,11 @@ export function formatEventDateRange(
 	// to its own time so the end isn't mislabelled with the start's offset; when
 	// they match, append once at the end as before.
 	if (startTz !== endTz) {
-		return `${dateFormatter.format(start)} • ${withTz(timeFormatter.format(start), startTz)} - ${dateFormatter.format(end)} • ${withTz(timeFormatter.format(end), endTz)}`;
+		return `${dateFormatter.format(start)} • ${withTz(timeFormatter.format(start), startTz)}${RANGE_SEPARATOR}${dateFormatter.format(end)} • ${withTz(timeFormatter.format(end), endTz)}`;
 	}
 
 	return withTz(
-		`${dateFormatter.format(start)} • ${timeFormatter.format(start)} - ${dateFormatter.format(end)} • ${timeFormatter.format(end)}`,
+		`${dateFormatter.format(start)} • ${timeFormatter.format(start)}${RANGE_SEPARATOR}${dateFormatter.format(end)} • ${timeFormatter.format(end)}`,
 		startTz
 	);
 }
@@ -193,7 +220,9 @@ export function getRSVPDeadlineRelative(deadlineString: string): string | null {
 
 	const rtf = new Intl.RelativeTimeFormat(getDateLocale(), { numeric: 'always' });
 
-	const diffMinutes = Math.floor(diffMs / (1000 * 60));
+	// Clamp to at least 1 minute: a deadline seconds away must never read
+	// "in 0 minutes" while the RSVP is technically still open.
+	const diffMinutes = Math.max(1, Math.floor(diffMs / (1000 * 60)));
 	const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
 	const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
@@ -215,6 +244,9 @@ export function getRSVPDeadlineRelative(deadlineString: string): string | null {
  * "2 hours ago" / "yesterday". Uses Intl.RelativeTimeFormat so the
  * directional word ("in" / "ago" and its translations) is supplied by
  * the active locale rather than hardcoded.
+ *
+ * Month/year thresholds are calendar approximations (30/365 days) —
+ * adequate for casual UI copy, not for exact anniversary arithmetic.
  *
  * @param dateString ISO 8601 date-time string
  * @returns Relative phrase (e.g., "in 3 days", "2 hours ago")
@@ -246,12 +278,15 @@ export function formatRelativeTime(dateString: string): string {
  */
 export function isEventPast(endString: string): boolean {
 	const end = new Date(endString);
-	const now = new Date();
-	return end < now;
+	return end.getTime() <= Date.now();
 }
 
 /**
- * Check if RSVP deadline has passed
+ * Check if RSVP deadline has passed.
+ *
+ * Boundary matches getRSVPDeadlineRelative: the exact deadline instant counts
+ * as closed ("RSVP by X" means X itself is too late), so a surface combining
+ * both never shows an open button next to closed copy.
  * @param deadlineString ISO 8601 date-time string, null, or undefined
  * @returns true if deadline has passed
  */
@@ -259,8 +294,7 @@ export function isRSVPClosed(deadlineString: string | null | undefined): boolean
 	if (!deadlineString) return false;
 
 	const deadline = new Date(deadlineString);
-	const now = new Date();
-	return deadline < now;
+	return deadline.getTime() <= Date.now();
 }
 
 /**
@@ -294,11 +328,11 @@ export function formatEventDateForScreenReader(dateString: string, timeZone?: st
 	// the locale's own connector word ("Friday, October 20, 2025 at 8:00 PM" in
 	// en-US, "Freitag, 20. Oktober 2025 um 20:00" in de-DE) — replacing the
 	// previous hand-built string with an English-only ordinal suffix.
-	const formatted = date.toLocaleString(locale, {
+	const formatted = getFormatter(locale, {
 		dateStyle: 'full',
 		timeStyle: 'short',
 		...tzOpt(timeZone)
-	});
+	}).format(date);
 
 	return withTz(formatted, getTimeZoneAbbreviation(date, locale, timeZone));
 }
@@ -315,36 +349,34 @@ export function formatEventDateForScreenReader(dateString: string, timeZone?: st
  * @returns Formatted time string (e.g., "8:00 PM" for en-US or "20:00" for de-DE)
  */
 export function formatTimeOfDay(dateString: string, timeZone?: string): string {
-	const date = new Date(dateString);
-	const locale = getDateLocale();
-
-	return date.toLocaleTimeString(locale, {
+	return getFormatter(getDateLocale(), {
 		hour: 'numeric',
 		minute: '2-digit',
 		...tzOpt(timeZone)
-	});
+	}).format(new Date(dateString));
 }
 
 /**
  * Format a date for display in admin pages and lists
  * Uses locale-aware formatting with medium date and short time
- * @param dateString ISO 8601 date-time string
+ * @param date ISO 8601 date-time string, or an already-parsed Date (lets
+ *   callers that validated the value avoid a second parse)
  * @returns Formatted date string (e.g., "Oct 20, 2025, 8:00 PM" for en-US or "20. Okt. 2025, 20:00" for de-DE)
  */
-export function formatDateTime(dateString: string, timeZone?: string): string {
-	const date = new Date(dateString);
+export function formatDateTime(date: string | Date, timeZone?: string): string {
+	const parsed = date instanceof Date ? date : new Date(date);
 	const locale = getDateLocale();
 
-	const formatted = date.toLocaleString(locale, {
+	const formatted = getFormatter(locale, {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',
 		hour: 'numeric',
 		minute: '2-digit',
 		...tzOpt(timeZone)
-	});
+	}).format(parsed);
 
-	return withTz(formatted, getTimeZoneAbbreviation(date, locale, timeZone));
+	return withTz(formatted, getTimeZoneAbbreviation(parsed, locale, timeZone));
 }
 
 /**
@@ -363,7 +395,7 @@ export function formatDateTimeReadback(value: string | null | undefined): string
 	if (!value) return '';
 	const date = new Date(value);
 	if (isNaN(date.getTime())) return '';
-	return formatDateTime(value);
+	return formatDateTime(date);
 }
 
 /**
@@ -372,49 +404,45 @@ export function formatDateTimeReadback(value: string | null | undefined): string
  * @returns Formatted date string (e.g., "Oct 20, 2025" for en-US or "20. Okt. 2025" for de-DE)
  */
 export function formatDate(dateString: string, timeZone?: string): string {
-	const date = new Date(dateString);
-	const locale = getDateLocale();
-
 	// Date-only: apply the timezone so the calendar day is correct, but don't
 	// append a tz abbreviation (it reads oddly next to a date with no time).
-	return date.toLocaleDateString(locale, {
+	return getFormatter(getDateLocale(), {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',
 		...tzOpt(timeZone)
-	});
+	}).format(new Date(dateString));
 }
 
 /** Long-month date, no time, e.g. "October 20, 2025". */
 export function formatDateLongMonth(dateString: string, timeZone?: string): string {
-	return new Date(dateString).toLocaleDateString(getDateLocale(), {
+	return getFormatter(getDateLocale(), {
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',
 		...tzOpt(timeZone)
-	});
+	}).format(new Date(dateString));
 }
 
 /** Long-month date + time, e.g. "October 20, 2025, 8:00 PM". */
 export function formatDateTimeVerbose(dateString: string, timeZone?: string): string {
-	const locale = getDateLocale();
-	return new Date(dateString).toLocaleString(locale, {
+	return getFormatter(getDateLocale(), {
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',
 		hour: 'numeric',
 		minute: '2-digit',
 		...tzOpt(timeZone)
-	});
+	}).format(new Date(dateString));
 }
 
 /** Month + year only, e.g. "October 2025". */
 export function formatMonthYearLabel(dateString: string, timeZone?: string): string {
-	return new Date(dateString).toLocaleDateString(getDateLocale(), {
+	return getFormatter(getDateLocale(), {
 		year: 'numeric',
 		month: 'long',
 		...tzOpt(timeZone)
-	});
+	}).format(new Date(dateString));
 }
 
 /**


### PR DESCRIPTION
## What

Makes all human-facing date/time strings in `date.ts` fully locale-aware, and (follow-up commits) fixes RSVP boundary/rounding edge cases, unifies range punctuation, memoizes formatter construction, and switches the Portuguese date locale to pt-BR so short dates keep a textual month. Previously, several formatters hand-assembled strings in US field order and hardcoded English-specific behavior, so non-English UI languages got half-translated output (e.g. `Fr., Okt. 24 • 20:00`).

## Changes

### Locale-aware formatting

- `formatEventDate` / `formatEventDateRange` now build date and time parts with `Intl.DateTimeFormat` instead of manual string assembly. Same-day ranges use `formatRange()` for locale-aware span punctuation. The per-side tz abbreviations on multi-day DST-straddling ranges are preserved.
- `formatEventDateRange` also fixes a latent DST bug: a *same-local-day* range can straddle the autumn fall-back (e.g. Europe/Vienna 2026-10-25, 01:00 GMT+2 → 12:00 GMT+1), and previously the end time was labelled with the start's offset. When the abbreviations differ, each time now carries its own; single-zone same-day output is unchanged.
- Removed the `hour12: locale === 'en-US'` switch everywhere. Omitting `hour12` lets Intl pick the hour cycle per locale — identical output for the six current locales, and correct for any locale added later.
- `getRSVPDeadlineRelative` uses `Intl.RelativeTimeFormat` for localized wording and pluralization ("in 2 Tagen", "dans 2 jours"), and now returns `null` instead of the English `'closed'` sentinel when the deadline has passed. The caller decides the "closed" copy for its surface; `EventQuickInfo.svelte` is updated to branch on `null` and keeps rendering its own translated `eventQuickInfo.rsvpClosed` message. The `string | null` signature makes the passed-deadline case a compile-time obligation for any caller.
- `formatEventDateForScreenReader` uses `dateStyle: 'full'` + `timeStyle: 'short'`, which supplies the locale's connector word. The English-only ordinal-suffix branch is gone.
- Deleted unused helpers `getOrdinalSuffix` and `dayOfMonthInZone`.

### Portuguese maps to pt-BR: textual short months

`LOCALE_MAP` now maps the `pt` UI language to `pt-BR` instead of `pt-PT`. pt-PT's CLDR data resolves the short-month-with-day skeletons to *numeric* patterns (`MMMd` → `d/MM`, `yMMMd` → `dd/MM/y` — Portugal's editorial convention for medium-length dates), so `formatEventDate` and `formatDateTime` rendered `sexta, 24/10` where every other supported locale shows a month word, silently breaking the app-wide "month is always textual" intent (cf. `formatDateTimeReadback`). This is a pattern-selection property of the locale data, not a month-name gap — pt-PT *has* abbreviated month names (`out.`), Intl just never selects them for these skeletons, and no option forces it to.

The language material is identical between the two variants (same month/weekday names, same `de … de …` construction, same `às` connector); pt-BR differs only in editorial convention — textual medium dates (`sex., 24 de out.`) and three-letter weekday abbreviations (`sex.` vs pt-PT `sexta`). The invariant "every mapped locale renders a textual month for the short skeletons" is documented on `LOCALE_MAP` and guarded by a test over all supported languages (see Testing).

### Follow-up: boundary consistency, rounding, punctuation, performance

- `getRSVPDeadlineRelative` clamps to ≥1 minute, so a deadline seconds away never reads "in 0 minutes" while the RSVP is technically still open.
- `isRSVPClosed` and `isEventPast` now treat the exact instant as closed/past (`<=` instead of `<`), aligning with `getRSVPDeadlineRelative` (which already treated the exact deadline as closed). A surface combining both can no longer show an open control next to "closed" copy at the boundary instant.
- The hand-built range branches (the DST-straddling cases where `formatRange` can't be used because each end carries its own offset) now use the en dash separator (` – `) instead of a plain hyphen, matching `formatRange` output across locales.
- `Intl.DateTimeFormat` construction is memoized behind a shared cache keyed on locale + options. Event lists rendering many dates no longer rebuild formatters per call (`formatEventDateRange` with abbreviations previously constructed four per invocation).
- `formatDateTime` accepts `string | Date`; `formatDateTimeReadback` reuses its already-validated `Date` instead of re-parsing the input string.

## Sample output (Europe/Vienna, event 2025-10-24 20:00 local; all `LOCALE_MAP` languages)

**Event date — `formatEventDate`**

| Locale | Output |
|---|---|
| en | Fri, Oct 24 • 8:00 PM GMT+2 |
| de | Fr., 24. Okt. • 20:00 MESZ |
| fr | ven. 24 oct. • 20:00 UTC+2 |
| it | ven 24 ott • 20:00 CEST |
| es | vie, 24 oct • 20:00 CEST |
| pt | sex., 24 de out. • 20:00 GMT+2 |

**Same-day range — `formatEventDateRange`**

| Locale | Output |
|---|---|
| en | Fri, Oct 24 • 8:00 – 11:00 PM GMT+2 |
| de | Fr., 24. Okt. • 20:00–23:00 Uhr MESZ |
| fr | ven. 24 oct. • 20:00 – 23:00 UTC+2 |
| it | ven 24 ott • 20:00–23:00 CEST |
| es | vie, 24 oct • 20:00–23:00 CEST |
| pt | sex., 24 de out. • 20:00 – 23:00 GMT+2 |

**Same-local-day range across the autumn fall-back — `formatEventDateRange`**

| Locale | Output |
|---|---|
| en | Sun, Oct 25 • 1:00 AM GMT+2 – 12:00 PM GMT+1 |
| de | So., 25. Okt. • 1:00 MESZ – 12:00 MEZ |
| fr | dim. 25 oct. • 1:00 UTC+2 – 12:00 UTC+1 |
| it | dom 25 ott • 1:00 CEST – 12:00 CET |
| es | dom, 25 oct • 1:00 CEST – 12:00 CET |
| pt | dom., 25 de out. • 1:00 GMT+2 – 12:00 GMT+1 |

This branch is hand-built (see Open question below): `formatRange` cannot be used here because ICU treats the timezone name as a shared field and would label the whole range with the end's offset (`01:00–12:00 Uhr MEZ`), mislabelling the 01:00 start. As a consequence, the de output deviates from the native de range convention in two ways: the separator is the fixed spaced en dash rather than de's bare `–`, and `hour: 'numeric'` drops the leading zero (`1:00`, not `01:00`).

**Multi-day range straddling the DST transition — `formatEventDateRange`**

| Locale | Output |
|---|---|
| en | Fri, Oct 24 • 8:00 PM GMT+2 – Sun, Oct 26 • 10:00 AM GMT+1 |
| de | Fr., 24. Okt. • 20:00 MESZ – So., 26. Okt. • 10:00 MEZ |
| fr | ven. 24 oct. • 20:00 UTC+2 – dim. 26 oct. • 10:00 UTC+1 |
| it | ven 24 ott • 20:00 CEST – dom 26 ott • 10:00 CET |
| es | vie, 24 oct • 20:00 CEST – dom, 26 oct • 10:00 CET |
| pt | sex., 24 de out. • 20:00 GMT+2 – dom., 26 de out. • 10:00 GMT+1 |

**Screen reader — `formatEventDateForScreenReader`**

| Locale | Output |
|---|---|
| en | Friday, October 24, 2025 at 8:00 PM GMT+2 |
| de | Freitag, 24. Oktober 2025 um 20:00 Uhr MESZ |
| fr | vendredi 24 octobre 2025 à 20:00 UTC+2 |
| it | venerdì 24 ottobre 2025 alle ore 20:00 CEST |
| es | viernes, 24 de octubre de 2025, 20:00 CEST |
| pt | sexta-feira, 24 de outubro de 2025 às 20:00 GMT+2 |

The German screen-reader string carries a spoken "Uhr" after the minutes. CLDR's single-instant time pattern omits it (correct visual convention — de UIs show bare `20:00`), but this string exists to be read aloud, and German times are spoken "zwanzig Uhr". The word is not hardcoded: it is derived from the locale's own CLDR *interval* pattern (`20:00–23:00 Uhr`), by probing `formatRangeToParts` once per locale and reusing the trailing shared suffix when it is purely literal. A tail containing a real field is rejected — en's interval tail is the collapsed shared day period (`8:00 – 11:00 PM`), which the single format already renders itself. Any locale added later whose CLDR interval data carries a literal time word gets it automatically; the suffix is inserted after the `minute` part via `formatToParts`, so placement is pattern-order-independent.

**Admin list — `formatDateTime`**

| Locale | Output |
|---|---|
| en | Oct 24, 2025, 8:00 PM GMT+2 |
| de | 24. Okt. 2025, 20:00 MESZ |
| fr | 24 oct. 2025, 20:00 UTC+2 |
| it | 24 ott 2025, 20:00 CEST |
| es | 24 oct 2025, 20:00 CEST |
| pt | 24 de out. de 2025, 20:00 GMT+2 |

**RSVP deadline (2 days out) — `getRSVPDeadlineRelative`**

| Locale | Output |
|---|---|
| en | in 2 days |
| de | in 2 Tagen |
| fr | dans 2 jours |
| it | tra 2 giorni |
| es | dentro de 2 días |
| pt | em 2 dias |

## Breaking / visible changes

- Same-day time ranges use the locale's range dash with a collapsed day-period (`5:00 – 10:00 PM`) instead of `" - "` (`5:00 PM - 10:00 PM`). Note on invisible characters: ICU inserts a narrow no-break space (U+202F) before "AM"/"PM", and in en-US and fr-FR it wraps the range dash itself in thin spaces (U+2009), so the literal en output is `5:00<U+2009>–<U+2009>10:00<U+202F>PM`. String assertions against this output should match whitespace with `\s` (which covers both).
- The hand-built DST-straddling range branches now also use ` – ` (en dash) instead of ` - `, so all range output shares the same separator.
- en-US screen-reader dates no longer carry an ordinal suffix (`October 24`, not `October 24th`).
- All Portuguese dates switch from pt-PT to pt-BR conventions:
  - short dates become textual (`sex., 24 de out.` / `24 de out. de 2025` instead of `sexta, 24/10` / `24/10/2025`);
  - abbreviated weekdays are clipped (`sex.`, `dom.` instead of `sexta`, `domingo`);
  - timezone abbreviations render as offsets (`GMT+2`/`GMT+1` instead of `CEST`/`CET`), since pt-BR CLDR carries no short names for European zones;
  - relative-time wording changes (`em 2 dias` instead of `dentro de 2 dias`).
  All output remains identical *language* — same month/weekday names and connectors — only the editorial conventions differ.
- API change: `getRSVPDeadlineRelative` returns `string | null` (`null` = deadline passed) instead of the `'closed'` sentinel. `EventQuickInfo.svelte` is the only caller and is updated in this PR; external callers, if any, must handle `null`.
- API change: `formatDateTime` now accepts `string | Date`. Backward compatible for all existing string callers.
- Behavior change: `isRSVPClosed(deadline)` and `isEventPast(end)` return `true` at the exact deadline/end instant (previously `false`). This aligns the predicates with `getRSVPDeadlineRelative` and matches the "RSVP by X means X itself is too late" semantics. Practically observable only in the single millisecond at the boundary.
- Behavior change: `getRSVPDeadlineRelative` returns `"in 1 minute"` (not `"in 0 minutes"`) for deadlines under a minute away.

## Open question: separator in the hand-built DST branches

Raised in review and deliberately left unresolved in this PR: the two DST-straddling branches (same-local-day fall-back, multi-day transition) currently use a fixed spaced en dash (`' – '`) in all locales, while native ICU range separators vary — en-US `<thin space>–<thin space>`, fr/pt `' – '`, de/it/es bare `–` (de additionally appends `Uhr` in its range pattern).

Constraints established while investigating:

- `formatRange` with `timeZoneName` cannot replace the hand-built branches: ICU emits the timezone as a shared trailing field and labels the entire range with the end's offset, reintroducing the mislabelling bug this PR fixes.
- Full de nativeness is unattainable in these branches regardless of separator: the `Uhr` literal belongs to the range pattern (it would sit after the — wrong — single shared offset), and `hour: 'numeric'` drops de's leading zero (`1:00` vs. native `01:00`).

Two candidate resolutions, to be decided in a follow-up:

- **A — extract the separator per locale** via `formatRangeToParts` (shared literal), cached per locale with `' – '` fallback. Fixes spacing for de/it/es; does not fix the leading zero; bare `–` between two long `date • time offset` blocks in the cross-day case reads cramped.
- **B — declare the fixed `' – '` an app convention** for these composite strings (the ` • ` bullet is likewise app-designed, not CLDR), document it, and pin it with a multi-locale test.

Until decided, the fixed `' – '` output shown in the sample tables above is the enforced behavior and is what the current tests assert.

## Testing

- `vitest`: full `date.test.ts` suite passes (63 tests). New/updated coverage:
  - a same-local-day range across the 2026-10-25 Europe/Vienna fall-back (regression test for the offset-labelling fix), plus the spring-forward multi-day case;
  - all wall-clock-dependent tests (`getRSVPDeadlineRelative`, `formatRelativeTime`, `isEventPast`, `isRSVPClosed`, `isRSVPClosingSoon`) run under fake timers with a frozen system time and exact assertions — removes a race where `getRSVPDeadlineRelative(now + 2h)` floored to "in 1 hour" whenever real time elapsed between test setup and the call;
  - boundary tests: exact-instant behavior of `isRSVPClosed` asserted consistent with `getRSVPDeadlineRelative`; the ≥1-minute clamp; the days branch;
  - first coverage for `formatRelativeTime` (future/past/`yesterday` idiom via `numeric: 'auto'`/seconds fall-through), `formatTimeOfDay`, `isEventPast`, `isRSVPClosingSoon`, and the `getDateLocale` en-US fallback for unmapped UI languages (via a mutable locale mock);
  - the en-dash separator in the hand-built cross-day branch;
  - `formatDateTime` with an already-parsed `Date` argument;
  - **textual-month invariant** across all six supported UI languages: `formatToParts` must resolve the month of both short skeletons used in the file (`MMMd`, `yMMMd`) to a word (`/\p{L}/u`), and `formatEventDate` output must contain no numeric `d/M`; plus a pt-specific assertion pinning the Brazilian rendering (`fev.`, not `06/02`). Verified the suite fails (3 tests) when `LOCALE_MAP` is reverted to `pt-PT`, so the guard also catches any future locale addition that reintroduces the same CLDR pattern quirk. The language list in the test mirrors `LOCALE_MAP`'s keys (the map is not exported); a comment in both places keeps them in sync.
- Recommended (noted in the test file header): pin `TZ=UTC` for the test run (`test.env: { TZ: 'UTC' }` in vitest config) so the no-timezone code paths are fully deterministic.
- `EventQuickInfo.test.ts` → "displays 'RSVP closed' when rsvp_before is in the past" passes again with the `null` branch.
- `tsc --strict` passes.
- Manual smoke test of all formatters across en/de/fr/it/pt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

* Date and time displays now adapt to the selected locale, including calendar formats, hour cycles, date ranges, and screen-reader text.
* Portuguese formatting is supported, with improved localized separators and textual date styles.
* Event times more accurately reflect time zone changes, including daylight saving transitions.
* RSVP deadlines now use localized relative-time wording, clearly show when registration is closed, and remain hidden when no deadline is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->