### PR TITLE
fix(csp): stop mode-watcher emitting a nonce-less inline script

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -27,11 +27,15 @@
 		-->
 		<!--
 			Anti-FOUC: apply the dark class before first paint so dark-mode users
-			never see a light flash on SSR loads (#440). mode-watcher injects an
-			equivalent <svelte:head> snippet, but it carries no nonce and is blocked
-			by our production CSP (script-src 'self'); this script is nonced via
-			%sveltekit.nonce% so it runs. Must stay synchronous (no defer/async) and
-			mirror mode-watcher's storage key ('mode-watcher-mode') and dark class.
+			never see a light flash on SSR loads (#440). This is the ONLY anti-FOUC
+			script: mode-watcher used to inject an equivalent <svelte:head> snippet,
+			but it carried no nonce, was blocked by our production CSP
+			(script-src 'self' 'nonce-…') and logged a violation on every page load,
+			so `<ModeWatcher disableHeadScriptInjection />` in src/routes/+layout.svelte
+			now turns it off (#816). This script is nonced via %sveltekit.nonce% so it
+			runs. Must stay synchronous (no defer/async) and mirror mode-watcher's
+			storage key ('mode-watcher-mode') and dark class — mode-watcher no longer
+			has a fallback to cover a drift here.
 
 			Embed documents (/embed/*) with an explicit ?theme=light|dark carry
 			data-theme-locked and are skipped: their theme is already applied to

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -298,7 +298,19 @@
 	-->
 	{@render children()}
 {:else}
-	<ModeWatcher />
+	<!--
+		`disableHeadScriptInjection` (#816): mode-watcher's own FOUC snippet is
+		injected via {@html} as a BARE inline <script>. Its `nonce` prop can't help
+		us — SvelteKit's per-response nonce is only interpolated into app.html
+		(`%sveltekit.nonce%`) and is never exposed to components or load functions —
+		so under our production CSP (`script-src 'self' 'nonce-…'`) the browser
+		refused it and logged a violation on EVERY page load. The snippet never ran
+		anyway: the equivalent nonced script in src/app.html does the same job (same
+		'mode-watcher-mode' storage key, same `dark` class, same colorScheme), so
+		turning the injection off changes nothing but the console noise. Keep the two
+		in sync — app.html is now the ONLY anti-FOUC script.
+	-->
+	<ModeWatcher disableHeadScriptInjection />
 	<QueryClientProvider client={queryClient}>
 		<Toaster richColors position="top-right" />
 		<ImpersonationBanner />

--- a/tests/e2e/regression/csp.spec.ts
+++ b/tests/e2e/regression/csp.spec.ts
@@ -55,11 +55,13 @@ test.describe('production CSP', () => {
 		// CSP allow-lists it) or be a non-executable data block (ld+json), which
 		// the HTML spec never runs and CSP therefore never blocks. Anything else
 		// is a guaranteed console violation on every page load.
+		// The attribute must be a real `src`/`nonce` (not `data-src`/`data-nonce`)
+		// with a non-empty quoted value — `nonce=""` does not allow-list anything.
 		const offenders = [...html.matchAll(/<script\b([^>]*)>/g)]
 			.map(([, attrs]) => attrs)
-			.filter((attrs) => !/\bsrc=/.test(attrs))
-			.filter((attrs) => !/\bnonce=/.test(attrs))
-			.filter((attrs) => !/\btype=["']application\/ld\+json["']/.test(attrs));
+			.filter((attrs) => !/(?:^|\s)src\s*=\s*("[^"]+"|'[^']+')/.test(attrs))
+			.filter((attrs) => !/(?:^|\s)nonce\s*=\s*("[^"]+"|'[^']+')/.test(attrs))
+			.filter((attrs) => !/(?:^|\s)type\s*=\s*["']application\/ld\+json["']/.test(attrs));
 
 		expect(offenders, 'inline scripts without a nonce').toEqual([]);
 	});

--- a/tests/e2e/regression/csp.spec.ts
+++ b/tests/e2e/regression/csp.spec.ts
@@ -9,6 +9,10 @@ const API_ORIGIN = new URL(process.env.PUBLIC_API_URL ?? 'http://localhost:8000'
 //   `script-src 'self'` policy (the dark-mode FOUC — see the sibling spec).
 //   Here we pin the policy itself: script-src must stay nonce-based and must
 //   never regress to 'unsafe-inline'.
+// - #816: `<ModeWatcher />` injected its own nonce-less anti-FOUC <script>,
+//   which the policy below refused on every single page load (console error +
+//   CSP-report noise). It is now disabled via `disableHeadScriptInjection`;
+//   the third test pins that NO nonce-less executable inline script ships.
 // - #396: the CSP is generated at BUILD time, but the API origin is a RUNTIME
 //   setting (PUBLIC_API_URL). hooks.server.ts (handleCsp) appends the runtime
 //   origin to connect-src/img-src/media-src; if that patch breaks, every API
@@ -40,6 +44,24 @@ test.describe('production CSP', () => {
 		expect(scriptSrc).toContain("'self'");
 		expect(scriptSrc).toContain("'nonce-");
 		expect(scriptSrc).not.toContain("'unsafe-inline'");
+	});
+
+	test('ships no nonce-less executable inline script (#816)', async ({ request }) => {
+		const response = await request.get('/');
+		expect(response.ok()).toBeTruthy();
+		const html = await response.text();
+
+		// Every inline <script> in the document must either carry a nonce (so the
+		// CSP allow-lists it) or be a non-executable data block (ld+json), which
+		// the HTML spec never runs and CSP therefore never blocks. Anything else
+		// is a guaranteed console violation on every page load.
+		const offenders = [...html.matchAll(/<script\b([^>]*)>/g)]
+			.map(([, attrs]) => attrs)
+			.filter((attrs) => !/\bsrc=/.test(attrs))
+			.filter((attrs) => !/\bnonce=/.test(attrs))
+			.filter((attrs) => !/\btype=["']application\/ld\+json["']/.test(attrs));
+
+		expect(offenders, 'inline scripts without a nonce').toEqual([]);
 	});
 
 	test('runtime API origin is appended to connect-src / img-src / media-src (#396)', async ({


### PR DESCRIPTION
## Symptom

Every route in the production build logged, once per page load:

```
Executing inline script violates the following Content Security Policy directive
'script-src 'self' 'nonce-idTh8tvLr2IxELsfy3eOQA=='. Either the 'unsafe-inline' …
```

The served HTML carried the two nonce-carrying scripts from `app.html` plus one **bare** `<script>` with no nonce.

## Root cause

`<ModeWatcher />` (mode-watcher 1.1.0) renders its anti-FOUC snippet through `{@html}` in `<svelte:head>`:

```svelte
{@html `<script${trueNonce ? ` nonce=${trueNonce}` : ""}>(` + setInitialMode.toString() + …}
```

With no `nonce` prop set, that is a bare inline `<script>` — which our `script-src 'self' 'nonce-…'` policy refuses. Confirmed by grepping the served HTML:

```
$ curl -s http://localhost:4173/ | grep -o '<script>[^<]\{0,160\}'
<script>(function setInitialMode({ defaultMode = "system", themeColors, darkClassNames = ["dark"], …
```

Its `nonce` prop is **not** a usable escape hatch here: SvelteKit's per-response nonce is only interpolated into `app.html` (`%sveltekit.nonce%`) and is never exposed to components or `load` functions, so there is nothing to thread through.

Visible impact was nil, because the snippet never executed and the nonced anti-FOUC script already in `app.html` (#440) does the identical job — same `mode-watcher-mode` storage key, same `dark` class, same `colorScheme`. So this was pure console-error and CSP-report noise.

## Fix

`<ModeWatcher disableHeadScriptInjection />`. mode-watcher documents that prop for exactly this case ("Set this if you are manually injecting the script using a hook"), and it swaps `ModeWatcherFull` for `ModeWatcherLite`, which emits no script at all. Both `app.html` and `+layout.svelte` now carry a comment recording that `app.html` is the **only** anti-FOUC script and the two must stay in sync.

Zero new dependencies; three files touched (layout, app.html, one regression spec).

## Evidence

Production build (`make build`) served by adapter-node, before vs. after:

```
--- BEFORE ---
   2 <script nonce="f59gFPKugO6+Xvi71Q0EWw==">
   1 <script type="application/ld+json">
   1 <script>                                    ← setInitialMode(…), no nonce

--- AFTER ---
   2 <script nonce="rMOmRoy3Aymy6Pbz8moJ4A==">
   1 <script type="application/ld+json">
```

(`application/ld+json` is a data block — the HTML spec never executes it, so CSP never checks it. Verified on `/`, `/events`, `/login`, `/organizations`.)

Real Chromium console against the two builds side by side:

```
BEFORE (unfixed preview)  csp-violations=1
    Executing inline script violates the following Content Security Policy directive 'script-src 'self' 'nonce-idTh8tvLr2IxELsfy3eOQA==''. Either the 'uns…
AFTER  (fixed preview)    csp-violations=0
```

## No FOUC regression

The existing `#440` specs plus the new `#816` guard, run against a production build+preview on chromium / firefox / webkit:

```
✓ production CSP › ships no nonce-less executable inline script (#816)
✓ production CSP › document responses carry a nonce-based script-src without unsafe-inline
✓ production CSP › runtime API origin is appended to connect-src / img-src / media-src (#396)
✓ dark-mode anti-FOUC (#440) › serves a nonced anti-FOUC script that the CSP allow-lists
✓ dark-mode anti-FOUC (#440) › applies the dark class before hydration for a dark-mode user
✓ dark-mode anti-FOUC (#440) › does not force dark on an explicit light-mode user

  18 passed (7.9s)
```

The new guard is not vacuous — it **failed** when first run against a stale preview server built from `main`, and passes on this branch.

## Quality gate

```
$ make fix && make check
… ✓ Type gate is armed (deliberate errors in .ts and .svelte both caught)
… ✅ No new hardcoded user-facing strings (i18n).
… ✅ All files are within line limits (Svelte: 750, TS/JS: 500).
… ✓ No SSR access-token leaks
… ✓ image-alt audit clean
make check exit code: 0
```

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDXmzqVQzDQTBwT98KL9Wf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection against content security policy violations by ensuring inline scripts use a valid security nonce.
  - Prevented flashes of unstyled content during page loading with a consistent synchronous startup script.
  - Preserved appearance-mode detection and switching while eliminating duplicate automatic script injection.

- **Tests**
  - Added regression coverage to detect executable inline scripts that lack the required security nonce.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->