### PR TITLE
fix(checkout): treat /api/me/billing 404 as an empty state, not an error

### DIFF
--- a/src/lib/components/tickets/CheckoutBillingSection.svelte
+++ b/src/lib/components/tickets/CheckoutBillingSection.svelte
@@ -69,7 +69,21 @@
 	// Form validation
 	let billingNameError = $state('');
 
-	// 4. Query: pre-fill from billing profile when authenticated
+	// 4. Query: pre-fill from billing profile when the user asks for an invoice.
+	// Gated on `isOpen` as well: the profile is read ONLY by the prefill below, so
+	// firing on mount spent a request on every paid-checkout dialog — and for the
+	// many users with nothing saved the endpoint answers 404, which the browser
+	// still logs as a failed request even though we handle it (#817).
+	// All three operands are read unconditionally: `&&` evaluated inside the
+	// tracked options getter would leave the later ones unread — and therefore
+	// untracked — freezing `enabled` at its initial value.
+	const shouldLoadBillingProfile = $derived.by(() => {
+		const authenticated = isAuthenticated;
+		const hasToken = !!authToken;
+		const sectionOpen = isOpen;
+		return authenticated && hasToken && sectionOpen;
+	});
+
 	const billingProfileQuery = createQuery<UserBillingProfileSchema | null>(() => ({
 		queryKey: ['user-billing-profile'],
 		queryFn: async () => {
@@ -77,11 +91,14 @@
 			const response = await userbillingGetBillingProfile({
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			// 404 = "nothing saved yet", an expected empty state rather than a
+			// failure: resolve to null so the query never lands in an error state
+			// and nothing is logged. `retry: false` keeps it from repeating too.
 			if (response.response?.status === 404) return null;
 			if (response.error) return null;
 			return (response.data as UserBillingProfileSchema) ?? null;
 		},
-		enabled: isAuthenticated && !!authToken,
+		enabled: shouldLoadBillingProfile,
 		retry: false,
 		staleTime: 60_000
 	}));

--- a/src/lib/components/tickets/CheckoutBillingSection.test.ts
+++ b/src/lib/components/tickets/CheckoutBillingSection.test.ts
@@ -308,4 +308,75 @@ describe('CheckoutBillingSection', () => {
 			});
 		});
 	});
