### PR TITLE
chore(release): v2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.2] - 2026-09-06
+
+### Fixed
+
+- Long email addresses (and email-shaped display names) no longer overflow the Submitter Information card on the questionnaire submission review page — they now wrap inside the card.
+
 ## [2.8.1] - 2026-09-06
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "2.8.1",
+	"version": "2.8.2",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## [2.8.2] - 2026-09-06

### Fixed

- Long email addresses (and email-shaped display names) no longer overflow the Submitter Information card on the questionnaire submission review page — they now wrap inside the card.

