### PR TITLE
fix(auth): pass the request-scoped fetch to server-side SDK calls

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -107,7 +107,12 @@ async function refreshSession(
 	const rememberMe = event.cookies.get('remember_me') === 'true';
 
 	try {
-		const { data, error: refreshError } = await tokenRefresh({ body: { refresh: refreshToken } });
+		// `event.fetch` (not the global) so `handleFetch` below rewrites this call
+		// to INTERNAL_API_URL — see #883.
+		const { data, error: refreshError } = await tokenRefresh({
+			body: { refresh: refreshToken },
+			fetch: event.fetch
+		});
 
 		if (refreshError || !data || !data.access || !data.refresh) {
 			log.warning('token_refresh_failed', { error: refreshError });

--- a/src/routes/api/auth/refresh/+server.ts
+++ b/src/routes/api/auth/refresh/+server.ts
@@ -21,8 +21,15 @@ import {
  *
  * The client can't access the httpOnly refresh token cookie directly,
  * so this server endpoint reads it and calls the backend.
+ *
+ * The request-scoped `fetch` MUST be forwarded to the SDK call (see #883).
+ * Without it the generated client falls back to `globalThis.fetch`, which
+ * `handleFetch` never sees — so the refresh is not rewritten to
+ * INTERNAL_API_URL. In containerized deployments where the browser-facing API
+ * origin is unreachable from the frontend container, that makes sign-in appear
+ * to succeed and then silently fall back to logged-out.
  */
-export const POST: RequestHandler = async ({ cookies }) => {
+export const POST: RequestHandler = async ({ cookies, fetch }) => {
 	const refreshToken = cookies.get('refresh_token');
 	// Read the "remember me" preference to preserve cookie behavior
 	const rememberMe = cookies.get('remember_me') === 'true';
@@ -39,7 +46,8 @@ export const POST: RequestHandler = async ({ cookies }) => {
 		const { data, error: refreshError } = await tokenRefresh({
 			body: {
 				refresh: refreshToken
-			}
+			},
+			fetch
 		});
 
 		if (refreshError || !data || !data.access) {

--- a/src/routes/api/auth/refresh/server.test.ts
+++ b/src/routes/api/auth/refresh/server.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Cookies } from '@sveltejs/kit';
+
+vi.mock('$lib/api/generated', () => ({
+	tokenRefresh: vi.fn()
+}));
+
+import { tokenRefresh } from '$lib/api/generated';
+import { POST } from './+server';
+
+const mockedTokenRefresh = vi.mocked(tokenRefresh);
+
+/** A cookie jar that records writes so assertions can read them back. */
+function fakeCookies(initial: Record<string, string> = {}) {
+	const jar = new Map<string, string>(Object.entries(initial));
+	const deleted: string[] = [];
+	const cookies = {
+		get: vi.fn((name: string) => jar.get(name)),
+		set: vi.fn((name: string, value: string) => {
+			jar.set(name, value);
+		}),
+		delete: vi.fn((name: string) => {
+			jar.delete(name);
+			deleted.push(name);
+		})
+	} as unknown as Cookies;
+	return { cookies, jar, deleted };
+}
+
+/** The request-scoped fetch SvelteKit hands the handler; `handleFetch` wraps it. */
+const requestFetch = vi.fn() as unknown as typeof fetch;
+
+function postArgs(cookies: Cookies) {
+	return { cookies, fetch: requestFetch } as unknown as Parameters<typeof POST>[0];
+}
+
+/** Run POST and return the HTTP status, whether it resolved or threw. */
+async function postStatus(cookies: Cookies): Promise<number> {
+	try {
+		return (await POST(postArgs(cookies))).status;
+	} catch (err) {
+		const httpError = err as { status?: number };
+		if (typeof httpError.status === 'number') return httpError.status;
+		throw err;
+	}
+}
+
+beforeEach(() => {
+	mockedTokenRefresh.mockReset();
+});
+
+describe('POST /api/auth/refresh', () => {
+	it('forwards the request-scoped fetch so handleFetch can rewrite to INTERNAL_API_URL (#883)', async () => {
+		mockedTokenRefresh.mockResolvedValue({
+			data: { access: 'new-access', refresh: 'new-refresh' },
+			error: undefined
+		} as never);
+
+		const { cookies } = fakeCookies({ refresh_token: 'old-refresh' });
+		const response = await POST(postArgs(cookies));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ access: 'new-access' });
+		// The generated client defaults to globalThis.fetch when `fetch` is
+		// omitted, which bypasses handleFetch entirely — the bug in #883.
+		expect(mockedTokenRefresh).toHaveBeenCalledWith(
+			expect.objectContaining({ body: { refresh: 'old-refresh' }, fetch: requestFetch })
+		);
+	});
+
+	it('stores the rotated refresh token and never returns it to the client', async () => {
+		mockedTokenRefresh.mockResolvedValue({
+			data: { access: 'new-access', refresh: 'new-refresh' },
+			error: undefined
+		} as never);
+
+		const { cookies, jar } = fakeCookies({ refresh_token: 'old-refresh', remember_me: 'true' });
+		const body = await (await POST(postArgs(cookies))).json();
+
+		expect(jar.get('access_token')).toBe('new-access');
+		expect(jar.get('refresh_token')).toBe('new-refresh');
+		expect(body).not.toHaveProperty('refresh');
+	});
+
+	it('401s without calling the backend when there is no refresh cookie', async () => {
+		const { cookies, deleted } = fakeCookies();
+
+		expect(await postStatus(cookies)).toBe(401);
+		expect(mockedTokenRefresh).not.toHaveBeenCalled();
+		expect(deleted).toContain('access_token');
+	});
+
+	it('401s and clears both cookies when the backend rejects the refresh token', async () => {
+		mockedTokenRefresh.mockResolvedValue({
+			data: undefined,
+			error: { detail: 'Token is blacklisted' }
+		} as never);
+
+		const { cookies, deleted } = fakeCookies({ refresh_token: 'blacklisted' });
+
+		expect(await postStatus(cookies)).toBe(401);
+		expect(deleted).toEqual(expect.arrayContaining(['refresh_token', 'access_token']));
+	});
+
+	it('clears the cookies when the refresh request throws (backend unreachable)', async () => {
+		mockedTokenRefresh.mockRejectedValue(new Error('ECONNREFUSED'));
+
+		const { cookies, deleted } = fakeCookies({ refresh_token: 'old-refresh' });
+
+		expect(await postStatus(cookies)).toBe(500);
+		expect(deleted).toEqual(expect.arrayContaining(['refresh_token', 'access_token']));
+	});
+});

--- a/src/routes/api/auth/refresh/server.test.ts
+++ b/src/routes/api/auth/refresh/server.test.ts
@@ -10,8 +10,14 @@ import { POST } from './+server';
 
 const mockedTokenRefresh = vi.mocked(tokenRefresh);
 
+interface FakeCookies {
+	cookies: Cookies;
+	jar: Map<string, string>;
+	deleted: string[];
+}
+
 /** A cookie jar that records writes so assertions can read them back. */
-function fakeCookies(initial: Record<string, string> = {}) {
+function fakeCookies(initial: Record<string, string> = {}): FakeCookies {
 	const jar = new Map<string, string>(Object.entries(initial));
 	const deleted: string[] = [];
 	const cookies = {
@@ -30,7 +36,7 @@ function fakeCookies(initial: Record<string, string> = {}) {
 /** The request-scoped fetch SvelteKit hands the handler; `handleFetch` wraps it. */
 const requestFetch = vi.fn() as unknown as typeof fetch;
 
-function postArgs(cookies: Cookies) {
+function postArgs(cookies: Cookies): Parameters<typeof POST>[0] {
 	return { cookies, fetch: requestFetch } as unknown as Parameters<typeof POST>[0];
 }
 

--- a/src/routes/api/events/[event_id]/potluck/+server.ts
+++ b/src/routes/api/events/[event_id]/potluck/+server.ts
@@ -6,7 +6,7 @@ import { potluckListPotluckItems, potluckCreatePotluckItem } from '$lib/api';
  * GET /api/events/[event_id]/potluck
  * List all potluck items for an event
  */
-export const GET: RequestHandler = async ({ params, locals }) => {
+export const GET: RequestHandler = async ({ params, locals, fetch }) => {
 	if (!locals.user?.accessToken) {
 		throw error(401, 'Unauthorized');
 	}
@@ -16,7 +16,8 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 			path: { event_id: params.event_id },
 			headers: {
 				Authorization: `Bearer ${locals.user.accessToken}`
-			}
+			},
+			fetch
 		});
 
 		if (!response.data) {
@@ -34,7 +35,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
  * POST /api/events/[event_id]/potluck
  * Create a new potluck item
  */
-export const POST: RequestHandler = async ({ request, params, locals }) => {
+export const POST: RequestHandler = async ({ request, params, locals, fetch }) => {
 	if (!locals.user?.accessToken) {
 		throw error(401, 'Unauthorized');
 	}
@@ -53,7 +54,8 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 			},
 			headers: {
 				Authorization: `Bearer ${locals.user.accessToken}`
-			}
+			},
+			fetch
 		});
 
 		if (!response.data) {

--- a/src/routes/api/events/[event_id]/potluck/[item_id]/+server.ts
+++ b/src/routes/api/events/[event_id]/potluck/[item_id]/+server.ts
@@ -26,7 +26,7 @@ function getErrorMessage(err: unknown): unknown {
  * PATCH /api/events/[event_id]/potluck/[item_id]
  * Update a potluck item
  */
-export const PATCH: RequestHandler = async ({ request, params, locals }) => {
+export const PATCH: RequestHandler = async ({ request, params, locals, fetch }) => {
 	if (!locals.user?.accessToken) {
 		throw error(401, 'Unauthorized');
 	}
@@ -44,7 +44,8 @@ export const PATCH: RequestHandler = async ({ request, params, locals }) => {
 			},
 			headers: {
 				Authorization: `Bearer ${locals.user.accessToken}`
-			}
+			},
+			fetch
 		});
 
 		if (!response.data) {
@@ -79,7 +80,7 @@ export const PATCH: RequestHandler = async ({ request, params, locals }) => {
  * DELETE /api/events/[event_id]/potluck/[item_id]
  * Delete a potluck item
  */
-export const DELETE: RequestHandler = async ({ params, locals }) => {
+export const DELETE: RequestHandler = async ({ params, locals, fetch }) => {
 	if (!locals.user?.accessToken) {
 		throw error(401, 'Unauthorized');
 	}
@@ -89,7 +90,8 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 			path: { event_id: params.event_id, item_id: params.item_id },
 			headers: {
 				Authorization: `Bearer ${locals.user.accessToken}`
-			}
+			},
+			fetch
 		});
 
 		return json({ success: true });

--- a/src/routes/api/events/[event_id]/potluck/[item_id]/claim/+server.ts
+++ b/src/routes/api/events/[event_id]/potluck/[item_id]/claim/+server.ts
@@ -6,7 +6,7 @@ import { potluckClaimPotluckItem, potluckUnclaimPotluckItem } from '$lib/api';
  * POST /api/events/[event_id]/potluck/[item_id]/claim
  * Claim a potluck item
  */
-export const POST: RequestHandler = async ({ params, locals }) => {
+export const POST: RequestHandler = async ({ params, locals, fetch }) => {
 	if (!locals.user?.accessToken) {
 		throw error(401, 'Unauthorized');
 	}
@@ -16,7 +16,8 @@ export const POST: RequestHandler = async ({ params, locals }) => {
 			path: { event_id: params.event_id, item_id: params.item_id },
 			headers: {
 				Authorization: `Bearer ${locals.user.accessToken}`
-			}
+			},
+			fetch
 		});
 
 		if (!response.data) {
@@ -34,7 +35,7 @@ export const POST: RequestHandler = async ({ params, locals }) => {
  * DELETE /api/events/[event_id]/potluck/[item_id]/claim
  * Unclaim a potluck item
  */
-export const DELETE: RequestHandler = async ({ params, locals }) => {
+export const DELETE: RequestHandler = async ({ params, locals, fetch }) => {
 	if (!locals.user?.accessToken) {
 		throw error(401, 'Unauthorized');
 	}
@@ -44,7 +45,8 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 			path: { event_id: params.event_id, item_id: params.item_id },
 			headers: {
 				Authorization: `Bearer ${locals.user.accessToken}`
-			}
+			},
+			fetch
 		});
 
 		if (!response.data) {


### PR DESCRIPTION
## Problem

`src/routes/api/auth/refresh/+server.ts` destructured only `{ cookies }` from the request event, so the `tokenRefresh()` call inside ran on `globalThis.fetch` — the generated client's documented default when no `fetch` option is supplied (`src/lib/api/generated/client/client.gen.ts:45`: `fetch: options.fetch ?? _config.fetch ?? globalThis.fetch`).

`handleFetch` therefore never saw the request, and the call was never rewritten to `INTERNAL_API_URL`. In containerized deployments where the browser-facing API origin is not reachable from the frontend container, sign-in appears to succeed and then silently falls back to logged-out — the client auth store can never bootstrap, because `/api/auth/refresh` is exactly how it mints its in-memory token.

Found during the revel-demos docker-compose E2E run; worked around there by having the frontend container join the API's network namespace.

Per the SvelteKit types, `handleFetch` intercepts `event.fetch` "inside an endpoint, `load`, `action`, `handle`, `handleError` or `reroute`" — so passing the event fetch is all that is needed, and the existing `handleFetch` rewrite applies unchanged.

## Fix

Forward the request-scoped `fetch` into every server-side SDK call that was missing it:

| File | Calls |
| --- | --- |
| `src/routes/api/auth/refresh/+server.ts` | `tokenRefresh` — the reported endpoint |
| `src/hooks.server.ts` (`refreshSession`) | `tokenRefresh` — same bypass on the SSR cold-start path |
| `src/routes/api/events/[event_id]/potluck/**` | 5 potluck SDK calls, identical pattern |

The `hooks.server.ts` one is the same root cause with the same function: a returning user's cold-start refresh also went out on the global fetch.

### Sweep of `src/routes/api/**/+server.ts`

All six endpoints were checked:

- `api/auth/refresh` — **fixed**
- `api/events/[event_id]/potluck/+server.ts`, `.../[item_id]/+server.ts`, `.../[item_id]/claim/+server.ts` — **fixed** (5 calls)
- `api/auth/session-token` — no change needed, reads the cookie only, makes no outbound call
- `api/indexnow` — no change needed, already destructures `fetch` (and targets an external host, not the API)

No behavior changes beyond the fetch plumbing; no drive-by refactors.

## Tests

Adds `src/routes/api/auth/refresh/server.test.ts` (5 tests), following the existing endpoint-test pattern (`src/routes/auth/callback/page.server.test.ts`, `src/lib/server/session.test.ts`): mock the SDK module, drive the handler with a fake cookie jar.

The load-bearing one asserts the event fetch actually reaches `tokenRefresh`. **Canary-verified**: removing the `fetch` option from the endpoint makes exactly that test fail (1 failed / 4 passed), so the test is decisive rather than vacuous.

`hooks.server.ts` is not unit-tested here — importing it runs `startMetricsServer()` and registers the whole hook chain at module scope, which is a much larger harness than this one-line change warrants; the endpoint test covers the identical call shape.

## Quality gate

- `make fix` ✅
- `make check` ✅ (exit 0 — type gate reports armed)
- `make test` ✅ 283 files / 3350 tests passed

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server-side authentication refresh reliability when using internal API routing.
  - Improved potluck API request handling by consistently using the request context, preserving existing authorization and error behavior.
  - Prevented refresh-token requests from failing when custom internal API routing is configured.

- **Tests**
  - Added coverage for token refresh success and failure scenarios, cookie handling, token rotation, response protection, and request routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->