### PR TITLE
feat(cart): checkout sheet — names, PWYC, discount, billing (PR 2/4, #853)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -9526,6 +9526,7 @@
 		"discountApplies": "Gilt für {tierName}",
 		"discountNotApplicable": "Gilt nicht für diesen Tickettyp",
 		"discountNoMatch": "Dieser Code gilt für nichts in deinem Warenkorb",
+		"discountCheckFailed": "Wir konnten diesen Code nicht überprüfen — er wird an der Kasse trotzdem angewendet",
 		"billingSection": "Rechnungsinformationen",
 		"close": "Schließen"
 	}

--- a/messages/de.json
+++ b/messages/de.json
@@ -9499,6 +9499,34 @@
 				}
 			}
 		],
-		"summaryRegion": "Warenkorb-Übersicht"
+		"summaryRegion": "Warenkorb-Übersicht",
+		"discountLink": "Rabattcode?"
+	},
+	"cartSheet": {
+		"title": "Kasse",
+		"payNow": "Jetzt bezahlen",
+		"reserve": "Reservieren",
+		"claim": "Sichern",
+		"groupTickets": [
+			{
+				"declarations": ["input tierName", "input count", "local countPlural = count: plural"],
+				"selectors": ["countPlural"],
+				"match": {
+					"countPlural=one": "{tierName} × {count}",
+					"countPlural=*": "{tierName} × {count}"
+				}
+			}
+		],
+		"namesHeading": "Namen der Ticketinhaber*innen",
+		"nameLabel": "Name für Ticket {index}",
+		"nameRequired": "Bitte gib für jedes Ticket einen Namen ein",
+		"pwycRange": "Bereich: {min} – {max}",
+		"pwycHeading": "Wähle deinen Betrag",
+		"discountSection": "Rabattcode",
+		"discountApplies": "Gilt für {tierName}",
+		"discountNotApplicable": "Gilt nicht für diesen Tickettyp",
+		"discountNoMatch": "Dieser Code gilt für nichts in deinem Warenkorb",
+		"billingSection": "Rechnungsinformationen",
+		"close": "Schließen"
 	}
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -9499,6 +9499,34 @@
 				}
 			}
 		],
-		"summaryRegion": "Cart summary"
+		"summaryRegion": "Cart summary",
+		"discountLink": "Discount code?"
+	},
+	"cartSheet": {
+		"title": "Checkout",
+		"payNow": "Pay Now",
+		"reserve": "Reserve",
+		"claim": "Claim",
+		"groupTickets": [
+			{
+				"declarations": ["input tierName", "input count", "local countPlural = count: plural"],
+				"selectors": ["countPlural"],
+				"match": {
+					"countPlural=one": "{tierName} × {count}",
+					"countPlural=*": "{tierName} × {count}"
+				}
+			}
+		],
+		"namesHeading": "Ticket holder names",
+		"nameLabel": "Name for ticket {index}",
+		"nameRequired": "Please enter a name for every ticket",
+		"pwycRange": "Range: {min} – {max}",
+		"pwycHeading": "Choose your amount",
+		"discountSection": "Discount code",
+		"discountApplies": "Applies to {tierName}",
+		"discountNotApplicable": "Doesn't apply to this ticket type",
+		"discountNoMatch": "This code doesn't apply to anything in your cart",
+		"billingSection": "Billing information",
+		"close": "Close"
 	}
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -9526,6 +9526,7 @@
 		"discountApplies": "Applies to {tierName}",
 		"discountNotApplicable": "Doesn't apply to this ticket type",
 		"discountNoMatch": "This code doesn't apply to anything in your cart",
+		"discountCheckFailed": "We couldn't check this code — it will still be applied at checkout",
 		"billingSection": "Billing information",
 		"close": "Close"
 	}

--- a/messages/es.json
+++ b/messages/es.json
@@ -9499,6 +9499,34 @@
 				}
 			}
 		],
-		"summaryRegion": "Resumen del carrito"
+		"summaryRegion": "Resumen del carrito",
+		"discountLink": "¿Código de descuento?"
+	},
+	"cartSheet": {
+		"title": "Pago",
+		"payNow": "Pagar ahora",
+		"reserve": "Reservar",
+		"claim": "Conseguir",
+		"groupTickets": [
+			{
+				"declarations": ["input tierName", "input count", "local countPlural = count: plural"],
+				"selectors": ["countPlural"],
+				"match": {
+					"countPlural=one": "{tierName} × {count}",
+					"countPlural=*": "{tierName} × {count}"
+				}
+			}
+		],
+		"namesHeading": "Nombres de las personas titulares de las entradas",
+		"nameLabel": "Nombre para la entrada {index}",
+		"nameRequired": "Introduce un nombre para cada entrada",
+		"pwycRange": "Rango: {min} – {max}",
+		"pwycHeading": "Elige tu importe",
+		"discountSection": "Código de descuento",
+		"discountApplies": "Se aplica a {tierName}",
+		"discountNotApplicable": "No se aplica a este tipo de entrada",
+		"discountNoMatch": "Este código no se aplica a nada en tu carrito",
+		"billingSection": "Información de facturación",
+		"close": "Cerrar"
 	}
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -9526,6 +9526,7 @@
 		"discountApplies": "Se aplica a {tierName}",
 		"discountNotApplicable": "No se aplica a este tipo de entrada",
 		"discountNoMatch": "Este código no se aplica a nada en tu carrito",
+		"discountCheckFailed": "No pudimos comprobar este código — aun así se aplicará al finalizar la compra",
 		"billingSection": "Información de facturación",
 		"close": "Cerrar"
 	}

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -9526,6 +9526,7 @@
 		"discountApplies": "S'applique à {tierName}",
 		"discountNotApplicable": "Ne s'applique pas à ce type de billet",
 		"discountNoMatch": "Ce code ne s'applique à rien dans ton panier",
+		"discountCheckFailed": "Nous n'avons pas pu vérifier ce code — il sera quand même appliqué au paiement",
 		"billingSection": "Informations de facturation",
 		"close": "Fermer"
 	}

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -9499,6 +9499,34 @@
 				}
 			}
 		],
-		"summaryRegion": "Résumé du panier"
+		"summaryRegion": "Résumé du panier",
+		"discountLink": "Code de réduction ?"
+	},
+	"cartSheet": {
+		"title": "Paiement",
+		"payNow": "Payer maintenant",
+		"reserve": "Réserver",
+		"claim": "Obtenir",
+		"groupTickets": [
+			{
+				"declarations": ["input tierName", "input count", "local countPlural = count: plural"],
+				"selectors": ["countPlural"],
+				"match": {
+					"countPlural=one": "{tierName} × {count}",
+					"countPlural=*": "{tierName} × {count}"
+				}
+			}
+		],
+		"namesHeading": "Noms des titulaires des billets",
+		"nameLabel": "Nom pour le billet {index}",
+		"nameRequired": "Saisis un nom pour chaque billet",
+		"pwycRange": "Plage : {min} – {max}",
+		"pwycHeading": "Choisis ton montant",
+		"discountSection": "Code de réduction",
+		"discountApplies": "S'applique à {tierName}",
+		"discountNotApplicable": "Ne s'applique pas à ce type de billet",
+		"discountNoMatch": "Ce code ne s'applique à rien dans ton panier",
+		"billingSection": "Informations de facturation",
+		"close": "Fermer"
 	}
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -9526,6 +9526,7 @@
 		"discountApplies": "Si applica a {tierName}",
 		"discountNotApplicable": "Non si applica a questo tipo di biglietto",
 		"discountNoMatch": "Questo codice non si applica a nulla nel tuo carrello",
+		"discountCheckFailed": "Non siamo riusciti a verificare questo codice — verrà comunque applicato al pagamento",
 		"billingSection": "Dati di fatturazione",
 		"close": "Chiudi"
 	}

--- a/messages/it.json
+++ b/messages/it.json
@@ -9499,6 +9499,34 @@
 				}
 			}
 		],
-		"summaryRegion": "Riepilogo carrello"
+		"summaryRegion": "Riepilogo carrello",
+		"discountLink": "Codice sconto?"
+	},
+	"cartSheet": {
+		"title": "Cassa",
+		"payNow": "Paga ora",
+		"reserve": "Prenota",
+		"claim": "Ottieni",
+		"groupTickets": [
+			{
+				"declarations": ["input tierName", "input count", "local countPlural = count: plural"],
+				"selectors": ["countPlural"],
+				"match": {
+					"countPlural=one": "{tierName} × {count}",
+					"countPlural=*": "{tierName} × {count}"
+				}
+			}
+		],
+		"namesHeading": "Nomi dei titolari dei biglietti",
+		"nameLabel": "Nome per il biglietto {index}",
+		"nameRequired": "Inserisci un nome per ogni biglietto",
+		"pwycRange": "Intervallo: {min} – {max}",
+		"pwycHeading": "Scegli il tuo importo",
+		"discountSection": "Codice sconto",
+		"discountApplies": "Si applica a {tierName}",
+		"discountNotApplicable": "Non si applica a questo tipo di biglietto",
+		"discountNoMatch": "Questo codice non si applica a nulla nel tuo carrello",
+		"billingSection": "Dati di fatturazione",
+		"close": "Chiudi"
 	}
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -9526,6 +9526,7 @@
 		"discountApplies": "Aplica-se a {tierName}",
 		"discountNotApplicable": "Não se aplica a este tipo de bilhete",
 		"discountNoMatch": "Este código não se aplica a nada no teu carrinho",
+		"discountCheckFailed": "Não conseguimos verificar este código — ainda assim será aplicado no pagamento",
 		"billingSection": "Dados de faturação",
 		"close": "Fechar"
 	}

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -9499,6 +9499,34 @@
 				}
 			}
 		],
-		"summaryRegion": "Resumo do carrinho"
+		"summaryRegion": "Resumo do carrinho",
+		"discountLink": "Código de desconto?"
+	},
+	"cartSheet": {
+		"title": "Pagamento",
+		"payNow": "Pagar agora",
+		"reserve": "Reservar",
+		"claim": "Obter",
+		"groupTickets": [
+			{
+				"declarations": ["input tierName", "input count", "local countPlural = count: plural"],
+				"selectors": ["countPlural"],
+				"match": {
+					"countPlural=one": "{tierName} × {count}",
+					"countPlural=*": "{tierName} × {count}"
+				}
+			}
+		],
+		"namesHeading": "Nomes das pessoas titulares dos bilhetes",
+		"nameLabel": "Nome para o bilhete {index}",
+		"nameRequired": "Indica um nome para cada bilhete",
+		"pwycRange": "Intervalo: {min} – {max}",
+		"pwycHeading": "Escolhe o teu valor",
+		"discountSection": "Código de desconto",
+		"discountApplies": "Aplica-se a {tierName}",
+		"discountNotApplicable": "Não se aplica a este tipo de bilhete",
+		"discountNoMatch": "Este código não se aplica a nada no teu carrinho",
+		"billingSection": "Dados de faturação",
+		"close": "Fechar"
 	}
 }

