### PR TITLE
fix(questionnaires): stop submitter email overflowing its card

### DIFF
--- a/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
+++ b/src/routes/(auth)/org/[slug]/admin/questionnaires/[id]/submissions/[submission_id]/+page.svelte
@@ -272,11 +272,11 @@
 							class="shrink-0"
 							clickable={true}
 						/>
-						<div class="flex-1">
+						<div class="min-w-0 flex-1">
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['questionnaireSubmissionDetailPage.nameLabel']()}
 							</p>
-							<p class="text-base font-medium">
+							<p class="break-words text-base font-medium">
 								{data.submission.user.display_name}
 								{#if data.submission.user.pronouns}
 									<span class="font-normal text-muted-foreground"
@@ -319,7 +319,7 @@
 						>
 							<Mail class="h-5 w-5 text-primary" aria-hidden="true" />
 						</div>
-						<div class="flex-1">
+						<div class="min-w-0 flex-1">
 							<p class="text-sm font-medium text-muted-foreground">
 								{m['questionnaireSubmissionDetailPage.emailLabel']()}
 							</p>


### PR DESCRIPTION
The Submitter Information card on the Review Submission page let long email addresses overflow the card to the right.

Root cause: the icon-row text columns are flex children without `min-w-0` — a flex item's min-width defaults to its content's min-content size, and an email is one unbreakable word, so the column could never shrink and the existing `break-words` never engaged.

Fix: `min-w-0` on the name and email columns (name too, because accounts without a name render an email-shaped `display_name`), plus `break-words` on the display name. 3-line class-only diff.

Verified: `make fix` / `make check` / `make test` (3350 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wrapping of long submitter names and email addresses in the submission details sidebar.
  * Prevented lengthy text from overflowing its container in the sidebar layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->