### PR TITLE
fix(i18n): let the relative RSVP deadline stand alone and add the absolute cutoff

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1795,7 +1795,6 @@
 		"spotsTaken": "{current} / {max} Plätze belegt",
 		"attendeeCount": "{count} Teilnehmer*innen",
 		"rsvpClosed": "Anmeldung geschlossen",
-		"rsvpBy": "Anmeldung bis {deadline}",
 		"openInMaps": "In Karten öffnen",
 		"mapOf": "Karte von",
 		"visibilityNote": "Sichtbarkeit: {visibility}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1795,7 +1795,6 @@
 		"spotsTaken": "{current} / {max} spots taken",
 		"attendeeCount": "{count} attending",
 		"rsvpClosed": "RSVP closed",
-		"rsvpBy": "RSVP by {deadline}",
 		"openInMaps": "Open in Maps",
 		"mapOf": "Map of",
 		"visibilityNote": "Visibility: {visibility}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1795,7 +1795,6 @@
 		"spotsTaken": "{current} / {max} plazas ocupadas",
 		"attendeeCount": "{count} participantes",
 		"rsvpClosed": "Confirmación cerrada",
-		"rsvpBy": "Confirma antes de {deadline}",
 		"openInMaps": "Abrir en Mapas",
 		"mapOf": "Mapa de",
 		"visibilityNote": "Visibilidad: {visibility}",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1681,7 +1681,6 @@
 		"spotsTaken": "{current} / {max} places prises",
 		"attendeeCount": "{count} participants",
 		"rsvpClosed": "Inscriptions closes",
-		"rsvpBy": "Inscription avant {deadline}",
 		"openInMaps": "Ouvrir dans Plans",
 		"mapOf": "Carte de",
 		"visibilityNote": "Visibilité : {visibility}",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1795,7 +1795,6 @@
 		"spotsTaken": "{current} / {max} posti occupati",
 		"attendeeCount": "{count} partecipanti",
 		"rsvpClosed": "RSVP chiuso",
-		"rsvpBy": "RSVP entro {deadline}",
 		"openInMaps": "Apri in Mappe",
 		"mapOf": "Mappa di",
 		"visibilityNote": "Visibilità: {visibility}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1795,7 +1795,6 @@
 		"spotsTaken": "{current} / {max} vagas ocupadas",
 		"attendeeCount": "{count} a participar",
 		"rsvpClosed": "Inscrições encerradas",
-		"rsvpBy": "Inscrição até {deadline}",
 		"openInMaps": "Abrir no Mapas",
 		"mapOf": "Mapa de",
 		"visibilityNote": "Visibilidade: {visibility}",

--- a/src/lib/components/events/EventQuickInfo.svelte
+++ b/src/lib/components/events/EventQuickInfo.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import type { EventDetailSchema } from '$lib/api/generated/types.gen';
-	import { formatEventDate, getRSVPDeadlineRelative, isRSVPClosingSoon } from '$lib/utils/date';
+	import {
+		formatDateTime,
+		formatEventDate,
+		getRSVPDeadlineRelative,
+		isRSVPClosingSoon
+	} from '$lib/utils/date';
 	import { cn } from '$lib/utils/cn';
 	import {
 		Calendar,
@@ -155,13 +160,22 @@
 		return remaining <= 10 && remaining > 0;
 	});
 