--- a/src/lib/components/events/EventPurchaseDialogs.svelte
+++ b/src/lib/components/events/EventPurchaseDialogs.svelte
@@ -1,0 +1,237 @@
+<script lang="ts">
+	/**
+	 * The event page's purchase-dialog cluster (#853 task 7): TicketTierModal,
+	 * MyTicketModal, GuestRsvpDialog, VenueOverviewDialog, GuestTicketDialog.
+	 * Pure markup + state extraction from +page.svelte for page headroom — no
+	 * behavior change. The five `open` flags are bindable because other page
+	 * code (sidebar callbacks, the cart controller, TicketTierList's
+	 * onViewSeatingMap) writes them directly; `preSelectedTier`,
+	 * `selectedTierForGuest`, and `guestFocusSeating` are bindable because both
+	 * this component's own inline handlers (onSwitchTier, onViewSeatingMap) AND
+	 * the page's `handleSelectTier`/`openGuestTicketDialog` (still needed there
+	 * for TicketTierList's onSelectTier/onGuestTierClick) read and write them —
+	 * keeping them page-owned avoids duplicating that state in two places.
+	 */
+	import { useQueryClient } from '@tanstack/svelte-query';
+	import type { TierSchemaWithId, SeatingCheckoutFields } from '$lib/types/tickets';
+	import type {
+		EventDetailSchema,
+		MembershipTierSchema,
+		TierRemainingTicketsSchema,
+		TicketPurchaseItem,
+		BuyerBillingInfoSchema
+	} from '$lib/api/generated/types.gen';
+	import type { EventTicketSchemaActual } from '$lib/utils/eligibility';
+	import { formatEventDate } from '$lib/utils/date';
+	import { formatEventLocation } from '$lib/utils/event';
+	import TicketTierModal from '$lib/components/tickets/TicketTierModal.svelte';
+	import MyTicketModal from '$lib/components/tickets/MyTicketModal.svelte';
+	import GuestRsvpDialog from './GuestRsvpDialog.svelte';
+	import GuestTicketDialog from './GuestTicketDialog.svelte';
+	import VenueOverviewDialog from './VenueOverviewDialog.svelte';
+
+	interface Props {
+		event: EventDetailSchema;
+		ticketTiers: TierSchemaWithId[];
+		tierRemainingTickets?: TierRemainingTicketsSchema[];
+		isAuthenticated: boolean;
+		membershipTier?: MembershipTierSchema | null;
+		capacityDisclosed?: boolean;
+		ticketHolderDefaultName: string;
+		initialDiscountCode: string;
+		hasSeatingMap: boolean;
+		userTickets: EventTicketSchemaActual[];
+		isResumingPayment: boolean;
+		isCancellingReservation: boolean;
+		/** Refreshes `userStatus` on the page — also drives the two MyTicketModal closures below. */
+		refreshUserStatus: () => Promise<void>;
+		onClaimTicket: (
+			tierId: string,
+			tickets?: TicketPurchaseItem[],
+			discountCode?: string,
+			billingInfo?: BuyerBillingInfoSchema,
+			seating?: SeatingCheckoutFields
+		) => void;
+		onCheckout?: (
+			tierId: string,
+			isPwyc: boolean,
+			amount?: number,
+			tickets?: TicketPurchaseItem[],
+			discountCode?: string,
+			billingInfo?: BuyerBillingInfoSchema,
+			seating?: SeatingCheckoutFields
+		) => void;
+		hasResumableCheckout?: (
+			tierId: string,
+			isPwyc: boolean,
+			amount?: number,
+			tickets?: TicketPurchaseItem[],
+			discountCode?: string,
+			billingInfo?: BuyerBillingInfoSchema,
+			seating?: SeatingCheckoutFields
+		) => boolean;
+		onResumePayment?: (paymentId: string) => void;
+		onCancelReservation?: (paymentId: string) => void;
+		/** Also used by the page's TicketTierList (map §7). */
+		onSelectTier: (tier: TierSchemaWithId) => void;
+		/** Also used by the page's TicketTierList (map §7). */
+		onGuestTierClick?: (tier?: TierSchemaWithId) => void;
+		onGuestRsvpClose: () => void;
+		onGuestAttendanceSuccess: () => void | Promise<void>;
+		onGuestTicketClose: () => void;
+		onTicketTierModalClose: () => void;
+		showTicketTierModal: boolean;
+		showMyTicketModal: boolean;
+		showGuestRsvpDialog: boolean;
+		showGuestTicketDialog: boolean;
+		showVenueOverview: boolean;
+		preSelectedTier: TierSchemaWithId | null;
+		selectedTierForGuest: TierSchemaWithId | null;
+		guestFocusSeating: boolean;
+	}
+
+	let {
+		event,
+		ticketTiers,
+		tierRemainingTickets,
+		isAuthenticated,
+		membershipTier = null,
+		capacityDisclosed = true,
+		ticketHolderDefaultName,
+		initialDiscountCode,
+		hasSeatingMap,
+		userTickets,
+		isResumingPayment,
+		isCancellingReservation,
+		refreshUserStatus,
+		onClaimTicket,
+		onCheckout,
+		hasResumableCheckout,
+		onResumePayment,
+		onCancelReservation,
+		onSelectTier,
+		onGuestTierClick,
+		onGuestRsvpClose,
+		onGuestAttendanceSuccess,
+		onGuestTicketClose,
+		onTicketTierModalClose,
+		showTicketTierModal = $bindable(),
+		showMyTicketModal = $bindable(),
+		showGuestRsvpDialog = $bindable(),
+		showGuestTicketDialog = $bindable(),
+		showVenueOverview = $bindable(),
+		preSelectedTier = $bindable(),
+		selectedTierForGuest = $bindable(),
+		guestFocusSeating = $bindable()
+	}: Props = $props();
+
+	const queryClient = useQueryClient();
+</script>
+
+<!-- Ticket Tier Selection Modal -->
+<TicketTierModal
+	seriesInfo={event.event_series
+		? {
+				seriesId: event.event_series.id,
+				orgSlug: event.organization.slug,
+				seriesSlug: event.event_series.slug
+			}
+		: null}
+	bind:open={showTicketTierModal}
+	tiers={ticketTiers}
+	eventId={event.id}
+	organizationSlug={event.organization.slug}
+	{isAuthenticated}
+	{membershipTier}
+	canAttendWithoutLogin={event.can_attend_without_login}
+	{tierRemainingTickets}
+	timezone={event.timezone}
+	{capacityDisclosed}
+	eventMaxTicketsPerUser={event.max_tickets_per_user}
+	userName={ticketHolderDefaultName}
+	requireTicketNames={event.require_ticket_names}
+	{preSelectedTier}
+	{initialDiscountCode}
+	onClose={onTicketTierModalClose}
+	{onClaimTicket}
+	{onCheckout}
+	{hasResumableCheckout}
+	{onGuestTierClick}
+	onViewSeatingMap={hasSeatingMap
+		? () => {
+				showVenueOverview = true;
+			}
+		: undefined}
+/>
+
+<!-- My Ticket Modal -->
+{#if userTickets.length > 0}
+	<MyTicketModal
+		bind:open={showMyTicketModal}
+		tickets={userTickets}
+		eventName={event.name}
+		eventDate={event.start ? formatEventDate(event.start, event.timezone) : undefined}
+		eventLocation={formatEventLocation(event)}
+		{onResumePayment}
+		{isResumingPayment}
+		{onCancelReservation}
+		{isCancellingReservation}
+		onTicketCancelled={async () => {
+			showMyTicketModal = false;
+			await refreshUserStatus();
+			queryClient.invalidateQueries({ queryKey: ['event-status', event.id] });
+		}}
+		onTicketRenamed={async () => {
+			await refreshUserStatus();
+			queryClient.invalidateQueries({ queryKey: ['event-status', event.id] });
+		}}
+	/>
+{/if}
+
+<!-- Guest RSVP Dialog -->
+{#if !isAuthenticated && event.can_attend_without_login && !event.requires_ticket}
+	<GuestRsvpDialog
+		bind:open={showGuestRsvpDialog}
+		eventId={event.id}
+		acceptsNotes={event.accept_rsvp_notes}
+		onClose={onGuestRsvpClose}
+		onSuccess={onGuestAttendanceSuccess}
+	/>
+{/if}
+
+<!-- Whole-venue seating overview (map-first tier selection, #679) -->
+{#if hasSeatingMap}
+	<VenueOverviewDialog
+		bind:open={showVenueOverview}
+		eventId={event.id}
+		tiers={ticketTiers}
+		{isAuthenticated}
+		canAttendWithoutLogin={event.can_attend_without_login}
+		{tierRemainingTickets}
+		eventMaxTicketsPerUser={event.max_tickets_per_user}
+		{onSelectTier}
+		{onGuestTierClick}
+	/>
+{/if}
+
+<!-- Guest Ticket Dialog -->
+{#if !isAuthenticated && event.can_attend_without_login && event.requires_ticket && selectedTierForGuest}
+	{#key selectedTierForGuest.id}
+		<GuestTicketDialog
+			bind:open={showGuestTicketDialog}
+			eventId={event.id}
+			tier={selectedTierForGuest}
+			allTiers={ticketTiers}
+			eventMaxTicketsPerUser={event.max_tickets_per_user}
+			requireTicketNames={event.require_ticket_names}
+			onClose={onGuestTicketClose}
+			onSuccess={onGuestAttendanceSuccess}
+			focusSeating={guestFocusSeating}
+			onSwitchTier={(tier) => {
+				selectedTierForGuest = tier;
+				showGuestTicketDialog = true;
+				guestFocusSeating = true;
+			}}
+		/>
+	{/key}
+{/if}

--- a/src/lib/components/events/cart-checkout-controller.svelte.ts
+++ b/src/lib/components/events/cart-checkout-controller.svelte.ts
@@ -5,7 +5,7 @@
  * The two-step reserve → checkout-session machinery below (`resumeHeldCheckout`,
  * `withCheckoutSessionUrl`, `sessionFailureError`, `handleCheckoutSuccess`) is
  * mirrored from `event-checkout-controller.svelte.ts`, which this cart flow will
- * fully replace: its single-tier mutations are deleted in PR 2 of this series
+ * fully replace: its single-tier mutations are deleted in PR 3 of this series
  * once the cart UI ships everywhere the old ticket-tier modal does today.
  */
 import { createMutation, type QueryClient } from '@tanstack/svelte-query';

--- a/src/lib/components/tickets/CartSummaryBar.svelte
+++ b/src/lib/components/tickets/CartSummaryBar.svelte
@@ -12,9 +12,13 @@
 		isFree: boolean;
 		isPending: boolean;
 		onBuy: () => void;
+		/** Sheet entry point for the discount code (PR 2). Bar renders no link
+		 * when omitted — callers that never mount the sheet stay unaffected. */
+		onDiscountClick?: () => void;
 	}
 
-	const { count, totalDisplay, currency, isFree, isPending, onBuy }: Props = $props();
+	const { count, totalDisplay, currency, isFree, isPending, onBuy, onDiscountClick }: Props =
+		$props();
 </script>
 
 <div
@@ -24,14 +28,25 @@
 	data-testid="cart-summary-bar"
 >
 	<div class="container mx-auto flex items-center justify-between gap-4 px-6 py-3 md:px-8">
-		<p class="text-sm font-bold" aria-live="polite">
-			{m['cart.ticketCount']({ count })}
-			{#if isFree}
-				<span class="text-muted-foreground">· {m['cart.free']()}</span>
-			{:else if totalDisplay !== null}
-				<span class="text-muted-foreground">· {currency} {totalDisplay}</span>
+		<div class="min-w-0">
+			<p class="text-sm font-bold" aria-live="polite">
+				{m['cart.ticketCount']({ count })}
+				{#if isFree}
+					<span class="text-muted-foreground">· {m['cart.free']()}</span>
+				{:else if totalDisplay !== null}
+					<span class="text-muted-foreground">· {currency} {totalDisplay}</span>
+				{/if}
+			</p>
+			{#if onDiscountClick}
+				<button
+					type="button"
+					onclick={onDiscountClick}
+					class="text-xs font-semibold text-primary underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				>
+					{m['cart.discountLink']()}
+				</button>
 			{/if}
-		</p>
+		</div>
 		<Button onclick={onBuy} disabled={isPending || count === 0} class="min-w-28">
 			{#if isPending}
 				<LoaderCircle class="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />

--- a/src/lib/components/tickets/CheckoutBillingSection.svelte
+++ b/src/lib/components/tickets/CheckoutBillingSection.svelte
@@ -14,7 +14,8 @@
 	import type {
 		UserBillingProfileSchema,
 		BuyerBillingInfoSchema,
-		VatPreviewResponseSchema
+		VatPreviewResponseSchema,
+		VatPreviewItemSchema
 	} from '$lib/api/generated/types.gen';
 
 	// 2. Props interface
@@ -34,6 +35,16 @@
 		isAuthenticated: boolean;
 		authToken?: string | null;
 		disabled?: boolean;
+		/** Cart-aware preview: when present, supersedes the single-tier
+		 * `tierId`/`quantity`/`priceCategoryId` fields in the VAT preview
+		 * request body. The legacy fields stay untouched for existing callers. */
+		items?: VatPreviewItemSchema[];
+		/** PWYC price override for the multi-item preview. Only read when
+		 * `items` is provided; the caller passes it iff exactly one PWYC
+		 * group exists in the cart — with 2+ PWYC groups it is omitted
+		 * (the preview is then an estimate; checkout resolves each group's
+		 * amount server-side). */
+		pwycAmountOverride?: string | null;
 	}
 
 	const {
@@ -49,7 +60,9 @@
 		priceCategoryId = null,
 		isAuthenticated,
 		authToken = null,
-		disabled = false
+		disabled = false,
+		items,
+		pwycAmountOverride = null
 	}: Props = $props();
 
 	// 3. Local state
@@ -129,12 +142,14 @@
 		}
 	});
 
-	// A zone switch changes the unit price on a mapped best-available tier —
-	// refresh an already-visible preview so it never quotes the old zone. Only
-	// the zone is tracked: the guard reads are untracked so the fetch writing
+	// A zone switch (or, for the cart-aware caller, a changed cart `items`
+	// array) changes the unit price / composition of the preview — refresh an
+	// already-visible preview so it never quotes stale data. Only those two
+	// are tracked: the guard reads are untracked so the fetch writing
 	// `vatPreview` can't re-trigger the effect.
 	$effect(() => {
 		void priceCategoryId;
+		void items;
 		untrack(() => {
 			if (isOpen && vatPreview) void fetchVatPreview();
 		});
@@ -152,7 +167,18 @@
 		vatPreviewError = '';
 
 		try {
-			const pwycValue = isPwyc && pwycAmount ? parseFloat(pwycAmount) : undefined;
+			// Cart-aware callers (multi-item preview) pass `pwycAmountOverride` only
+			// when exactly one PWYC group exists in the cart; with 2+ PWYC groups it
+			// is omitted on purpose — the preview is then an estimate and checkout
+			// resolves each group's amount server-side. Legacy single-tier callers
+			// keep the old isPwyc/pwycAmount behavior untouched.
+			const pwycValue = items
+				? pwycAmountOverride
+					? parseFloat(pwycAmountOverride)
+					: undefined
+				: isPwyc && pwycAmount
+					? parseFloat(pwycAmount)
+					: undefined;
 
 			const response = await eventpublicticketsVatPreview({
 				path: { event_id: eventId },
@@ -164,7 +190,7 @@
 						billing_address: billingAddress.trim() || undefined,
 						billing_email: billingEmail.trim() || undefined
 					},
-					items: [
+					items: items ?? [
 						{
 							tier_id: tierId,
 							count: quantity,

--- a/src/lib/components/tickets/CheckoutSheet.svelte
+++ b/src/lib/components/tickets/CheckoutSheet.svelte
@@ -5,6 +5,7 @@
 	 * survives a close — so writes go through `cart.setGuestName`/
 	 * `setPwycAmount` only. Only the discount input/results and the
 	 * accordion-open flags are sheet-local (see `EventCart.needsSheet`). */
+	import { untrack } from 'svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import {
 		Dialog,
@@ -24,6 +25,7 @@
 	import type { EventCart, CartGroup } from './cart.svelte';
 	import {
 		discountApplicable,
+		discountStaysApplied,
 		makeValidateDiscountFn,
 		validateCartDiscount,
 		type CartDiscountResult
@@ -81,15 +83,29 @@
 
 	// Seed the initial (e.g. URL param) code exactly once, on first mount —
 	// never re-seed on a later reopen, which would stomp whatever the buyer
-	// has since typed or cleared.
+	// has since typed or cleared. Validation is deferred to the open-effect
+	// below: `+page.svelte` opens the sheet whenever a URL discount code is
+	// present (even for a single-tier direct "Buy"), so seeding must not fire
+	// the network call while the sheet is still closed.
 	$effect(() => {
 		if (seeded) return;
 		seeded = true;
 		if (initialDiscountCode) {
 			discountInput = initialDiscountCode;
 			discountOpen = true;
-			void applyDiscount();
 		}
+	});
+
+	// Re-validate whenever the sheet opens with a code on the books — covers
+	// both the seeded code's first check and refreshing stale per-group
+	// feedback/footer total after the buyer changed quantities or groups while
+	// the sheet was closed. Keyed on `open` only: applyDiscount() itself
+	// writes discountInput/appliedDiscountCode, so reading them untracked here
+	// keeps this effect from re-triggering on its own writes.
+	$effect(() => {
+		if (!open) return;
+		const hasCode = untrack(() => !!discountInput.trim());
+		if (hasCode) void applyDiscount();
 	});
 
 	async function applyDiscount() {
@@ -99,7 +115,7 @@
 		const result = await validateCartDiscount(code, cart.groups, makeValidateDiscountFn(eventId));
 		discountValidating = false;
 		discountResult = result;
-		appliedDiscountCode = result.anyValid ? code : '';
+		appliedDiscountCode = discountStaysApplied(result, cart.groups) ? code : '';
 	}
 
 	// Billing section ref: getBillingInfo()/validate() called at submit time.
@@ -119,8 +135,9 @@
 	const showBilling = $derived(cart.groups.some((group) => group.tier.invoicing_available));
 
 	// Submit gate: the pure, unit-tested helper decides which rule fails
-	// first. `submitAttempted` only governs when per-field inline errors show.
-	let submitAttempted = $state(false);
+	// first. It's live (no "submit attempted" flag) and drives both the
+	// disabled confirm button and the footer hint below — the shipped
+	// disabled-with-hint UX, not per-field inline alerts on submit.
 	const validationError = $derived(sheetValidationError(cart.groups, requireTicketNames));
 
 	// First offending PWYC group's precise reason (empty/below-min/above-max)
@@ -167,17 +184,14 @@
 		return Array.from({ length: group.quantity }, (_, index) => group.guestNames[index] ?? '');
 	}
 
-	function groupNameError(group: CartGroup): string {
-		if (!submitAttempted || !requireTicketNames) return '';
-		const missing = guestNamesFor(group).some((name) => !name.trim());
-		return missing ? m['cartSheet.nameRequired']() : '';
-	}
-
+	// Live inline feedback for the amount field only — below-min/above-max/
+	// non-numeric entries show as the buyer types. The "empty" case is
+	// suppressed here: an untouched field isn't an error to nag about inline,
+	// the disabled button + footer hint already cover it.
 	function groupPwycError(group: CartGroup): string {
-		if (!submitAttempted) return '';
 		const { minAmount, maxAmount } = pwycBounds(group.tier);
 		const validation = validatePwycAmount(group.pwycAmount ?? '', minAmount, maxAmount);
-		if (validation.valid) return '';
+		if (validation.valid || validation.error === 'empty') return '';
 		return pwycErrorMessage(validation.error, group.tier.currency, minAmount, maxAmount);
 	}
 
@@ -195,8 +209,7 @@
 	}
 
 	async function handleConfirm() {
-		submitAttempted = true;
-		if (sheetValidationError(cart.groups, requireTicketNames)) return;
+		if (validationError) return;
 		if (billingSection && !billingSection.validate()) return;
 		await onConfirm({
 			discountCode: appliedDiscountCode,
@@ -204,9 +217,19 @@
 		});
 	}
 
+	// GuestNameInputs' onClearError exists for callers with real per-field,
+	// submit-triggered error state (e.g. TicketConfirmationDialog). This sheet
+	// has none — the disabled button + footer hint is the whole submit gate —
+	// so there's nothing to clear, and importantly nothing shared across groups.
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	function noop(): void {}
+
+	// Same guard as the (disabled) confirm button: Enter in a PWYC field must
+	// not bypass it and submit while some group is still invalid.
 	function handlePwycKeydown(e: KeyboardEvent) {
 		if (e.key === 'Enter' && !isProcessing) {
 			e.preventDefault();
+			if (validationError) return;
 			void handleConfirm();
 		}
 	}
@@ -246,13 +269,15 @@
 					</div>
 
 					{#if requireTicketNames}
+						<!-- No per-field inline alert here: the disabled confirm button +
+						     footer hint (below) is the shipped submit gate. -->
 						<GuestNameInputs
 							guestNames={guestNamesFor(group)}
 							idPrefix={group.tier.id}
 							{isProcessing}
-							guestNameError={groupNameError(group)}
+							guestNameError=""
 							onUpdateName={(index, value) => cart.setGuestName(group.tier.id, index, value)}
-							onClearError={() => (submitAttempted = false)}
+							onClearError={noop}
 						/>
 					{/if}
 
@@ -342,9 +367,15 @@
 											<span class="text-success">
 												{m['cartSheet.discountApplies']({ tierName: group.tier.name })}
 											</span>
-										{:else}
+										{:else if response}
 											<span class="text-destructive">
-												{response?.message || m['cartSheet.discountNoMatch']()}
+												{response.message || m['cartSheet.discountNoMatch']()}
+											</span>
+										{:else}
+											<!-- Transport failure for this group's check specifically — not
+											     "invalid", so stay neutral rather than implying the code is bad. -->
+											<span class="text-muted-foreground">
+												{m['cartSheet.discountCheckFailed']()}
 											</span>
 										{/if}
 									</p>
@@ -388,7 +419,7 @@
 		<DialogFooter class="flex-col gap-2">
 			{#if validationError && !isProcessing}
 				<p class="text-center text-sm text-highlight-foreground dark:text-highlight">
-					<AlertCircle class="mr-1 inline-block h-4 w-4" />
+					<AlertCircle class="mr-1 inline-block h-4 w-4" aria-hidden="true" />
 					{#if validationError === 'names'}
 						{m['cartSheet.nameRequired']()}
 					{:else if firstInvalidPwyc}

--- a/src/lib/components/tickets/CheckoutSheet.svelte
+++ b/src/lib/components/tickets/CheckoutSheet.svelte
@@ -1,0 +1,434 @@
+<script lang="ts">
+	/** Multi-group checkout sheet (#853 PR 2): the sole place where names, PWYC
+	 * amounts, discount code, and billing info come together for a cart with
+	 * several tiers. Per-group data (names/PWYC amount) lives on `cart` — it
+	 * survives a close — so writes go through `cart.setGuestName`/
+	 * `setPwycAmount` only. Only the discount input/results and the
+	 * accordion-open flags are sheet-local (see `EventCart.needsSheet`). */
+	import * as m from '$lib/paraglide/messages.js';
+	import {
+		Dialog,
+		DialogContent,
+		DialogHeader,
+		DialogTitle,
+		DialogDescription,
+		DialogFooter
+	} from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { AlertCircle, ChevronDown, Loader2, Tag } from '@lucide/svelte';
+	import GuestNameInputs from './GuestNameInputs.svelte';
+	import PwycInput from './PwycInput.svelte';
+	import PurchaseErrorAlert from './PurchaseErrorAlert.svelte';
+	import CheckoutBillingSection from './CheckoutBillingSection.svelte';
+	import type { EventCart, CartGroup } from './cart.svelte';
+	import {
+		discountApplicable,
+		makeValidateDiscountFn,
+		validateCartDiscount,
+		type CartDiscountResult
+	} from './cart-discount';
+	import { cartTotal, cartTotalArgs, checkoutTotal } from './checkout-total';
+	import {
+		pwycBounds,
+		pwycErrorMessage,
+		pwycSuggestions,
+		validatePwycAmount
+	} from './pwyc-validation';
+	import { sheetValidationError } from './checkout-sheet-validation';
+	import { formatMoney } from '$lib/utils/format';
+	import type { BuyerBillingInfoSchema, VatPreviewItemSchema } from '$lib/api/generated/types.gen';
+
+	interface Props {
+		open: boolean;
+		cart: EventCart;
+		eventId: string;
+		requireTicketNames: boolean;
+		isAuthenticated: boolean;
+		authToken: string | null;
+		organizationSlug: string;
+		initialDiscountCode?: string;
+		isProcessing: boolean;
+		purchaseError: unknown;
+		onConfirm: (opts: {
+			discountCode: string;
+			billingInfo: BuyerBillingInfoSchema | null;
+		}) => Promise<void>;
+	}
+
+	let {
+		open = $bindable(),
+		cart,
+		eventId,
+		requireTicketNames,
+		isAuthenticated,
+		authToken,
+		organizationSlug,
+		initialDiscountCode = '',
+		isProcessing,
+		purchaseError,
+		onConfirm
+	}: Props = $props();
+
+	// Discount: sheet-local input/results. Only the APPLIED code string
+	// travels back up (via onConfirm) — the cart itself has no discount field.
+	let discountOpen = $state(false);
+	let discountInput = $state('');
+	let discountValidating = $state(false);
+	let discountResult = $state<CartDiscountResult | null>(null);
+	let appliedDiscountCode = $state('');
+	let seeded = $state(false);
+
+	// Seed the initial (e.g. URL param) code exactly once, on first mount —
+	// never re-seed on a later reopen, which would stomp whatever the buyer
+	// has since typed or cleared.
+	$effect(() => {
+		if (seeded) return;
+		seeded = true;
+		if (initialDiscountCode) {
+			discountInput = initialDiscountCode;
+			discountOpen = true;
+			void applyDiscount();
+		}
+	});
+
+	async function applyDiscount() {
+		const code = discountInput.trim().toUpperCase();
+		if (!code) return;
+		discountValidating = true;
+		const result = await validateCartDiscount(code, cart.groups, makeValidateDiscountFn(eventId));
+		discountValidating = false;
+		discountResult = result;
+		appliedDiscountCode = result.anyValid ? code : '';
+	}
+
+	// Billing section ref: getBillingInfo()/validate() called at submit time.
+	let billingSection: CheckoutBillingSection | undefined = $state();
+
+	const billingItems = $derived<VatPreviewItemSchema[]>(
+		cart.groups.map((group) => ({
+			tier_id: group.tier.id,
+			count: group.quantity,
+			...(group.priceCategoryId ? { price_category_id: group.priceCategoryId } : {})
+		}))
+	);
+	const pwycGroups = $derived(cart.groups.filter((group) => group.tier.price_type === 'pwyc'));
+	// Exactly one PWYC group: its amount previews honestly. With 2+, omitted —
+	// the preview stays an estimate and checkout resolves each server-side.
+	const pwycAmountOverride = $derived(pwycGroups.length === 1 ? pwycGroups[0].pwycAmount : null);
+	const showBilling = $derived(cart.groups.some((group) => group.tier.invoicing_available));
+
+	// Submit gate: the pure, unit-tested helper decides which rule fails
+	// first. `submitAttempted` only governs when per-field inline errors show.
+	let submitAttempted = $state(false);
+	const validationError = $derived(sheetValidationError(cart.groups, requireTicketNames));
+
+	// First offending PWYC group's precise reason (empty/below-min/above-max)
+	// for the footer hint text — sheetValidationError only reports the tag.
+	const firstInvalidPwyc = $derived.by(() => {
+		for (const group of cart.groups) {
+			if (group.tier.price_type !== 'pwyc') continue;
+			const bounds = pwycBounds(group.tier);
+			const validation = validatePwycAmount(
+				group.pwycAmount ?? '',
+				bounds.minAmount,
+				bounds.maxAmount
+			);
+			if (!validation.valid) return { group, validation, bounds };
+		}
+		return null;
+	});
+
+	const currency = $derived(cart.currency ?? '');
+	const isFree = $derived(cart.paymentMethod === 'free');
+	const total = $derived(
+		cartTotal(
+			cart.groups.map((group) =>
+				cartTotalArgs({
+					tier: group.tier,
+					quantity: group.quantity,
+					seatIds: group.seatIds,
+					pwycAmount: group.pwycAmount,
+					priceCategoryId: group.priceCategoryId,
+					discountedPrice: discountResult?.byTier.get(group.tier.id)?.discounted_price ?? null
+				})
+			)
+		)
+	);
+
+	const confirmLabel = $derived.by(() => {
+		if (cart.paymentMethod === 'online') return m['cartSheet.payNow']();
+		if (cart.paymentMethod === 'offline' || cart.paymentMethod === 'at_the_door')
+			return m['cartSheet.reserve']();
+		return m['cartSheet.claim']();
+	});
+
+	function guestNamesFor(group: CartGroup): string[] {
+		return Array.from({ length: group.quantity }, (_, index) => group.guestNames[index] ?? '');
+	}
+
+	function groupNameError(group: CartGroup): string {
+		if (!submitAttempted || !requireTicketNames) return '';
+		const missing = guestNamesFor(group).some((name) => !name.trim());
+		return missing ? m['cartSheet.nameRequired']() : '';
+	}
+
+	function groupPwycError(group: CartGroup): string {
+		if (!submitAttempted) return '';
+		const { minAmount, maxAmount } = pwycBounds(group.tier);
+		const validation = validatePwycAmount(group.pwycAmount ?? '', minAmount, maxAmount);
+		if (validation.valid) return '';
+		return pwycErrorMessage(validation.error, group.tier.currency, minAmount, maxAmount);
+	}
+
+	function groupTotal(group: CartGroup): string | null {
+		return checkoutTotal(
+			cartTotalArgs({
+				tier: group.tier,
+				quantity: group.quantity,
+				seatIds: group.seatIds,
+				pwycAmount: group.pwycAmount,
+				priceCategoryId: group.priceCategoryId,
+				discountedPrice: discountResult?.byTier.get(group.tier.id)?.discounted_price ?? null
+			})
+		);
+	}
+
+	async function handleConfirm() {
+		submitAttempted = true;
+		if (sheetValidationError(cart.groups, requireTicketNames)) return;
+		if (billingSection && !billingSection.validate()) return;
+		await onConfirm({
+			discountCode: appliedDiscountCode,
+			billingInfo: billingSection?.getBillingInfo() ?? null
+		});
+	}
+
+	function handlePwycKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' && !isProcessing) {
+			e.preventDefault();
+			void handleConfirm();
+		}
+	}
+</script>
+
+<Dialog bind:open>
+	<DialogContent
+		class="flex max-h-[92vh] flex-col sm:max-w-lg"
+		showCloseButton={!isProcessing}
+		escapeKeydownBehavior={isProcessing ? 'ignore' : 'close'}
+		interactOutsideBehavior={isProcessing ? 'ignore' : 'close'}
+	>
+		<DialogHeader>
+			<DialogTitle class="text-3xl font-black leading-[1.12]">{m['cartSheet.title']()}</DialogTitle>
+			<DialogDescription>
+				{m['cart.ticketCount']({ count: cart.totalCount })}
+				{#if isFree}
+					· {m['cart.free']()}
+				{:else if total !== null}
+					· {formatMoney(total, currency)}
+				{/if}
+			</DialogDescription>
+		</DialogHeader>
+
+		<div class="min-h-0 flex-1 space-y-4 overflow-y-auto py-2">
+			{#each cart.groups as group (group.tier.id)}
+				<div class="space-y-3 rounded-[1.25rem] border-2 border-border bg-card p-4 shadow-poster">
+					<div class="flex items-center justify-between gap-3">
+						<p class="font-bold">
+							{m['cartSheet.groupTickets']({ tierName: group.tier.name, count: group.quantity })}
+						</p>
+						{#if !isFree}
+							<p class="text-sm font-semibold text-primary">
+								{formatMoney(groupTotal(group), group.tier.currency)}
+							</p>
+						{/if}
+					</div>
+
+					{#if requireTicketNames}
+						<GuestNameInputs
+							guestNames={guestNamesFor(group)}
+							idPrefix={group.tier.id}
+							{isProcessing}
+							guestNameError={groupNameError(group)}
+							onUpdateName={(index, value) => cart.setGuestName(group.tier.id, index, value)}
+							onClearError={() => (submitAttempted = false)}
+						/>
+					{/if}
+
+					{#if group.tier.price_type === 'pwyc'}
+						{@const bounds = pwycBounds(group.tier)}
+						<!-- No separate "Choose your amount" heading here: PwycInput's own
+						     "Payment Amount" <Label> already names this control — stacking
+						     cartSheet.pwycHeading directly above it would say the same thing
+						     twice (flagged in Task 5's report as a call this task must make). -->
+						<PwycInput
+							currency={group.tier.currency}
+							idPrefix={group.tier.id}
+							minAmount={bounds.minAmount}
+							maxAmount={bounds.maxAmount}
+							pwycAmount={group.pwycAmount ?? ''}
+							pwycError={groupPwycError(group)}
+							{isProcessing}
+							suggestions={pwycSuggestions(bounds.minAmount, bounds.maxAmount)}
+							onAmountChange={(value) => cart.setPwycAmount(group.tier.id, value)}
+							onKeydown={handlePwycKeydown}
+						/>
+					{/if}
+				</div>
+			{/each}
+
+			<!-- Discount code (cart-wide, fans out over every applicable group) -->
+			<div class="rounded-lg border">
+				<button
+					type="button"
+					onclick={() => (discountOpen = !discountOpen)}
+					class="flex w-full items-center justify-between px-4 py-3 text-sm font-medium hover:bg-accent"
+					aria-expanded={discountOpen}
+				>
+					<span class="flex items-center gap-2">
+						<Tag class="h-4 w-4" aria-hidden="true" />
+						{m['cartSheet.discountSection']()}
+					</span>
+					<ChevronDown
+						class="h-4 w-4 transition-transform {discountOpen ? 'rotate-180' : ''}"
+						aria-hidden="true"
+					/>
+				</button>
+				{#if discountOpen}
+					<div class="space-y-3 border-t px-4 py-3">
+						<div class="flex gap-2">
+							<Input
+								type="text"
+								bind:value={discountInput}
+								placeholder={m['discountCodeInput.codePlaceholder']()}
+								disabled={isProcessing || discountValidating}
+								class="flex-1 uppercase"
+								aria-label={m['cartSheet.discountSection']()}
+								oninput={() => {
+									discountInput = discountInput.replace(/[^\p{L}\p{N}]/gu, '').toUpperCase();
+								}}
+								onkeydown={(e) => {
+									if (e.key === 'Enter') {
+										e.preventDefault();
+										void applyDiscount();
+									}
+								}}
+							/>
+							<Button
+								variant="outline"
+								onclick={() => void applyDiscount()}
+								disabled={isProcessing || discountValidating || !discountInput.trim()}
+							>
+								{#if discountValidating}
+									<Loader2 class="h-4 w-4 animate-spin" />
+								{:else}
+									{m['discountCodeInput.apply']()}
+								{/if}
+							</Button>
+						</div>
+						{#if discountResult}
+							<div class="space-y-1 text-xs" aria-live="polite">
+								{#each cart.groups as group (group.tier.id)}
+									{@const applicable = discountApplicable(group.tier)}
+									{@const response = discountResult.byTier.get(group.tier.id)}
+									<p class="flex items-center justify-between gap-2">
+										<span class="text-muted-foreground">{group.tier.name}</span>
+										{#if !applicable}
+											<span class="text-muted-foreground">
+												{m['cartSheet.discountNotApplicable']()}
+											</span>
+										{:else if response?.valid}
+											<span class="text-success">
+												{m['cartSheet.discountApplies']({ tierName: group.tier.name })}
+											</span>
+										{:else}
+											<span class="text-destructive">
+												{response?.message || m['cartSheet.discountNoMatch']()}
+											</span>
+										{/if}
+									</p>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
+
+			<!-- Billing / invoicing (any group's tier allows it) -->
+			{#if showBilling}
+				<div class="space-y-2">
+					<p class="text-sm font-semibold">{m['cartSheet.billingSection']()}</p>
+					<CheckoutBillingSection
+						bind:this={billingSection}
+						{eventId}
+						tierId={cart.groups[0]?.tier.id ?? ''}
+						tierName={cart.groups[0]?.tier.name ?? ''}
+						quantity={cart.totalCount}
+						{currency}
+						price={cart.groups[0]?.tier.price ?? '0'}
+						isPwyc={false}
+						items={billingItems}
+						{pwycAmountOverride}
+						discountCode={appliedDiscountCode || undefined}
+						{isAuthenticated}
+						{authToken}
+						disabled={isProcessing}
+					/>
+				</div>
+			{/if}
+
+			<PurchaseErrorAlert
+				error={purchaseError}
+				tiers={cart.groups.map((group) => group.tier)}
+				{organizationSlug}
+			/>
+		</div>
+
+		<DialogFooter class="flex-col gap-2">
+			{#if validationError && !isProcessing}
+				<p class="text-center text-sm text-highlight-foreground dark:text-highlight">
+					<AlertCircle class="mr-1 inline-block h-4 w-4" />
+					{#if validationError === 'names'}
+						{m['cartSheet.nameRequired']()}
+					{:else if firstInvalidPwyc}
+						{pwycErrorMessage(
+							firstInvalidPwyc.validation.error,
+							firstInvalidPwyc.group.tier.currency,
+							firstInvalidPwyc.bounds.minAmount,
+							firstInvalidPwyc.bounds.maxAmount
+						)}
+					{/if}
+				</p>
+			{/if}
+			<p class="flex w-full items-center justify-between border-t border-border pt-2 text-sm">
+				<span class="text-muted-foreground">{m['checkoutFooter.total']()}</span>
+				<span class="text-base font-bold">
+					{isFree ? m['cart.free']() : formatMoney(total, currency)}
+				</span>
+			</p>
+			<div class="flex w-full gap-2 sm:justify-end">
+				<Button
+					variant="outline"
+					onclick={() => (open = false)}
+					disabled={isProcessing}
+					class="flex-1 sm:flex-initial"
+				>
+					{m['cartSheet.close']()}
+				</Button>
+				<Button
+					onclick={handleConfirm}
+					disabled={isProcessing || !!validationError}
+					class="flex-1 sm:flex-initial"
+				>
+					{#if isProcessing}
+						<Loader2 class="mr-2 h-4 w-4 animate-spin" />
+						{m['ticketConfirmationDialog.processing']()}
+					{:else}
+						{confirmLabel}
+					{/if}
+				</Button>
+			</div>
+		</DialogFooter>
+	</DialogContent>
+</Dialog>

--- a/src/lib/components/tickets/GuestNameInputs.svelte
+++ b/src/lib/components/tickets/GuestNameInputs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert';
@@ -6,30 +7,35 @@
 
 	interface Props {
 		guestNames: string[];
-		quantity: number;
 		isProcessing: boolean;
 		guestNameError: string;
+		/** Prefixes every input/label/error id so two instances (one per cart group) never collide. */
+		idPrefix: string;
+		/** Overrides the default section label; omit to keep the generic one. */
+		heading?: string;
 		onUpdateName: (index: number, value: string) => void;
 		onClearError: () => void;
 	}
 
-	const { guestNames, quantity, isProcessing, guestNameError, onUpdateName, onClearError }: Props =
-		$props();
+	const {
+		guestNames,
+		isProcessing,
+		guestNameError,
+		idPrefix,
+		heading,
+		onUpdateName,
+		onClearError
+	}: Props = $props();
+
+	const errorId = $derived(`${idPrefix}-name-error`);
 </script>
 
 <div class="space-y-3 rounded-lg border-2 border-primary/20 bg-primary/5 p-4">
 	<div class="flex items-center gap-2">
 		<User class="h-5 w-5 text-primary" aria-hidden="true" />
-		<Label class="text-base font-semibold">
-			{quantity === 1 ? 'Ticket Holder' : 'Ticket Holders'}
-		</Label>
+		<Label class="text-base font-semibold">{heading ?? m['cartSheet.namesHeading']()}</Label>
 		<span class="text-sm text-destructive">*</span>
 	</div>
-	<p class="text-sm text-muted-foreground">
-		{quantity === 1
-			? 'Please enter your name for the ticket'
-			: 'Please enter a name for each ticket holder'}
-	</p>
 	<div class="space-y-2">
 		{#each guestNames as name, index (index)}
 			<div class="flex items-center gap-2">
@@ -38,24 +44,30 @@
 				>
 					{index + 1}
 				</span>
-				<Input
-					type="text"
-					value={name}
-					oninput={(e) => {
-						onUpdateName(index, e.currentTarget.value);
-						onClearError();
-					}}
-					placeholder={index === 0 ? 'Your name' : `Guest ${index + 1} name`}
-					disabled={isProcessing}
-					class="flex-1"
-					required
-					aria-invalid={guestNameError && !name.trim() ? 'true' : 'false'}
-				/>
+				<div class="flex-1 space-y-1">
+					<Label for="{idPrefix}-name-{index}" class="sr-only">
+						{m['cartSheet.nameLabel']({ index: index + 1 })}
+					</Label>
+					<Input
+						id="{idPrefix}-name-{index}"
+						type="text"
+						value={name}
+						oninput={(e) => {
+							onUpdateName(index, e.currentTarget.value);
+							onClearError();
+						}}
+						placeholder={m['cartSheet.nameLabel']({ index: index + 1 })}
+						disabled={isProcessing}
+						required
+						aria-invalid={guestNameError && !name.trim() ? 'true' : 'false'}
+						aria-describedby={guestNameError ? errorId : undefined}
+					/>
+				</div>
 			</div>
 		{/each}
 	</div>
 	{#if guestNameError}
-		<Alert variant="destructive">
+		<Alert variant="destructive" id={errorId}>
 			<AlertCircle class="h-4 w-4" />
 			<AlertDescription>{guestNameError}</AlertDescription>
 		</Alert>

--- a/src/lib/components/tickets/PurchaseErrorAlert.svelte
+++ b/src/lib/components/tickets/PurchaseErrorAlert.svelte
@@ -10,8 +10,10 @@
 	interface Props {
 		/** Whatever the purchase path threw, or `null` when there is no error. */
 		error?: unknown;
-		/** The tier being bought — the only source of the required tier names. */
-		tier: TierSchemaWithId;
+		/** The tier being bought — a source of the required tier names. */
+		tier?: TierSchemaWithId;
+		/** Multiple tiers (cart checkout) — unioned with `tier` when both are given. */
+		tiers?: TierSchemaWithId[];
 		/**
 		 * Organizing org's slug. Without it the membership link is omitted rather
 		 * than guessed: a wrong destination is worse than none.
@@ -19,22 +21,31 @@
 		organizationSlug?: string | null;
 	}
 
-	const { error = null, tier, organizationSlug = null }: Props = $props();
+	const { error = null, tier, tiers, organizationSlug = null }: Props = $props();
 
 	const message = $derived(
 		error ? extractPurchaseErrorMessage(error, m['ticketConfirmationDialog.errorGeneric']()) : ''
 	);
 
-	// The purchase was refused because this tier is gated to membership tiers the
-	// buyer does not hold (BE #807). It is the one purchase error with somewhere
-	// to send the buyer, so it gets a CTA the others don't.
+	// The purchase was refused because a tier in the purchase is gated to
+	// membership tiers the buyer does not hold (BE #807). It is the one purchase
+	// error with somewhere to send the buyer, so it gets a CTA the others don't.
 	const membershipGateRefused = $derived(isMembershipTierRefusal(error));
 
 	// Which membership tiers would satisfy the gate. The refusal payload names
 	// NONE of them (and cannot say whether the buyer is a non-member or a member
-	// on the wrong tier), so they come off the tier — the same list TierCard reads.
+	// on the wrong tier), so they come off the tier(s) — the same list TierCard
+	// reads. `tier` and `tiers` union (deduped) so a single-tier purchase and a
+	// multi-group cart checkout both work through the same prop.
+	const consideredTiers = $derived([...(tier ? [tier] : []), ...(tiers ?? [])]);
 	const requiredTierNames = $derived(
-		(tier.restricted_to_membership_tiers ?? []).map((t) => t.name).filter(Boolean)
+		Array.from(
+			new Set(
+				consideredTiers.flatMap((t) =>
+					(t.restricted_to_membership_tiers ?? []).map((mt) => mt.name).filter(Boolean)
+				)
+			)
+		)
 	);
 
 	// The link below points at the org's membership page — the only surface where

--- a/src/lib/components/tickets/PwycInput.svelte
+++ b/src/lib/components/tickets/PwycInput.svelte
@@ -12,6 +12,8 @@
 		pwycError: string;
 		isProcessing: boolean;
 		suggestions: number[];
+		/** Prefixes the amount input/error ids so two instances (one per cart group) never collide. */
+		idPrefix: string;
 		onAmountChange: (value: string) => void;
 		onKeydown: (e: KeyboardEvent) => void;
 	}
@@ -24,29 +26,35 @@
 		pwycError,
 		isProcessing,
 		suggestions,
+		idPrefix,
 		onAmountChange,
 		onKeydown
 	}: Props = $props();
 
 	// Derive aria-invalid from error and validation state
 	const hasError = $derived(!!pwycError);
+	const amountId = $derived(`${idPrefix}-pwyc-amount`);
+	const errorId = $derived(`${idPrefix}-amount-error`);
 </script>
 
 <div class="space-y-3">
 	<div class="space-y-2">
-		<Label for="pwyc-amount">{m['ticketConfirmationDialog.paymentAmount']()}</Label>
+		<Label for={amountId}>{m['ticketConfirmationDialog.paymentAmount']()}</Label>
 		<div class="text-xs text-muted-foreground">
-			Range: {currency}
-			{minAmount.toFixed(2)} - {maxAmount !== null
-				? `${currency} ${maxAmount.toFixed(2)}`
-				: 'any amount'}
+			{m['cartSheet.pwycRange']({
+				min: `${currency} ${minAmount.toFixed(2)}`,
+				max:
+					maxAmount !== null
+						? `${currency} ${maxAmount.toFixed(2)}`
+						: m['ticketConfirmationDialog.anyAmount']()
+			})}
 		</div>
 		<div class="relative">
 			<span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
 				{currency}
 			</span>
 			<Input
-				id="pwyc-amount"
+				id={amountId}
 				type="text"
 				inputmode="decimal"
 				value={pwycAmount}
@@ -61,11 +69,11 @@
 				placeholder={minAmount.toFixed(2)}
 				disabled={isProcessing}
 				aria-invalid={hasError ? 'true' : 'false'}
-				aria-describedby={hasError ? 'amount-error' : undefined}
+				aria-describedby={hasError ? errorId : undefined}
 			/>
 		</div>
 		{#if pwycError}
-			<p id="amount-error" class="text-sm text-destructive" role="alert">
+			<p id={errorId} class="text-sm text-destructive" role="alert">
 				{pwycError}
 			</p>
 		{/if}

--- a/src/lib/components/tickets/TicketConfirmationDialog.svelte
+++ b/src/lib/components/tickets/TicketConfirmationDialog.svelte
@@ -562,7 +562,7 @@
 			{#if showGuestNames}
 				<GuestNameInputs
 					{guestNames}
-					{quantity}
+					idPrefix="tcd"
 					{isProcessing}
 					{guestNameError}
 					onUpdateName={updateGuestName}
@@ -593,6 +593,7 @@
 			{#if isPwyc}
 				<PwycInput
 					currency={tier.currency}
+					idPrefix="tcd"
 					{minAmount}
 					{maxAmount}
 					{pwycAmount}

--- a/src/lib/components/tickets/TicketTierList.svelte
+++ b/src/lib/components/tickets/TicketTierList.svelte
@@ -43,8 +43,6 @@
 		/** Disables every quick-buy stepper (both buttons) — set while a cart
 		 * checkout is in flight so quantities can't change mid-submit. */
 		quickBuyDisabled?: boolean;
-		/** Tiers that require per-ticket guest names are never quick-buy eligible. */
-		requireTicketNames?: boolean;
 		/** Event-level shared remaining budget (BE #901); null = no cap / unknown. */
 		eventRemaining?: number | null;
 		onSelectTier: (tier: TierSchemaWithId) => void;
@@ -70,7 +68,6 @@
 		capacityDisclosed = true,
 		cart,
 		quickBuyDisabled = false,
-		requireTicketNames = false,
 		eventRemaining = null,
 		onSelectTier,
 		onGuestTierClick,
@@ -177,7 +174,7 @@
 					tierRemainingInfo={getTierRemainingInfo(tier.id)}
 					{timezone}
 					{capacityDisclosed}
-					quickBuy={cart && quickBuyEligible(tier, requireTicketNames)
+					quickBuy={cart && quickBuyEligible(tier)
 						? {
 								quantity: cart.quantityFor(tier.id),
 								max: cart.maxQuantity(tier),

--- a/src/lib/components/tickets/cart-discount.test.ts
+++ b/src/lib/components/tickets/cart-discount.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { discountApplicable, validateCartDiscount } from './cart-discount';
+import { discountApplicable, discountStaysApplied, validateCartDiscount } from './cart-discount';
 import type { ValidateDiscountFn } from './cart-discount';
 import type { CartGroup } from './cart.svelte';
 import type { TierSchemaWithId } from '$lib/types/tickets';
@@ -151,5 +151,50 @@ describe('validateCartDiscount', () => {
 		// Both starts happen before either group's promise settles sequentially-blocking.
 		expect(order[0]).toBe('start-tier-a');
 		expect(order[1]).toBe('start-tier-b');
+	});
+});
+
+describe('discountStaysApplied', () => {
+	it('stays applied when at least one applicable group came back valid', () => {
+		const groupA = makeGroup({ tier: makeTier({ id: 'tier-a' }) });
+		const groupB = makeGroup({ tier: makeTier({ id: 'tier-b' }) });
+		const result = {
+			byTier: new Map([
+				['tier-a', makeValidationResponse({ valid: false, message: 'nope' })],
+				['tier-b', makeValidationResponse({ valid: true })]
+			]),
+			anyValid: true
+		};
+
+		expect(discountStaysApplied(result, [groupA, groupB])).toBe(true);
+	});
+
+	it('stays applied when every applicable group is a transport failure (no map entries)', () => {
+		const groupA = makeGroup({ tier: makeTier({ id: 'tier-a' }) });
+		const groupB = makeGroup({ tier: makeTier({ id: 'tier-b' }) });
+		const result = { byTier: new Map(), anyValid: false };
+
+		expect(discountStaysApplied(result, [groupA, groupB])).toBe(true);
+	});
+
+	it('clears once there is at least one real invalid response and none valid', () => {
+		const groupA = makeGroup({ tier: makeTier({ id: 'tier-a' }) });
+		const groupB = makeGroup({ tier: makeTier({ id: 'tier-b' }) });
+		const result = {
+			byTier: new Map([
+				['tier-a', makeValidationResponse({ valid: false, message: 'invalid code' })]
+				// tier-b: transport failure, no entry — still a real "no" from tier-a.
+			]),
+			anyValid: false
+		};
+
+		expect(discountStaysApplied(result, [groupA, groupB])).toBe(false);
+	});
+
+	it('is false when there are no applicable groups at all', () => {
+		const freeGroup = makeGroup({ tier: makeTier({ payment_method: 'free' }) });
+		const result = { byTier: new Map(), anyValid: false };
+
+		expect(discountStaysApplied(result, [freeGroup])).toBe(false);
 	});
 });

--- a/src/lib/components/tickets/cart-discount.test.ts
+++ b/src/lib/components/tickets/cart-discount.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { discountApplicable, validateCartDiscount } from './cart-discount';
+import type { ValidateDiscountFn } from './cart-discount';
+import type { CartGroup } from './cart.svelte';
+import type { TierSchemaWithId } from '$lib/types/tickets';
+import type { DiscountCodeValidationResponse } from '$lib/api/generated/types.gen';
+
+function makeTier(overrides: Partial<TierSchemaWithId> = {}): TierSchemaWithId {
+	return {
+		id: overrides.id ?? crypto.randomUUID(),
+		name: 'GA',
+		payment_method: 'online',
+		price_type: 'fixed',
+		seat_assignment_mode: 'none',
+		currency: 'EUR',
+		price: '25.00',
+		total_available: 100,
+		...overrides
+	} as TierSchemaWithId;
+}
+
+function makeGroup(overrides: Partial<CartGroup> = {}): CartGroup {
+	return {
+		tier: makeTier(),
+		quantity: 1,
+		guestNames: [],
+		pwycAmount: null,
+		priceCategoryId: null,
+		accessibleRequired: false,
+		seatIds: [],
+		...overrides
+	};
+}
+
+function makeValidationResponse(
+	overrides: Partial<DiscountCodeValidationResponse> = {}
+): DiscountCodeValidationResponse {
+	return {
+		valid: true,
+		discount_type: 'percentage',
+		discount_value: '10',
+		discounted_price: '22.50',
+		message: null,
+		...overrides
+	};
+}
+
+describe('discountApplicable', () => {
+	it('is applicable for an online, fixed-price, unseated tier', () => {
+		expect(discountApplicable(makeTier())).toBe(true);
+	});
+
+	it('is not applicable for a free tier', () => {
+		expect(discountApplicable(makeTier({ payment_method: 'free' }))).toBe(false);
+	});
+
+	it('is not applicable for a pwyc tier', () => {
+		expect(discountApplicable(makeTier({ price_type: 'pwyc' }))).toBe(false);
+	});
+
+	it('is not applicable for a seated tier', () => {
+		expect(discountApplicable(makeTier({ seat_assignment_mode: 'user_choice' }))).toBe(false);
+	});
+});
+
+describe('validateCartDiscount', () => {
+	it('fans out only across applicable groups and aggregates results, anyValid true if any group is valid', async () => {
+		const applicableA = makeGroup({ tier: makeTier({ id: 'tier-a' }) });
+		const applicableB = makeGroup({ tier: makeTier({ id: 'tier-b' }) });
+		const freeGroup = makeGroup({ tier: makeTier({ id: 'tier-free', payment_method: 'free' }) });
+
+		const validate: ValidateDiscountFn = vi.fn(async (tierId: string) => {
+			if (tierId === 'tier-a') return makeValidationResponse({ valid: false, message: 'nope' });
+			if (tierId === 'tier-b') return makeValidationResponse({ valid: true });
+			throw new Error('should not be called for inapplicable groups');
+		});
+
+		const result = await validateCartDiscount(
+			'CODE',
+			[applicableA, applicableB, freeGroup],
+			validate
+		);
+
+		expect(validate).toHaveBeenCalledTimes(2);
+		expect(result.byTier.size).toBe(2);
+		expect(result.byTier.get('tier-a')?.valid).toBe(false);
+		expect(result.byTier.get('tier-a')?.message).toBe('nope');
+		expect(result.byTier.get('tier-b')?.valid).toBe(true);
+		expect(result.anyValid).toBe(true);
+	});
+
+	it('anyValid is false when no applicable group validates as valid', async () => {
+		const groupA = makeGroup({ tier: makeTier({ id: 'tier-a' }) });
+		const groupB = makeGroup({ tier: makeTier({ id: 'tier-b' }) });
+
+		const validate: ValidateDiscountFn = vi.fn(async () =>
+			makeValidationResponse({ valid: false, message: 'invalid code' })
+		);
+
+		const result = await validateCartDiscount('BAD', [groupA, groupB], validate);
+
+		expect(result.byTier.size).toBe(2);
+		expect(result.anyValid).toBe(false);
+	});
+
+	it('tolerates a null (transport error) from one group without failing the others', async () => {
+		const groupA = makeGroup({ tier: makeTier({ id: 'tier-a' }) });
+		const groupB = makeGroup({ tier: makeTier({ id: 'tier-b' }) });
+
+		const validate: ValidateDiscountFn = vi.fn(async (tierId: string) => {
+			if (tierId === 'tier-a') return null;
+			return makeValidationResponse({ valid: true });
+		});
+
+		const result = await validateCartDiscount('CODE', [groupA, groupB], validate);
+
+		expect(result.byTier.size).toBe(1);
+		expect(result.byTier.has('tier-a')).toBe(false);
+		expect(result.byTier.get('tier-b')?.valid).toBe(true);
+		expect(result.anyValid).toBe(true);
+	});
+
+	it('returns an empty map and anyValid false when zero groups are applicable', async () => {
+		const freeGroup = makeGroup({ tier: makeTier({ payment_method: 'free' }) });
+		const pwycGroup = makeGroup({ tier: makeTier({ price_type: 'pwyc' }) });
+
+		const validate: ValidateDiscountFn = vi.fn();
+
+		const result = await validateCartDiscount('CODE', [freeGroup, pwycGroup], validate);
+
+		expect(validate).not.toHaveBeenCalled();
+		expect(result.byTier.size).toBe(0);
+		expect(result.anyValid).toBe(false);
+	});
+
+	it('calls validate in parallel (Promise.all), not sequentially', async () => {
+		const groupA = makeGroup({ tier: makeTier({ id: 'tier-a' }) });
+		const groupB = makeGroup({ tier: makeTier({ id: 'tier-b' }) });
+
+		const order: string[] = [];
+		const validate: ValidateDiscountFn = vi.fn(async (tierId: string) => {
+			order.push(`start-${tierId}`);
+			// tier-a resolves slower than tier-b, but both should be *started* before either resolves
+			await new Promise((resolve) => setTimeout(resolve, tierId === 'tier-a' ? 10 : 0));
+			order.push(`end-${tierId}`);
+			return makeValidationResponse({ valid: true });
+		});
+
+		await validateCartDiscount('CODE', [groupA, groupB], validate);
+
+		// Both starts happen before either group's promise settles sequentially-blocking.
+		expect(order[0]).toBe('start-tier-a');
+		expect(order[1]).toBe('start-tier-b');
+	});
+});

--- a/src/lib/components/tickets/cart-discount.ts
+++ b/src/lib/components/tickets/cart-discount.ts
@@ -63,6 +63,20 @@ export async function validateCartDiscount(
 	return { byTier, anyValid };
 }
 
+/**
+ * Whether a checked code should stay "applied" after `validateCartDiscount`:
+ * true when it's valid for some group, OR when every applicable group's check
+ * failed at the transport layer (a `null` response is "no answer", not
+ * "invalid" — dropping the code there would silently lose a possibly-good
+ * code over a network hiccup instead of letting checkout retry it honestly).
+ * False only once there's at least one REAL response and none of them valid.
+ */
+export function discountStaysApplied(result: CartDiscountResult, groups: CartGroup[]): boolean {
+	const applicableCount = groups.filter((group) => discountApplicable(group.tier)).length;
+	const allChecksFailed = applicableCount > 0 && result.byTier.size === 0;
+	return result.anyValid || allChecksFailed;
+}
+
 /** Real ValidateDiscountFn wrapping the generated SDK call for a fixed event. */
 export function makeValidateDiscountFn(eventId: string): ValidateDiscountFn {
 	return async (tierId: string, code: string) => {

--- a/src/lib/components/tickets/cart-discount.ts
+++ b/src/lib/components/tickets/cart-discount.ts
@@ -1,0 +1,79 @@
+/**
+ * Cart-level discount fan-out (#853 PR 2). A single code the buyer types once
+ * gets validated against every applicable group's tier in parallel — the
+ * backend validates per-tier (BE endpoint takes {event_id, tier_id}), so the
+ * cart has to fan a single code out itself.
+ */
+import type { DiscountCodeValidationResponse } from '$lib/api/generated/types.gen';
+import { eventpublicticketsValidateDiscount } from '$lib/api/generated/sdk.gen';
+import type { CartGroup } from './cart.svelte';
+
+/** A group a discount code can actually reduce client-side: flat-priced, paid.
+ *  PR 2 carts are unseated anyway; keep the seat clause for PR 3 safety. */
+export function discountApplicable(tier: CartGroup['tier']): boolean {
+	return (
+		tier.payment_method !== 'free' &&
+		tier.price_type !== 'pwyc' &&
+		tier.seat_assignment_mode === 'none'
+	);
+}
+
+export interface CartDiscountResult {
+	/** Applicable groups only, keyed by tier id. */
+	byTier: Map<string, DiscountCodeValidationResponse>;
+	anyValid: boolean;
+}
+
+export type ValidateDiscountFn = (
+	tierId: string,
+	code: string
+) => Promise<DiscountCodeValidationResponse | null>;
+
+/**
+ * Fans one code out across the cart's applicable groups. Injected fn for
+ * testability; the real one (`makeValidateDiscountFn`) wraps
+ * eventpublicticketsValidateDiscount and returns null on transport error — a
+ * failed call is "no answer", not "invalid", so it contributes no map entry
+ * and never fails the other groups (each call is isolated, not Promise.all-
+ * rejecting).
+ */
+export async function validateCartDiscount(
+	code: string,
+	groups: CartGroup[],
+	validate: ValidateDiscountFn
+): Promise<CartDiscountResult> {
+	const applicable = groups.filter((group) => discountApplicable(group.tier));
+
+	const results = await Promise.all(
+		applicable.map(async (group) => {
+			const tierId = group.tier.id;
+			const response = await validate(tierId, code);
+			return { tierId, response };
+		})
+	);
+
+	const byTier = new Map<string, DiscountCodeValidationResponse>();
+	let anyValid = false;
+	for (const { tierId, response } of results) {
+		if (response === null) continue;
+		byTier.set(tierId, response);
+		if (response.valid) anyValid = true;
+	}
+
+	return { byTier, anyValid };
+}
+
+/** Real ValidateDiscountFn wrapping the generated SDK call for a fixed event. */
+export function makeValidateDiscountFn(eventId: string): ValidateDiscountFn {
+	return async (tierId: string, code: string) => {
+		try {
+			const response = await eventpublicticketsValidateDiscount({
+				path: { event_id: eventId, tier_id: tierId },
+				body: { code }
+			});
+			return response.data ?? null;
+		} catch {
+			return null;
+		}
+	};
+}

--- a/src/lib/components/tickets/cart-payload.test.ts
+++ b/src/lib/components/tickets/cart-payload.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { buildCartItems } from './cart-payload';
+import { buildCartItems, buildCartCheckoutParams } from './cart-payload';
 import type { TierSchemaWithId } from '$lib/types/tickets';
+import type { CheckoutGroupSchema, BuyerBillingInfoSchema } from '$lib/api/generated/types.gen';
 
 function makeTier(overrides: Partial<TierSchemaWithId> = {}): TierSchemaWithId {
 	return {
@@ -75,5 +76,83 @@ describe('buildCartItems', () => {
 			{ guest_name: 'Alice', seat_id: 's1' },
 			{ guest_name: '', seat_id: 's2' }
 		]);
+	});
+	it('namesShown is true when requireTicketNames is true, regardless of quantity', () => {
+		const tier = makeTier();
+		// Test with quantity = 1 (the key case: should now have namesShown: true)
+		const items = buildCartItems(
+			[
+				{
+					tier,
+					quantity: 1,
+					guestNames: [''],
+					pwycAmount: null,
+					priceCategoryId: null,
+					accessibleRequired: false,
+					seatIds: []
+				}
+			],
+			{ requireTicketNames: true, defaultName: 'DefaultName' }
+		);
+		// The ticket should have guest_name: '' (not substituted with defaultName)
+		expect(items[0].tickets[0]).toEqual({ guest_name: '' });
+	});
+});
+
+describe('buildCartCheckoutParams', () => {
+	function makeCheckoutGroup(): CheckoutGroupSchema {
+		return {
+			tier_id: crypto.randomUUID(),
+			tickets: [{ guest_name: 'Alice' }]
+		};
+	}
+
+	it('normalizes empty and whitespace discountCode to undefined', () => {
+		const items: CheckoutGroupSchema[] = [makeCheckoutGroup()];
+		const billingInfo: BuyerBillingInfoSchema = { country: 'US' };
+
+		const result1 = buildCartCheckoutParams(items, '', billingInfo);
+		expect(result1.discountCode).toBeUndefined();
+
+		const result2 = buildCartCheckoutParams(items, '  ', billingInfo);
+		expect(result2.discountCode).toBeUndefined();
+
+		const result3 = buildCartCheckoutParams(items, ' CODE ', billingInfo);
+		expect(result3.discountCode).toBe('CODE');
+	});
+
+	it('normalizes null billingInfo to undefined', () => {
+		const items: CheckoutGroupSchema[] = [makeCheckoutGroup()];
+
+		const result = buildCartCheckoutParams(items, 'CODE', null);
+		expect(result.billingInfo).toBeUndefined();
+	});
+
+	it('constructs with key order: items, discountCode, billingInfo', () => {
+		const items: CheckoutGroupSchema[] = [makeCheckoutGroup()];
+		const billingInfo: BuyerBillingInfoSchema = { country: 'US' };
+
+		const result = buildCartCheckoutParams(items, 'CODE', billingInfo);
+		const keys = Object.keys(result);
+		expect(keys).toEqual(['items', 'discountCode', 'billingInfo']);
+	});
+
+	it('produces byte-identical fingerprint with undefined vs empty params', () => {
+		const items: CheckoutGroupSchema[] = [makeCheckoutGroup()];
+
+		// Call with empty code and null billing
+		const result1 = buildCartCheckoutParams(items, '', null);
+		// Call with only items (equivalent)
+		const result2 = buildCartCheckoutParams(items, '', null);
+
+		// Both must have identical byte representation for fingerprinting
+		const json1 = JSON.stringify(result1);
+		const json2 = JSON.stringify(result2);
+		expect(json1).toBe(json2);
+
+		// And should match a minimal object with just items
+		const minimal = { items };
+		const minimalJson = JSON.stringify(minimal);
+		expect(json1).toBe(minimalJson);
 	});
 });

--- a/src/lib/components/tickets/cart-payload.ts
+++ b/src/lib/components/tickets/cart-payload.ts
@@ -4,8 +4,9 @@
  * buildPurchaseTicketItems so name/seat semantics stay byte-identical with the
  * legacy single-tier flow (the resume fingerprint depends on it).
  */
-import type { CheckoutGroupSchema } from '$lib/api/generated/types.gen';
+import type { CheckoutGroupSchema, BuyerBillingInfoSchema } from '$lib/api/generated/types.gen';
 import type { CartGroup } from './cart.svelte';
+import type { CartCheckoutParams } from '../events/cart-checkout-controller.svelte';
 import { buildPurchaseTicketItems } from './purchase-items';
 
 export interface CartPayloadOptions {
@@ -25,7 +26,7 @@ export function buildCartItems(
 			tickets: buildPurchaseTicketItems({
 				guestNames: names,
 				requireTicketNames: opts.requireTicketNames,
-				namesShown: opts.requireTicketNames && group.quantity > 1,
+				namesShown: opts.requireTicketNames,
 				defaultName: opts.defaultName,
 				heldSeatIds: group.seatIds,
 				useHeldSeats: group.seatIds.length > 0
@@ -38,4 +39,27 @@ export function buildCartItems(
 		if (group.accessibleRequired) item.accessible_required = true;
 		return item;
 	});
+}
+
+/**
+ * Construct a CartCheckoutParams object with normalized, undefined-safe values.
+ *
+ * Normalizes discountCode (trim, empty → undefined) and billingInfo (null →
+ * undefined), ensuring the fingerprint never varies between ''/"  " and
+ * undefined. Key order is fixed (items, discountCode, billingInfo) so
+ * JSON.stringify() always produces byte-identical output for equivalent inputs.
+ */
+export function buildCartCheckoutParams(
+	items: CheckoutGroupSchema[],
+	discountCode: string,
+	billingInfo: BuyerBillingInfoSchema | null
+): CartCheckoutParams {
+	const trimmedCode = discountCode.trim() || undefined;
+	const normalizedBilling = billingInfo ?? undefined;
+
+	// Build result with strict key order: items first, then optional discountCode, then optional billingInfo
+	const result: CartCheckoutParams = { items };
+	if (trimmedCode !== undefined) result.discountCode = trimmedCode;
+	if (normalizedBilling !== undefined) result.billingInfo = normalizedBilling;
+	return result;
 }

--- a/src/lib/components/tickets/cart.svelte.test.ts
+++ b/src/lib/components/tickets/cart.svelte.test.ts
@@ -18,17 +18,16 @@ function makeTier(overrides: Partial<TierSchemaWithId> = {}): TierSchemaWithId {
 const noLimits = { remainingFor: () => undefined, eventRemaining: () => null };
 
 describe('quickBuyEligible', () => {
-	it('accepts fixed-price unseated tiers when names are off', () => {
-		expect(quickBuyEligible(makeTier(), false)).toBe(true);
+	it('accepts fixed-price unseated tiers', () => {
+		expect(quickBuyEligible(makeTier())).toBe(true);
 	});
-	it('rejects when names required / pwyc / seated / hidden', () => {
-		expect(quickBuyEligible(makeTier(), true)).toBe(false);
-		expect(quickBuyEligible(makeTier({ price_type: 'pwyc' }), false)).toBe(false);
-		expect(quickBuyEligible(makeTier({ seat_assignment_mode: 'user_choice' }), false)).toBe(false);
-		expect(quickBuyEligible(makeTier({ seat_assignment_mode: 'best_available' }), false)).toBe(
-			false
-		);
-		expect(quickBuyEligible(makeTier({ payment_method: 'hidden' }), false)).toBe(false);
+	it('accepts pwyc and names-required tiers now (sheet handles the extra input)', () => {
+		expect(quickBuyEligible(makeTier({ price_type: 'pwyc' }))).toBe(true);
+	});
+	it('rejects seated/hidden tiers', () => {
+		expect(quickBuyEligible(makeTier({ seat_assignment_mode: 'user_choice' }))).toBe(false);
+		expect(quickBuyEligible(makeTier({ seat_assignment_mode: 'best_available' }))).toBe(false);
+		expect(quickBuyEligible(makeTier({ payment_method: 'hidden' }))).toBe(false);
 	});
 });
 
@@ -94,5 +93,62 @@ describe('EventCart', () => {
 		cart.setQuantity(makeTier(), 2);
 		cart.clear();
 		expect(cart.isEmpty).toBe(true);
+	});
+
+	describe('needsSheet', () => {
+		it('is false for an empty cart or all-flat groups regardless of requireTicketNames', () => {
+			const cart = new EventCart(noLimits);
+			expect(cart.needsSheet(false)).toBe(false);
+			expect(cart.needsSheet(true)).toBe(false);
+			cart.setQuantity(makeTier(), 2);
+			expect(cart.needsSheet(false)).toBe(false);
+		});
+		it('is true when requireTicketNames is set and any group exists', () => {
+			const cart = new EventCart(noLimits);
+			cart.setQuantity(makeTier(), 1);
+			expect(cart.needsSheet(true)).toBe(true);
+		});
+		it('is true when a pwyc group joins, even with requireTicketNames false', () => {
+			const cart = new EventCart(noLimits);
+			cart.setQuantity(makeTier(), 1);
+			cart.setQuantity(makeTier({ price_type: 'pwyc' }), 1);
+			expect(cart.needsSheet(false)).toBe(true);
+		});
+	});
+
+	describe('setGuestName', () => {
+		it('pads guestNames to quantity and writes the given index', () => {
+			const cart = new EventCart(noLimits);
+			const tier = makeTier();
+			cart.setQuantity(tier, 3);
+			cart.setGuestName(tier.id, 1, 'Ada Lovelace');
+			expect(cart.groupFor(tier.id)?.guestNames).toEqual(['', 'Ada Lovelace', '']);
+		});
+		it('is a no-op for an unknown tierId', () => {
+			const cart = new EventCart(noLimits);
+			const tier = makeTier();
+			cart.setQuantity(tier, 2);
+			cart.setGuestName('does-not-exist', 0, 'Nope');
+			expect(cart.groupFor(tier.id)?.guestNames).toEqual([]);
+		});
+	});
+
+	describe('setPwycAmount', () => {
+		it('writes the pwyc amount on the matching group', () => {
+			const cart = new EventCart(noLimits);
+			const tier = makeTier({ price_type: 'pwyc' });
+			cart.setQuantity(tier, 1);
+			cart.setPwycAmount(tier.id, '15.00');
+			expect(cart.groupFor(tier.id)?.pwycAmount).toBe('15.00');
+			cart.setPwycAmount(tier.id, null);
+			expect(cart.groupFor(tier.id)?.pwycAmount).toBe(null);
+		});
+		it('is a no-op for an unknown tierId', () => {
+			const cart = new EventCart(noLimits);
+			const tier = makeTier();
+			cart.setQuantity(tier, 1);
+			cart.setPwycAmount('does-not-exist', '9.00');
+			expect(cart.groupFor(tier.id)?.pwycAmount).toBe(null);
+		});
 	});
 });

--- a/src/lib/components/tickets/cart.svelte.ts
+++ b/src/lib/components/tickets/cart.svelte.ts
@@ -34,14 +34,13 @@ export interface EventCartDeps {
 	eventRemaining: () => number | null;
 }
 
-/** A tier the buyer can quantity-pick without any extra input (spec §2.1). */
-export function quickBuyEligible(tier: TierSchemaWithId, requireTicketNames: boolean): boolean {
-	return (
-		!requireTicketNames &&
-		tier.price_type !== 'pwyc' &&
-		tier.seat_assignment_mode === 'none' &&
-		tier.payment_method !== 'hidden'
-	);
+/**
+ * A tier the buyer can quantity-pick with a stepper (spec §2.1). Names and
+ * PWYC amounts are no longer disqualifying here — they're collected in the
+ * checkout sheet before submit (see `EventCart.needsSheet`).
+ */
+export function quickBuyEligible(tier: TierSchemaWithId): boolean {
+	return tier.seat_assignment_mode === 'none' && tier.payment_method !== 'hidden';
 }
 
 export class EventCart {
@@ -120,5 +119,24 @@ export class EventCart {
 
 	clear(): void {
 		this.groups = [];
+	}
+
+	/** True when checkout needs the sheet: any group needs names or a PWYC amount. */
+	needsSheet(requireTicketNames: boolean): boolean {
+		return this.groups.some((g) => requireTicketNames || g.tier.price_type === 'pwyc');
+	}
+
+	/** Writes a guest name at `index`, padding `guestNames` to the group's quantity first. */
+	setGuestName(tierId: string, index: number, value: string): void {
+		const group = this.groupFor(tierId);
+		if (!group) return;
+		while (group.guestNames.length < group.quantity) group.guestNames.push('');
+		group.guestNames[index] = value;
+	}
+
+	setPwycAmount(tierId: string, value: string | null): void {
+		const group = this.groupFor(tierId);
+		if (!group) return;
+		group.pwycAmount = value;
 	}
 }

--- a/src/lib/components/tickets/checkout-sheet-validation.test.ts
+++ b/src/lib/components/tickets/checkout-sheet-validation.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { sheetValidationError } from './checkout-sheet-validation';
+import type { CartGroup } from './cart.svelte';
+import type { TierSchemaWithId } from '$lib/types/tickets';
+
+function makeTier(overrides: Partial<TierSchemaWithId> = {}): TierSchemaWithId {
+	return {
+		id: overrides.id ?? crypto.randomUUID(),
+		name: 'GA',
+		payment_method: 'online',
+		price_type: 'fixed',
+		seat_assignment_mode: 'none',
+		currency: 'EUR',
+		price: '25.00',
+		total_available: 100,
+		pwyc_min: null,
+		pwyc_max: null,
+		...overrides
+	} as TierSchemaWithId;
+}
+
+function makeGroup(overrides: Partial<CartGroup> = {}): CartGroup {
+	return {
+		tier: makeTier(),
+		quantity: 1,
+		guestNames: [],
+		pwycAmount: null,
+		priceCategoryId: null,
+		accessibleRequired: false,
+		seatIds: [],
+		...overrides
+	};
+}
+
+describe('sheetValidationError', () => {
+	it('returns "names" when a required name is missing for one ticket in a group', () => {
+		const group = makeGroup({ quantity: 2, guestNames: ['Alice', ''] });
+		expect(sheetValidationError([group], true)).toBe('names');
+	});
+
+	it('returns "names" when guestNames is shorter than quantity (unpadded)', () => {
+		const group = makeGroup({ quantity: 2, guestNames: ['Alice'] });
+		expect(sheetValidationError([group], true)).toBe('names');
+	});
+
+	it('returns "names" when a name is present but only whitespace', () => {
+		const group = makeGroup({ quantity: 1, guestNames: ['   '] });
+		expect(sheetValidationError([group], true)).toBe('names');
+	});
+
+	it('ignores missing names when requireTicketNames is false', () => {
+		const group = makeGroup({ quantity: 2, guestNames: [] });
+		expect(sheetValidationError([group], false)).toBeNull();
+	});
+
+	it('returns "pwyc" when a pwyc group has no amount entered', () => {
+		const group = makeGroup({
+			tier: makeTier({ price_type: 'pwyc' }),
+			pwycAmount: null
+		});
+		expect(sheetValidationError([group], false)).toBe('pwyc');
+	});
+
+	it('returns "pwyc" when a pwyc group amount is below the tier minimum', () => {
+		const group = makeGroup({
+			tier: makeTier({ price_type: 'pwyc', pwyc_min: '10.00' }),
+			pwycAmount: '5.00'
+		});
+		expect(sheetValidationError([group], false)).toBe('pwyc');
+	});
+
+	it('returns "pwyc" when a pwyc group amount exceeds the tier maximum', () => {
+		const group = makeGroup({
+			tier: makeTier({ price_type: 'pwyc', pwyc_min: '5.00', pwyc_max: '20.00' }),
+			pwycAmount: '25.00'
+		});
+		expect(sheetValidationError([group], false)).toBe('pwyc');
+	});
+
+	it('returns "names" before "pwyc" when both a names group and an earlier pwyc group are invalid (first-failing order)', () => {
+		const pwycGroup = makeGroup({
+			tier: makeTier({ id: 'pwyc-tier', price_type: 'pwyc' }),
+			quantity: 1,
+			guestNames: ['Alice'],
+			pwycAmount: null
+		});
+		const namesGroup = makeGroup({
+			tier: makeTier({ id: 'named-tier' }),
+			quantity: 1,
+			guestNames: ['']
+		});
+		// pwyc group appears first in the array, but a name failure on ANY group
+		// still surfaces — order within the array determines which tag wins when
+		// a single group offends on names; here they're separate groups so the
+		// first group in iteration order (pwyc) reports first.
+		expect(sheetValidationError([pwycGroup, namesGroup], true)).toBe('pwyc');
+		expect(sheetValidationError([namesGroup, pwycGroup], true)).toBe('names');
+	});
+
+	it('returns null when every group is valid: names filled and pwyc in range', () => {
+		const namesGroup = makeGroup({
+			tier: makeTier({ id: 'named-tier' }),
+			quantity: 2,
+			guestNames: ['Alice', 'Bob']
+		});
+		const pwycGroup = makeGroup({
+			tier: makeTier({ id: 'pwyc-tier', price_type: 'pwyc', pwyc_min: '5.00' }),
+			quantity: 1,
+			guestNames: ['Carol'],
+			pwycAmount: '10.00'
+		});
+		expect(sheetValidationError([namesGroup, pwycGroup], true)).toBeNull();
+	});
+
+	it('returns null for an empty cart', () => {
+		expect(sheetValidationError([], true)).toBeNull();
+	});
+
+	it('does not require names for a pwyc-only, non-required-names cart with a valid amount', () => {
+		const group = makeGroup({
+			tier: makeTier({ price_type: 'pwyc', pwyc_min: '1.00' }),
+			pwycAmount: '5.00'
+		});
+		expect(sheetValidationError([group], false)).toBeNull();
+	});
+});

--- a/src/lib/components/tickets/checkout-sheet-validation.ts
+++ b/src/lib/components/tickets/checkout-sheet-validation.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure submit-gate for `CheckoutSheet` (#853 PR 2): checks every cart group's
+ * ticket-name and PWYC-amount requirements and reports the FIRST offending
+ * rule, in group order. No runes here — plain function so this stays
+ * unit-testable without mounting the sheet.
+ */
+import type { CartGroup } from './cart.svelte';
+import { pwycBounds, validatePwycAmount } from './pwyc-validation';
+
+export type SheetValidationError = 'names' | 'pwyc';
+
+/**
+ * `null` means every group is ready to submit. `'names'` means some ticket in
+ * some group is missing a (non-blank) holder name — only checked when
+ * `requireTicketNames` is true. `'pwyc'` means some PWYC group's entered
+ * amount fails `validatePwycAmount` against that tier's bounds.
+ */
+export function sheetValidationError(
+	groups: readonly CartGroup[],
+	requireTicketNames: boolean
+): SheetValidationError | null {
+	for (const group of groups) {
+		if (requireTicketNames) {
+			for (let index = 0; index < group.quantity; index++) {
+				const name = group.guestNames[index] ?? '';
+				if (!name.trim()) return 'names';
+			}
+		}
+		if (group.tier.price_type === 'pwyc') {
+			const { minAmount, maxAmount } = pwycBounds(group.tier);
+			const validation = validatePwycAmount(group.pwycAmount ?? '', minAmount, maxAmount);
+			if (!validation.valid) return 'pwyc';
+		}
+	}
+	return null;
+}

--- a/src/lib/components/tickets/checkout-total.test.ts
+++ b/src/lib/components/tickets/checkout-total.test.ts
@@ -103,7 +103,7 @@ describe('checkoutTotal', () => {
 });
 
 describe('cartTotal', () => {
-	const fixed = (price: string, quantity: number): CheckoutTotalArgs =>
+	const fixed = (price: string, quantity: number, discountedPrice?: string): CheckoutTotalArgs =>
 		cartTotalArgs({
 			tier: {
 				payment_method: 'online',
@@ -115,10 +115,31 @@ describe('cartTotal', () => {
 			quantity,
 			seatIds: [],
 			pwycAmount: null,
-			priceCategoryId: null
+			priceCategoryId: null,
+			discountedPrice: discountedPrice ?? null
 		});
 	it('sums groups in integer cents', () => {
 		expect(cartTotal([fixed('25.00', 2), fixed('10.00', 1)])).toBe('60.00');
+	});
+	it('uses the discounted price when supplied on a flat-priced group', () => {
+		expect(cartTotal([fixed('30.00', 2, '20.00')])).toBe('40.00');
+	});
+	it('ignores discountedPrice on a PWYC group (branch precedence makes it inert)', () => {
+		const pwyc = cartTotalArgs({
+			tier: {
+				payment_method: 'online',
+				price_type: 'pwyc',
+				price: '5',
+				seat_assignment_mode: 'none',
+				seat_pricing: null
+			},
+			quantity: 2,
+			seatIds: [],
+			pwycAmount: '10.00',
+			priceCategoryId: null,
+			discountedPrice: '5.00'
+		});
+		expect(cartTotal([pwyc])).toBe('20.00');
 	});
 	it('is 0.00 for free carts and null when empty or any group is unknown', () => {
 		expect(
@@ -134,7 +155,8 @@ describe('cartTotal', () => {
 					quantity: 2,
 					seatIds: [],
 					pwycAmount: null,
-					priceCategoryId: null
+					priceCategoryId: null,
+					discountedPrice: null
 				})
 			])
 		).toBe('0.00');
@@ -152,7 +174,8 @@ describe('cartTotal', () => {
 					quantity: 1,
 					seatIds: [],
 					pwycAmount: null,
-					priceCategoryId: null
+					priceCategoryId: null,
+					discountedPrice: null
 				})
 			])
 		).toBe(null);

--- a/src/lib/components/tickets/checkout-total.ts
+++ b/src/lib/components/tickets/checkout-total.ts
@@ -88,6 +88,7 @@ export interface CartTotalGroup {
 	seatIds: readonly string[];
 	pwycAmount: string | null;
 	priceCategoryId: string | null;
+	discountedPrice?: string | null;
 }
 
 export function cartTotalArgs(group: CartTotalGroup): CheckoutTotalArgs {
@@ -98,7 +99,7 @@ export function cartTotalArgs(group: CartTotalGroup): CheckoutTotalArgs {
 		chart: null,
 		selectedZoneId: group.priceCategoryId,
 		pwycAmount: group.pwycAmount ?? '',
-		discountedPrice: null
+		discountedPrice: group.discountedPrice ?? null
 	};
 }
 

--- a/src/lib/components/tickets/pwyc-validation.test.ts
+++ b/src/lib/components/tickets/pwyc-validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { pwycBounds } from './pwyc-validation';
+
+describe('pwycBounds', () => {
+	it('falls back min to price when pwyc_min is absent', () => {
+		expect(pwycBounds({ price: '25.00', pwyc_min: undefined, pwyc_max: null })).toEqual({
+			minAmount: 25,
+			maxAmount: null
+		});
+	});
+	it('uses pwyc_min over price when present', () => {
+		expect(pwycBounds({ price: '25.00', pwyc_min: '5.00', pwyc_max: null })).toEqual({
+			minAmount: 5,
+			maxAmount: null
+		});
+	});
+	it('defaults min to 1 when both pwyc_min and price are unparsable', () => {
+		expect(pwycBounds({ price: 'not-a-number', pwyc_min: undefined, pwyc_max: null })).toEqual({
+			minAmount: 1,
+			maxAmount: null
+		});
+	});
+	it('parses pwyc_max when present, null when absent', () => {
+		expect(pwycBounds({ price: '25.00', pwyc_min: '5.00', pwyc_max: '100.00' })).toEqual({
+			minAmount: 5,
+			maxAmount: 100
+		});
+		expect(pwycBounds({ price: '25.00', pwyc_min: '5.00', pwyc_max: null })).toEqual({
+			minAmount: 5,
+			maxAmount: null
+		});
+		expect(pwycBounds({ price: '25.00', pwyc_min: '5.00', pwyc_max: undefined })).toEqual({
+			minAmount: 5,
+			maxAmount: null
+		});
+	});
+	it('treats an unparsable pwyc_max as absent (null)', () => {
+		expect(pwycBounds({ price: '25.00', pwyc_min: '5.00', pwyc_max: 'not-a-number' })).toEqual({
+			minAmount: 5,
+			maxAmount: null
+		});
+	});
+});

--- a/src/lib/components/tickets/pwyc-validation.ts
+++ b/src/lib/components/tickets/pwyc-validation.ts
@@ -4,12 +4,35 @@
  * No runes here — plain functions so this stays unit-testable.
  */
 import * as m from '$lib/paraglide/messages.js';
+import type { TierSchemaWithId } from '$lib/types/tickets';
 
 export type PwycValidationError = 'empty' | 'invalid' | 'below_min' | 'above_max';
 
 export interface PwycValidation {
 	valid: boolean;
 	error: PwycValidationError | null;
+}
+
+export interface PwycBounds {
+	minAmount: number;
+	maxAmount: number | null;
+}
+
+/**
+ * Derives the buyer-facing PWYC amount bounds for a tier: min falls back to
+ * the tier's flat price when no explicit `pwyc_min` is set (and to 1 if
+ * neither parses), max is the parsed `pwyc_max` or null when absent/invalid.
+ */
+export function pwycBounds(
+	tier: Pick<TierSchemaWithId, 'price' | 'pwyc_min' | 'pwyc_max'>
+): PwycBounds {
+	const parsedMin = parseFloat(tier.pwyc_min ?? tier.price);
+	const minAmount = Number.isNaN(parsedMin) ? 1 : parsedMin;
+
+	const parsedMax = tier.pwyc_max != null ? parseFloat(tier.pwyc_max) : NaN;
+	const maxAmount = Number.isNaN(parsedMax) ? null : parsedMax;
+
+	return { minAmount, maxAmount };
 }
 
 export function validatePwycAmount(

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -19,11 +19,7 @@
 	import TicketTierList from '$lib/components/tickets/TicketTierList.svelte';
 	import EventSeriesPassOffers from '$lib/components/series-passes/EventSeriesPassOffers.svelte';
 	import MyTicket from '$lib/components/tickets/MyTicket.svelte';
-	import TicketTierModal from '$lib/components/tickets/TicketTierModal.svelte';
-	import MyTicketModal from '$lib/components/tickets/MyTicketModal.svelte';
-	import GuestRsvpDialog from '$lib/components/events/GuestRsvpDialog.svelte';
-	import GuestTicketDialog from '$lib/components/events/GuestTicketDialog.svelte';
-	import VenueOverviewDialog from '$lib/components/events/VenueOverviewDialog.svelte';
+	import EventPurchaseDialogs from '$lib/components/events/EventPurchaseDialogs.svelte';
 	import { eventHasSeatingMap } from '$lib/components/events/venue-overview';
 	import EventConfirmationBanners from '$lib/components/events/EventConfirmationBanners.svelte';
 	import { createCheckoutController } from '$lib/components/events/event-checkout-controller.svelte';
@@ -640,110 +636,38 @@
 	/>
 {/if}
 
-<!-- Ticket Tier Selection Modal -->
-<TicketTierModal
-	seriesInfo={event.event_series
-		? {
-				seriesId: event.event_series.id,
-				orgSlug: event.organization.slug,
-				seriesSlug: event.event_series.slug
-			}
-		: null}
-	bind:open={showTicketTierModal}
-	tiers={ticketTiers}
-	eventId={event.id}
-	organizationSlug={event.organization.slug}
+<!-- Purchase-dialog cluster (TicketTierModal, MyTicketModal, GuestRsvpDialog, VenueOverviewDialog, GuestTicketDialog) -->
+<EventPurchaseDialogs
+	{event}
+	{ticketTiers}
+	{tierRemainingTickets}
 	isAuthenticated={data.isAuthenticated}
 	membershipTier={data.membershipTier}
-	canAttendWithoutLogin={event.can_attend_without_login}
-	{tierRemainingTickets}
-	timezone={event.timezone}
 	capacityDisclosed={viewerVisibility.show_capacity}
-	eventMaxTicketsPerUser={event.max_tickets_per_user}
-	userName={ticketHolderDefaultName}
-	requireTicketNames={event.require_ticket_names}
-	{preSelectedTier}
+	{ticketHolderDefaultName}
 	{initialDiscountCode}
-	onClose={closeTicketTierModal}
+	{hasSeatingMap}
+	{userTickets}
+	isResumingPayment={resumePaymentMutation.isPending}
+	isCancellingReservation={cancelReservationMutation.isPending}
+	{refreshUserStatus}
 	onClaimTicket={handleClaimTicket}
 	onCheckout={handleCheckout}
 	{hasResumableCheckout}
+	onResumePayment={handleResumePayment}
+	onCancelReservation={handleCancelReservation}
+	onSelectTier={handleSelectTier}
 	onGuestTierClick={openGuestTicketDialog}
-	onViewSeatingMap={hasSeatingMap
-		? () => {
-				showVenueOverview = true;
-			}
-		: undefined}
+	onGuestRsvpClose={closeGuestRsvpDialog}
+	onGuestAttendanceSuccess={handleGuestAttendanceSuccess}
+	onGuestTicketClose={closeGuestTicketDialog}
+	onTicketTierModalClose={closeTicketTierModal}
+	bind:showTicketTierModal
+	bind:showMyTicketModal
+	bind:showGuestRsvpDialog
+	bind:showGuestTicketDialog
+	bind:showVenueOverview
+	bind:preSelectedTier
+	bind:selectedTierForGuest
+	bind:guestFocusSeating
 />
-
-<!-- My Ticket Modal -->
-{#if userTickets.length > 0}
-	<MyTicketModal
-		bind:open={showMyTicketModal}
-		tickets={userTickets}
-		eventName={event.name}
-		eventDate={event.start ? formatEventDate(event.start, event.timezone) : undefined}
-		eventLocation={formatEventLocation(event)}
-		onResumePayment={handleResumePayment}
-		isResumingPayment={resumePaymentMutation.isPending}
-		onCancelReservation={handleCancelReservation}
-		isCancellingReservation={cancelReservationMutation.isPending}
-		onTicketCancelled={async () => {
-			showMyTicketModal = false;
-			await refreshUserStatus();
-			queryClient.invalidateQueries({ queryKey: ['event-status', event.id] });
-		}}
-		onTicketRenamed={async () => {
-			await refreshUserStatus();
-			queryClient.invalidateQueries({ queryKey: ['event-status', event.id] });
-		}}
-	/>
-{/if}
-
-<!-- Guest RSVP Dialog -->
-{#if !data.isAuthenticated && event.can_attend_without_login && !event.requires_ticket}
-	<GuestRsvpDialog
-		bind:open={showGuestRsvpDialog}
-		eventId={event.id}
-		acceptsNotes={event.accept_rsvp_notes}
-		onClose={closeGuestRsvpDialog}
-		onSuccess={handleGuestAttendanceSuccess}
-	/>
-{/if}
-
-<!-- Whole-venue seating overview (map-first tier selection, #679) -->
-{#if hasSeatingMap}
-	<VenueOverviewDialog
-		bind:open={showVenueOverview}
-		eventId={event.id}
-		tiers={ticketTiers}
-		isAuthenticated={data.isAuthenticated}
-		canAttendWithoutLogin={event.can_attend_without_login}
-		{tierRemainingTickets}
-		eventMaxTicketsPerUser={event.max_tickets_per_user}
-		onSelectTier={handleSelectTier}
-		onGuestTierClick={openGuestTicketDialog}
-	/>
-{/if}
-
-<!-- Guest Ticket Dialog -->
-{#if !data.isAuthenticated && event.can_attend_without_login && event.requires_ticket && selectedTierForGuest}
-	{#key selectedTierForGuest.id}
-		<GuestTicketDialog
-			bind:open={showGuestTicketDialog}
-			eventId={event.id}
-			tier={selectedTierForGuest}
-			allTiers={ticketTiers}
-			eventMaxTicketsPerUser={event.max_tickets_per_user}
-			requireTicketNames={event.require_ticket_names}
-			onClose={closeGuestTicketDialog}
-			onSuccess={handleGuestAttendanceSuccess}
-			focusSeating={guestFocusSeating}
-			onSwitchTier={(tier) => {
-				selectedTierForGuest = tier;
-				showGuestTicketDialog = true;
-				guestFocusSeating = true;
-			}}
-		/>
-	{/key}
-{/if}

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -453,7 +453,6 @@
 								: undefined}
 							cart={data.isAuthenticated ? cart : undefined}
 							quickBuyDisabled={cartController.isPending}
-							requireTicketNames={event.require_ticket_names}
 							{eventRemaining}
 						/>
 					{/if}

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -35,7 +35,10 @@
 		hasAttendingSignal,
 		type EventTicketSchemaActual
 	} from '$lib/utils/eligibility';
-	import type { TierRemainingTicketsSchema } from '$lib/api/generated/types.gen';
+	import type {
+		TierRemainingTicketsSchema,
+		BuyerBillingInfoSchema
+	} from '$lib/api/generated/types.gen';
 	import { getPotluckPermissions } from '$lib/utils/permissions';
 	import { formatEventLocation } from '$lib/utils/event';
 	import { getUserRealName } from '$lib/utils/user-display';
@@ -45,8 +48,9 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { EventCart } from '$lib/components/tickets/cart.svelte';
 	import { cartTotal, cartTotalArgs } from '$lib/components/tickets/checkout-total';
-	import { buildCartItems } from '$lib/components/tickets/cart-payload';
+	import { buildCartItems, buildCartCheckoutParams } from '$lib/components/tickets/cart-payload';
 	import CartSummaryBar from '$lib/components/tickets/CartSummaryBar.svelte';
+	import CheckoutSheet from '$lib/components/tickets/CheckoutSheet.svelte';
 	import { createCartCheckoutController } from '$lib/components/events/cart-checkout-controller.svelte';
 	import { defaultGuestName } from '$lib/components/tickets/purchase-items';
 
@@ -259,16 +263,63 @@
 
 	const cartTotalDisplay = $derived(cartTotal(cart.groups.map(cartTotalArgs)));
 
+	// Checkout sheet (#853 PR 2): multi-tier carts and any require_ticket_names
+	// event route here for names/PWYC/discount/billing; single-tier carts on a
+	// no-names event skip it entirely (direct checkout below).
+	let showCheckoutSheet = $state(false);
+	let cartPurchaseError = $state<unknown>(null);
+
+	// Stranded-cart guard: a cart that empties out from under an open sheet
+	// (e.g. the last held seat expiring) must close it rather than show an
+	// empty checkout form.
+	$effect(() => {
+		if (cart.isEmpty) showCheckoutSheet = false;
+	});
+
+	// Closing the sheet (confirm, cancel, or the stranded-cart guard above)
+	// discards any inline purchase error — the next open starts clean.
+	$effect(() => {
+		if (!showCheckoutSheet) cartPurchaseError = null;
+	});
+
+	function buildCartCheckoutItems() {
+		return buildCartItems(cart.groups, {
+			requireTicketNames: event.require_ticket_names,
+			defaultName: defaultGuestName(ticketHolderDefaultName)
+		});
+	}
+
 	async function handleCartBuy() {
+		if (cart.needsSheet(event.require_ticket_names)) {
+			showCheckoutSheet = true;
+			return;
+		}
 		try {
-			await cartController.checkoutCart({
-				items: buildCartItems(cart.groups, {
-					requireTicketNames: event.require_ticket_names,
-					defaultName: defaultGuestName(ticketHolderDefaultName)
-				})
-			});
+			// '' / null keep the fingerprint byte-identical to PR 1's `{ items }`.
+			await cartController.checkoutCart(
+				buildCartCheckoutParams(buildCartCheckoutItems(), '', null)
+			);
 		} catch {
 			// error surfaced via controller toast
+		}
+	}
+
+	async function handleSheetConfirm({
+		discountCode,
+		billingInfo
+	}: {
+		discountCode: string;
+		billingInfo: BuyerBillingInfoSchema | null;
+	}) {
+		try {
+			await cartController.checkoutCart(
+				buildCartCheckoutParams(buildCartCheckoutItems(), discountCode, billingInfo)
+			);
+			showCheckoutSheet = false;
+		} catch (e) {
+			// Sheet stays open with the inline error; the controller's toast still
+			// fires too (accepted duplication — see task brief).
+			cartPurchaseError = e;
 		}
 	}
 
@@ -633,6 +684,23 @@
 		isFree={cart.paymentMethod === 'free'}
 		isPending={cartController.isPending}
 		onBuy={handleCartBuy}
+		onDiscountClick={() => {
+			showCheckoutSheet = true;
+		}}
+	/>
+
+	<CheckoutSheet
+		bind:open={showCheckoutSheet}
+		{cart}
+		eventId={event.id}
+		requireTicketNames={event.require_ticket_names}
+		isAuthenticated={data.isAuthenticated}
+		authToken={authStore.accessToken}
+		organizationSlug={event.organization.slug}
+		{initialDiscountCode}
+		isProcessing={cartController.isPending}
+		purchaseError={cartPurchaseError}
+		onConfirm={handleSheetConfirm}
 	/>
 {/if}
 

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -48,6 +48,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { EventCart } from '$lib/components/tickets/cart.svelte';
 	import { cartTotal, cartTotalArgs } from '$lib/components/tickets/checkout-total';
+	import { discountApplicable } from '$lib/components/tickets/cart-discount';
 	import { buildCartItems, buildCartCheckoutParams } from '$lib/components/tickets/cart-payload';
 	import CartSummaryBar from '$lib/components/tickets/CartSummaryBar.svelte';
 	import CheckoutSheet from '$lib/components/tickets/CheckoutSheet.svelte';
@@ -290,7 +291,9 @@
 	}
 
 	async function handleCartBuy() {
-		if (cart.needsSheet(event.require_ticket_names)) {
+		// A URL-seeded discount code needs the sheet too, even on a direct
+		// single-tier "Buy" — skipping straight to checkout would drop it.
+		if (cart.needsSheet(event.require_ticket_names) || initialDiscountCode) {
 			showCheckoutSheet = true;
 			return;
 		}
@@ -684,9 +687,11 @@
 		isFree={cart.paymentMethod === 'free'}
 		isPending={cartController.isPending}
 		onBuy={handleCartBuy}
-		onDiscountClick={() => {
-			showCheckoutSheet = true;
-		}}
+		onDiscountClick={cart.groups.some((g) => discountApplicable(g.tier))
+			? () => {
+					showCheckoutSheet = true;
+				}
+			: undefined}
 	/>
 
 	<CheckoutSheet

--- a/tests/e2e/journeys/j06-tickets/batch-purchase.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/batch-purchase.spec.ts
@@ -63,8 +63,8 @@ test.describe('J6 batch purchase @p3', () => {
 
 			// Take 2 of the 3 allowed — a second guest-name input appears.
 			await page.getByRole('button', { name: 'Increase quantity' }).click();
-			await expect(page.getByText('Ticket Holders', { exact: true })).toBeVisible();
-			await page.getByPlaceholder('Guest 2 name').fill('E2E Guest Two');
+			await expect(page.getByText('Ticket holder names', { exact: true })).toBeVisible();
+			await page.getByPlaceholder('Name for ticket 2').fill('E2E Guest Two');
 
 			const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
 			const claim = page.getByRole('button', { name: 'Claim Ticket', exact: true });

--- a/tests/e2e/journeys/j06-tickets/best-available.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/best-available.spec.ts
@@ -87,12 +87,12 @@ async function claimTwoBestAvailable(
 	// with the buyer's profile name but is re-filled when empty (defensive:
 	// canSubmit requires every name once quantity > 1).
 	await confirmDialog.getByRole('button', { name: 'Increase quantity' }).click();
-	await expect(confirmDialog.getByText('Ticket Holders', { exact: true })).toBeVisible();
-	const firstGuest = confirmDialog.getByPlaceholder('Your name');
+	await expect(confirmDialog.getByText('Ticket holder names', { exact: true })).toBeVisible();
+	const firstGuest = confirmDialog.getByPlaceholder('Name for ticket 1');
 	if ((await firstGuest.inputValue()).trim() === '') {
 		await firstGuest.fill('E2E Guest One');
 	}
-	await confirmDialog.getByPlaceholder('Guest 2 name').fill('E2E Guest Two');
+	await confirmDialog.getByPlaceholder('Name for ticket 2').fill('E2E Guest Two');
 
 	// Reserve: holds the best-available block, then the claim consumes it. On
 	// a retry the dialog releases the stale block first, so no holds leak.

--- a/tests/e2e/journeys/j06-tickets/cart-checkout-sheet.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/cart-checkout-sheet.spec.ts
@@ -1,0 +1,297 @@
+import { test, expect } from '../../support/fixtures';
+import {
+	createTicketedEvent,
+	createTicketTier,
+	createVerifiedUser,
+	deleteDefaultTier
+} from '../../support/factories';
+import { authenticateContext } from '../../support/session';
+import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
+import type { Browser } from '@playwright/test';
+
+// #853 (PR 2) — checkout sheet: the multi-group dialog that opens instead of
+// a direct checkout whenever the cart needs input the steppers alone can't
+// collect (`EventCart.needsSheet` — ticket-holder names on a
+// require_ticket_names event, or a PWYC amount). PR 2 widened
+// `quickBuyEligible` so PWYC and names-required tiers ALSO render a stepper
+// (cart-quick-buy.spec.ts covers the no-sheet path for plain fixed-price
+// tiers); the sheet is where those tiers actually get bought.
+//
+// All three scenarios use payment_method 'offline' — PENDING tickets + a
+// "reserved" toast, no Stripe round-trip (same rationale as
+// cart-quick-buy.spec.ts: 'at_the_door' skips the pending gate entirely, and
+// Stripe/online is PR 4's payment matrix).
+//
+// Isolation: each test API-arranges its own event + tiers + throwaway buyer.
+
+async function openBuyerPage(browser: Browser, path: string) {
+	const buyer = await createVerifiedUser('CartCheckoutSheet');
+	const context = await browser.newContext();
+	await authenticateContext(context, buyer);
+	const page = await context.newPage();
+	await gotoHydrated(page, path);
+	await waitForClientAuth(page);
+	return { context, page };
+}
+
+test.describe('J6 cart checkout sheet @p1', () => {
+	test('names-required cart: blank submit is blocked, filled names reserve two tickets', async ({
+		browser
+	}) => {
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: { require_ticket_names: true }
+		});
+		await deleteDefaultTier(event.id); // its card also has a stepper
+
+		const tier = await createTicketTier(event.id, {
+			name: 'Named Entry',
+			payment_method: 'offline',
+			price: '10.00',
+			price_type: 'fixed',
+			seat_assignment_mode: 'none',
+			total_quantity: 50
+		});
+
+		const { context, page } = await openBuyerPage(browser, event.path);
+
+		const stepper = page.getByRole('group', { name: `Quantity for ${tier.name}` });
+		const addButton = stepper.getByRole('button', { name: `Add one ${tier.name}` });
+
+		await addButton.click();
+		await expect(stepper.getByRole('button', { name: `Remove one ${tier.name}` })).toBeEnabled();
+		await addButton.click();
+		await expect(stepper.locator('span[aria-live="polite"]')).toHaveText('2');
+
+		const summaryBar = page.getByTestId('cart-summary-bar');
+		await summaryBar.getByRole('button', { name: 'Buy', exact: true }).click();
+
+		// Checkout sheet opens instead of a direct checkout — this cart needs
+		// per-ticket holder names.
+		const sheet = page.getByRole('dialog', { name: 'Checkout' });
+		await expect(sheet).toBeVisible();
+
+		const confirmButton = sheet.getByRole('button', { name: 'Reserve', exact: true });
+		const nameError = sheet.getByText('Please enter a name for every ticket');
+		const name1 = sheet.getByLabel('Name for ticket 1');
+		const name2 = sheet.getByLabel('Name for ticket 2');
+		await expect(name1).toBeVisible();
+		await expect(name2).toBeVisible();
+
+		// Blank state: the sheet starts with no names entered, so the footer's
+		// nameRequired hint is already up and the confirm button is disabled —
+		// there is no way to submit a blank cart.
+		await expect(nameError).toBeVisible();
+		await expect(confirmButton).toBeDisabled();
+
+		// Filling only one of the two still leaves the cart invalid.
+		await name1.fill('Ada Lovelace');
+		await expect(nameError).toBeVisible();
+		await expect(confirmButton).toBeDisabled();
+
+		// Both filled: the hint clears and the confirm button unlocks.
+		await name2.fill('Grace Hopper');
+		await expect(nameError).toBeHidden();
+		await expect(confirmButton).toBeEnabled();
+
+		await confirmButton.click();
+
+		// "Reserved" toast — offline creates PENDING tickets directly.
+		await expect(page.getByText(/reserved/i)).toBeVisible({ timeout: 10_000 });
+
+		// Sheet closes and the my-ticket modal auto-opens with both tickets.
+		await expect(sheet).toBeHidden({ timeout: 8_000 });
+		const modal = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+		await expect(modal).toBeVisible({ timeout: 8_000 });
+		await expect(modal.getByText('2 pending payment')).toBeVisible();
+		await expect(modal.getByText('Ticket 1 of 2')).toBeVisible();
+
+		// Cart cleared: the summary bar disappears once the purchase completes.
+		await page.keyboard.press('Escape');
+		await expect(summaryBar).toBeHidden();
+
+		await context.close();
+	});
+
+	test('PWYC + flat mixed cart: invalid amount blocks confirm, footer totals the mix', async ({
+		browser
+	}) => {
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: { require_ticket_names: false }
+		});
+		await deleteDefaultTier(event.id);
+
+		const pwycTier = await createTicketTier(event.id, {
+			name: 'Sheet PWYC',
+			payment_method: 'offline',
+			price_type: 'pwyc',
+			price: '5.00',
+			pwyc_min: '5.00',
+			pwyc_max: '50.00',
+			seat_assignment_mode: 'none',
+			total_quantity: 50
+		});
+		const flatTier = await createTicketTier(event.id, {
+			name: 'Sheet Flat',
+			payment_method: 'offline',
+			price: '12.00',
+			price_type: 'fixed',
+			seat_assignment_mode: 'none',
+			total_quantity: 50
+		});
+
+		const { context, page } = await openBuyerPage(browser, event.path);
+
+		const pwycStepper = page.getByRole('group', { name: `Quantity for ${pwycTier.name}` });
+		const flatStepper = page.getByRole('group', { name: `Quantity for ${flatTier.name}` });
+		await pwycStepper.getByRole('button', { name: `Add one ${pwycTier.name}` }).click();
+		await expect(pwycStepper.locator('span[aria-live="polite"]')).toHaveText('1');
+		await flatStepper.getByRole('button', { name: `Add one ${flatTier.name}` }).click();
+		await expect(flatStepper.locator('span[aria-live="polite"]')).toHaveText('1');
+
+		const summaryBar = page.getByTestId('cart-summary-bar');
+		await summaryBar.getByRole('button', { name: 'Buy', exact: true }).click();
+
+		const sheet = page.getByRole('dialog', { name: 'Checkout' });
+		await expect(sheet).toBeVisible();
+
+		const confirmButton = sheet.getByRole('button', { name: 'Reserve', exact: true });
+		const amountInput = sheet.getByLabel('Payment Amount');
+
+		// Empty PWYC amount blocks confirm from the start (no separate submit
+		// click is needed to surface the footer hint).
+		await expect(confirmButton).toBeDisabled();
+
+		// Below the tier's minimum (5.00) — still blocked, with the precise
+		// min-amount hint in the footer.
+		await amountInput.fill('2');
+		await expect(sheet.getByText('Minimum amount is EUR 5.00')).toBeVisible();
+		await expect(confirmButton).toBeDisabled();
+
+		// A valid amount unblocks confirm and the footer totals the mix:
+		// 10.00 (PWYC) + 12.00 (flat) = 22.00.
+		await amountInput.fill('10');
+		await expect(sheet.getByText('Minimum amount is EUR 5.00')).toBeHidden();
+		await expect(confirmButton).toBeEnabled();
+		// Scoped to the footer's "Total" row specifically — the dialog
+		// description above it renders the same total inline, and an
+		// unscoped text match would hit both.
+		const footerTotal = sheet.locator('p', { hasText: 'Total' });
+		await expect(footerTotal).toContainText('€22.00');
+
+		await confirmButton.click();
+
+		await expect(page.getByText(/reserved/i)).toBeVisible({ timeout: 10_000 });
+		await expect(sheet).toBeHidden({ timeout: 8_000 });
+		const modal = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+		await expect(modal).toBeVisible({ timeout: 8_000 });
+		await expect(modal.getByText('2 pending payment')).toBeVisible();
+		await expect(modal.getByText('Ticket 1 of 2')).toBeVisible();
+
+		await page.keyboard.press('Escape');
+		await expect(summaryBar).toBeHidden();
+
+		await context.close();
+	});
+
+	// No discount-code-creation factory exists yet (checked: `grep -rl
+	// "discount" tests/e2e` finds only discount-lifecycle.spec.ts, which
+	// creates its code through the admin UI, not an API factory) — this
+	// exercises the "code doesn't match anything" path with a bogus code
+	// instead of a real applied discount. COVERAGE GAP: the positive
+	// discount-applies path (cartSheet.discountApplies + a discounted footer
+	// total) is untested here; add it once an API discount-code factory
+	// exists.
+	test('discount feedback: bogus code reports per-group results, confirm still charges full price', async ({
+		browser
+	}) => {
+		const event = await createTicketedEvent({
+			freeTier: false,
+			event: { require_ticket_names: false }
+		});
+		await deleteDefaultTier(event.id);
+
+		// Discount-applicable: flat-priced, paid, unseated.
+		const flatTier = await createTicketTier(event.id, {
+			name: 'Discount Flat',
+			payment_method: 'offline',
+			price: '20.00',
+			price_type: 'fixed',
+			seat_assignment_mode: 'none',
+			total_quantity: 50
+		});
+		// NOT discount-applicable: PWYC tiers are excluded regardless of code
+		// (cart-discount.ts's discountApplicable).
+		const pwycTier = await createTicketTier(event.id, {
+			name: 'Discount Pwyc',
+			payment_method: 'offline',
+			price_type: 'pwyc',
+			price: '5.00',
+			pwyc_min: '5.00',
+			pwyc_max: '50.00',
+			seat_assignment_mode: 'none',
+			total_quantity: 50
+		});
+
+		const { context, page } = await openBuyerPage(browser, event.path);
+
+		const flatStepper = page.getByRole('group', { name: `Quantity for ${flatTier.name}` });
+		const pwycStepper = page.getByRole('group', { name: `Quantity for ${pwycTier.name}` });
+		await flatStepper.getByRole('button', { name: `Add one ${flatTier.name}` }).click();
+		await expect(flatStepper.locator('span[aria-live="polite"]')).toHaveText('1');
+		await pwycStepper.getByRole('button', { name: `Add one ${pwycTier.name}` }).click();
+		await expect(pwycStepper.locator('span[aria-live="polite"]')).toHaveText('1');
+
+		const summaryBar = page.getByTestId('cart-summary-bar');
+		await summaryBar.getByRole('button', { name: 'Buy', exact: true }).click();
+
+		const sheet = page.getByRole('dialog', { name: 'Checkout' });
+		await expect(sheet).toBeVisible();
+
+		// Fill the PWYC amount first so the discount round-trip below isn't
+		// confounded by the unrelated PWYC validation gate.
+		await sheet.getByLabel('Payment Amount').fill('10');
+
+		// Open the discount accordion and apply a bogus code.
+		await sheet.getByRole('button', { name: 'Discount code' }).click();
+		const discountInput = sheet.getByRole('textbox', { name: 'Discount code' });
+		await discountInput.fill('NOPECODE99');
+		await sheet.getByRole('button', { name: 'Apply' }).click();
+
+		// Per-group feedback, scoped to the discount results' single
+		// aria-live="polite" region: the applicable flat tier gets the
+		// backend's "invalid code" message, the PWYC tier gets the
+		// not-applicable message — proving the fan-out is genuinely per-tier,
+		// not a single cart-wide verdict.
+		const results = sheet.locator('[aria-live="polite"]');
+		await expect(results.locator('p', { hasText: flatTier.name })).toContainText(
+			/invalid discount code/i,
+			{ timeout: 10_000 }
+		);
+		await expect(results.locator('p', { hasText: pwycTier.name })).toContainText(
+			"Doesn't apply to this ticket type"
+		);
+
+		// No discount applied: confirm is still allowed, at the full
+		// undiscounted total (20.00 flat + 10.00 PWYC = 30.00).
+		const confirmButton = sheet.getByRole('button', { name: 'Reserve', exact: true });
+		await expect(confirmButton).toBeEnabled();
+		const footerTotal = sheet.locator('p', { hasText: 'Total' });
+		await expect(footerTotal).toContainText('€30.00');
+
+		await confirmButton.click();
+
+		await expect(page.getByText(/reserved/i)).toBeVisible({ timeout: 10_000 });
+		await expect(sheet).toBeHidden({ timeout: 8_000 });
+		const modal = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
+		await expect(modal).toBeVisible({ timeout: 8_000 });
+		await expect(modal.getByText('2 pending payment')).toBeVisible();
+		await expect(modal.getByText('Ticket 1 of 2')).toBeVisible();
+
+		await page.keyboard.press('Escape');
+		await expect(summaryBar).toBeHidden();
+
+		await context.close();
+	});
+});

--- a/tests/e2e/journeys/j06-tickets/cart-checkout-sheet.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/cart-checkout-sheet.spec.ts
@@ -163,16 +163,23 @@ test.describe('J6 cart checkout sheet @p1', () => {
 		// click is needed to surface the footer hint).
 		await expect(confirmButton).toBeDisabled();
 
-		// Below the tier's minimum (5.00) — still blocked, with the precise
-		// min-amount hint in the footer.
+		// Below the tier's minimum (5.00) — still blocked. Both the field's own
+		// live error (PwycInput, role="alert") and the footer's precise hint
+		// (a plain, non-alert paragraph) show the same text.
 		await amountInput.fill('2');
-		await expect(sheet.getByText('Minimum amount is EUR 5.00')).toBeVisible();
+		const inlineError = sheet.getByRole('alert');
+		const footerHint = sheet.locator('p:not([role="alert"])', {
+			hasText: 'Minimum amount is EUR 5.00'
+		});
+		await expect(inlineError).toHaveText('Minimum amount is EUR 5.00');
+		await expect(footerHint).toBeVisible();
 		await expect(confirmButton).toBeDisabled();
 
 		// A valid amount unblocks confirm and the footer totals the mix:
 		// 10.00 (PWYC) + 12.00 (flat) = 22.00.
 		await amountInput.fill('10');
-		await expect(sheet.getByText('Minimum amount is EUR 5.00')).toBeHidden();
+		await expect(inlineError).toBeHidden();
+		await expect(footerHint).toBeHidden();
 		await expect(confirmButton).toBeEnabled();
 		// Scoped to the footer's "Total" row specifically — the dialog
 		// description above it renders the same total inline, and an

--- a/tests/e2e/journeys/j06-tickets/nameless-checkout.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/nameless-checkout.spec.ts
@@ -76,10 +76,11 @@ test.describe('J6 nameless checkout @p1', () => {
 			await page.getByRole('button', { name: 'Increase quantity' }).click();
 			await expect(page.getByRole('button', { name: 'Decrease quantity' })).toBeEnabled();
 
-			// With names required this would now reveal the "Ticket Holders" block
-			// and a "Guest 2 name" input — with the flag off neither may appear.
-			await expect(page.getByText('Ticket Holders', { exact: true })).toBeHidden();
-			await expect(page.getByPlaceholder('Guest 2 name')).toBeHidden();
+			// With names required this would now reveal the "Ticket holder names"
+			// block and a "Name for ticket 2" input — with the flag off neither may
+			// appear.
+			await expect(page.getByText('Ticket holder names', { exact: true })).toBeHidden();
+			await expect(page.getByPlaceholder('Name for ticket 2')).toBeHidden();
 
 			// `exact` matters: a substring match on "Your Ticket" also hits the
 			// "Select Your Ticket" tier dialog.

--- a/tests/e2e/journeys/j06-tickets/venue-overview.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/venue-overview.spec.ts
@@ -280,8 +280,8 @@ test.describe('J6 map-first venue overview @p2', () => {
 			await expect(confirmDialog.getByText('2 / 2 selected')).toBeVisible();
 
 			// Reserve to success — the adopted holds become the tickets' seats.
-			await confirmDialog.getByPlaceholder('Your name').fill('Seat Buyer');
-			await confirmDialog.getByPlaceholder('Guest 2 name').fill('Plus One');
+			await confirmDialog.getByPlaceholder('Name for ticket 1').fill('Seat Buyer');
+			await confirmDialog.getByPlaceholder('Name for ticket 2').fill('Plus One');
 			const success = page.getByRole('dialog', { name: 'Your Ticket', exact: true });
 			await expect(async () => {
 				if (await success.isVisible()) return;

--- a/tests/e2e/journeys/j08-org-owner/seating-self-service.spec.ts
+++ b/tests/e2e/journeys/j08-org-owner/seating-self-service.spec.ts
@@ -307,12 +307,12 @@ async function claimTwoBestAvailableFree(
 	// with the buyer's profile name but re-filled when empty (canSubmit requires
 	// every name once quantity > 1).
 	await confirmDialog.getByRole('button', { name: 'Increase quantity' }).click();
-	await expect(confirmDialog.getByText('Ticket Holders', { exact: true })).toBeVisible();
-	const firstGuest = confirmDialog.getByPlaceholder('Your name');
+	await expect(confirmDialog.getByText('Ticket holder names', { exact: true })).toBeVisible();
+	const firstGuest = confirmDialog.getByPlaceholder('Name for ticket 1');
 	if ((await firstGuest.inputValue()).trim() === '') {
 		await firstGuest.fill('E2E Guest One');
 	}
-	await confirmDialog.getByPlaceholder('Guest 2 name').fill('E2E Guest Two');
+	await confirmDialog.getByPlaceholder('Name for ticket 2').fill('E2E Guest Two');
 
 	// Claim: holds the best-available block, then the claim consumes it. On a
 	// retry the dialog releases the stale block first, so no holds leak.


### PR DESCRIPTION
Part of #853 — PR 2 of 4 on `feature/cart-checkout`.

## What this ships

**Quick-buy steppers now cover ALL non-seated tiers** (PWYC and names-required included — and note `require_ticket_names` defaults true server-side, so this is the dominant path), backed by the new **checkout sheet**: one skippable dialog collecting per-ticket names, per-group PWYC amounts (each with its own min/max validation), a cart-level discount code with honest per-group applicability feedback, and billing with a multi-item VAT preview. An authenticated no-input cart still goes straight from Buy to checkout; the sticky bar gains a "Discount code?" entry point (shown only when a group can actually be discounted).

- Discount feedback fans out N tier-scoped `validate-discount` calls (no cart endpoint exists); three honest states per group: applies / server-says-invalid / couldn't-check (transport failure keeps the code applied — server re-validates at checkout).
- Fingerprint-safe params builder: the direct path's resume fingerprint stays byte-identical to PR 1's.
- Per-group input state lives on the cart store (survives sheet close); `EventPurchaseDialogs` extraction bought the page headroom (741→746/750 after wiring).
- i18n: `cartSheet.*` in all six locales; inputs got id-prefixes (unique DOM ids per group) and lost their hardcoded English.

## Spec deviations (ruled during execution)

- `TicketConfirmationDialog` is NOT deleted here (spec §6 said PR 2) — seated tiers need it until PR 3; it now sits at exactly 750/750.
- `TicketTierModal` untouched (legacy path until PR 3).
- Spec §5's 404 "drop vanished groups" treatment still deferred (honest refresh copy meanwhile).

## Test evidence

`make check` clean; unit 3130 passed; **full j06+j08 E2E: 126 passed / 0 skipped**, with 2 pre-existing `self-cancel.spec.ts` failures (Stripe webhook timing — no `stripe listen` in the E2E env; verified isolated from this diff). The final-review fix wave repaired four sibling specs broken by the i18n copy change and re-armed `nameless-checkout.spec.ts`'s discriminating locators — full-suite E2E is now a hard gate for PRs 3–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016E4XJLoiiYVTjaadaMsfgp
