### PR TITLE
fix(cart): use live auth truth for checkout branching after mid-page sign-in (#853)

### DIFF
--- a/src/lib/components/events/cart-purchase-flow.svelte.ts
+++ b/src/lib/components/events/cart-purchase-flow.svelte.ts
@@ -144,9 +144,11 @@ export function createCartPurchaseFlow(deps: CartPurchaseFlowDeps) {
 	// wiped a real authenticated buyer's cart. See `sign-in-detector.ts` for
 	// the fixed state machine and its tests.
 	//
-	// Beyond clearing the anonymous cart, the same one-shot transition flips
-	// `liveAuth.isAuthenticated` permanently (monotonic: SSR `true`, OR a
-	// sign-in was observed) — the checkout branching below (`handleCartBuy`'s
+	// Beyond clearing the anonymous cart, the same one-shot transition raises
+	// `liveAuth.isAuthenticated` (SSR `true`, OR a sign-in was observed —
+	// lowered again only by a real in-place logout after the live store
+	// confirmed a session; see live-auth.svelte.ts) — the checkout branching
+	// below (`handleCartBuy`'s
 	// `needsSheet`, `handleSheetConfirm`'s authed-vs-guest controller pick)
 	// and the page's CheckoutSheet props read THAT, never the captured SSR
 	// value, so a re-built cart after a mid-page sign-in checks out
@@ -279,9 +281,10 @@ export function createCartPurchaseFlow(deps: CartPurchaseFlowDeps) {
 		get isProcessing() {
 			return cartController.isPending || guestCartController.isPending || holdingSeats;
 		},
-		/** Monotonic live truth (SSR seed OR observed sign-in) — what the
-		 * CheckoutSheet props and all checkout branching must read, never the
-		 * static `data.isAuthenticated`. */
+		/** Live truth (SSR seed OR observed sign-in, lowered by an in-place
+		 * logout after session confirmation — see live-auth.svelte.ts) — what
+		 * the CheckoutSheet props and all checkout branching must read, never
+		 * the static `data.isAuthenticated`. */
 		get isAuthenticated() {
 			return liveAuth.isAuthenticated;
 		},

--- a/src/lib/components/events/cart-purchase-flow.svelte.ts
+++ b/src/lib/components/events/cart-purchase-flow.svelte.ts
@@ -27,15 +27,16 @@ import { defaultGuestName } from '../tickets/purchase-items';
 import * as cartBaHolds from '../tickets/cart-ba-holds';
 import { createCartCheckoutController } from './cart-checkout-controller.svelte';
 import { createGuestCartCheckoutController } from './guest-cart-checkout-controller.svelte';
-import { createSignInDetector } from './sign-in-detector';
+import { createLiveAuth } from './live-auth.svelte';
 
 export interface CartPurchaseFlowDeps {
 	event: EventDetailSchema;
 	eventId: string;
 	queryClient: QueryClient;
 	/** The trustworthy per-request SSR truth (`data.isAuthenticated`) — static
-	 * for the page's lifetime; see the login-mid-cart effect below for why the
-	 * live `authStore` is read separately rather than used here. */
+	 * for the page's lifetime, used only to SEED the flow's live auth state;
+	 * see the login-mid-cart effect below for why the live `authStore` is
+	 * read separately rather than used here. */
 	isAuthenticated: boolean;
 	cart: EventCart;
 	registry: CartSeatHoldRegistry;
@@ -129,22 +130,34 @@ export function createCartPurchaseFlow(deps: CartPurchaseFlowDeps) {
 	// `/login` in another tab, or client-side navigation back to this page)
 	// while cart items and a guest identity are still in memory — those were
 	// priced/held under the anonymous identity and must not silently carry
-	// over to the new authenticated one. `createSignInDetector` (pure, unit
-	// tested) is seeded from `isAuthenticated` (the trustworthy per-request
-	// SSR truth) and reports a genuine false→true transition on the LIVE
-	// `authStore` exactly once — critically, it does NOT fire on the client
-	// auth store's bootstrap-gate catch-up (auth.svelte.ts), which can observe
-	// `authStore.isAuthenticated === false` on this effect's first several
-	// runs even for an already-authenticated visitor. An earlier version of
-	// this guard wrote `wasAuthenticated = nowAuthenticated` unconditionally,
-	// which let that stale bootstrap `false` clobber the `true` SSR seed —
-	// the eventual bootstrap resolution then looked exactly like a guest
-	// signing in and wiped a real authenticated buyer's cart. See
-	// `sign-in-detector.ts` for the fixed state machine and its tests.
-	const signInDetector = createSignInDetector(isAuthenticated);
+	// over to the new authenticated one. `createLiveAuth` (unit tested) wraps
+	// `createSignInDetector`, which is seeded from `isAuthenticated` (the
+	// trustworthy per-request SSR truth) and reports a genuine false→true
+	// transition on the LIVE `authStore` exactly once — critically, it does
+	// NOT fire on the client auth store's bootstrap-gate catch-up
+	// (auth.svelte.ts), which can observe `authStore.isAuthenticated ===
+	// false` on this effect's first several runs even for an
+	// already-authenticated visitor. An earlier version of this guard wrote
+	// `wasAuthenticated = nowAuthenticated` unconditionally, which let that
+	// stale bootstrap `false` clobber the `true` SSR seed — the eventual
+	// bootstrap resolution then looked exactly like a guest signing in and
+	// wiped a real authenticated buyer's cart. See `sign-in-detector.ts` for
+	// the fixed state machine and its tests.
+	//
+	// Beyond clearing the anonymous cart, the same one-shot transition flips
+	// `liveAuth.isAuthenticated` permanently (monotonic: SSR `true`, OR a
+	// sign-in was observed) — the checkout branching below (`handleCartBuy`'s
+	// `needsSheet`, `handleSheetConfirm`'s authed-vs-guest controller pick)
+	// and the page's CheckoutSheet props read THAT, never the captured SSR
+	// value, so a re-built cart after a mid-page sign-in checks out
+	// authenticated instead of as a stale guest (#863 review). `observe` is
+	// called exactly once per effect run — the detector's result must never
+	// be consumed twice — and the flip happens regardless of cart emptiness,
+	// while the cart-clearing branch keeps its non-empty condition.
+	const liveAuth = createLiveAuth(isAuthenticated);
 	$effect(() => {
-		const nowAuthenticated = authStore.isAuthenticated;
-		if (signInDetector.check(nowAuthenticated) && !cart.isEmpty) {
+		const justSignedIn = liveAuth.observe(authStore.isAuthenticated);
+		if (justSignedIn && !cart.isEmpty) {
 			// Bare-client release FIRST: the anonymous-cookie identity, not the
 			// new Bearer token, owns these holds (see seat-holds.ts's module
 			// doc) — releasing after `cart.clear()` would let the per-group
@@ -187,9 +200,10 @@ export function createCartPurchaseFlow(deps: CartPurchaseFlowDeps) {
 		// single-tier "Buy" — skipping straight to checkout would drop it.
 		// `needsSheet` is unconditionally true for a guest (identity has nowhere
 		// else to go), so this only ever short-circuits to checkout for an
-		// authenticated buyer.
+		// authenticated buyer. Live truth, not the captured SSR value: a buyer
+		// who signed in mid-page must not be forced through the guest sheet.
 		if (
-			cart.needsSheet(event.require_ticket_names, !isAuthenticated) ||
+			cart.needsSheet(event.require_ticket_names, !liveAuth.isAuthenticated) ||
 			deps.getInitialDiscountCode()
 		) {
 			showCheckoutSheet = true;
@@ -219,7 +233,10 @@ export function createCartPurchaseFlow(deps: CartPurchaseFlowDeps) {
 		// controller's own toast fires too. The guest branch's `message`
 		// response closes the sheet itself (`onEmailConfirmationPending`) before
 		// `submitCart` resolves, so the `ok`-guarded close below is a no-op then.
-		const ok = isAuthenticated
+		// Live truth: after a mid-page sign-in a re-built cart must check out
+		// via the authed controller, never `/checkout/public` with the cleared
+		// guest identity.
+		const ok = liveAuth.isAuthenticated
 			? await cartBaHolds.submitCart(
 					buildCartCheckoutParams(items, discountCode, billingInfo),
 					cartSubmitDeps,
@@ -261,6 +278,12 @@ export function createCartPurchaseFlow(deps: CartPurchaseFlowDeps) {
 		},
 		get isProcessing() {
 			return cartController.isPending || guestCartController.isPending || holdingSeats;
+		},
+		/** Monotonic live truth (SSR seed OR observed sign-in) — what the
+		 * CheckoutSheet props and all checkout branching must read, never the
+		 * static `data.isAuthenticated`. */
+		get isAuthenticated() {
+			return liveAuth.isAuthenticated;
 		},
 		handleCartBuy,
 		handleSheetConfirm

--- a/src/lib/components/events/live-auth.svelte.test.ts
+++ b/src/lib/components/events/live-auth.svelte.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { createLiveAuth } from './live-auth.svelte';
+
+describe('createLiveAuth', () => {
+	it('seeded true: authenticated from the start, and bootstrap false reads never lower it', () => {
+		// SSR-authenticated visitor whose client auth store hasn't hydrated yet:
+		// the first several observations of the live store read false.
+		const auth = createLiveAuth(true);
+
+		expect(auth.isAuthenticated).toBe(true);
+		expect(auth.observe(false)).toBe(false);
+		expect(auth.isAuthenticated).toBe(true);
+		expect(auth.observe(false)).toBe(false);
+		// Bootstrap resolves — not a sign-in.
+		expect(auth.observe(true)).toBe(false);
+		expect(auth.isAuthenticated).toBe(true);
+	});
+
+	it('seeded false: stays guest until a genuine sign-in, then flips authenticated', () => {
+		const auth = createLiveAuth(false);
+
+		expect(auth.isAuthenticated).toBe(false);
+		expect(auth.observe(false)).toBe(false);
+		expect(auth.isAuthenticated).toBe(false);
+
+		// Genuine mid-cart sign-in: observe reports it, and from this point on
+		// every checkout decision must treat the buyer as authenticated.
+		expect(auth.observe(true)).toBe(true);
+		expect(auth.isAuthenticated).toBe(true);
+	});
+
+	it('reports the sign-in transition exactly once (no double consumption)', () => {
+		const auth = createLiveAuth(false);
+
+		expect(auth.observe(true)).toBe(true);
+		expect(auth.observe(true)).toBe(false);
+		expect(auth.observe(true)).toBe(false);
+		expect(auth.isAuthenticated).toBe(true);
+	});
+
+	it('is monotonic: a later false observation (logout without reload) never lowers it', () => {
+		const auth = createLiveAuth(false);
+
+		expect(auth.observe(true)).toBe(true);
+		// Flap back to false and true again — the detector stays quiet and the
+		// live flag never drops (the page's SSR data is stale either way; a
+		// signed-out buyer gets fresh truth on the next navigation/reload).
+		expect(auth.observe(false)).toBe(false);
+		expect(auth.isAuthenticated).toBe(true);
+		expect(auth.observe(true)).toBe(false);
+		expect(auth.isAuthenticated).toBe(true);
+	});
+
+	it('seeded true: staying true from the very first observation never fires', () => {
+		const auth = createLiveAuth(true);
+
+		expect(auth.observe(true)).toBe(false);
+		expect(auth.observe(true)).toBe(false);
+		expect(auth.isAuthenticated).toBe(true);
+	});
+});

--- a/src/lib/components/events/live-auth.svelte.test.ts
+++ b/src/lib/components/events/live-auth.svelte.test.ts
@@ -38,16 +38,44 @@ describe('createLiveAuth', () => {
 		expect(auth.isAuthenticated).toBe(true);
 	});
 
-	it('is monotonic: a later false observation (logout without reload) never lowers it', () => {
+	it('lowers on a false observed AFTER the live store confirmed a session (#869 review)', () => {
+		// authStore.logout() runs in place on refresh failure or impersonation
+		// expiry, without navigating — the page stays mounted with no token. A
+		// false read after a confirmed true is that logout, not bootstrap
+		// noise, and checkout branching must stop claiming authenticated (or
+		// confirm submits to the authed endpoint with no Authorization header).
 		const auth = createLiveAuth(false);
 
 		expect(auth.observe(true)).toBe(true);
-		// Flap back to false and true again — the detector stays quiet and the
-		// live flag never drops (the page's SSR data is stale either way; a
-		// signed-out buyer gets fresh truth on the next navigation/reload).
 		expect(auth.observe(false)).toBe(false);
-		expect(auth.isAuthenticated).toBe(true);
+		expect(auth.isAuthenticated).toBe(false);
+
+		// A later sign-in raises it again (the one-shot transition report
+		// stays once-ever — only isAuthenticated recovers).
 		expect(auth.observe(true)).toBe(false);
+		expect(auth.isAuthenticated).toBe(true);
+	});
+
+	it('seeded true: an in-place logout after bootstrap catch-up lowers it (#869 review)', () => {
+		const auth = createLiveAuth(true);
+
+		expect(auth.observe(false)).toBe(false); // bootstrap noise
+		expect(auth.observe(true)).toBe(false); // catch-up: session confirmed
+		expect(auth.isAuthenticated).toBe(true);
+
+		expect(auth.observe(false)).toBe(false); // real logout
+		expect(auth.isAuthenticated).toBe(false);
+	});
+
+	it('seeded true: a store that NEVER confirms keeps the seed (matches every other SSR read)', () => {
+		// Bootstrap-refresh failure: the live store never reaches true. Every
+		// false read is indistinguishable from bootstrap noise, so the SSR
+		// seed stands — the same stale-true the rest of the page's
+		// data.isAuthenticated reads have (pre-existing, out of scope).
+		const auth = createLiveAuth(true);
+
+		expect(auth.observe(false)).toBe(false);
+		expect(auth.observe(false)).toBe(false);
 		expect(auth.isAuthenticated).toBe(true);
 	});
 

--- a/src/lib/components/events/live-auth.svelte.ts
+++ b/src/lib/components/events/live-auth.svelte.ts
@@ -9,10 +9,19 @@
  *
  * This wraps `createSignInDetector` (which reports the genuine false→true
  * transition exactly once, immune to the auth-store bootstrap catch-up — see
- * its module doc) with a monotonic, reactive `isAuthenticated`: SSR-seeded
- * `true`, OR the detector has fired. It never lowers on a later `false`
- * observation — the page's SSR data is stale after any mid-page auth change,
- * and a signed-out buyer gets fresh truth on the next navigation/reload.
+ * its module doc) with a reactive `isAuthenticated`: SSR-seeded `true`, OR
+ * the detector has fired. The seed survives bootstrap noise (`false` reads
+ * before the live store hydrates), but a `false` observed AFTER the live
+ * store has confirmed a session is a real in-place logout —
+ * `authStore.logout()` runs without navigating on refresh failure and
+ * impersonation-token expiry — and lowers the value, so confirm can't submit
+ * to the authenticated endpoint with no token (#869 review). A store that
+ * never confirms keeps the seed: that read is indistinguishable from
+ * bootstrap noise, and matches every other `data.isAuthenticated` read on
+ * the page. A sign-in after a lowering raises `isAuthenticated` again, but
+ * the one-shot transition report stays once-ever (the clear-anonymous-cart
+ * branch fires only on the FIRST sign-in — a guest cart rebuilt after a
+ * logout-then-relogin on the same mounted page is a residual edge).
  *
  * `observe()` forwards the detector's one-shot result so the caller's effect
  * can also run the clear-anonymous-cart branch off the SAME check — the
@@ -21,12 +30,12 @@
 import { createSignInDetector } from './sign-in-detector';
 
 export interface LiveAuth {
-	/** Monotonic live truth: seeded SSR `true`, or a sign-in was observed. */
+	/** Live truth: seeded SSR `true` or an observed sign-in, lowered again by
+	 * a `false` observed after the live store confirmed a session. */
 	readonly isAuthenticated: boolean;
 	/**
 	 * Call on every observation of the live auth store. Returns `true` exactly
-	 * once, on the genuine false→true transition (the detector's contract);
-	 * flips `isAuthenticated` permanently at that moment.
+	 * once, on the genuine false→true transition (the detector's contract).
 	 */
 	observe(nowAuthenticated: boolean): boolean;
 }
@@ -34,14 +43,26 @@ export interface LiveAuth {
 export function createLiveAuth(seededAuthenticated: boolean): LiveAuth {
 	const detector = createSignInDetector(seededAuthenticated);
 	let sawSignIn = $state(false);
+	// The live store confirmed a session at least once — from then on a false
+	// read is a real logout, not bootstrap noise. Plain field: only ever read
+	// inside observe(), never from a reactive context.
+	let sessionConfirmed = false;
+	let signedOut = $state(false);
 
 	return {
 		get isAuthenticated() {
+			if (signedOut) return false;
 			return seededAuthenticated || sawSignIn;
 		},
 		observe(nowAuthenticated: boolean): boolean {
 			const justSignedIn = detector.check(nowAuthenticated);
 			if (justSignedIn) sawSignIn = true;
+			if (nowAuthenticated) {
+				sessionConfirmed = true;
+				signedOut = false;
+			} else if (sessionConfirmed) {
+				signedOut = true;
+			}
 			return justSignedIn;
 		}
 	};

--- a/src/lib/components/events/live-auth.svelte.ts
+++ b/src/lib/components/events/live-auth.svelte.ts
@@ -1,0 +1,48 @@
+/**
+ * Live authentication truth for the cart purchase flow (#853, Copilot finding
+ * on #863). The page's SSR `data.isAuthenticated` is a trustworthy per-request
+ * seed but static for the page's lifetime — a guest who signs in without a
+ * full reload (login in another tab, client-side navigation back) would keep
+ * being branched as a guest by every checkout decision that captured it:
+ * `needsSheet` would force the sheet, and confirm would check out via the
+ * guest controller (`/checkout/public`) with a stale anonymous identity.
+ *
+ * This wraps `createSignInDetector` (which reports the genuine false→true
+ * transition exactly once, immune to the auth-store bootstrap catch-up — see
+ * its module doc) with a monotonic, reactive `isAuthenticated`: SSR-seeded
+ * `true`, OR the detector has fired. It never lowers on a later `false`
+ * observation — the page's SSR data is stale after any mid-page auth change,
+ * and a signed-out buyer gets fresh truth on the next navigation/reload.
+ *
+ * `observe()` forwards the detector's one-shot result so the caller's effect
+ * can also run the clear-anonymous-cart branch off the SAME check — the
+ * transition must never be consumed twice.
+ */
+import { createSignInDetector } from './sign-in-detector';
+
+export interface LiveAuth {
+	/** Monotonic live truth: seeded SSR `true`, or a sign-in was observed. */
+	readonly isAuthenticated: boolean;
+	/**
+	 * Call on every observation of the live auth store. Returns `true` exactly
+	 * once, on the genuine false→true transition (the detector's contract);
+	 * flips `isAuthenticated` permanently at that moment.
+	 */
+	observe(nowAuthenticated: boolean): boolean;
+}
+
+export function createLiveAuth(seededAuthenticated: boolean): LiveAuth {
+	const detector = createSignInDetector(seededAuthenticated);
+	let sawSignIn = $state(false);
+
+	return {
+		get isAuthenticated() {
+			return seededAuthenticated || sawSignIn;
+		},
+		observe(nowAuthenticated: boolean): boolean {
+			const justSignedIn = detector.check(nowAuthenticated);
+			if (justSignedIn) sawSignIn = true;
+			return justSignedIn;
+		}
+	};
+}

--- a/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
+++ b/src/routes/(public)/events/[org_slug]/[event_slug]/+page.svelte
@@ -649,7 +649,7 @@
 		{cart}
 		eventId={event.id}
 		requireTicketNames={event.require_ticket_names}
-		isAuthenticated={data.isAuthenticated}
+		isAuthenticated={purchaseFlow.isAuthenticated}
 		authToken={authStore.accessToken}
 		organizationSlug={event.organization.slug}
 		{initialDiscountCode}
@@ -658,7 +658,7 @@
 		onConfirm={purchaseFlow.handleSheetConfirm}
 		chart={seatHoldRegistry.chart}
 		registry={seatHoldRegistry}
-		identity={data.isAuthenticated ? undefined : purchaseFlow.guestIdentity}
+		identity={purchaseFlow.isAuthenticated ? undefined : purchaseFlow.guestIdentity}
 	/>
 {/if}
 


### PR DESCRIPTION
## The bug (Copilot finding on PR #863, deferred from b1e8bec9)

A guest can sign in without a full page reload while on the event page (login in another tab, or client-side navigation back). `createSignInDetector` correctly reports the false→true transition once and the existing effect clears the anonymous cart + guest identity with a toast — that part worked and is unchanged. But all checkout branching kept reading the **captured SSR `isAuthenticated`** (still `false`):

- `handleCartBuy` passed `!isAuthenticated` to `cart.needsSheet(...)` — the now-authed buyer was still forced through the guest sheet.
- `handleSheetConfirm` picked the guest controller on the same stale value — a re-built cart checked out via `/checkout/public` with the (cleared) guest identity even though the buyer was signed in.
- The `CheckoutSheet` mount's `isAuthenticated`/`identity` props read `data.isAuthenticated` and were stale the same way.

## The fix: monotonic live authentication

New `createLiveAuth(seeded)` in `src/lib/components/events/live-auth.svelte.ts` wraps the sign-in detector with a reactive (`$state`-backed) `isAuthenticated` getter: **SSR seed `true`, OR the detector has fired** — never lowered by a later `false` observation (the SSR data is stale after any mid-page auth change; a signed-out buyer gets fresh truth on the next navigation).

Wiring in `cart-purchase-flow.svelte.ts`:

- The login-mid-cart effect calls `liveAuth.observe(authStore.isAuthenticated)` **exactly once per run** (the detector's one-shot result must never be consumed twice), stores the result, and uses it for both concerns: the auth flip happens regardless of cart emptiness, while the cart-clearing branch keeps its existing `!cart.isEmpty` condition.
- `handleCartBuy` and `handleSheetConfirm` branch on `liveAuth.isAuthenticated`.
- The flow exposes `get isAuthenticated()` alongside the existing accessors, and the page's `CheckoutSheet` `isAuthenticated`/`identity` props now read `purchaseFlow.isAuthenticated`.

Deliberately untouched: `canUseCart` and every other `data.isAuthenticated` read on the page (out of scope), the `authToken` prop (already live via `authStore.accessToken`), and the cart-clearing behavior itself.

## Testing

TDD: `live-auth.svelte.test.ts` written first and watched fail, then the helper implemented — 5 tests covering the SSR-true bootstrap catch-up, the genuine sign-in flip, exactly-once transition reporting, monotonicity through a logout flap, and the steady-true seed.

- `make check`: fully green (format, lint --max-warnings 0, types + armed canary, i18n, file-length, ssr-leak, image-alt audits)
- `make test`: **270 files passed, 3274 tests passed, 1 todo, 0 failures**

**E2E was NOT run** — this branch was built in a worktree (single backend on :8000 rule). Reviewer: please run the j06+j07 buyer-checkout matrix before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)