-	const rsvpDeadlineDisplay = $derived.by(() => {
+	// The relative phrase already carries its own directional word ("in 6 days" /
+	// "in 6 Tagen" / "em 6 dias"), so it must stand ALONE under the "RSVP deadline"
+	// label — feeding it into a composing "RSVP by {deadline}" string doubled the
+	// preposition in every locale (#814). Same shape EventDetails already uses.
+	// A null from getRSVPDeadlineRelative means the deadline has passed.
+	const rsvpDeadlineText = $derived.by(() => {
 		if (!event.rsvp_before) return null;
-		const relative = getRSVPDeadlineRelative(event.rsvp_before);
-		return relative === null
-			? m['eventQuickInfo.rsvpClosed']()
-			: m['eventQuickInfo.rsvpBy']({ deadline: relative });
+		return getRSVPDeadlineRelative(event.rsvp_before) ?? m['eventQuickInfo.rsvpClosed']();
 	});
+
+	// The relative phrase alone leaves the exact cutoff undiscoverable, so the
+	// absolute instant is spelled out beneath it — in the event's timezone, with
+	// the tz abbreviation formatDateTime appends.
+	const rsvpDeadlineAbsolute = $derived(
+		event.rsvp_before ? formatDateTime(event.rsvp_before, event.timezone) : null
+	);
 
 	const isDeadlineSoon = $derived.by(() => {
 		if (!event.rsvp_before) return false;
@@ -322,7 +336,7 @@
 	{/if}
 
 	<!-- RSVP Deadline (if rsvp_closes_at exists and event is not ticketed) -->
-	{#if rsvpDeadlineDisplay && !event.requires_ticket}
+	{#if rsvpDeadlineText && !event.requires_ticket}
 		<div
 			class={cn(itemClasses, isDeadlineSoon && 'text-highlight-foreground dark:text-highlight')}
 			role="listitem"
@@ -330,8 +344,20 @@
 		>
 			<Clock class={iconClasses} aria-hidden="true" />
 			<div class={textClasses}>
-				<time datetime={event.rsvp_before} class="block font-bold">
-					{rsvpDeadlineDisplay}
+				<span
+					class="block text-xs font-extrabold uppercase tracking-[0.12em] text-muted-foreground"
+				>
+					{m['eventDetails.rsvpDeadline_label']()}
+				</span>
+				<!-- Both lines describe the same instant, so one <time> wraps them:
+				     the relative phrase reads first, the exact cutoff sits under it. -->
+				<time datetime={event.rsvp_before} class="block">
+					<span class="block font-bold">{rsvpDeadlineText}</span>
+					{#if rsvpDeadlineAbsolute}
+						<span class="block text-xs font-normal text-muted-foreground">
+							{rsvpDeadlineAbsolute}
+						</span>
+					{/if}
 				</time>
 				{#if isDeadlineSoon}
 					<span class="text-xs text-muted-foreground">{m['eventQuickInfo.closesSoon']()}</span>

--- a/src/lib/components/events/EventQuickInfo.test.ts
+++ b/src/lib/components/events/EventQuickInfo.test.ts
@@ -110,12 +110,33 @@ describe('EventQuickInfo', () => {
 		expect(screen.getByText('Limited spots remaining')).toBeInTheDocument();
 	});
 
+	// #814: the relative phrase carries its own preposition ("in 7 days"), so it
+	// must stand alone under the "RSVP Deadline" label — never composed into an
+	// "RSVP by {deadline}" string, which doubled the preposition in every locale.
 	it('displays RSVP deadline when rsvp_before is set in the future', () => {
 		// Use a future deadline relative to "now" — past deadlines render "RSVP closed"
 		const futureDeadline = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
 		const eventWithFutureDeadline = { ...mockEvent, rsvp_before: futureDeadline };
 		render(EventQuickInfo, { props: { event: eventWithFutureDeadline } });
-		expect(screen.getByText(/RSVP by/i)).toBeInTheDocument();
+		expect(screen.getByText('RSVP Deadline')).toBeInTheDocument();
+		// The relative phrase is the whole content of its own element — nothing
+		// prefixes it (a few ms of drift floors "7 days" to 6, hence the \d+).
+		expect(screen.getByText(/^in \d+ days$/)).toBeInTheDocument();
+		expect(screen.queryByText(/RSVP by/i)).not.toBeInTheDocument();
+	});
+
+	it('shows the absolute cutoff alongside the relative deadline', () => {
+		const eventWithFutureDeadline = {
+			...mockEvent,
+			rsvp_before: '2099-10-24T19:00:00Z',
+			timezone: 'UTC'
+		};
+		const { container } = render(EventQuickInfo, { props: { event: eventWithFutureDeadline } });
+
+		// Textual month, never a numeric one (no DD/MM vs MM/DD ambiguity)
+		expect(screen.getByText(/Oct 24, 2099/)).toBeInTheDocument();
+		// The machine-readable instant rides on a <time datetime>
+		expect(container.querySelector('time[datetime="2099-10-24T19:00:00Z"]')).toBeInTheDocument();
 	});
 
 	it('displays "RSVP closed" when rsvp_before is in the past', () => {
@@ -123,6 +144,8 @@ describe('EventQuickInfo', () => {
 		const eventWithPastDeadline = { ...mockEvent, rsvp_before: pastDeadline };
 		render(EventQuickInfo, { props: { event: eventWithPastDeadline } });
 		expect(screen.getByText('RSVP closed')).toBeInTheDocument();
+		// The exact cutoff stays discoverable even once the deadline has passed
+		expect(screen.getByText('RSVP Deadline')).toBeInTheDocument();
 	});
 
 	it('does not display RSVP deadline when rsvp_before is not set', () => {


### PR DESCRIPTION
## Symptom

The public event page rendered the RSVP deadline as **"RSVP by in 6 days"**.

`EventQuickInfo` fed the output of `getRSVPDeadlineRelative()` — which already carries its own directional word — into the composing message `eventQuickInfo.rsvpBy` (`"RSVP by {deadline}"`). Every locale doubled the preposition:

| Locale | Composed output (before) |
| --- | --- |
| en | RSVP by **in** 6 days |
| it | RSVP entro **tra** 6 giorni |
| de | Anmeldung bis **in** 6 Tagen |
| fr | Inscription avant **dans** 6 jours |
| es | Confirma antes de **dentro de** 6 días |
| pt | Inscrição até **em** 6 dias |

Secondly, the deadline was only ever shown **relatively** — no absolute date/time anywhere on the public page, not even a tooltip — so the exact cutoff was undiscoverable.

## Fix

`EventQuickInfo` now uses the shape `EventDetails` already had, where the relative phrase stands alone under a label and reads fine:

```
RSVP DEADLINE
in 6 days
Aug 14, 2026, 7:00 PM CEST
```

- The composed `rsvpBy {deadline}` string is gone; the relative phrase is rendered on its own under the **`eventDetails.rsvpDeadline_label`** kicker (already translated in all six locales, so no new copy needed and no six-locale rewording).
- The **absolute cutoff** is rendered beneath it via `formatDateTime(event.rsvp_before, event.timezone)` — textual month, in the event's timezone with the tz abbreviation the helper appends. No `toLocale*` (ESLint-banned outside `date.ts`).
- Both lines sit inside a single `<time datetime={event.rsvp_before}>` — they describe the same instant, and the ISO value stays machine-readable.
- The passed-deadline case still shows "RSVP closed", now with the label and exact cutoff still visible.

### Message keys

**Removed** (no other call site — grepped both nested and flat-dotted shapes across `src/`, `tests/`, and `messages/`): `eventQuickInfo.rsvpBy`

| Locale | Removed value |
| --- | --- |
| en | `"RSVP by {deadline}"` |
| it | `"RSVP entro {deadline}"` |
| de | `"Anmeldung bis {deadline}"` |
| fr | `"Inscription avant {deadline}"` |
| es | `"Confirma antes de {deadline}"` |
| pt | `"Inscrição até {deadline}"` |

**Added:** none — the fix reuses the existing `eventDetails.rsvpDeadline_label`.

## Accessibility

No `aria-label` hacks: the visible text is what screen readers announce, and it now reads "RSVP Deadline / in 6 days / Aug 14, 2026, 7:00 PM CEST" instead of the ungrammatical composed string. The row keeps its `role="listitem"` and `aria-live="polite"`; the label is real visible text, not a hidden one.

## Verification

```
$ pnpm paraglide:compile
✓ Paraglide messages compiled (locale-modules)

$ make fix
(prettier --write + eslint --fix, clean)

$ make check
✓ prettier: All matched files use Prettier code style!
✓ eslint --max-warnings 0: clean
✓ Paraglide compiled bundle is up to date (6 locale files checked)
✓ All languages have the same number of keys
✓ All keys are aligned across languages
✓ All placeholders are consistent
✓ All validations passed!            (i18n-check)
  COMPLETED 6176 FILES 0 ERRORS      (svelte-check)
✓ Type gate is armed (deliberate errors in .ts and .svelte both caught)
✅ No new hardcoded user-facing strings (i18n).
✅ All files are within line limits (Svelte: 750, TS/JS: 500).
✓ No SSR access-token leaks
✓ image-alt audit clean
EXIT=0
```

```
$ pnpm vitest run src/lib/components/events/EventQuickInfo.test.ts
Test Files  1 passed (1)
     Tests  25 passed (25)

$ pnpm vitest run src/lib/components/events/EventDetails.test.ts src/lib/utils/date.test.ts
Test Files  2 passed (2)
     Tests  73 passed (73)
```

Test changes: the existing deadline test now asserts the label plus a standalone `/^in \d+ days$/` and explicitly asserts `RSVP by` is **absent**; a new test asserts the absolute cutoff renders with a textual month and that the `<time datetime="…">` carries the ISO instant; the closed-deadline test asserts the label (and therefore the cutoff) survives once the deadline passes.

Scope kept to `EventQuickInfo.svelte`, the six locale files, and `EventQuickInfo.test.ts` — no overlap with the other date surfaces covered by #818.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
