### PR TITLE
chore(e2e): one-command E2E setup/run/teardown make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ playwright/.cache/
 *.lcov
 .tests.output
 .tests.output.full
+.e2e.output
 
 # Vite
 vite.config.js.timestamp-*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ Individual checks (also available separately):
 - `make e2e` - Full E2E run: reseeds + spins up the backend (`../revel-backend`, daemonized gunicorn), then runs Playwright
 - `make e2e-setup` / `make e2e-run` / `make e2e-teardown` - the pieces: backend up+seeded; suite with a mass-skip warning (a wedged backend makes journey specs self-skip → false green); stop the daemon. Environment contract and caveats: `tests/e2e/README.md`. `stripe listen` stays a manual step; don't run from worktrees (one backend, one :8000).
 
+**Claude may run unit tests (`make test`) and drive E2E runs (`make e2e-setup` / `make e2e-run` / `make e2e-teardown`) whenever appropriate** — decided 2026-08-09, superseding the earlier "let the user run tests" rule. Judge the skip count on E2E runs, not just the exit code.
+
 ### Workflow: Before Committing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Individual checks (also available separately):
 - `make test` - Run unit tests (saves failures to `.tests.output`)
 - `make test-coverage` - Run tests with coverage report
 - `make test-e2e` - Run Playwright E2E tests
+- `make e2e` - Full E2E run: reseeds + spins up the backend (`../revel-backend`, daemonized gunicorn), then runs Playwright
+- `make e2e-setup` / `make e2e-run` / `make e2e-teardown` - the pieces: backend up+seeded; suite with a mass-skip warning (a wedged backend makes journey specs self-skip → false green); stop the daemon. Environment contract and caveats: `tests/e2e/README.md`. `stripe listen` stays a manual step; don't run from worktrees (one backend, one :8000).
 
 ### Workflow: Before Committing
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build preview format format-check lint lint-fix types types-canary i18n-check i18n-freshness i18n-hardcoded i18n-hardcoded-update file-length no-ssr-token audit-images audit-soft-404 audit licensecheck audit-deps check fix test test-coverage test-e2e generate-api bump-version bump-minor release
+.PHONY: dev build preview format format-check lint lint-fix types types-canary i18n-check i18n-freshness i18n-hardcoded i18n-hardcoded-update file-length no-ssr-token audit-images audit-soft-404 audit licensecheck audit-deps check fix test test-coverage test-e2e generate-api bump-version bump-minor release e2e-setup e2e-run e2e e2e-teardown
 
 # ─────────────────────────────────────────────
 # Development
@@ -122,6 +122,46 @@ test-coverage:
 
 test-e2e:
 	pnpm playwright test
+
+# ─────────────────────────────────────────────
+# E2E — full-stack quality-of-life targets
+# ─────────────────────────────────────────────
+
+BACKEND_DIR := ../revel-backend
+
+# Spin up + reseed the backend for an E2E run: docker + PgBouncer + a
+# daemonized gunicorn (pid/log at $(BACKEND_DIR)/.e2e-gunicorn.*), preceded by
+# the canonical reseed. Idempotent — any stale backend on :8000 is killed
+# first. Out of scope: `stripe listen` (interactive auth; Stripe specs
+# self-skip). Don't run from worktrees: one backend instance, one :8000.
+e2e-setup:
+	@test -d $(BACKEND_DIR) || { echo "❌ $(BACKEND_DIR) not found — expected the backend checkout next to this repo"; exit 1; }
+	$(MAKE) -C $(BACKEND_DIR) e2e-seed run-e2e-daemon
+
+# Playwright suite with a mass-skip guard: journey specs self-skip when the
+# backend probe fails, so a wedged backend yields exit 0 with hundreds of
+# skips (false green). Warn loudly, don't fail — partial runs (--grep) skip
+# legitimately. `make test-e2e` remains the raw, guard-free run.
+e2e-run:
+	@pnpm playwright test 2>&1 | tee .e2e.output; \
+	exit_code=$${PIPESTATUS[0]}; \
+	skipped=$$(grep -oE '[0-9]+ skipped' .e2e.output | tail -1 | grep -oE '[0-9]+' || true); \
+	if [ -n "$$skipped" ] && [ "$$skipped" -gt 10 ]; then \
+		echo ""; \
+		echo "⚠️⚠️⚠️  $$skipped tests SKIPPED — possible mass-skip FALSE GREEN (exit code $$exit_code)."; \
+		echo "Journey specs self-skip when the backend probe fails. Verify the backend"; \
+		echo "is healthy (make e2e-setup) before trusting this result."; \
+	fi; \
+	exit $$exit_code
+
+# The whole thing: backend up + reseeded, then the suite.
+e2e: e2e-setup
+	$(MAKE) e2e-run
+
+# Stop the daemonized backend. The docker stack (postgres/redis/mailpit/
+# pgbouncer) stays up — it's the shared dev environment.
+e2e-teardown:
+	$(MAKE) -C $(BACKEND_DIR) stop-e2e
 
 # ─────────────────────────────────────────────
 # API client

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,8 @@ BACKEND_DIR := ../revel-backend
 # self-skip). Don't run from worktrees: one backend instance, one :8000.
 e2e-setup:
 	@test -d $(BACKEND_DIR) || { echo "❌ $(BACKEND_DIR) not found — expected the backend checkout next to this repo"; exit 1; }