+
+	// A user who never saved billing details gets a 404 from GET /api/me/billing.
+	// That is an empty state, not a failure (#817).
+	describe('billing profile 404 (nothing saved yet)', () => {
+		function mock404(getBillingProfile: ReturnType<typeof vi.fn>) {
+			getBillingProfile.mockResolvedValue({
+				data: undefined,
+				error: { detail: 'Not found' },
+				response: { status: 404 } as Response
+			});
+		}
+
+		it('does not request the billing profile until the invoice section is opened', async () => {
+			const { userbillingGetBillingProfile } = await import('$lib/api/generated/sdk.gen');
+			mock404(vi.mocked(userbillingGetBillingProfile));
+
+			renderWithQueryClient({ isAuthenticated: true, authToken: 'token-xyz' });
+
+			// Collapsed: the profile is only ever read by the prefill, so nothing is fetched.
+			await waitFor(() => {
+				expect(userbillingGetBillingProfile).not.toHaveBeenCalled();
+			});
+
+			await fireEvent.click(screen.getByRole('checkbox', { name: /Request Invoice/i }));
+			await waitFor(() => {
+				expect(userbillingGetBillingProfile).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		it('resolves to an empty profile without erroring or logging', async () => {
+			const { userbillingGetBillingProfile } = await import('$lib/api/generated/sdk.gen');
+			mock404(vi.mocked(userbillingGetBillingProfile));
+			const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+			renderWithQueryClient({ isAuthenticated: true, authToken: 'token-xyz' });
+			await fireEvent.click(screen.getByRole('checkbox', { name: /Request Invoice/i }));
+
+			await waitFor(() => {
+				expect(userbillingGetBillingProfile).toHaveBeenCalled();
+			});
+
+			// The form is simply blank — the 404 resolved to null, it did not throw.
+			const nameInput = screen.getByLabelText(/Legal Name/i) as HTMLInputElement;
+			expect(nameInput.value).toBe('');
+			expect(consoleError).not.toHaveBeenCalled();
+			consoleError.mockRestore();
+		});
+
+		it('does not retry a 404, even under a retrying query client', async () => {
+			const { userbillingGetBillingProfile } = await import('$lib/api/generated/sdk.gen');
+			mock404(vi.mocked(userbillingGetBillingProfile));
+
+			const queryClient = new QueryClient({
+				defaultOptions: { queries: { retry: 3, retryDelay: 0 } }
+			});
+			render(QueryClientTestWrapper, {
+				props: {
+					client: queryClient,
+					component: CheckoutBillingSection,
+					componentProps: { ...defaultProps, isAuthenticated: true, authToken: 'token-xyz' }
+				}
+			});
+			await fireEvent.click(screen.getByRole('checkbox', { name: /Request Invoice/i }));
+
+			await waitFor(() => {
+				expect(userbillingGetBillingProfile).toHaveBeenCalledTimes(1);
+			});
+			expect(queryClient.getQueryState(['user-billing-profile'])?.status).toBe('success');
+			expect(queryClient.getQueryData(['user-billing-profile'])).toBeNull();
+		});
+	});
 });


### PR DESCRIPTION
## Symptom

Opening the paid-ticket checkout dialog fired `GET /api/me/billing` on mount for every authenticated buyer. The endpoint 404s for anyone who has never saved billing details (BE: `get_object_or_404(UserBillingProfile, user=...)`) — semantically "nothing saved yet" — so a first-time purchase logged a red failed-request line on every dialog open.

## What was already true

The queryFn in `CheckoutBillingSection.svelte` already returned `null` on 404 with `retry: false`, and the generated client returns `{ error, response }` rather than throwing when `throwOnError` is off. So nothing ever reached a TanStack error state, and no `console.error` in the app (or in the API client interceptors, or the app `QueryClient`) fires for a 404. The red line is the **browser's own** network log for the 404 response — JS handling cannot suppress it; only not making the request can.

## Fix

The billing profile is read by exactly one thing: the prefill that runs when the user ticks "request invoice". So the query is now gated on the section being open as well as on auth:

- A plain paid-checkout dialog now makes **no** `/api/me/billing` request at all — the symptom ("on every paid-checkout dialog") is gone.
- The 404 only happens for a user who actually asked for an invoice, and there it stays what it always was: an empty form, no error state, no retry.
- Prefill still lands (guarded by `if (!field)`, so it never clobbers anything typed in the meantime); the only behavioural change is that it arrives a request later than before, after the tick, instead of being pre-warmed on mount.

The three `enabled` operands are read unconditionally in a `$derived.by` — `&&` evaluated inside the tracked options getter would leave the later ones unread, and therefore untracked, freezing `enabled` at its initial value (the tracked-props freeze from #629).

The 404-as-null handling itself is unchanged; the comments now explain why it is there so it does not get "simplified" away.

## Consumers checked

All three callers of `userbillingGetBillingProfile` share the `['user-billing-profile']` query key; none uses the error state as its empty-UI branch:

| Consumer | 404 handling | Change |
| --- | --- | --- |
| `tickets/CheckoutBillingSection.svelte` | 404 → `null`, all other errors → `null` (best-effort prefill), `retry: false` | gated on section open |
| `billing/BillingProfileForm.svelte` (account settings) | 404 → `null`, other errors throw, `retry: false`; empty state via `hasBillingProfile` | none — the request is expected on a page dedicated to billing |
| `(auth)/account/referral/+page.svelte` | same shape as above | none — same reason |

## Tests

`CheckoutBillingSection.test.ts` gains three cases: no request while collapsed (then exactly one after opening), a 404 yielding a blank form with no `console.error`, and — under a `retry: 3` query client — a single call landing in `status: 'success'` with `null` data.

Canary: reverting the `enabled` gate makes the first new test fail, so it is decisive rather than vacuous.

## Follow-up (not in scope)

For a user who *does* tick "request invoice" with no saved profile, the browser still logs that one 404. Removing it entirely needs the BE to answer `200` + empty payload, as the issue notes.

## Verification

```
$ pnpm vitest run src/lib/components/tickets/CheckoutBillingSection.test.ts src/lib/components/billing/BillingProfileForm.test.ts
 Test Files  2 passed (2)
      Tests  33 passed (33)

$ make fix && make check   # EXIT=0
All matched files use Prettier code style!
pnpm eslint . --max-warnings 0
✓ All validations passed!            (i18n)
COMPLETED 6176 FILES 0 ERRORS 381 WARNINGS   (svelte-check; warnings = pre-existing baseline)
✓ Type gate is armed (deliberate errors in .ts and .svelte both caught)
✅ No new hardcoded user-facing strings (i18n).
✅ All files are within line limits (Svelte: 750, TS/JS: 500).
✓ No SSR access-token leaks
✓ image-alt audit clean
```

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDXmzqVQzDQTBwT98KL9Wf
