### PR TITLE
fix(events): include end and is_open_ended in create-event payload

### DIFF
--- a/src/lib/components/events/admin/event-payload.test.ts
+++ b/src/lib/components/events/admin/event-payload.test.ts
@@ -1,15 +1,103 @@
 import { describe, it, expect } from 'vitest';
 import {
 	buildEditorUpdateData,
+	buildEventCreateData,
 	buildRecurringTemplateCreateData,
 	buildWizardStep1UpdateData,
 	buildWizardStep2UpdateData,
 	type EventFormPayloadData
 } from './event-payload';
+import { toISOString } from '$lib/utils/datetime';
 
 const NAME = 'Weekly Game Night';
 const START_ISO = '2026-08-01T18:00:00+02:00';
 const CITY_ID = 42;
+
+// The `datetime-local` value the organizer types, and the ISO string the
+// builders must derive from it. Resolved through the same helper the builders
+// use so the expectation stays correct under any machine timezone — what is
+// asserted here is that the field survives into the payload at all.
+const END_LOCAL = '2026-08-01T22:00';
+const END_ISO = toISOString(END_LOCAL);
+
+// #813. The create payload is the ONLY write for an organizer who fills in the
+// essentials, hits "Create", and navigates away — anything the form collects but
+// the builder drops is silently replaced by a backend default and never
+// repaired. `end` was dropped, and `Event.save()` sets `end = start + 1 day`
+// when it is falsy, so every abandoned draft became a 24-hour event.
+describe('buildEventCreateData', () => {
+	// Every field EssentialsStep (the pre-creation form) collects, plus the
+	// create-mode seeds EventEditor applies before the first POST.
+	const formData: EventFormPayloadData = {
+		name: NAME,
+		start: '2026-08-01T18:00',
+		end: END_LOCAL,
+		is_open_ended: false,
+		city_id: CITY_ID,
+		visibility: 'private',
+		event_type: 'members-only',
+		requires_ticket: true,
+		requires_full_profile: true,
+		accept_rsvp_notes: true,
+		event_series_id: 'series-1',
+		venue_id: 'venue-1'
+	};
+
+	it('carries every field the create form collects into the POST body', () => {
+		const payload = buildEventCreateData(formData, NAME, START_ISO);
+
+		expect(payload).toEqual({
+			name: NAME,
+			start: START_ISO,
+			end: END_ISO,
+			is_open_ended: false,
+			city_id: CITY_ID,
+			visibility: 'private',
+			event_type: 'members-only',
+			status: 'draft',
+			requires_ticket: true,
+			requires_full_profile: true,
+			accept_rsvp_notes: true,
+			event_series_id: 'series-1',
+			venue_id: 'venue-1'
+		});
+	});
+
+	it('sends the typed end so the backend does not default it to start + 24h', () => {
+		const payload = buildEventCreateData(formData, NAME, START_ISO);
+
+		expect(payload.end).toBe(END_ISO);
+		expect(payload.end).toContain('2026-08-01T22:00:00');
+		expect(payload.end).not.toBeNull();
+		expect(JSON.parse(JSON.stringify(payload))).toHaveProperty('end');
+	});
+
+	it('sends end as null and the flag as true for an open-ended event', () => {
+		const payload = buildEventCreateData({ ...formData, is_open_ended: true }, NAME, START_ISO);
+
+		expect(payload.end).toBeNull();
+		expect(payload.is_open_ended).toBe(true);
+	});
+
+	it('sends is_open_ended as an explicit false when the form never set it', () => {
+		const payload = buildEventCreateData({}, NAME, START_ISO);
+
+		expect(payload.is_open_ended).toBe(false);
+		expect(payload.end).toBeNull();
+	});
+
+	it('omits no field that the wizard/editor update payloads write back', () => {
+		const created = buildEventCreateData(formData, NAME, START_ISO);
+		const updated = buildEditorUpdateData(formData, START_ISO);
+
+		// Every key the create payload sends must round-trip identically through
+		// the first "Save" — a create/update disagreement is exactly the #813 bug.
+		for (const key of Object.keys(created) as (keyof typeof created)[]) {
+			if (key === 'status' || key === 'requires_ticket') continue; // create-only
+			expect([key, created[key]]).toEqual([key, updated[key as keyof typeof updated]]);
+		}
+	});
+});
 
 describe('buildRecurringTemplateCreateData', () => {
 	it('includes accept_rsvp_notes when the organizer enabled it', () => {

--- a/src/lib/components/events/admin/event-payload.ts
+++ b/src/lib/components/events/admin/event-payload.ts
@@ -52,6 +52,24 @@ function visibilitySettingsForWrite(
  * Build the create-event payload (essential fields only). Identical between
  * EventWizard and EventEditor. `name`/`startIso` are passed explicitly because
  * callers validate them (non-null) before invoking.
+ *
+ * "Essentials only" means: everything the pre-creation form (EssentialsStep)
+ * actually collects must be here. It is not a free choice — a field the
+ * organizer filled in but that this builder drops is silently replaced by a
+ * backend default, and the value is only repaired by the PUT on the first
+ * subsequent "Save". An organizer who creates the draft and navigates away
+ * keeps the default forever (#813: `end` was dropped, so every new draft became
+ * a 24-hour event — `Event.save()` sets `end = start + 1 day` when `end` is
+ * falsy).
+ *
+ * `end`/`is_open_ended` follow the same rule as every update builder: an
+ * open-ended event sends `end: null` (the backend still derives its internal
+ * `start + 24h` horizon) and the flag decides, never the raw input value.
+ *
+ * `event_series_id` is included because create mode can be seeded with one:
+ * EventEditor's `initialEventSeriesId` prop (the ExdatesChipList "create a
+ * one-off event for this date" action) pre-attaches the new event to the
+ * originating series, and `Event.objects.create(**payload)` honors it.
  */
 export function buildEventCreateData(
 	formData: EventFormPayloadData,
@@ -61,6 +79,8 @@ export function buildEventCreateData(
 	return {
 		name,
 		start: startIso,
+		end: formData.is_open_ended ? null : toISOString(formData.end),
+		is_open_ended: formData.is_open_ended ?? false,
 		city_id: formData.city_id,
 		visibility: formData.visibility || 'public',
 		event_type: formData.event_type || 'public',
@@ -68,6 +88,7 @@ export function buildEventCreateData(
 		requires_ticket: formData.requires_ticket || false, // Send explicit false when unchecked
 		requires_full_profile: formData.requires_full_profile || false,
 		accept_rsvp_notes: formData.accept_rsvp_notes || false,
+		event_series_id: formData.event_series_id || null,
 		venue_id: formData.venue_id || null
 	};
 }


### PR DESCRIPTION
## Symptom

Creating an event through the org-admin UI POSTs to
`/api/organization-admin/{slug}/create-event` **without** `end`, even though
EssentialsStep marks End as required and validates it. Observed body (End typed
as `2026-08-21T22:00`):

```json
{"name":"Smoke Test Soirée …","start":"2026-08-21T19:00:00+02:00","city_id":1,"visibility":"public","event_type":"public","status":"draft","requires_ticket":false, …}
```

## Root cause

`src/lib/components/events/admin/event-payload.ts` — `buildEventCreateData`
omitted `end` and `is_open_ended`, while its sibling
`buildRecurringTemplateCreateData` and all three update builders send them.
Backend `Event.save()` sets `end = start + timedelta(days=1)` when `end` is
falsy (`revel-backend/src/events/models/event.py:426`), so every new draft
became a 24-hour event. The PUT on the first subsequent "Save" repaired it —
so an organizer who created the draft and navigated away never got the value
they typed.

## Fix

`buildEventCreateData` now sends, matching the update builders:

- **`end`** — `formData.is_open_ended ? null : toISOString(formData.end)`, the
  identical expression used by `buildWizardStep1UpdateData`,
  `buildWizardStep2UpdateData` and `buildEditorUpdateData`. Open-ended events
  still send `null`; the backend derives its internal `start + 24h` horizon.
- **`is_open_ended`** — `?? false`, so the flag is never silently defaulted.
- **`event_series_id`** — the one other field create mode can hold but dropped:
  `EventEditor`'s `initialEventSeriesId` prop (the ExdatesChipList "create a
  one-off event for this date" action on the recurring-series dashboard)
  pre-attaches the new event to its originating series, and the backend's
  `Event.objects.create(**payload.model_dump())` honors it.

Everything else EssentialsStep collects (`name`, `start`, `visibility`,
`event_type`, `requires_ticket`) was already present. `visibility_settings`
stays deliberately omitted on create (see the existing
`visibilitySettingsForWrite` note — an unseeded all-`true` default would assert
a disclosure choice the organizer never made). No component was touched; the
change is confined to the payload builder and its tests.

## Tests

New `buildEventCreateData` suite in `event-payload.test.ts`:

- carries every field the pre-creation form collects into the POST body;
- `end` survives (and is not `null`/absent after JSON round-trip);
- open-ended sends `end: null` + `is_open_ended: true`;
- an unset flag sends an explicit `false`;
- no key the create payload sends disagrees with `buildEditorUpdateData` for
  the same `formData` — the create/update divergence that produced this bug.

## Verification

```
$ pnpm vitest run src/lib/components/events/admin/event-payload.test.ts
 Test Files  1 passed (1)
      Tests  34 passed (34)

$ pnpm vitest run src/lib/components/events/admin
 Test Files  12 passed (12)
      Tests  141 passed (141)

$ make fix && make check   # EXIT=0
All matched files use Prettier code style!
pnpm eslint . --max-warnings 0        (clean)
COMPLETED 6176 FILES 0 ERRORS
✓ Type gate is armed (deliberate errors in .ts and .svelte both caught)
✅ No new hardcoded user-facing strings (i18n).
✅ All files are within line limits
✓ No SSR access-token leaks
✓ image-alt audit clean
```

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event creation now preserves all event details entered during setup.
  * Open-ended events are handled correctly without an end date.
  * End times are normalized consistently across time zones.
  * New events retain draft status and correctly associate with an event series when applicable.

* **Tests**
  * Added coverage for event creation payloads, including missing values, open-ended events, and consistency with event updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->