-	$(MAKE) -C $(BACKEND_DIR) e2e-seed run-e2e-daemon
+	$(MAKE) -C $(BACKEND_DIR) e2e-seed
+	$(MAKE) -C $(BACKEND_DIR) run-e2e-daemon
 
 # Playwright suite with a mass-skip guard: journey specs self-skip when the
 # backend probe fails, so a wedged backend yields exit 0 with hundreds of

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,8 +11,8 @@ the built frontend.
 
 | Dependency | Where | Notes |
 | --- | --- | --- |
-| Backend | `http://localhost:8000` | `make run-e2e` in `revel-backend` (gunicorn + PgBouncer; plain `make run` exhausts Postgres connections at 4 workers) |
-| Reset | `uv run python src/manage.py reset_events --no-input && make seed && make bootstrap-tests` (backend repo) | Run before a full suite for determinism. Order matters: `reset_events` already re-runs `bootstrap_events` (a following `make bootstrap` fails on duplicates), and `seed` must run **before** `bootstrap-tests` — the seeder's payment/quantity sweeps are global, so seeding last would mutate the test fixtures (e.g. randomly refunding the sold-out event's tickets). The showcase seed (`make seed`) is required by the Teatro Grande specs (`getSeededBestAvailableEvent`).<br>**`reset_db → make bootstrap → make seed` is the WRONG order** and the way this has actually gone wrong: `make bootstrap` chains `bootstrap_test_events`, so a later `make seed` reaches those fixtures. `TicketSeeder._create_payments` selects `Ticket.objects.filter(tier__payment_method=ONLINE, payment__isnull=True)` with no scope at all and rolls some of them REFUNDED → ticket CANCELLED (`cancellation_source=stripe_dashboard`) + `tier.quantity_sold` decremented. Repairing a fixture after that takes BOTH halves — the `Ticket.status` rows *and* the denormalized counter |
+| Backend | `http://localhost:8000` | `make e2e-setup` (this repo) starts it — or manually: `make run-e2e` in `revel-backend` (gunicorn + PgBouncer; plain `make run` exhausts Postgres connections at 4 workers) |
+| Reset | `uv run python src/manage.py reset_events --no-input && make seed && make bootstrap-tests` (backend repo) | Included in `make e2e-setup` — or manually: run before a full suite for determinism. Order matters: `reset_events` already re-runs `bootstrap_events` (a following `make bootstrap` fails on duplicates), and `seed` must run **before** `bootstrap-tests` — the seeder's payment/quantity sweeps are global, so seeding last would mutate the test fixtures (e.g. randomly refunding the sold-out event's tickets). The showcase seed (`make seed`) is required by the Teatro Grande specs (`getSeededBestAvailableEvent`).<br>**`reset_db → make bootstrap → make seed` is the WRONG order** and the way this has actually gone wrong: `make bootstrap` chains `bootstrap_test_events`, so a later `make seed` reaches those fixtures. `TicketSeeder._create_payments` selects `Ticket.objects.filter(tier__payment_method=ONLINE, payment__isnull=True)` with no scope at all and rolls some of them REFUNDED → ticket CANCELLED (`cancellation_source=stripe_dashboard`) + `tier.quantity_sold` decremented. Repairing a fixture after that takes BOTH halves — the `Ticket.status` rows *and* the denormalized counter |
 | Celery | inline/eager | Questionnaire auto-eval, exports, etc. complete synchronously |
 | Mailpit | `http://localhost:8025` | Captures all outbound email; override with `E2E_MAILPIT_URL` |
 | Stripe | `stripe listen` forwarding to the backend | Backend `.env` needs `CONNECTED_TEST_STRIPE_ID` **at bootstrap time**, or online checkout fails |
@@ -21,6 +21,8 @@ the built frontend.
 ## Running
 
 ```bash
+make e2e                           # backend up + reseeded, then everything
+make e2e-setup && make e2e-run     # …as two halves; make e2e-teardown stops the backend
 pnpm test:e2e                      # everything
 pnpm test:e2e --grep @p0           # one tier (@p0–@p3)
 pnpm test:e2e --project=chromium   # desktop journeys only


### PR DESCRIPTION
`make e2e` = reseed + daemonized backend + Playwright; `make e2e-run` adds a mass-skip false-green warning; `make e2e-teardown` stops the daemon. Docs in CLAUDE.md + tests/e2e/README.md.

Companion backend PR: https://github.com/letsrevel/revel-backend/pull/864

**Merge order note:** this PR merges fine before the backend one, but `make e2e-setup` needs the `chore/e2e-make-targets` backend branch checked out at `../revel-backend` until letsrevel/revel-backend#864 merges (otherwise: `No rule to make target 'e2e-seed'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands for setting up, running, and tearing down end-to-end tests.
  * Added a combined command to execute the full end-to-end test workflow.

* **Documentation**
  * Updated end-to-end testing instructions, including environment setup, backend seeding, execution options, and teardown.

* **Chores**
  * Configured end-to-end test output files to be ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->