### PR TITLE
chore(tickets): move Make member and Manage on Stripe into the row overflow menu

### DIFF
--- a/src/lib/components/tickets/TicketCardList.svelte
+++ b/src/lib/components/tickets/TicketCardList.svelte
@@ -253,16 +253,22 @@
 						{m['eventTicketsAdmin.actionCheckIn']()}
 					</Button>
 				{/if}
-				{#if canConfirmPayment(ticket)}
+				{#if onRefundTicket && canRefundTicketPayment(ticket)}
+					<Button size="sm" variant="outline" onclick={() => onRefundTicket(ticket)} class="flex-1">
+						<Undo2 class="h-4 w-4" aria-hidden="true" />
+						{m['refundTicket.menuItem']()}
+					</Button>
+				{/if}
+				{#if canAdminCancelTicket(ticket)}
 					<Button
 						size="sm"
-						variant="default"
-						onclick={() => onConfirmPayment(ticket)}
-						disabled={confirmPaymentPending}
-						class="flex-1"
+						variant="outline"
+						class="flex-1 text-destructive hover:text-destructive"
+						onclick={() => onCancelTicket(ticket)}
+						disabled={cancelTicketPending}
 					>
-						<Check class="h-4 w-4" aria-hidden="true" />
-						{m['eventTicketsAdmin.actionConfirmPayment']()}
+						<X class="h-4 w-4" aria-hidden="true" />
+						{m['ticketCardList.cancelTicket']()}
 					</Button>
 				{/if}
 				<!-- More actions dropdown for mobile -->
@@ -281,6 +287,15 @@
 						{/snippet}
 					</DropdownMenu.Trigger>
 					<DropdownMenu.Content align="end">
+						{#if canConfirmPayment(ticket)}
+							<DropdownMenu.Item
+								onclick={() => onConfirmPayment(ticket)}
+								disabled={confirmPaymentPending}
+							>
+								<Check class="mr-2 h-4 w-4" aria-hidden="true" />
+								{m['eventTicketsAdmin.actionConfirmPayment']()}
+							</DropdownMenu.Item>
+						{/if}
 						{#if !ticket.membership && ticket.user?.id}
 							<DropdownMenu.Item
 								onclick={() => onMakeMember(ticket)}
@@ -317,22 +332,6 @@
 							>
 								<Undo2 class="mr-2 h-4 w-4" aria-hidden="true" />
 								{m['eventTicketsAdmin.actionUnconfirmPayment']()}
-							</DropdownMenu.Item>
-						{/if}
-						{#if onRefundTicket && canRefundTicketPayment(ticket)}
-							<DropdownMenu.Item onclick={() => onRefundTicket(ticket)}>
-								<Undo2 class="mr-2 h-4 w-4" aria-hidden="true" />
-								{m['refundTicket.menuItem']()}
-							</DropdownMenu.Item>
-						{/if}
-						{#if canAdminCancelTicket(ticket)}
-							<DropdownMenu.Item
-								onclick={() => onCancelTicket(ticket)}
-								disabled={cancelTicketPending}
-								class="text-destructive focus:text-destructive"
-							>
-								<X class="mr-2 h-4 w-4" aria-hidden="true" />
-								{m['ticketCardList.cancelTicket']()}
 							</DropdownMenu.Item>
 						{/if}
 						{#if ticket.user?.id}

--- a/src/lib/components/tickets/TicketCardList.svelte
+++ b/src/lib/components/tickets/TicketCardList.svelte
@@ -265,29 +265,6 @@
 						{m['eventTicketsAdmin.actionConfirmPayment']()}
 					</Button>
 				{/if}
-				{#if !ticket.membership && ticket.user?.id}
-					<Button
-						size="sm"
-						variant="outline"
-						onclick={() => onMakeMember(ticket)}
-						disabled={addMemberPending || tiersLoading}
-						class="flex-1"
-					>
-						<UserPlus class="h-4 w-4" aria-hidden="true" />
-						{m['makeMemberAction.button']()}
-					</Button>
-				{/if}
-				{#if ticket.tier?.payment_method === 'online' && ticket.payment?.stripe_dashboard_url}
-					<Button
-						size="sm"
-						variant="outline"
-						onclick={() => window.open(ticket.payment?.stripe_dashboard_url, '_blank')}
-						class="w-full"
-					>
-						<ExternalLink class="h-4 w-4" aria-hidden="true" />
-						{m['ticketCardList.manageOnStripe']()}
-					</Button>
-				{/if}
 				<!-- More actions dropdown for mobile -->
 				<DropdownMenu.Root>
 					<DropdownMenu.Trigger>
@@ -304,6 +281,23 @@
 						{/snippet}
 					</DropdownMenu.Trigger>
 					<DropdownMenu.Content align="end">
+						{#if !ticket.membership && ticket.user?.id}
+							<DropdownMenu.Item
+								onclick={() => onMakeMember(ticket)}
+								disabled={addMemberPending || tiersLoading}
+							>
+								<UserPlus class="mr-2 h-4 w-4" aria-hidden="true" />
+								{m['makeMemberAction.button']()}
+							</DropdownMenu.Item>
+						{/if}
+						{#if ticket.tier?.payment_method === 'online' && ticket.payment?.stripe_dashboard_url}
+							<DropdownMenu.Item
+								onclick={() => window.open(ticket.payment?.stripe_dashboard_url, '_blank')}
+							>
+								<ExternalLink class="mr-2 h-4 w-4" aria-hidden="true" />
+								{m['ticketCardList.manageOnStripe']()}
+							</DropdownMenu.Item>
+						{/if}
 						{#if onRenameHolder && ticket.status !== 'checked_in' && ticket.status !== 'cancelled'}
 							<DropdownMenu.Item onclick={() => onRenameHolder(ticket)}>
 								<Pencil class="mr-2 h-4 w-4" aria-hidden="true" />

--- a/src/lib/components/tickets/TicketTable.svelte
+++ b/src/lib/components/tickets/TicketTable.svelte
@@ -207,7 +207,7 @@
 						</div>
 					</td>
 					<td class="px-4 py-3">
-						<div class="font-medium">{ticket.tier?.name || 'N/A'}</div>
+						<div class="whitespace-nowrap font-medium">{ticket.tier?.name || 'N/A'}</div>
 						{#if ticket.series_pass}
 							<SeriesPassBadge seriesPass={ticket.series_pass} class="mt-0.5" />
 						{/if}
@@ -222,7 +222,7 @@
 								})
 							: undefined}
 					>
-						<div class="font-medium">
+						<div class="whitespace-nowrap font-medium">
 							{formatPrice(
 								getTicketPrice(ticket),
 								ticket.payment?.currency || ticket.tier?.currency,
@@ -232,7 +232,7 @@
 						<TicketDiscountBadge {ticket} />
 					</td>
 					<td class="px-4 py-3">
-						<div class="flex items-center gap-1 text-sm">
+						<div class="flex items-center gap-1 whitespace-nowrap text-sm">
 							{@render paymentMethodIcon(ticket.tier?.payment_method || '')}
 							{getPaymentMethodLabel(ticket.tier?.payment_method || '')}
 						</div>
@@ -242,7 +242,7 @@
 							<StatusBadge
 								tone={getTicketStatusTone(ticket.status ?? '')}
 								label={getTicketStatusLabel(ticket.status ?? '')}
-								class="w-fit"
+								class="w-fit whitespace-nowrap"
 							/>
 							<!-- Refund state renders independent of ticket status: since
 							     organizer refunds, an active ticket can carry a (partial)
@@ -254,7 +254,7 @@
 							/>
 						</div>
 					</td>
-					<td class="px-4 py-3 text-sm text-muted-foreground">
+					<td class="whitespace-nowrap px-4 py-3 text-sm text-muted-foreground">
 						{formatDate(ticket.created_at)}
 					</td>
 					<td class="px-4 py-3">
@@ -270,15 +270,22 @@
 									{m['eventTicketsAdmin.actionCheckIn']()}
 								</Button>
 							{/if}
-							{#if canConfirmPayment(ticket)}
+							{#if onRefundTicket && canRefundTicketPayment(ticket)}
+								<Button size="sm" variant="outline" onclick={() => onRefundTicket(ticket)}>
+									<Undo2 class="h-4 w-4" aria-hidden="true" />
+									{m['refundTicket.menuItem']()}
+								</Button>
+							{/if}
+							{#if canAdminCancelTicket(ticket)}
 								<Button
 									size="sm"
-									variant="default"
-									onclick={() => onConfirmPayment(ticket)}
-									disabled={confirmPaymentPending}
+									variant="outline"
+									class="text-destructive hover:text-destructive"
+									onclick={() => onCancelTicket(ticket)}
+									disabled={cancelTicketPending}
 								>
-									<Check class="h-4 w-4" aria-hidden="true" />
-									{m['eventTicketsAdmin.actionConfirmPayment']()}
+									<X class="h-4 w-4" aria-hidden="true" />
+									{m['ticketTable.cancelTicket']()}
 								</Button>
 							{/if}
 							<!-- More actions dropdown -->
@@ -297,6 +304,15 @@
 									{/snippet}
 								</DropdownMenu.Trigger>
 								<DropdownMenu.Content align="end">
+									{#if canConfirmPayment(ticket)}
+										<DropdownMenu.Item
+											onclick={() => onConfirmPayment(ticket)}
+											disabled={confirmPaymentPending}
+										>
+											<Check class="mr-2 h-4 w-4" aria-hidden="true" />
+											{m['eventTicketsAdmin.actionConfirmPayment']()}
+										</DropdownMenu.Item>
+									{/if}
 									{#if !ticket.membership && ticket.user?.id}
 										<DropdownMenu.Item
 											onclick={() => onMakeMember(ticket)}
@@ -333,22 +349,6 @@
 										>
 											<Undo2 class="mr-2 h-4 w-4" aria-hidden="true" />
 											{m['eventTicketsAdmin.actionUnconfirmPayment']()}
-										</DropdownMenu.Item>
-									{/if}
-									{#if onRefundTicket && canRefundTicketPayment(ticket)}
-										<DropdownMenu.Item onclick={() => onRefundTicket(ticket)}>
-											<Undo2 class="mr-2 h-4 w-4" aria-hidden="true" />
-											{m['refundTicket.menuItem']()}
-										</DropdownMenu.Item>
-									{/if}
-									{#if canAdminCancelTicket(ticket)}
-										<DropdownMenu.Item
-											onclick={() => onCancelTicket(ticket)}
-											disabled={cancelTicketPending}
-											class="text-destructive focus:text-destructive"
-										>
-											<X class="mr-2 h-4 w-4" aria-hidden="true" />
-											{m['ticketTable.cancelTicket']()}
 										</DropdownMenu.Item>
 									{/if}
 									{#if ticket.user?.id}

--- a/src/lib/components/tickets/TicketTable.svelte
+++ b/src/lib/components/tickets/TicketTable.svelte
@@ -281,27 +281,6 @@
 									{m['eventTicketsAdmin.actionConfirmPayment']()}
 								</Button>
 							{/if}
-							{#if !ticket.membership && ticket.user?.id}
-								<Button
-									size="sm"
-									variant="outline"
-									onclick={() => onMakeMember(ticket)}
-									disabled={addMemberPending || tiersLoading}
-								>
-									<UserPlus class="h-4 w-4" aria-hidden="true" />
-									{m['makeMemberAction.button']()}
-								</Button>
-							{/if}
-							{#if ticket.tier?.payment_method === 'online' && ticket.payment?.stripe_dashboard_url}
-								<Button
-									size="sm"
-									variant="outline"
-									onclick={() => window.open(ticket.payment?.stripe_dashboard_url, '_blank')}
-								>
-									<ExternalLink class="h-4 w-4" aria-hidden="true" />
-									{m['ticketTable.manageOnStripe']()}
-								</Button>
-							{/if}
 							<!-- More actions dropdown -->
 							<DropdownMenu.Root>
 								<DropdownMenu.Trigger>
@@ -318,6 +297,23 @@
 									{/snippet}
 								</DropdownMenu.Trigger>
 								<DropdownMenu.Content align="end">
+									{#if !ticket.membership && ticket.user?.id}
+										<DropdownMenu.Item
+											onclick={() => onMakeMember(ticket)}
+											disabled={addMemberPending || tiersLoading}
+										>
+											<UserPlus class="mr-2 h-4 w-4" aria-hidden="true" />
+											{m['makeMemberAction.button']()}
+										</DropdownMenu.Item>
+									{/if}
+									{#if ticket.tier?.payment_method === 'online' && ticket.payment?.stripe_dashboard_url}
+										<DropdownMenu.Item
+											onclick={() => window.open(ticket.payment?.stripe_dashboard_url, '_blank')}
+										>
+											<ExternalLink class="mr-2 h-4 w-4" aria-hidden="true" />
+											{m['ticketTable.manageOnStripe']()}
+										</DropdownMenu.Item>
+									{/if}
 									{#if onRenameHolder && ticket.status !== 'checked_in' && ticket.status !== 'cancelled'}
 										<DropdownMenu.Item onclick={() => onRenameHolder(ticket)}>
 											<Pencil class="mr-2 h-4 w-4" aria-hidden="true" />

--- a/tests/e2e/journeys/j06-tickets/offline.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/offline.spec.ts
@@ -71,7 +71,7 @@ test.describe('J6 offline payment @p2', () => {
 		await expect(success.getByText('Payment Instructions:')).toBeVisible();
 		await expect(success.getByText(INSTRUCTIONS)).toBeVisible();
 
-		// Staff side: the pending ticket has an inline "Confirm Payment" action.
+		// Staff side: confirm the pending ticket via the row's actions menu.
 		await gotoHydrated(asOwner, `/org/${event.orgSlug}/admin/events/${event.id}/tickets`);
 		await waitForClientAuth(asOwner);
 		const buyerRow = asOwner
@@ -80,7 +80,12 @@ test.describe('J6 offline payment @p2', () => {
 			.filter({ hasText: /Pending/i })
 			.first();
 		await expect(buyerRow).toBeVisible({ timeout: 15_000 });
-		await buyerRow.getByRole('button', { name: 'Confirm Payment' }).click();
+		await asOwner
+			.getByRole('button', { name: `More actions for ${buyer.firstName} ${buyer.lastName}` })
+			.filter({ visible: true })
+			.first()
+			.click();
+		await asOwner.getByRole('menuitem', { name: 'Confirm Payment' }).click();
 
 		const confirmPayment = asOwner.getByRole('dialog', { name: 'Confirm Payment' });
 		await expect(confirmPayment).toBeVisible({ timeout: 15_000 });

--- a/tests/e2e/journeys/j10-event-admin/manage-tickets.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/manage-tickets.spec.ts
@@ -66,32 +66,23 @@ test.describe('J10 manage tickets @p1', () => {
 			await expect(page).toHaveURL(/order_by=/, { timeout: 15_000 });
 		}
 
-		// Confirm alpha's offline payment → ACTIVE.
+		// Confirm alpha's offline payment → ACTIVE, via the row's actions menu.
 		const activeAlphaRow = page
 			.locator('tr, article, li, div')
 			.filter({ hasText: alphaName })
 			.filter({ hasText: /Active/ })
 			.filter({ visible: true })
 			.first();
-		// Scope to a container holding alpha but NOT beta — both tickets are
-		// pending, so a page-wide .first() could hit the wrong row.
-		await page
-			.locator('tr, article, li, div')
-			.filter({ hasText: alphaName })
-			.filter({ hasNot: page.getByText(`${beta.firstName} ${beta.lastName}`) })
-			.filter({ visible: true })
-			.first()
-			.getByRole('button', { name: 'Confirm Payment' })
-			.first()
-			.click();
+		const alphaKebab = page
+			.getByRole('button', { name: `More actions for ${alphaName}` })
+			.filter({ visible: true });
+		await alphaKebab.first().click();
+		await page.getByRole('menuitem', { name: 'Confirm Payment' }).click();
 		const confirmDialog = page.getByRole('dialog', { name: 'Confirm Payment' });
 		await confirmDialog.getByRole('button', { name: 'Confirm Payment' }).click();
 		await expect(activeAlphaRow).toBeVisible({ timeout: 20_000 });
 
 		// Revert it back to pending via the row's actions menu.
-		const alphaKebab = page
-			.getByRole('button', { name: `More actions for ${alphaName}` })
-			.filter({ visible: true });
 		const pendingAlphaRow = page
 			.locator('tr, article, li, div')
 			.filter({ hasText: alphaName })
@@ -110,11 +101,16 @@ test.describe('J10 manage tickets @p1', () => {
 			await expect(pendingAlphaRow).toBeVisible({ timeout: 5_000 });
 		}).toPass({ timeout: 60_000 });
 
-		// Admin-cancel beta's ticket.
+		// Admin-cancel beta's ticket via the inline row action.
 		const betaName = `${beta.firstName} ${beta.lastName}`;
-		const betaKebab = page
-			.getByRole('button', { name: `More actions for ${betaName}` })
-			.filter({ visible: true });
+		// Scope to a container holding beta but NOT alpha — a page-wide
+		// .first() could hit the wrong row's Cancel Ticket button.
+		const betaRow = page
+			.locator('tr, article, li, div')
+			.filter({ hasText: betaName })
+			.filter({ hasNot: page.getByText(alphaName) })
+			.filter({ visible: true })
+			.first();
 		const cancelledBetaRow = page
 			.locator('tr, article, li, div')
 			.filter({ hasText: betaName })
@@ -123,8 +119,10 @@ test.describe('J10 manage tickets @p1', () => {
 			.first();
 		await expect(async () => {
 			if (!(await cancelledBetaRow.isVisible())) {
-				await betaKebab.first().click({ timeout: 3_000 });
-				await page.getByRole('menuitem', { name: 'Cancel Ticket' }).click({ timeout: 3_000 });
+				await betaRow
+					.getByRole('button', { name: 'Cancel Ticket' })
+					.first()
+					.click({ timeout: 3_000 });
 				const cancelDialog = page.getByRole('dialog', { name: 'Cancel Ticket' });
 				await cancelDialog.getByRole('button', { name: 'Cancel Ticket' }).click({
 					timeout: 3_000

--- a/tests/e2e/journeys/j10-event-admin/organizer-refunds.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/organizer-refunds.spec.ts
@@ -70,13 +70,8 @@ test.describe('J10 organizer refunds @p2', () => {
 			await expect(activeRow).toBeVisible({ timeout: 5_000 });
 		}).toPass({ timeout: 120_000 });
 
-		// Refund €5 of €20 via the row's actions menu.
-		await page
-			.getByRole('button', { name: `More actions for ${buyerName}` })
-			.filter({ visible: true })
-			.first()
-			.click();
-		await page.getByRole('menuitem', { name: 'Refund payment' }).click();
+		// Refund €5 of €20 via the row's inline Refund action.
+		await activeRow.getByRole('button', { name: 'Refund payment' }).first().click();
 
 		const refundDialog = page.getByRole('dialog', { name: 'Refund payment' });
 		await expect(refundDialog).toBeVisible({ timeout: 15_000 });
@@ -108,12 +103,7 @@ test.describe('J10 organizer refunds @p2', () => {
 		}).toPass({ timeout: 90_000 });
 
 		// The refund history in the dialog records the attempt.
-		await page
-			.getByRole('button', { name: `More actions for ${buyerName}` })
-			.filter({ visible: true })
-			.first()
-			.click();
-		await page.getByRole('menuitem', { name: 'Refund payment' }).click();
+		await refundBadgeRow.getByRole('button', { name: 'Refund payment' }).first().click();
 		const reopened = page.getByRole('dialog', { name: 'Refund payment' });
 		await expect(reopened.getByText('Refund history')).toBeVisible({ timeout: 15_000 });
 		await expect(reopened.getByText(/5[.,]00/).first()).toBeVisible();


### PR DESCRIPTION
## Summary

Declutters and rebalances the actions column of the tickets admin dashboard (desktop table + mobile card list, so the event-level and org-level admin tickets pages stay consistent).

**Commit 1 — overflow menu:** Make member and Manage on Stripe move from inline outline buttons into the existing three-dot menu.

**Commit 2 — inline actions & column balance:** the inline row actions are now **Check In / Refund payment / Cancel Ticket** (cancel as outline + destructive text); **Confirm Payment** joins the rest in the three-dot menu (Confirm Payment, Make member, Manage on Stripe, Rename holder, Move seat, Revert to Pending, Blacklist). Short data columns (Tier, Price, Payment Method, Purchased, status badge) get `whitespace-nowrap` so the actions column no longer squeezes them into wrapping.

All visibility conditions and pending/disabled states are unchanged.

## Testing

- `svelte-autofixer` clean on both components
- `make check` green (format, lint, types + canary, i18n, file-length, SSR-token, image-alt audits)
- `make test` green: 2694 passed, 1 todo
- Targeted E2E run (seeded backend + `stripe listen`): `manage-tickets`, `offline`, `organizer-refunds` specs updated for the new action placement — **8/8 passed** (chromium + mobile-chrome), 0 skipped
- Visually verified in the browser: columns balanced, no cell wrapping, per-row menu contents correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDXmzqVQzDQTBwT98KL9Wf