### PR TITLE
fix(api-errors): surface swallowed HTTP errors in TierForm + sweep of 16 mutationFns

### DIFF
--- a/src/lib/components/events/BookmarkButton.svelte
+++ b/src/lib/components/events/BookmarkButton.svelte
@@ -44,11 +44,10 @@
 	// *before* mutationFn runs.
 	const mutation = createMutation(() => ({
 		mutationFn: async (next: boolean) => {
-			if (next) {
-				await eventpublicattendanceBookmarkEvent({ path: { event_id: eventId } });
-			} else {
-				await eventpublicattendanceUnbookmarkEvent({ path: { event_id: eventId } });
-			}
+			const res = next
+				? await eventpublicattendanceBookmarkEvent({ path: { event_id: eventId } })
+				: await eventpublicattendanceUnbookmarkEvent({ path: { event_id: eventId } });
+			if (res.error) throw res.error;
 		},
 		onMutate: (next: boolean) => {
 			pending = true;

--- a/src/lib/components/events/BookmarkButton.test.ts
+++ b/src/lib/components/events/BookmarkButton.test.ts
@@ -147,6 +147,25 @@ describe('BookmarkButton', () => {
 		expect(toast.success).not.toHaveBeenCalled();
 	});
 
+	it('reverts and shows an error toast when the API resolves with an HTTP error body', async () => {
+		// The generated client does not reject on HTTP errors — it resolves with
+		// `{ error }` — so the mutationFn must throw it for onError to fire.
+		const user = userEvent.setup();
+		vi.mocked(eventpublicattendanceBookmarkEvent).mockResolvedValueOnce({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 }
+		} as never);
+		renderButton({ eventId: 'e1', isBookmarked: false });
+		const btn = screen.getByRole('button');
+
+		await user.click(btn);
+
+		await waitFor(() => expect(btn).toHaveAttribute('aria-pressed', 'false'));
+		expect(toast.error).toHaveBeenCalled();
+		expect(toast.success).not.toHaveBeenCalled();
+	});
+
 	describe('onlyWhenBookmarked (card indicator)', () => {
 		it('renders nothing when not bookmarked', () => {
 			const { container } = renderButton({

--- a/src/lib/components/events/admin/TierForm.svelte
+++ b/src/lib/components/events/admin/TierForm.svelte
@@ -30,7 +30,7 @@
 	import TierFormAvailabilitySection from './TierFormAvailabilitySection.svelte';
 	import TierFormSeatingSection from './TierFormSeatingSection.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import { extractErrorMessage, extractFieldErrors } from '$lib/utils/errors';
+	import { extractErrorMessage, extractFieldErrors, markSilent } from '$lib/utils/errors';
 	import { tierFieldLabel } from './tier-field-labels';
 	import {
 		CURRENCY_SYMBOLS,
@@ -297,14 +297,17 @@
 	// The generated client resolves with `{ error }` on HTTP errors instead of
 	// rejecting (ThrowOnError = false), so each mutationFn must throw the error
 	// body itself — otherwise a 400/422 lands in onSuccess and closes the dialog
-	// without ever showing the error panel below.
+	// without ever showing the error panel below. `markSilent` keeps the global
+	// "Action failed" toast from duplicating that panel (the RefundTicketDialog
+	// convention); the body is thrown unwrapped so extractFieldErrors still
+	// sees the pydantic detail array.
 	const tierCreateMutation = createMutation(() => ({
 		mutationFn: async (data: TicketTierCreateSchema) => {
 			const res = await eventadminticketsCreateTicketTier({
 				path: { event_id: eventId },
 				body: data
 			});
-			if (res.error) throw res.error;
+			if (res.error) throw markSilent(res.error);
 			return res.data;
 		},
 		onSuccess: () => {
@@ -320,7 +323,7 @@
 				path: { event_id: eventId, tier_id: tier.id },
 				body: data
 			});
-			if (res.error) throw res.error;
+			if (res.error) throw markSilent(res.error);
 			return res.data;
 		},
 		onSuccess: () => {
@@ -335,7 +338,7 @@
 			const res = await eventadminticketsDeleteTicketTier({
 				path: { event_id: eventId, tier_id: tier.id }
 			});
-			if (res.error) throw res.error;
+			if (res.error) throw markSilent(res.error);
 			return res.data;
 		},
 		onSuccess: () => {

--- a/src/lib/components/events/admin/TierForm.svelte
+++ b/src/lib/components/events/admin/TierForm.svelte
@@ -294,12 +294,19 @@
 	// Get current currency symbol for display
 	const currencySymbol = $derived(CURRENCY_SYMBOLS[currency] || currency);
 
+	// The generated client resolves with `{ error }` on HTTP errors instead of
+	// rejecting (ThrowOnError = false), so each mutationFn must throw the error
+	// body itself — otherwise a 400/422 lands in onSuccess and closes the dialog
+	// without ever showing the error panel below.
 	const tierCreateMutation = createMutation(() => ({
-		mutationFn: (data: TicketTierCreateSchema) =>
-			eventadminticketsCreateTicketTier({
+		mutationFn: async (data: TicketTierCreateSchema) => {
+			const res = await eventadminticketsCreateTicketTier({
 				path: { event_id: eventId },
 				body: data
-			}),
+			});
+			if (res.error) throw res.error;
+			return res.data;
+		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['event-admin', eventId, 'ticket-tiers'] });
 			onClose();
@@ -307,12 +314,14 @@
 	}));
 
 	const tierUpdateMutation = createMutation(() => ({
-		mutationFn: (data: TicketTierUpdateSchema) => {
+		mutationFn: async (data: TicketTierUpdateSchema) => {
 			if (!tier?.id) throw new Error('Cannot update tier without an id');
-			return eventadminticketsUpdateTicketTier({
+			const res = await eventadminticketsUpdateTicketTier({
 				path: { event_id: eventId, tier_id: tier.id },
 				body: data
 			});
+			if (res.error) throw res.error;
+			return res.data;
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['event-admin', eventId, 'ticket-tiers'] });
@@ -321,11 +330,13 @@
 	}));
 
 	const tierDeleteMutation = createMutation(() => ({
-		mutationFn: () => {
+		mutationFn: async () => {
 			if (!tier?.id) throw new Error('Cannot delete tier without an id');
-			return eventadminticketsDeleteTicketTier({
+			const res = await eventadminticketsDeleteTicketTier({
 				path: { event_id: eventId, tier_id: tier.id }
 			});
+			if (res.error) throw res.error;
+			return res.data;
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['event-admin', eventId, 'ticket-tiers'] });

--- a/src/lib/components/events/admin/TierForm.test.ts
+++ b/src/lib/components/events/admin/TierForm.test.ts
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import TierForm from './TierForm.svelte';
+import type { TicketTierDetailSchema } from '$lib/api/generated/types.gen';
+import {
+	eventadminticketsCreateTicketTier,
+	eventadminticketsUpdateTicketTier
+} from '$lib/api/generated/sdk.gen';
+
+vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/api/generated/sdk.gen')>()),
+	eventadminticketsCreateTicketTier: vi.fn(),
+	eventadminticketsUpdateTicketTier: vi.fn(),
+	eventadminticketsDeleteTicketTier: vi.fn()
+}));
+
+type UpdateResult = Awaited<ReturnType<typeof eventadminticketsUpdateTicketTier>>;
+type CreateResult = Awaited<ReturnType<typeof eventadminticketsCreateTicketTier>>;
+
+// The generated client resolves (never rejects) with `error` set to the parsed
+// response body on HTTP errors — mirror both shapes here.
+function ok<T>(data: T) {
+	return { data, error: undefined, response: { ok: true, status: 200 } as Response };
+}
+
+function apiError(body: unknown, status = 400) {
+	return { data: undefined, error: body, response: { ok: false, status } as Response };
+}
+
+// Minimal paused ONLINE tier — the shape BE #945 guards: resuming it without
+// Stripe Connect now answers 400 StripeNotConnectedError.
+const pausedOnlineTier = {
+	id: 'tier-1',
+	event_id: 'evt-1',
+	name: 'General Admission',
+	payment_method: 'online',
+	price_type: 'fixed',
+	price: '25.00',
+	currency: 'EUR',
+	sales_paused: true,
+	seat_assignment_mode: 'none',
+	visibility: 'public',
+	purchasable_by: 'public'
+} as TicketTierDetailSchema;
+
+function renderForm(tier: TicketTierDetailSchema | null = pausedOnlineTier) {
+	const onClose = vi.fn();
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+	});
+	render(QueryClientTestWrapper, {
+		props: {
+			client,
+			component: TierForm,
+			componentProps: {
+				tier,
+				eventId: 'evt-1',
+				organizationSlug: 'acme',
+				organizationStripeConnected: false,
+				onClose
+			}
+		}
+	});
+	return { onClose };
+}
+
+describe('TierForm API error surfacing', () => {
+	beforeEach(() => {
+		vi.mocked(eventadminticketsUpdateTicketTier).mockResolvedValue(
+			apiError({ detail: 'You must connect to Stripe first.' }) as unknown as UpdateResult
+		);
+		vi.mocked(eventadminticketsCreateTicketTier).mockResolvedValue(
+			apiError({ detail: 'You must connect to Stripe first.' }) as unknown as CreateResult
+		);
+	});
+
+	it('keeps the dialog open and shows the backend detail when an update is rejected', async () => {
+		const user = userEvent.setup();
+		const { onClose } = renderForm();
+
+		await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+		await waitFor(() => expect(eventadminticketsUpdateTicketTier).toHaveBeenCalled());
+		await waitFor(() =>
+			expect(screen.getByText('You must connect to Stripe first.')).toBeInTheDocument()
+		);
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('closes the dialog when the update succeeds', async () => {
+		vi.mocked(eventadminticketsUpdateTicketTier).mockResolvedValue(
+			ok(pausedOnlineTier) as unknown as UpdateResult
+		);
+		const user = userEvent.setup();
+		const { onClose } = renderForm();
+
+		await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
+	});
+
+	it('keeps the dialog open and shows the backend detail when a create is rejected', async () => {
+		const user = userEvent.setup();
+		const { onClose } = renderForm(null);
+
+		await user.type(screen.getByLabelText(/Tier Name/i), 'Early Bird');
+		await user.click(screen.getByRole('button', { name: 'Create Tier' }));
+
+		await waitFor(() => expect(eventadminticketsCreateTicketTier).toHaveBeenCalled());
+		await waitFor(() =>
+			expect(screen.getByText('You must connect to Stripe first.')).toBeInTheDocument()
+		);
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/components/events/admin/TierForm.test.ts
+++ b/src/lib/components/events/admin/TierForm.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { QueryClient } from '@tanstack/svelte-query';
@@ -106,8 +106,17 @@ describe('TierForm API error surfacing', () => {
 		const user = userEvent.setup();
 		const { onClose } = renderForm(null);
 
-		await user.type(screen.getByLabelText(/Tier Name/i), 'Early Bird');
-		await user.click(screen.getByRole('button', { name: 'Create Tier' }));
+		// Fill the name via a direct input event: the dialog also mounts the
+		// tiptap MarkdownEditor, which can steal focus mid-`user.type` and
+		// swallow keystrokes (flaky in jsdom).
+		const nameInput = screen.getByLabelText(/Tier Name/i);
+		await fireEvent.input(nameInput, { target: { value: 'Early Bird' } });
+		await waitFor(() => expect(nameInput).toHaveValue('Early Bird'));
+		const createButton = screen.getByRole('button', { name: 'Create Tier' });
+		// The submit button stays disabled until the name state flushes; clicking
+		// a still-disabled button is a silent no-op, so wait for it.
+		await waitFor(() => expect(createButton).toBeEnabled());
+		await user.click(createButton);
 
 		await waitFor(() => expect(eventadminticketsCreateTicketTier).toHaveBeenCalled());
 		await waitFor(() =>

--- a/src/lib/components/events/admin/TierForm.test.ts
+++ b/src/lib/components/events/admin/TierForm.test.ts
@@ -48,8 +48,16 @@ const pausedOnlineTier = {
 
 function renderForm(tier: TicketTierDetailSchema | null = pausedOnlineTier) {
 	const onClose = vi.fn();
+	// Mirrors the app QueryClient: a default mutations.onError (the global
+	// "Action failed" toast in +layout.svelte) that skips errors marked
+	// `silent: true`. TierForm renders its own inline panel, so its thrown
+	// errors must carry that flag.
+	const globalOnError = vi.fn();
 	const client = new QueryClient({
-		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false, onError: globalOnError }
+		}
 	});
 	render(QueryClientTestWrapper, {
 		props: {
@@ -64,7 +72,7 @@ function renderForm(tier: TicketTierDetailSchema | null = pausedOnlineTier) {
 			}
 		}
 	});
-	return { onClose };
+	return { onClose, globalOnError };
 }
 
 describe('TierForm API error surfacing', () => {
@@ -88,6 +96,18 @@ describe('TierForm API error surfacing', () => {
 			expect(screen.getByText('You must connect to Stripe first.')).toBeInTheDocument()
 		);
 		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('marks the thrown error silent so the global "Action failed" toast is suppressed', async () => {
+		const user = userEvent.setup();
+		const { globalOnError } = renderForm();
+
+		await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+		await waitFor(() => expect(globalOnError).toHaveBeenCalled());
+		// The inline panel is the only feedback: the global handler must see
+		// `silent: true` (the RefundTicketDialog convention) and skip its toast.
+		expect(globalOnError.mock.calls[0][0]).toMatchObject({ silent: true });
 	});
 
 	it('closes the dialog when the update succeeds', async () => {

--- a/src/lib/components/invitations/InvitationRequestCard.svelte
+++ b/src/lib/components/invitations/InvitationRequestCard.svelte
@@ -10,6 +10,7 @@
 	import { eventpublicdiscoveryDeleteInvitationRequest } from '$lib/api/generated/sdk.gen';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { toast } from 'svelte-sonner';
+	import { extractErrorMessage } from '$lib/utils/errors';
 	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { Tone } from '$lib/components/common/tones';
 
@@ -70,10 +71,11 @@
 			if (!accessToken || !request.id) {
 				throw new Error('Missing authentication or request ID');
 			}
-			await eventpublicdiscoveryDeleteInvitationRequest({
+			const res = await eventpublicdiscoveryDeleteInvitationRequest({
 				headers: { Authorization: `Bearer ${accessToken}` },
 				path: { request_id: request.id }
 			});
+			if (res.error) throw res.error;
 		},
 		onSuccess: () => {
 			toast.success(m['invitationRequestCard.requestCancelled']());
@@ -83,7 +85,7 @@
 		onError: (error) => {
 			console.error('Failed to cancel request:', error);
 			toast.error(m['invitationRequestCard.cancelFailed'](), {
-				description: error.message || m['invitationRequestCard.pleaseTryAgain']()
+				description: extractErrorMessage(error, m['invitationRequestCard.pleaseTryAgain']())
 			});
 		}
 	}));

--- a/src/lib/components/invitations/InvitationRequestCard.test.ts
+++ b/src/lib/components/invitations/InvitationRequestCard.test.ts
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import InvitationRequestCard from './InvitationRequestCard.svelte';
+import { toast } from 'svelte-sonner';
+import type { EventInvitationRequestSchema } from '$lib/api/generated/types.gen';
+import { eventpublicdiscoveryDeleteInvitationRequest } from '$lib/api/generated/sdk.gen';
+
+vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/api/generated/sdk.gen')>()),
+	eventpublicdiscoveryDeleteInvitationRequest: vi.fn()
+}));
+vi.mock('$lib/stores/auth.svelte', () => ({ authStore: { accessToken: 'tok' } }));
+vi.mock('svelte-sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+type DeleteResult = Awaited<ReturnType<typeof eventpublicdiscoveryDeleteInvitationRequest>>;
+
+const request = {
+	id: 'req1',
+	status: 'pending',
+	message: '',
+	created_at: '2026-09-01T10:00:00Z',
+	event: {
+		id: 'e1',
+		name: 'Autumn Market',
+		start: '2026-10-01T18:00:00Z',
+		logo: null,
+		logo_thumbnail_url: null
+	}
+} as unknown as EventInvitationRequestSchema;
+
+function renderCard() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+	});
+	render(QueryClientTestWrapper, {
+		props: {
+			client,
+			component: InvitationRequestCard,
+			componentProps: { request }
+		}
+	});
+}
+
+describe('InvitationRequestCard cancel error handling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubGlobal('confirm', () => true);
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('toasts an error and no success when cancelling the request fails', async () => {
+		vi.mocked(eventpublicdiscoveryDeleteInvitationRequest).mockResolvedValue({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 } as Response
+		} as unknown as DeleteResult);
+		const user = userEvent.setup();
+		renderCard();
+
+		await user.click(screen.getByRole('button', { name: 'Cancel Request' }));
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalled());
+		expect(toast.success).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/components/notifications/NotificationDropdown.svelte
+++ b/src/lib/components/notifications/NotificationDropdown.svelte
@@ -32,9 +32,11 @@
 	// Mark all as read mutation
 	const markAllReadMutation = createMutation(() => ({
 		mutationFn: async () => {
-			return await notificationMarkAllRead({
+			const res = await notificationMarkAllRead({
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (res.error) throw res.error;
+			return res.data;
 		},
 		onSuccess: () => {
 			// Invalidate notification queries to refresh the list

--- a/src/lib/components/notifications/NotificationDropdown.test.ts
+++ b/src/lib/components/notifications/NotificationDropdown.test.ts
@@ -36,7 +36,13 @@ vi.mock('$lib/api/generated', () => ({
 				count: 2
 			}
 		})
-	)
+	),
+	notificationMarkAllRead: vi.fn(() => Promise.resolve({ data: {} }))
+}));
+
+// Mock toasts (asserted by the mark-all-read error test)
+vi.mock('svelte-sonner', () => ({
+	toast: { success: vi.fn(), error: vi.fn() }
 }));
 
 // Mock navigation
@@ -207,6 +213,42 @@ describe('NotificationDropdown', () => {
 	it('handles missing authToken gracefully', () => {
 		// Should still render but badge won't show
 		expect(() => renderWithQuery({ authToken: '' })).not.toThrow();
+	});
+
+	it('toasts an error and no success when mark all as read resolves with an HTTP error body', async () => {
+		// The generated client does not reject on HTTP errors — it resolves with
+		// `{ error }` — so the mutationFn must throw it for onError to fire.
+		const user = userEvent.setup();
+		const { notificationMarkAllRead } = await import('$lib/api/generated');
+		const { toast } = await import('svelte-sonner');
+
+		vi.mocked(notificationMarkAllRead).mockResolvedValueOnce({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 }
+		} as never);
+
+		renderWithQuery();
+		await user.click(screen.getByRole('button', { name: /open notifications/i }));
+
+		// The floating-ui wrapper stays `visibility: hidden` in jsdom (no layout
+		// engine), which also empties accessible names — reveal it the way
+		// AttributionBreakdownSection.test.ts does before querying by role.
+		const content = await waitFor(() => {
+			const el = document.querySelector('[data-dropdown-menu-content]');
+			if (!el) throw new Error('the dropdown content never opened');
+			return el;
+		});
+		const floatingWrapper = content.parentElement;
+		if (floatingWrapper instanceof HTMLElement) {
+			floatingWrapper.style.visibility = 'visible';
+		}
+		await user.click(screen.getByRole('button', { name: /mark all as read/i }));
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalled();
+		});
+		expect(toast.success).not.toHaveBeenCalled();
 	});
 
 	it('applies custom className', () => {

--- a/src/lib/components/notifications/NotificationItem.svelte
+++ b/src/lib/components/notifications/NotificationItem.svelte
@@ -50,10 +50,12 @@
 	// Mark as read mutation
 	const markReadMutation = createMutation(() => ({
 		mutationFn: async () => {
-			return await notificationMarkRead({
+			const res = await notificationMarkRead({
 				path: { notification_id: notification.id },
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (res.error) throw res.error;
+			return res.data;
 		},
 		onMutate: () => {
 			// Optimistic update
@@ -78,10 +80,12 @@
 	// Mark as unread mutation
 	const markUnreadMutation = createMutation(() => ({
 		mutationFn: async () => {
-			return await notificationMarkUnread({
+			const res = await notificationMarkUnread({
 				path: { notification_id: notification.id },
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (res.error) throw res.error;
+			return res.data;
 		},
 		onMutate: () => {
 			// Optimistic update

--- a/src/lib/components/notifications/NotificationItem.test.ts
+++ b/src/lib/components/notifications/NotificationItem.test.ts
@@ -372,6 +372,32 @@ describe('NotificationItem', () => {
 		});
 	});
 
+	it('shows error toast and skips onStatusChange when mark read resolves with an HTTP error body', async () => {
+		// The generated client does not reject on HTTP errors — it resolves with
+		// `{ error }` — so the mutationFn must throw it for onError to fire.
+		const notification = createMockNotification();
+		const onStatusChange = vi.fn();
+		const { notificationMarkRead } = await import('$lib/api/generated');
+		const { toast } = await import('svelte-sonner');
+
+		vi.mocked(notificationMarkRead).mockResolvedValueOnce({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 }
+		} as never);
+
+		renderItem({ notification, authToken: mockAuthToken, onStatusChange });
+
+		await user.click(screen.getByRole('button', { name: /mark as read/i }));
+
+		await vi.waitFor(() => {
+			expect(toast.error).toHaveBeenCalled();
+		});
+		expect(onStatusChange).not.toHaveBeenCalled();
+		// Optimistic flip reverted: the toggle offers "mark as read" again.
+		expect(screen.getByRole('button', { name: /mark as read/i })).toBeInTheDocument();
+	});
+
 	it('stops propagation when clicking mark read/unread button', async () => {
 		const notification = createMockNotification();
 		const { goto } = await import('$app/navigation');

--- a/src/lib/components/notifications/NotificationList.svelte
+++ b/src/lib/components/notifications/NotificationList.svelte
@@ -72,9 +72,11 @@
 	// Mark all as read mutation
 	const markAllReadMutation = createMutation(() => ({
 		mutationFn: async () => {
-			return await notificationMarkAllRead({
+			const res = await notificationMarkAllRead({
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (res.error) throw res.error;
+			return res.data;
 		},
 		onSuccess: () => {
 			// Invalidate all notification-related queries to trigger refetch

--- a/src/lib/components/notifications/NotificationList.test.ts
+++ b/src/lib/components/notifications/NotificationList.test.ts
@@ -224,6 +224,40 @@ describe('NotificationList', () => {
 		});
 	});
 
+	it('toasts an error and no success when mark all as read resolves with an HTTP error body', async () => {
+		// The generated client does not reject on HTTP errors — it resolves with
+		// `{ error }` — so the mutationFn must throw it for onError to fire.
+		const user = userEvent.setup();
+		const { toast } = await import('svelte-sonner');
+
+		vi.mocked(notificationListNotifications).mockResolvedValue(
+			listResult({
+				count: 3,
+				next: null,
+				previous: null,
+				results: mockNotifications
+			})
+		);
+		vi.mocked(notificationMarkAllRead).mockResolvedValueOnce({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 }
+		} as never);
+
+		renderComponent({ authToken: 'test-token' });
+
+		await waitFor(() => {
+			expect(screen.getByText('Event Invitation')).toBeInTheDocument();
+		});
+
+		await user.click(screen.getByRole('button', { name: /mark all as read/i }));
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalled();
+		});
+		expect(toast.success).not.toHaveBeenCalled();
+	});
+
 	it('renders in compact mode with limited items', async () => {
 		vi.mocked(notificationListNotifications).mockResolvedValue(
 			listResult({

--- a/src/lib/components/profile/DietaryPreferencesManager.svelte
+++ b/src/lib/components/profile/DietaryPreferencesManager.svelte
@@ -58,6 +58,7 @@
 				body: data,
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (response.error) throw response.error;
 			return response.data;
 		},
 		onSuccess: () => {
@@ -78,10 +79,11 @@
 	// Delete preference mutation
 	const deletePreferenceMutation = createMutation(() => ({
 		mutationFn: async (preferenceId: string) => {
-			await dietaryDeleteDietaryPreference({
+			const response = await dietaryDeleteDietaryPreference({
 				path: { preference_id: preferenceId },
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (response.error) throw response.error;
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['dietary', 'my-preferences'] });
@@ -107,6 +109,7 @@
 				body: data,
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (response.error) throw response.error;
 			return response.data;
 		},
 		onSuccess: () => {

--- a/src/lib/components/profile/DietaryPreferencesManager.test.ts
+++ b/src/lib/components/profile/DietaryPreferencesManager.test.ts
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import DietaryPreferencesManager from './DietaryPreferencesManager.svelte';
+import { toast } from 'svelte-sonner';
+import {
+	dietaryListMyDietaryPreferences,
+	dietaryListDietaryPreferences,
+	dietaryDeleteDietaryPreference
+} from '$lib/api/generated/sdk.gen';
+
+vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/api/generated/sdk.gen')>()),
+	dietaryListMyDietaryPreferences: vi.fn(),
+	dietaryListDietaryPreferences: vi.fn(),
+	dietaryAddDietaryPreference: vi.fn(),
+	dietaryDeleteDietaryPreference: vi.fn(),
+	dietaryUpdateDietaryPreference: vi.fn()
+}));
+vi.mock('svelte-sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+type MyListResult = Awaited<ReturnType<typeof dietaryListMyDietaryPreferences>>;
+type ListResult = Awaited<ReturnType<typeof dietaryListDietaryPreferences>>;
+type DeleteResult = Awaited<ReturnType<typeof dietaryDeleteDietaryPreference>>;
+
+function ok<T>(data: T) {
+	return { data, error: undefined, response: { ok: true, status: 200 } as Response };
+}
+
+const userPreference = {
+	id: 'up1',
+	preference: { id: 'p1', name: 'Vegan' },
+	comment: '',
+	is_public: true
+};
+
+function renderManager() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+	});
+	render(QueryClientTestWrapper, {
+		props: {
+			client,
+			component: DietaryPreferencesManager,
+			componentProps: { authToken: 'tok' }
+		}
+	});
+}
+
+describe('DietaryPreferencesManager delete error handling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubGlobal('confirm', () => true);
+		vi.mocked(dietaryListMyDietaryPreferences).mockResolvedValue(
+			ok([userPreference]) as unknown as MyListResult
+		);
+		vi.mocked(dietaryListDietaryPreferences).mockResolvedValue(ok([]) as unknown as ListResult);
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('toasts an error and no success when removing a preference fails', async () => {
+		vi.mocked(dietaryDeleteDietaryPreference).mockResolvedValue({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 } as Response
+		} as unknown as DeleteResult);
+		const user = userEvent.setup();
+		renderManager();
+
+		const remove = await screen.findByRole('button', { name: 'Remove Vegan' });
+		await user.click(remove);
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalled());
+		expect(toast.success).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/components/profile/DietaryRestrictionsManager.svelte
+++ b/src/lib/components/profile/DietaryRestrictionsManager.svelte
@@ -11,6 +11,7 @@
 	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import { Plus, Trash2, Loader2, AlertTriangle } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
+	import { markSilent } from '$lib/utils/errors';
 	import StatusBadge from '$lib/components/common/StatusBadge.svelte';
 	import type { Tone } from '$lib/components/common/tones';
 	import type {
@@ -95,7 +96,9 @@
 				body: { name },
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
-			if (response.error) throw response.error;
+			// silent: no local onError here, so the global toast would fire on top
+			// of the toast handleAddRestriction's catch already shows.
+			if (response.error) throw markSilent(response.error);
 			return response.data;
 		}
 	}));

--- a/src/lib/components/profile/DietaryRestrictionsManager.svelte
+++ b/src/lib/components/profile/DietaryRestrictionsManager.svelte
@@ -95,6 +95,7 @@
 				body: { name },
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (response.error) throw response.error;
 			return response.data;
 		}
 	}));
@@ -118,6 +119,7 @@
 				body: data as DietaryRestrictionCreateSchema,
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (response.error) throw response.error;
 			return response.data;
 		},
 		onSuccess: () => {
@@ -142,10 +144,11 @@
 	// Delete restriction mutation
 	const deleteRestrictionMutation = createMutation(() => ({
 		mutationFn: async (restrictionId: string) => {
-			await dietaryDeleteDietaryRestriction({
+			const response = await dietaryDeleteDietaryRestriction({
 				path: { restriction_id: restrictionId },
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (response.error) throw response.error;
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['dietary', 'restrictions'] });
@@ -171,6 +174,7 @@
 				body: data,
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (response.error) throw response.error;
 			return response.data;
 		},
 		onSuccess: () => {

--- a/src/lib/components/profile/DietaryRestrictionsManager.test.ts
+++ b/src/lib/components/profile/DietaryRestrictionsManager.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { QueryClient } from '@tanstack/svelte-query';
@@ -8,7 +8,8 @@ import { toast } from 'svelte-sonner';
 import {
 	dietaryListDietaryRestrictions,
 	dietaryListFoodItems,
-	dietaryDeleteDietaryRestriction
+	dietaryDeleteDietaryRestriction,
+	dietaryCreateFoodItem
 } from '$lib/api/generated/sdk.gen';
 
 vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
@@ -25,6 +26,7 @@ vi.mock('svelte-sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } })
 type RestrictionsResult = Awaited<ReturnType<typeof dietaryListDietaryRestrictions>>;
 type FoodItemsResult = Awaited<ReturnType<typeof dietaryListFoodItems>>;
 type DeleteResult = Awaited<ReturnType<typeof dietaryDeleteDietaryRestriction>>;
+type CreateFoodItemResult = Awaited<ReturnType<typeof dietaryCreateFoodItem>>;
 
 function ok<T>(data: T) {
 	return { data, error: undefined, response: { ok: true, status: 200 } as Response };
@@ -39,8 +41,15 @@ const restriction = {
 };
 
 function renderManager() {
+	// Mirrors the app QueryClient: a default mutations.onError (the global
+	// "Action failed" toast in +layout.svelte) that skips errors marked
+	// `silent: true`.
+	const globalOnError = vi.fn();
 	const client = new QueryClient({
-		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false, onError: globalOnError }
+		}
 	});
 	render(QueryClientTestWrapper, {
 		props: {
@@ -49,6 +58,7 @@ function renderManager() {
 			componentProps: { authToken: 'tok' }
 		}
 	});
+	return { globalOnError };
 }
 
 describe('DietaryRestrictionsManager delete error handling', () => {
@@ -62,6 +72,27 @@ describe('DietaryRestrictionsManager delete error handling', () => {
 	});
 	afterEach(() => {
 		vi.unstubAllGlobals();
+	});
+
+	it('marks a failed food-item creation silent so the global toast does not duplicate the catch toast', async () => {
+		vi.mocked(dietaryCreateFoodItem).mockResolvedValue({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 } as Response
+		} as unknown as CreateFoodItemResult);
+		const user = userEvent.setup();
+		const { globalOnError } = renderManager();
+
+		await user.click((await screen.findAllByRole('button', { name: 'Add Restriction' }))[0]);
+		const dialog = await screen.findByRole('dialog');
+		await user.type(within(dialog).getByLabelText('Food or ingredient'), 'Durian');
+		await user.click(within(dialog).getByRole('button', { name: 'Add Restriction' }));
+
+		// handleAddRestriction's catch already toasts the failure...
+		await waitFor(() => expect(toast.error).toHaveBeenCalled());
+		// ...so the thrown error must carry `silent: true` for the global handler.
+		await waitFor(() => expect(globalOnError).toHaveBeenCalled());
+		expect(globalOnError.mock.calls[0][0]).toMatchObject({ silent: true });
 	});
 
 	it('toasts an error and no success when removing a restriction fails', async () => {

--- a/src/lib/components/profile/DietaryRestrictionsManager.test.ts
+++ b/src/lib/components/profile/DietaryRestrictionsManager.test.ts
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import DietaryRestrictionsManager from './DietaryRestrictionsManager.svelte';
+import { toast } from 'svelte-sonner';
+import {
+	dietaryListDietaryRestrictions,
+	dietaryListFoodItems,
+	dietaryDeleteDietaryRestriction
+} from '$lib/api/generated/sdk.gen';
+
+vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/api/generated/sdk.gen')>()),
+	dietaryListDietaryRestrictions: vi.fn(),
+	dietaryListFoodItems: vi.fn(),
+	dietaryCreateFoodItem: vi.fn(),
+	dietaryCreateDietaryRestriction: vi.fn(),
+	dietaryDeleteDietaryRestriction: vi.fn(),
+	dietaryUpdateDietaryRestriction: vi.fn()
+}));
+vi.mock('svelte-sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+type RestrictionsResult = Awaited<ReturnType<typeof dietaryListDietaryRestrictions>>;
+type FoodItemsResult = Awaited<ReturnType<typeof dietaryListFoodItems>>;
+type DeleteResult = Awaited<ReturnType<typeof dietaryDeleteDietaryRestriction>>;
+
+function ok<T>(data: T) {
+	return { data, error: undefined, response: { ok: true, status: 200 } as Response };
+}
+
+const restriction = {
+	id: 'r1',
+	food_item: { id: 'f1', name: 'Peanuts' },
+	restriction_type: 'allergy',
+	notes: '',
+	is_public: true
+};
+
+function renderManager() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+	});
+	render(QueryClientTestWrapper, {
+		props: {
+			client,
+			component: DietaryRestrictionsManager,
+			componentProps: { authToken: 'tok' }
+		}
+	});
+}
+
+describe('DietaryRestrictionsManager delete error handling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubGlobal('confirm', () => true);
+		vi.mocked(dietaryListDietaryRestrictions).mockResolvedValue(
+			ok([restriction]) as unknown as RestrictionsResult
+		);
+		vi.mocked(dietaryListFoodItems).mockResolvedValue(ok([]) as unknown as FoodItemsResult);
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('toasts an error and no success when removing a restriction fails', async () => {
+		vi.mocked(dietaryDeleteDietaryRestriction).mockResolvedValue({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 } as Response
+		} as unknown as DeleteResult);
+		const user = userEvent.setup();
+		renderManager();
+
+		const remove = await screen.findByRole('button', { name: 'Remove Peanuts' });
+		await user.click(remove);
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalled());
+		expect(toast.success).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/components/profile/TelegramConnectionManager.svelte
+++ b/src/lib/components/profile/TelegramConnectionManager.svelte
@@ -20,6 +20,7 @@
 		telegramConnectAccount,
 		telegramDisconnectAccount
 	} from '$lib/api/generated/sdk.gen';
+	import { extractErrorMessage } from '$lib/utils/errors';
 
 	interface Props {
 		authToken: string;
@@ -58,6 +59,7 @@
 				headers: { Authorization: `Bearer ${authToken}` },
 				body: { otp }
 			});
+			if (result.error) throw result.error;
 			return result.data;
 		},
 		onSuccess: () => {
@@ -66,18 +68,18 @@
 			otpValue = '';
 			otpError = '';
 		},
-		onError: (error: Error) => {
-			const errorMessage = error.message || 'Failed to connect Telegram account';
-			otpError = errorMessage;
+		onError: (error: unknown) => {
+			otpError = extractErrorMessage(error, m['telegram.connect_errorGeneric']());
 		}
 	}));
 
 	// Disconnect mutation
 	const disconnectMutation = createMutation(() => ({
 		mutationFn: async () => {
-			await telegramDisconnectAccount({
+			const result = await telegramDisconnectAccount({
 				headers: { Authorization: `Bearer ${authToken}` }
 			});
+			if (result.error) throw result.error;
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['telegram', 'status'] });
@@ -316,7 +318,7 @@
 				<Alert variant="destructive">
 					<AlertCircle class="h-4 w-4" />
 					<AlertDescription>
-						{connectMutation.error?.message || m['telegram.connect_errorGeneric']()}
+						{extractErrorMessage(connectMutation.error, m['telegram.connect_errorGeneric']())}
 					</AlertDescription>
 				</Alert>
 			{/if}

--- a/src/lib/components/profile/TelegramConnectionManager.test.ts
+++ b/src/lib/components/profile/TelegramConnectionManager.test.ts
@@ -1,0 +1,73 @@
+import { render, screen, waitFor, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import TelegramConnectionManager from './TelegramConnectionManager.svelte';
+import {
+	telegramGetLinkStatus,
+	telegramGetBotName,
+	telegramConnectAccount
+} from '$lib/api/generated/sdk.gen';
+
+vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/api/generated/sdk.gen')>()),
+	telegramGetLinkStatus: vi.fn(),
+	telegramGetBotName: vi.fn(),
+	telegramConnectAccount: vi.fn(),
+	telegramDisconnectAccount: vi.fn()
+}));
+
+type StatusResult = Awaited<ReturnType<typeof telegramGetLinkStatus>>;
+type BotNameResult = Awaited<ReturnType<typeof telegramGetBotName>>;
+type ConnectResult = Awaited<ReturnType<typeof telegramConnectAccount>>;
+
+function ok<T>(data: T) {
+	return { data, error: undefined, response: { ok: true, status: 200 } as Response };
+}
+
+function renderManager() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+	});
+	render(QueryClientTestWrapper, {
+		props: {
+			client,
+			component: TelegramConnectionManager,
+			componentProps: { authToken: 'tok' }
+		}
+	});
+}
+
+describe('TelegramConnectionManager connect error handling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(telegramGetLinkStatus).mockResolvedValue(
+			ok({ connected: false }) as unknown as StatusResult
+		);
+		vi.mocked(telegramGetBotName).mockResolvedValue(
+			ok({ botname: 'revel_bot' }) as unknown as BotNameResult
+		);
+	});
+
+	it('keeps the dialog open and shows the backend detail when the OTP is rejected', async () => {
+		vi.mocked(telegramConnectAccount).mockResolvedValue({
+			data: undefined,
+			error: { detail: 'Invalid or expired code.' },
+			response: { ok: false, status: 400 } as Response
+		} as unknown as ConnectResult);
+		const user = userEvent.setup();
+		renderManager();
+
+		await user.click(await screen.findByRole('button', { name: 'Connect Telegram' }));
+		const dialog = await screen.findByRole('dialog');
+		await user.type(within(dialog).getByLabelText('Verification Code'), '123456789');
+		await user.click(within(dialog).getByRole('button', { name: 'Connect Telegram' }));
+
+		await waitFor(() => expect(telegramConnectAccount).toHaveBeenCalled());
+		await waitFor(() =>
+			expect(screen.getByRole('alert')).toHaveTextContent('Invalid or expired code.')
+		);
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+	});
+});

--- a/src/lib/utils/errors.ts
+++ b/src/lib/utils/errors.ts
@@ -153,6 +153,22 @@ export function extractFieldErrors(error: unknown): { field: string; messages: s
 }
 
 /**
+ * Mark an error as already surfaced to the user so the global mutation
+ * `onError` in the root layout skips its generic "Action failed" toast.
+ *
+ * Use when a mutation has NO local `onError` (so the global default fires)
+ * but the failure is already shown some other way — an inline panel driven
+ * by `mutation.error`, or a caller's try/catch toast. Mutations WITH a local
+ * `onError` replace the global default entirely and don't need this.
+ */
+export function markSilent<T>(error: T): T {
+	if (typeof error === 'object' && error !== null) {
+		(error as { silent?: boolean }).silent = true;
+	}
+	return error;
+}
+
+/**
  * Get a user-friendly error message for an HTTP status code
  */
 function getStatusMessage(status: number): string | null {

--- a/src/routes/(auth)/account/privacy/+page.svelte
+++ b/src/routes/(auth)/account/privacy/+page.svelte
@@ -62,17 +62,20 @@
 	}));
 
 	// Mutation for deleting files
+	// The generated client resolves with `{ error }` on HTTP errors, so the
+	// mutationFn must throw it; with no local onError, the failure then reaches
+	// the global mutation handler (root layout), which toasts it.
 	const deleteMutation = createMutation(() => ({
 		mutationFn: async (fileId: string) => {
-			await questionnairefileDeleteFile({ path: { file_id: fileId } });
+			const res = await questionnairefileDeleteFile({ path: { file_id: fileId } });
+			if (res.error) throw res.error;
 			return fileId;
 		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['user-files'] });
 			queryClient.invalidateQueries({ queryKey: ['questionnaire-files'] });
-			deletingFileId = null;
 		},
-		onError: () => {
+		onSettled: () => {
 			deletingFileId = null;
 		}
 	}));

--- a/src/routes/(auth)/account/privacy/page.test.ts
+++ b/src/routes/(auth)/account/privacy/page.test.ts
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import Page from './+page.svelte';
+import {
+	questionnairefileListFiles,
+	questionnairefileDeleteFile
+} from '$lib/api/generated/sdk.gen';
+
+vi.mock('$lib/api/generated/sdk.gen', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/api/generated/sdk.gen')>()),
+	questionnairefileListFiles: vi.fn(),
+	questionnairefileDeleteFile: vi.fn()
+}));
+vi.mock('$app/forms', () => ({
+	enhance: () => ({
+		destroy: () => {
+			// no-op: the account-deletion form action is not under test
+		}
+	})
+}));
+
+type ListResult = Awaited<ReturnType<typeof questionnairefileListFiles>>;
+type DeleteResult = Awaited<ReturnType<typeof questionnairefileDeleteFile>>;
+
+const file = {
+	id: 'file-1',
+	original_filename: 'answer.pdf',
+	mime_type: 'application/pdf',
+	file_size: 1024,
+	file_url: null,
+	created_at: '2026-09-01T10:00:00Z'
+};
+
+function renderPage() {
+	// Mirror the app-level QueryClient contract from +layout.svelte: mutations
+	// without a local onError fall through to a global handler that surfaces
+	// the failure. The page's delete mutation must throw for that to happen.
+	const onMutationError = vi.fn();
+	const client = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false, onError: onMutationError }
+		}
+	});
+	render(QueryClientTestWrapper, {
+		props: {
+			client,
+			component: Page,
+			componentProps: { form: null }
+		}
+	});
+	return { onMutationError };
+}
+
+describe('privacy page file delete error handling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(questionnairefileListFiles).mockResolvedValue({
+			data: { results: [file], count: 1 },
+			error: undefined,
+			response: { ok: true, status: 200 } as Response
+		} as unknown as ListResult);
+	});
+
+	it('propagates a failed delete to the global mutation error handler and keeps the file listed', async () => {
+		vi.mocked(questionnairefileDeleteFile).mockResolvedValue({
+			data: undefined,
+			error: { detail: 'Nope' },
+			response: { ok: false, status: 400 } as Response
+		} as unknown as DeleteResult);
+		const user = userEvent.setup();
+		const { onMutationError } = renderPage();
+
+		await user.click(await screen.findByRole('button', { name: 'Delete file' }));
+		await user.click(await screen.findByRole('button', { name: 'Delete File' }));
+
+		await waitFor(() => expect(onMutationError).toHaveBeenCalled());
+		expect(screen.getByText('answer.pdf')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Problem

The generated API client resolves with `{ error }` on HTTP errors (`ThrowOnError = false`), so any `mutationFn` that returns/awaits an SDK call without checking `res.error` makes TanStack Query treat a 400/422/500 as a **success**: `onSuccess` side effects run (dialogs close, optimistic flips commit, success toasts fire) and the existing `onError` handlers — toasts, rollbacks, inline panels — are unreachable dead code.

Found while reviewing letsrevel/revel-backend#945 (un-pausing an ONLINE tier without Stripe Connect → new 400 `StripeNotConnectedError`): the TierForm path would have swallowed that error entirely.

## Fix

`if (res.error) throw res.error;` (the pattern `TicketingStep` already used) in every affected mutationFn — TierForm's three, plus a full sweep of the codebase (16 more across 9 files):

- **TierForm**: create / update / delete — the inline error panel (field errors, billing-info notice) is now reachable; a rejected save keeps the dialog open and shows the backend detail.
- **Account privacy page**: file delete — local no-feedback `onError` dropped (reset moved to `onSettled`) so the global mutation toast reports the failure.
- **DietaryPreferencesManager**: add / delete / update.
- **DietaryRestrictionsManager**: create food item / add / delete / update.
- **TelegramConnectionManager**: connect / disconnect — the inline OTP error now renders the backend detail via `extractErrorMessage`.
- **BookmarkButton**: bookmark / unbookmark — the optimistic flip now rolls back on failure.
- **NotificationItem** (mark read/unread), **NotificationDropdown** + **NotificationList** (mark all read) — optimistic state rolls back, error toasts fire.
- **InvitationRequestCard**: cancel — the error toast now carries the backend detail.

Verified fail-loud already (no change needed): EventEditor, EventWizard, event-image-mutations, questionnaire submission page, ResourceModal, PotluckSection, EventRSVP, both cart-checkout controllers, RefundTicketDialog, PlansList, SubscriptionDrawer.

## Tests

Every fix is covered by a test that resolves the mocked SDK call with an HTTP error body (`{ detail: ... }`) and asserts the failure is surfaced (toast / inline panel / rollback) and that success-only side effects do **not** run. Each was watched fail against the unfixed component before the fix. New specs: TierForm, DietaryPreferencesManager, DietaryRestrictionsManager, TelegramConnectionManager, InvitationRequestCard, privacy page; extended: BookmarkButton, NotificationItem, NotificationList, NotificationDropdown.

`make check` green; full unit suite green (309 files / 3558 passed + 1 todo).

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across event, invitation, notification, profile, Telegram, and privacy actions.
  * Failed requests now show appropriate error messages or toasts instead of being treated as successful.
  * Optimistic UI updates are correctly reverted when actions fail.
  * Dialogs remain open when ticket, connection, or other submitted actions encounter errors.
  * Privacy file deletion failures are surfaced consistently, while affected files remain listed.

* **Tests**
  * Added coverage for failed API responses, error notifications, state rollback, and dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->