### PR TITLE
fix: seat-picker → cart sync loss, and fail-fast Stripe forwarder detection

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,6 +30,8 @@ const REGRESSION_BROWSERS = [
 
 export default defineConfig({
 	testDir: './tests/e2e',
+	// Plants E2E_RUN_ID for the cross-worker Stripe webhook verdict (#919).
+	globalSetup: './tests/e2e/support/global-setup.ts',
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	// One local retry. The client-auth rotation race that originally motivated

--- a/src/lib/components/tickets/CartSeatGroupHolds.svelte
+++ b/src/lib/components/tickets/CartSeatGroupHolds.svelte
@@ -44,6 +44,15 @@
 	const tier = group.tier;
 	const isUserChoice = tier.seat_assignment_mode === 'user_choice';
 
+	// The seats this group ALREADY claims at mount (#918) — the picker's Done
+	// wrote them in the same flush that mounted this component. Captured once,
+	// deliberately, for the same reason `tier` is: it's the hand-off payload,
+	// not a value to track. Copied so a later `setSeatIds` can't retroactively
+	// change what the seed was told; fed to `seedFromAvailability` so a warm
+	// but PRE-hold availability snapshot can't make the controller disown them.
+	// svelte-ignore state_referenced_locally
+	const initialSeatIds: string[] = isUserChoice ? [...group.seatIds] : [];
+
 	// Declared ahead of `options` (explicit type annotation) so `getQuantity`
 	// can close over it without a circular type-inference error — it's only
 	// ever CALLED after the assignment below, never read synchronously.
@@ -136,23 +145,24 @@
 			// current holds keeps each group's adoption in its own lane.
 			const validIds = validSeatIdsFor(chart);
 			for (const id of registry.otherHolds(tier.id)) validIds.delete(id);
-			controller.seedFromAvailability(validIds);
+			controller.seedFromAvailability(validIds, initialSeatIds);
 			return;
 		}
 		controller.adoptServerHolds();
 	});
 
-	// Live sync: the controller's held seats ARE the group's seatIds. The
-	// ONLY other writer is the host's expiry sweep (which clears to []).
-	// Gated on `seeded` (shouldSyncSeatIds): on the very first reactive
-	// flush `controller.myHolds` is still `[]` (chart/availability are still
-	// in flight above), and `cart.setSeatIds(tier, [])` REMOVES the group —
-	// syncing before the seed/adopt effect's first pass would strip a group
-	// whose seats already exist server-side (the venue-overview hand-off)
-	// and unmount this very component before it gets the chance to adopt
-	// them. See cart-seat-sync.ts for the (unit-tested) gate itself.
+	// Live sync: the controller's held seats ARE the group's seatIds — but
+	// only ADDITIVELY. `cart.setSeatIds(tier, [])` REMOVES the group, and this
+	// effect must never be the writer that does so: before the first seed
+	// `myHolds` is still `[]` (chart/availability in flight), and after it the
+	// seed may itself have produced `[]` from a warm-but-pre-hold availability
+	// snapshot (#918) — either way, deleting here unmounts this very component
+	// and loses the group for good (no `#each` entry left to remount from).
+	// Emptying a group is owned by the two writers that do it explicitly: the
+	// seat picker and the host's expiry sweep. See cart-seat-sync.ts for the
+	// (unit-tested) gate itself.
 	$effect(() => {
-		if (!shouldSyncSeatIds(isUserChoice, seeded)) return;
+		if (!shouldSyncSeatIds(isUserChoice, seeded, controller.myHolds.length)) return;
 		cart.setSeatIds(tier, controller.myHolds);
 	});
 </script>

--- a/src/lib/components/tickets/CartSeatGroupHolds.svelte
+++ b/src/lib/components/tickets/CartSeatGroupHolds.svelte
@@ -44,12 +44,17 @@
 	const tier = group.tier;
 	const isUserChoice = tier.seat_assignment_mode === 'user_choice';
 
-	// The seats this group ALREADY claims at mount (#918) — the picker's Done
-	// wrote them in the same flush that mounted this component. Captured once,
-	// deliberately, for the same reason `tier` is: it's the hand-off payload,
-	// not a value to track. Copied so a later `setSeatIds` can't retroactively
-	// change what the seed was told; fed to `seedFromAvailability` so a warm
-	// but PRE-hold availability snapshot can't make the controller disown them.
+	// The seats this group ALREADY claims at mount (#918), written in the same
+	// flush by whichever writer created the group: the picker's Done
+	// (`SeatPickerDialog.handleDone`) or the picker-free venue-overview
+	// hand-off (the event page's `handleSelectTier`, which adopts seats the
+	// overview map already holds). Captured once, deliberately, for the same
+	// reason `tier` is: it's the hand-off payload, not a value to track.
+	// Copied so a later `setSeatIds` can't retroactively change what the seed
+	// was told. Fed to `seedFromAvailability` so a warm but PRE-hold
+	// availability snapshot can't make the controller disown them, and
+	// compared against `myHolds` below so a PARTIAL resolution can't make the
+	// live sync write a shrunken list.
 	// svelte-ignore state_referenced_locally
 	const initialSeatIds: string[] = isUserChoice ? [...group.seatIds] : [];
 
@@ -151,18 +156,27 @@
 		controller.adoptServerHolds();
 	});
 
-	// Live sync: the controller's held seats ARE the group's seatIds — but
-	// only ADDITIVELY. `cart.setSeatIds(tier, [])` REMOVES the group, and this
-	// effect must never be the writer that does so: before the first seed
-	// `myHolds` is still `[]` (chart/availability in flight), and after it the
-	// seed may itself have produced `[]` from a warm-but-pre-hold availability
-	// snapshot (#918) — either way, deleting here unmounts this very component
-	// and loses the group for good (no `#each` entry left to remount from).
-	// Emptying a group is owned by the two writers that do it explicitly: the
-	// seat picker and the host's expiry sweep. See cart-seat-sync.ts for the
-	// (unit-tested) gate itself.
+	// Live sync: the controller's held seats become the group's seatIds. NOT an
+	// additive writer — `cart.setSeatIds` REPLACES the list (and `[]` REMOVES
+	// the group) — so the gate's whole job is to withhold any write that would
+	// be worse than what the group already claims. `myHolds` can be empty
+	// (queries in flight, or a seed off a warm-but-pre-hold snapshot — #918)
+	// or PARTIAL (a claimed seat the warm chart doesn't list, so neither the
+	// seed's union nor any later adopt can resolve it — #918 review). Writing
+	// the first deletes the group and unmounts the only component that could
+	// have repaired it; writing the second drops a seat from the buyer's cart
+	// with no symptom at all. Shrinking and emptying belong to the writers
+	// that do it explicitly: the picker, the venue-overview hand-off, and the
+	// host's expiry sweep. See cart-seat-sync.ts for the (unit-tested) gate.
+	//
+	// `initialSeatIds` is a plain array, so the only reactive dependency this
+	// adds is `controller.myHolds` — which the effect already tracked. Reading
+	// `group.seatIds` here instead would make the effect depend on its own
+	// write and loop.
 	$effect(() => {
-		if (!shouldSyncSeatIds(isUserChoice, seeded, controller.myHolds.length)) return;
-		cart.setSeatIds(tier, controller.myHolds);
+		const held = controller.myHolds;
+		const unresolvedClaims = initialSeatIds.filter((id) => !held.includes(id)).length;
+		if (!shouldSyncSeatIds(isUserChoice, seeded, held.length, unresolvedClaims)) return;
+		cart.setSeatIds(tier, held);
 	});
 </script>

--- a/src/lib/components/tickets/CartSeatGroupHolds.test.ts
+++ b/src/lib/components/tickets/CartSeatGroupHolds.test.ts
@@ -31,6 +31,8 @@ vi.mock('$lib/api/generated/sdk.gen', () => ({
 const EVENT_ID = 'event-1';
 const SECTOR_ID = 'sector-1';
 const SEAT_ID = 'seat-1';
+const SEAT_ID_2 = 'seat-2';
+const SEAT_ID_3 = 'seat-3';
 
 function mockResult<T extends (...args: never[]) => unknown>(
 	op: T,
@@ -43,7 +45,8 @@ function mockResult<T extends (...args: never[]) => unknown>(
 	} as never);
 }
 
-function chart(): VenueChartSchema {
+/** A one-sector chart listing exactly `seatIds` as active, selectable seats. */
+function chart(seatIds: readonly string[] = [SEAT_ID]): VenueChartSchema {
 	return {
 		venue_id: 'venue-1',
 		venue_name: 'Test Hall',
@@ -53,7 +56,13 @@ function chart(): VenueChartSchema {
 				id: SECTOR_ID,
 				name: 'Stalls',
 				kind: 'seated',
-				seats: [{ id: SEAT_ID, label: 'A1', row_label: 'A', number: 1, is_active: true }]
+				seats: seatIds.map((id, index) => ({
+					id,
+					label: `A${index + 1}`,
+					row_label: 'A',
+					number: index + 1,
+					is_active: true
+				}))
 			}
 		]
 	} as unknown as VenueChartSchema;
@@ -87,9 +96,9 @@ function seatedTier(): TierSchemaWithId {
  * snapshot, exactly as the seat picker leaves it: both queries are warm, so a
  * freshly mounted controller gets them synchronously on its very first flush.
  */
-function mountGroup(snapshotHolds: string[], groupSeatIds: string[]) {
+function mountGroup(snapshotHolds: string[], groupSeatIds: string[], warmChart = chart()) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	client.setQueryData(['seating-chart', EVENT_ID], chart());
+	client.setQueryData(['seating-chart', EVENT_ID], warmChart);
 	client.setQueryData(['seating-availability', EVENT_ID], availability(snapshotHolds));
 
 	const cart = new EventCart({ remainingFor: () => undefined, eventRemaining: () => null });
@@ -190,6 +199,53 @@ describe('CartSeatGroupHolds', () => {
 		await settle();
 
 		expect(cart.groupFor(tier.id)?.seatIds).toEqual([SEAT_ID]);
+	});
+
+	// #918 review. `holdCount > 0` stops the live-sync effect DELETING a group;
+	// it does nothing about it SHRINKING one, and `cart.setSeatIds` REPLACES.
+	// A group claiming two seats mounts onto a warm `['seating-chart', eventId]`
+	// entry that lists only the first (a narrower/staler chart — the same shape
+	// the test above uses, one seat up). `validSeatIds` filters `seat-2` out of
+	// the seed's union AND out of every later `adoptServerHolds`, so the
+	// controller resolves `[seat-1]`, reports a hold count of 1, and the write
+	// used to drop `seat-2` from the buyer's cart with no visible symptom.
+	it('never shrinks a group when only some of its claimed seats resolve', async () => {
+		const narrowChart = chart([SEAT_ID]);
+		mockResult(eventpublicseatingGetChart, { data: narrowChart });
+		mockResult(eventpublicseatingGetAvailability, { data: availability([]) });
+
+		const { cart, tier, registry } = mountGroup([], [SEAT_ID, SEAT_ID_2], narrowChart);
+		await settle();
+
+		expect(cart.groupFor(tier.id)?.seatIds).toEqual([SEAT_ID, SEAT_ID_2]);
+		expect(cart.groupFor(tier.id)?.quantity).toBe(2);
+		// Not a vacuous pass: the seed really ran and really resolved the one
+		// seat it could, so what withheld the write is the gate — not a seed
+		// that never happened (which would leave `myHolds` empty).
+		expect(registry.get(tier.id)?.myHolds).toEqual([SEAT_ID]);
+	});
+
+	// The other direction of the same gate: once every claimed seat resolves,
+	// the live sync is still a live sync. Proves the partial-resolution term
+	// withholds writes rather than disabling them — here it lets an extra
+	// server-side hold the seed picked up reach the group.
+	it('still syncs once every claimed seat resolves', async () => {
+		const fullChart = chart([SEAT_ID, SEAT_ID_2, SEAT_ID_3]);
+		mockResult(eventpublicseatingGetChart, { data: fullChart });
+		mockResult(eventpublicseatingGetAvailability, {
+			data: availability([SEAT_ID, SEAT_ID_2, SEAT_ID_3])
+		});
+
+		const { cart, tier, registry } = mountGroup(
+			[SEAT_ID, SEAT_ID_2, SEAT_ID_3],
+			[SEAT_ID, SEAT_ID_2],
+			fullChart
+		);
+		await settle();
+
+		expect(registry.get(tier.id)?.myHolds).toEqual([SEAT_ID, SEAT_ID_2, SEAT_ID_3]);
+		expect(cart.groupFor(tier.id)?.seatIds).toEqual([SEAT_ID, SEAT_ID_2, SEAT_ID_3]);
+		expect(cart.groupFor(tier.id)?.quantity).toBe(3);
 	});
 
 	it('keeps the group and adopts the seat when the snapshot already reports the hold', async () => {

--- a/src/lib/components/tickets/CartSeatGroupHolds.test.ts
+++ b/src/lib/components/tickets/CartSeatGroupHolds.test.ts
@@ -1,0 +1,243 @@
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import CartSeatGroupHolds from './CartSeatGroupHolds.svelte';
+import { EventCart, type CartGroup } from './cart.svelte';
+import { CartSeatHoldRegistry } from './cart-seat-registry.svelte';
+import type { TierSchemaWithId } from '$lib/types/tickets';
+import type { SeatingAvailabilitySchema, VenueChartSchema } from '$lib/api/generated/types.gen';
+import {
+	eventpublicseatingGetAvailability,
+	eventpublicseatingGetChart,
+	eventpublicseatingHoldBestAvailable,
+	eventpublicseatingHoldSeats,
+	eventpublicseatingReleaseSeats
+} from '$lib/api/generated/sdk.gen';
+
+// The controller behind this component reaches the backend only through the
+// generated sdk (re-exported by `$lib/api`), so mocking sdk.gen intercepts
+// every call it can make — including the fire-and-forget availability refetch
+// this test deliberately leaves unresolved-until-late.
+vi.mock('$lib/api/generated/sdk.gen', () => ({
+	eventpublicseatingGetChart: vi.fn(),
+	eventpublicseatingGetAvailability: vi.fn(),
+	eventpublicseatingHoldSeats: vi.fn(),
+	eventpublicseatingHoldBestAvailable: vi.fn(),
+	eventpublicseatingReleaseSeats: vi.fn()
+}));
+
+const EVENT_ID = 'event-1';
+const SECTOR_ID = 'sector-1';
+const SEAT_ID = 'seat-1';
+
+function mockResult<T extends (...args: never[]) => unknown>(
+	op: T,
+	result: { data?: unknown; error?: unknown; status?: number }
+) {
+	vi.mocked(op).mockResolvedValue({
+		data: result.data,
+		error: result.error,
+		response: { status: result.status ?? (result.error === undefined ? 200 : 409) }
+	} as never);
+}
+
+function chart(): VenueChartSchema {
+	return {
+		venue_id: 'venue-1',
+		venue_name: 'Test Hall',
+		price_categories: [],
+		sectors: [
+			{
+				id: SECTOR_ID,
+				name: 'Stalls',
+				kind: 'seated',
+				seats: [{ id: SEAT_ID, label: 'A1', row_label: 'A', number: 1, is_active: true }]
+			}
+		]
+	} as unknown as VenueChartSchema;
+}
+
+function availability(myHolds: string[]): SeatingAvailabilitySchema {
+	return {
+		seats: {},
+		standing: {},
+		my_holds: myHolds,
+		my_holds_expire_at: myHolds.length > 0 ? '2026-09-12T12:00:00Z' : null
+	} as unknown as SeatingAvailabilitySchema;
+}
+
+function seatedTier(): TierSchemaWithId {
+	return {
+		id: 'tier-1',
+		name: 'Seated',
+		payment_method: 'offline',
+		price_type: 'fixed',
+		seat_assignment_mode: 'user_choice',
+		currency: 'EUR',
+		price: '20.00',
+		total_available: 100,
+		sector: { id: SECTOR_ID, name: 'Stalls' }
+	} as unknown as TierSchemaWithId;
+}
+
+/**
+ * Mount the host over a query cache that ALREADY holds a chart + availability
+ * snapshot, exactly as the seat picker leaves it: both queries are warm, so a
+ * freshly mounted controller gets them synchronously on its very first flush.
+ */
+function mountGroup(snapshotHolds: string[], groupSeatIds: string[]) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	client.setQueryData(['seating-chart', EVENT_ID], chart());
+	client.setQueryData(['seating-availability', EVENT_ID], availability(snapshotHolds));
+
+	const cart = new EventCart({ remainingFor: () => undefined, eventRemaining: () => null });
+	const tier = seatedTier();
+	cart.setSeatIds(tier, groupSeatIds);
+	const group = cart.groupFor(tier.id) as CartGroup;
+
+	const registry = new CartSeatHoldRegistry();
+	render(QueryClientTestWrapper, {
+		props: {
+			client,
+			component: CartSeatGroupHolds,
+			componentProps: { cart, registry, eventId: EVENT_ID, group }
+		}
+	});
+	return { cart, tier, registry };
+}
+
+/** Let the mount's effects (seed → live-sync) and the refetch microtasks run. */
+async function settle(): Promise<void> {
+	await tick();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await tick();
+}
+
+describe('CartSeatGroupHolds', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockResult(eventpublicseatingGetChart, { data: chart() });
+		mockResult(eventpublicseatingReleaseSeats, { data: null });
+	});
+
+	// #918 regression. The picker's Done writes the group and closes in the same
+	// flush that mounts THIS component, whose fresh controller seeds from the
+	// warm availability entry — which is routinely still the PRE-hold snapshot,
+	// because the picker's post-tap refetch is fire-and-forget and the query has
+	// no staleTime. Before the fix, that seed produced `myHolds === []`, the
+	// live-sync effect wrote it through as `cart.setSeatIds(tier, [])` — which
+	// DELETES the group — and the deletion unmounted the only component that
+	// could have repaired it once the refetch landed.
+	it('never deletes the group it was mounted for when the seeded snapshot is pre-hold', async () => {
+		// The in-flight refetch is still returning the stale payload: the worst
+		// case, where nothing arrives to repair a bad seed.
+		mockResult(eventpublicseatingGetAvailability, { data: availability([]) });
+
+		const { cart, tier, registry } = mountGroup([], [SEAT_ID]);
+		await settle();
+
+		expect(cart.groupFor(tier.id)?.seatIds).toEqual([SEAT_ID]);
+		expect(cart.groupFor(tier.id)?.quantity).toBe(1);
+		// Not a vacuous pass: the controller having adopted the group's known
+		// seat proves the seed effect really ran during the flush above (a seed
+		// that never ran would leave `myHolds` empty). It also proves the
+		// controller now OWNS the seat, so its teardown releases it instead of
+		// leaking the hold for the full server-side TTL.
+		expect(registry.get(tier.id)?.myHolds).toEqual([SEAT_ID]);
+	});
+
+	// The residual the seed-side union CANNOT cover, so this pins the live-sync
+	// gate on its own: the group's seat is absent from the chart this controller
+	// mounted onto (a narrower/staler `['seating-chart', eventId]` entry), so it
+	// is filtered out of `validSeatIds` and the union has nothing to keep. The
+	// seed still produces `[]` — and the group must STILL survive it.
+	it('never deletes the group when the warm chart does not list its seat either', async () => {
+		mockResult(eventpublicseatingGetAvailability, { data: availability([]) });
+
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const narrowChart = chart();
+		// Same sector, different seat — nothing the group claims is selectable.
+		narrowChart.sectors = [
+			{
+				id: SECTOR_ID,
+				name: 'Stalls',
+				kind: 'seated',
+				seats: [{ id: 'seat-other', label: 'A2', row_label: 'A', number: 2, is_active: true }]
+			}
+		] as unknown as VenueChartSchema['sectors'];
+		client.setQueryData(['seating-chart', EVENT_ID], narrowChart);
+		client.setQueryData(['seating-availability', EVENT_ID], availability([]));
+		mockResult(eventpublicseatingGetChart, { data: narrowChart });
+
+		const cart = new EventCart({ remainingFor: () => undefined, eventRemaining: () => null });
+		const tier = seatedTier();
+		cart.setSeatIds(tier, [SEAT_ID]);
+		const registry = new CartSeatHoldRegistry();
+		render(QueryClientTestWrapper, {
+			props: {
+				client,
+				component: CartSeatGroupHolds,
+				componentProps: {
+					cart,
+					registry,
+					eventId: EVENT_ID,
+					group: cart.groupFor(tier.id) as CartGroup
+				}
+			}
+		});
+		await settle();
+
+		expect(cart.groupFor(tier.id)?.seatIds).toEqual([SEAT_ID]);
+	});
+
+	it('keeps the group and adopts the seat when the snapshot already reports the hold', async () => {
+		mockResult(eventpublicseatingGetAvailability, { data: availability([SEAT_ID]) });
+
+		const { cart, tier, registry } = mountGroup([SEAT_ID], [SEAT_ID]);
+		await settle();
+
+		expect(cart.groupFor(tier.id)?.seatIds).toEqual([SEAT_ID]);
+		expect(registry.get(tier.id)?.myHolds).toEqual([SEAT_ID]);
+	});
+
+	it('does not invent seats for a group that carries none', async () => {
+		mockResult(eventpublicseatingGetAvailability, { data: availability([]) });
+
+		// A group with no seat ids can't be created through `setSeatIds`, so this
+		// mounts the host directly against a hand-built group — the shape the
+		// expiry sweep leaves behind before it drops the group.
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		client.setQueryData(['seating-chart', EVENT_ID], chart());
+		client.setQueryData(['seating-availability', EVENT_ID], availability([]));
+		const cart = new EventCart({ remainingFor: () => undefined, eventRemaining: () => null });
+		const tier = seatedTier();
+		const group: CartGroup = {
+			tier,
+			quantity: 1,
+			guestNames: [],
+			pwycAmount: null,
+			priceCategoryId: null,
+			accessibleRequired: false,
+			seatIds: []
+		};
+		const registry = new CartSeatHoldRegistry();
+		render(QueryClientTestWrapper, {
+			props: {
+				client,
+				component: CartSeatGroupHolds,
+				componentProps: { cart, registry, eventId: EVENT_ID, group }
+			}
+		});
+		await settle();
+
+		expect(registry.get(tier.id)?.myHolds).toEqual([]);
+		expect(cart.isEmpty).toBe(true);
+	});
+});
+
+// Keeps the unused-import lint quiet for ops the component can reach but this
+// suite never drives; they still need to exist on the mocked module.
+void eventpublicseatingHoldSeats;
+void eventpublicseatingHoldBestAvailable;

--- a/src/lib/components/tickets/cart-seat-sync.test.ts
+++ b/src/lib/components/tickets/cart-seat-sync.test.ts
@@ -5,15 +5,26 @@ describe('shouldSyncSeatIds', () => {
 	it('is false for user_choice before any seed/adopt pass has run', () => {
 		// The critical case: myHolds is still [] on first flush — syncing here
 		// would remove the group via setSeatIds([]) before adoption can land it.
-		expect(shouldSyncSeatIds(true, false)).toBe(false);
+		expect(shouldSyncSeatIds(true, false, 0)).toBe(false);
 	});
 
-	it('is true for user_choice once a seed/adopt pass has run', () => {
-		expect(shouldSyncSeatIds(true, true)).toBe(true);
+	it('is true for user_choice once a seed/adopt pass has produced holds', () => {
+		expect(shouldSyncSeatIds(true, true, 1)).toBe(true);
 	});
 
-	it('is false for best_available regardless of seeded', () => {
-		expect(shouldSyncSeatIds(false, false)).toBe(false);
-		expect(shouldSyncSeatIds(false, true)).toBe(false);
+	// #918: `seeded` alone said "an empty myHolds is trustworthy now", but the
+	// seed reads a query-cache entry that may still be the PRE-hold availability
+	// snapshot — so it can flip `seeded` true while legitimately producing
+	// nothing. Writing that [] through deletes the group the picker created
+	// milliseconds earlier, AND unmounts the component that would have repaired
+	// it when the refetch landed. The live-sync effect is additive-only now.
+	it('is false for a seeded pass that produced no holds — it must never delete a group', () => {
+		expect(shouldSyncSeatIds(true, true, 0)).toBe(false);
+	});
+
+	it('is false for best_available regardless of seeded or hold count', () => {
+		expect(shouldSyncSeatIds(false, false, 0)).toBe(false);
+		expect(shouldSyncSeatIds(false, true, 0)).toBe(false);
+		expect(shouldSyncSeatIds(false, true, 2)).toBe(false);
 	});
 });

--- a/src/lib/components/tickets/cart-seat-sync.test.ts
+++ b/src/lib/components/tickets/cart-seat-sync.test.ts
@@ -5,11 +5,12 @@ describe('shouldSyncSeatIds', () => {
 	it('is false for user_choice before any seed/adopt pass has run', () => {
 		// The critical case: myHolds is still [] on first flush — syncing here
 		// would remove the group via setSeatIds([]) before adoption can land it.
-		expect(shouldSyncSeatIds(true, false, 0)).toBe(false);
+		expect(shouldSyncSeatIds(true, false, 0, 1)).toBe(false);
 	});
 
-	it('is true for user_choice once a seed/adopt pass has produced holds', () => {
-		expect(shouldSyncSeatIds(true, true, 1)).toBe(true);
+	it('is true for user_choice once a seed/adopt pass has resolved every claim', () => {
+		expect(shouldSyncSeatIds(true, true, 1, 0)).toBe(true);
+		expect(shouldSyncSeatIds(true, true, 3, 0)).toBe(true);
 	});
 
 	// #918: `seeded` alone said "an empty myHolds is trustworthy now", but the
@@ -17,14 +18,24 @@ describe('shouldSyncSeatIds', () => {
 	// snapshot — so it can flip `seeded` true while legitimately producing
 	// nothing. Writing that [] through deletes the group the picker created
 	// milliseconds earlier, AND unmounts the component that would have repaired
-	// it when the refetch landed. The live-sync effect is additive-only now.
+	// it when the refetch landed.
 	it('is false for a seeded pass that produced no holds — it must never delete a group', () => {
-		expect(shouldSyncSeatIds(true, true, 0)).toBe(false);
+		expect(shouldSyncSeatIds(true, true, 0, 1)).toBe(false);
+		expect(shouldSyncSeatIds(true, true, 0, 0)).toBe(false);
 	});
 
-	it('is false for best_available regardless of seeded or hold count', () => {
-		expect(shouldSyncSeatIds(false, false, 0)).toBe(false);
-		expect(shouldSyncSeatIds(false, true, 0)).toBe(false);
-		expect(shouldSyncSeatIds(false, true, 2)).toBe(false);
+	// #918 review: `holdCount > 0` only stops DELETION. `cart.setSeatIds`
+	// REPLACES, so a group claiming two seats whose controller resolved one
+	// still passes a positive hold count and the write silently drops the
+	// other. A partial resolution must withhold the write entirely.
+	it('is false while any seat the group claimed is still unresolved', () => {
+		expect(shouldSyncSeatIds(true, true, 1, 1)).toBe(false);
+		expect(shouldSyncSeatIds(true, true, 2, 3)).toBe(false);
+	});
+
+	it('is false for best_available regardless of every other term', () => {
+		expect(shouldSyncSeatIds(false, false, 0, 0)).toBe(false);
+		expect(shouldSyncSeatIds(false, true, 0, 0)).toBe(false);
+		expect(shouldSyncSeatIds(false, true, 2, 0)).toBe(false);
 	});
 });

--- a/src/lib/components/tickets/cart-seat-sync.ts
+++ b/src/lib/components/tickets/cart-seat-sync.ts
@@ -1,6 +1,6 @@
 /**
  * Whether `CartSeatGroupHolds` should push `controller.myHolds` into
- * `cart.setSeatIds` right now (#853 PR 3).
+ * `cart.setSeatIds` right now (#853 PR 3, hardened in #918).
  *
  * `cart.setSeatIds(tier, [])` REMOVES the group from the cart — that's its
  * documented behavior for an empty array, not "no seats yet". A freshly
@@ -13,11 +13,31 @@
  * from). Gating on `seeded` (set by the seed/adopt effect after its first
  * successful pass, once chart+availability have both loaded) means the
  * sync never fires until there's been at least one real chance to adopt
- * pre-existing holds, so an empty `myHolds` at that point is trustworthy.
+ * pre-existing holds.
+ *
+ * `seeded` alone was NOT enough (#918). The seed reads a query-cache entry,
+ * and "has data" is not "is fresh": the availability query carries no
+ * `staleTime` and the picker's post-tap refetch is fire-and-forget, so the
+ * snapshot a group's controller mounts onto is routinely the PRE-hold one
+ * (`my_holds: []`). The seed then legitimately produced nothing, `seeded`
+ * flipped true anyway, and this effect wrote that `[]` straight through —
+ * deleting the group the picker had created milliseconds earlier, and with
+ * it the component that would have repaired the group once the refetch
+ * landed. So the live-sync effect must never be ABLE to delete a group:
+ * `holdCount > 0` makes it a strictly additive writer.
+ *
+ * Deletion is legitimately owned by the two writers that clear `seatIds`
+ * explicitly, neither of which routes through here: the picker
+ * (`SeatPickerDialog.handleDone` / `seatPickerCloseAction`) and the
+ * event-wide expiry sweep (`CartSeatHolds.handleExpiry`).
  *
  * `best_available` groups never sync (seats aren't picked, they're
  * assigned at confirm — Task 8), regardless of `seeded`.
  */
-export function shouldSyncSeatIds(isUserChoice: boolean, seeded: boolean): boolean {
-	return isUserChoice && seeded;
+export function shouldSyncSeatIds(
+	isUserChoice: boolean,
+	seeded: boolean,
+	holdCount: number
+): boolean {
+	return isUserChoice && seeded && holdCount > 0;
 }

--- a/src/lib/components/tickets/cart-seat-sync.ts
+++ b/src/lib/components/tickets/cart-seat-sync.ts
@@ -1,43 +1,56 @@
 /**
  * Whether `CartSeatGroupHolds` should push `controller.myHolds` into
- * `cart.setSeatIds` right now (#853 PR 3, hardened in #918).
+ * `cart.setSeatIds` right now (#853 PR 3, hardened in #918 and its review).
  *
- * `cart.setSeatIds(tier, [])` REMOVES the group from the cart — that's its
- * documented behavior for an empty array, not "no seats yet". A freshly
- * mounted controller's `myHolds` starts at `[]` (chart/availability are
- * still in flight), so syncing on the very first reactive flush would strip
- * a group whose seats already exist server-side (the venue-overview
- * hand-off, or a re-mount of an existing group) before the seed/adopt
- * effect has had a chance to land them — unmounting this very component
- * mid-hand-off and losing it for good (no `#each` entry left to remount
- * from). Gating on `seeded` (set by the seed/adopt effect after its first
- * successful pass, once chart+availability have both loaded) means the
- * sync never fires until there's been at least one real chance to adopt
- * pre-existing holds.
+ * `cart.setSeatIds` REPLACES a group's `seatIds` — it never merges — and an
+ * empty array REMOVES the group outright. So every term below exists for one
+ * reason: this effect must never write a list that is WORSE than the one the
+ * group already carries.
  *
- * `seeded` alone was NOT enough (#918). The seed reads a query-cache entry,
- * and "has data" is not "is fresh": the availability query carries no
- * `staleTime` and the picker's post-tap refetch is fire-and-forget, so the
- * snapshot a group's controller mounts onto is routinely the PRE-hold one
- * (`my_holds: []`). The seed then legitimately produced nothing, `seeded`
+ * `seeded` — set by the seed/adopt effect after its first pass, once chart AND
+ * availability have both loaded. A freshly mounted controller's `myHolds`
+ * starts at `[]` (both queries still in flight), so syncing on the very first
+ * reactive flush would strip a group whose seats already exist server-side,
+ * unmounting this very component mid-hand-off and losing the group for good
+ * (no `#each` entry left to remount from).
+ *
+ * `holdCount > 0` — `seeded` alone was NOT enough (#918). The seed reads a
+ * query-cache entry, and "has data" is not "is fresh": the availability query
+ * carries no `staleTime` and the picker's post-tap refetch is fire-and-forget,
+ * so the snapshot a group's controller mounts onto is routinely the PRE-hold
+ * one (`my_holds: []`). The seed then legitimately produced nothing, `seeded`
  * flipped true anyway, and this effect wrote that `[]` straight through —
- * deleting the group the picker had created milliseconds earlier, and with
- * it the component that would have repaired the group once the refetch
- * landed. So the live-sync effect must never be ABLE to delete a group:
- * `holdCount > 0` makes it a strictly additive writer.
+ * deleting the group the picker had created milliseconds earlier, and with it
+ * the component that would have repaired the group once the refetch landed.
  *
- * Deletion is legitimately owned by the two writers that clear `seatIds`
- * explicitly, neither of which routes through here: the picker
- * (`SeatPickerDialog.handleDone` / `seatPickerCloseAction`) and the
+ * `unresolvedClaims === 0` — the same failure one size down (#918 review).
+ * `holdCount > 0` stops a group being DELETED; it does nothing about a group
+ * being SHRUNK. A group claiming [A, B] whose controller resolved only [A] —
+ * B absent from the warm `['seating-chart', eventId]` entry, or inactive, or
+ * excluded because another registered controller holds it — reports a hold
+ * count of 1 and passes, and the write drops B from the buyer's cart with no
+ * symptom at all. `adoptServerHolds` cannot bring B back: it filters through
+ * the same frozen `#validSeatIds`. So the write is withheld until the
+ * controller has resolved EVERY seat the group claimed at mount. A merely
+ * stale or narrow chart resolves on a later adopt and the sync opens; a
+ * permanently invalid seat leaves the group holding exactly what the buyer
+ * picked, which fails loudly at checkout rather than quietly selling them one
+ * seat fewer than they chose. Silent loss is the worse failure.
+ *
+ * Shrinking and emptying a group belong to the writers that do it EXPLICITLY,
+ * none of which routes through here: the seat picker
+ * (`SeatPickerDialog.handleDone` / `seatPickerCloseAction`), the
+ * venue-overview hand-off (the event page's `handleSelectTier`), and the
  * event-wide expiry sweep (`CartSeatHolds.handleExpiry`).
  *
- * `best_available` groups never sync (seats aren't picked, they're
- * assigned at confirm — Task 8), regardless of `seeded`.
+ * `best_available` groups never sync (seats aren't picked, they're assigned at
+ * confirm — Task 8), regardless of everything above.
  */
 export function shouldSyncSeatIds(
 	isUserChoice: boolean,
 	seeded: boolean,
-	holdCount: number
+	holdCount: number,
+	unresolvedClaims: number
 ): boolean {
-	return isUserChoice && seeded && holdCount > 0;
+	return isUserChoice && seeded && holdCount > 0 && unresolvedClaims === 0;
 }

--- a/src/lib/components/tickets/seat-hold-controller.svelte.ts
+++ b/src/lib/components/tickets/seat-hold-controller.svelte.ts
@@ -240,13 +240,28 @@ export class SeatHoldController {
 	 * foreign "held by someone else" seats. The counter is grown to match the
 	 * adopted selection instead (taps drive the counter, and so does a
 	 * restored selection). Holds beyond the max are left to expire server-side.
+	 *
+	 * `knownHeld` (#918) are seats the CONSUMER already knows the caller holds —
+	 * a cart group's `seatIds`, written by the picker moments before this
+	 * controller existed. UNIONED in, not overwritten: a warm snapshot is not a
+	 * fresh one (availability has no `staleTime` and the picker's post-tap
+	 * refetch is fire-and-forget), so the payload a freshly mounted controller
+	 * seeds from routinely predates the very hold it is seeding for. Without the
+	 * union it disowns seats the group still claims, `onDestroy` skips the
+	 * release, and they stay held server-side for the full TTL. Known ids go
+	 * first so `max` truncation can't be what splits controller and group apart.
+	 * Empty by default — every other consumer's behavior is unchanged.
 	 */
-	seedFromAvailability = (validSeatIds: Set<string>): void => {
+	seedFromAvailability = (validSeatIds: Set<string>, knownHeld: readonly string[] = []): void => {
 		this.#validSeatIds = validSeatIds;
 		const availability = this.availabilityQuery.data;
 		if (!availability) return;
 		const max = Math.max(1, this.#opts.getMaxQuantity());
-		const mine = (availability.my_holds ?? []).filter((id) => validSeatIds.has(id)).slice(0, max);
+		const known = knownHeld.filter((id) => validSeatIds.has(id));
+		const fromServer = (availability.my_holds ?? []).filter(
+			(id) => validSeatIds.has(id) && !known.includes(id)
+		);
+		const mine = [...known, ...fromServer].slice(0, max);
 		this.myHolds = mine;
 		this.holdExpiresAt = this.myHolds.length > 0 ? (availability.my_holds_expire_at ?? null) : null;
 		if (mine.length > this.#opts.getQuantity()) {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,7 +16,7 @@ the built frontend.
 | Celery | inline/eager | Questionnaire auto-eval, exports, etc. complete synchronously |
 | Mailpit | `http://localhost:8025` | Captures all outbound email; override with `E2E_MAILPIT_URL` |
 | Keycloak | `http://localhost:8080` (realm `revel`, admin `admin`/`admin`) | OIDC login journeys; started by `make e2e-setup` via the backend compose overlay (backend PR #920). Specs self-skip when `/api/version` lists no `keycloak` provider. Override with `E2E_KEYCLOAK_URL` |
-| Stripe | `stripe listen` forwarding to the backend | Backend `.env` needs `CONNECTED_TEST_STRIPE_ID` **at bootstrap time**, or online checkout fails |
+| Stripe | `stripe listen` forwarding to the backend | `make run-stripe` in `revel-backend` (`stripe listen --forward-to localhost:8000/api/stripe/webhook`) — **not** started by `make e2e-setup`, it stays a manual step. Backend `.env` also needs `CONNECTED_TEST_STRIPE_ID` **at bootstrap time**, or online checkout fails.<br>Without the forwarder the 12 Stripe specs **fail** (never skip — see below), and since #919 they fail *fast*: the first wait to expire names the forwarder and the rest of the run aborts in milliseconds instead of burning 90–150s each. Measured cost of the old behaviour: 36.5m without the forwarder vs 12.2m with it |
 | Frontend | `http://localhost:5173` | Started by Playwright (`pnpm build && pnpm preview`) with `PUBLIC_API_URL=http://localhost:8000` |
 
 ## Running
@@ -59,4 +59,21 @@ pnpm test:e2e tests/e2e/regression # CSP/FOUC guards (no backend needed)
   semantics identify elements); `data-testid` only as a last resort.
 - **Email**: assert through `support/mailpit.ts` with a unique recipient; never
   "the latest message".
+- **Stripe webhooks fail, they never skip** (#919). Anything that can only
+  arrive through the `stripe listen` forwarder is awaited with
+  `expectWebhookEffect()` from `support/stripe.ts` (same `toPass` polling and
+  the same timeout as before), and tests whose arrange drives hosted checkout
+  open with `requireStripeWebhooks()`. `stripe listen` binds no local port, so
+  there is nothing to probe up front: the verdict is the forwarder's *effect*.
+  The first webhook-only wait that burns its whole budget with no delivery
+  anywhere in the run writes a `missing` marker and fails naming the forwarder;
+  every later Stripe test then aborts immediately with that same message and
+  the title of the test that discovered it. The first delivery writes a
+  `delivered` marker, after which the guard is inert for the rest of the run —
+  later failures surface their own assertion errors, untouched. The markers live
+  in the OS temp dir keyed by `E2E_RUN_ID` (planted by `support/global-setup.ts`)
+  because Playwright spawns a **fresh worker process after every failure**, so
+  the per-worker caching `support/skip.ts` uses would be discarded exactly when
+  it matters. Deliberately not a skip — the payment paths are the last coverage
+  we can afford to lose silently, and the healthy skip baseline stays **3**.
 - **Check-in**: use the QR scanner modal's manual-entry path (no camera in CI).

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,7 +16,7 @@ the built frontend.
 | Celery | inline/eager | Questionnaire auto-eval, exports, etc. complete synchronously |
 | Mailpit | `http://localhost:8025` | Captures all outbound email; override with `E2E_MAILPIT_URL` |
 | Keycloak | `http://localhost:8080` (realm `revel`, admin `admin`/`admin`) | OIDC login journeys; started by `make e2e-setup` via the backend compose overlay (backend PR #920). Specs self-skip when `/api/version` lists no `keycloak` provider. Override with `E2E_KEYCLOAK_URL` |
-| Stripe | `stripe listen` forwarding to the backend | `make run-stripe` in `revel-backend` (`stripe listen --forward-to localhost:8000/api/stripe/webhook`) — **not** started by `make e2e-setup`, it stays a manual step. Backend `.env` also needs `CONNECTED_TEST_STRIPE_ID` **at bootstrap time**, or online checkout fails.<br>Without the forwarder the 12 Stripe specs **fail** (never skip — see below), and since #919 they fail *fast*: the first wait to expire names the forwarder and the rest of the run aborts in milliseconds instead of burning 90–150s each. Measured cost of the old behaviour: 36.5m without the forwarder vs 12.2m with it |
+| Stripe | `stripe listen` forwarding to the backend | `make run-stripe` in `revel-backend` (`stripe listen --forward-to localhost:8000/api/stripe/webhook`) — **not** started by `make e2e-setup`, it stays a manual step. Backend `.env` also needs `CONNECTED_TEST_STRIPE_ID` **at bootstrap time**, or online checkout fails.<br>Without the forwarder the 12 Stripe specs **fail** (never skip — see below), and since #919 they fail *fast*: once two distinct webhook waits expire with nothing delivered, the rest of the run aborts in milliseconds instead of burning 90–150s each. Measured cost of the old behaviour: 36.5m without the forwarder vs 12.2m with it |
 | Frontend | `http://localhost:5173` | Started by Playwright (`pnpm build && pnpm preview`) with `PUBLIC_API_URL=http://localhost:8000` |
 
 ## Running
@@ -65,15 +65,24 @@ pnpm test:e2e tests/e2e/regression # CSP/FOUC guards (no backend needed)
   the same timeout as before), and tests whose arrange drives hosted checkout
   open with `requireStripeWebhooks()`. `stripe listen` binds no local port, so
   there is nothing to probe up front: the verdict is the forwarder's *effect*.
-  The first webhook-only wait that burns its whole budget with no delivery
-  anywhere in the run writes a `missing` marker and fails naming the forwarder;
-  every later Stripe test then aborts immediately with that same message and
-  the title of the test that discovered it. The first delivery writes a
-  `delivered` marker, after which the guard is inert for the rest of the run —
-  later failures surface their own assertion errors, untouched. The markers live
-  in the OS temp dir keyed by `E2E_RUN_ID` (planted by `support/global-setup.ts`)
-  because Playwright spawns a **fresh worker process after every failure**, so
-  the per-worker caching `support/skip.ts` uses would be discarded exactly when
-  it matters. Deliberately not a skip — the payment paths are the last coverage
-  we can afford to lose silently, and the healthy skip baseline stays **3**.
+  A webhook-only wait that burns its whole budget with no delivery anywhere in
+  the run files an expiry record keyed by its `description` and **rethrows its
+  own assertion error untouched**, with the forwarder attached as a report
+  annotation — one expiry cannot tell a missing forwarder apart from a UI
+  regression on that surface, so it never rules out the run on its own. Once
+  **two distinct** effects have expired that way, the run is ruled out and every
+  later Stripe test aborts immediately, listing both expiries and offering the
+  forwarder as the leading hypothesis. The first delivery writes a `delivered`
+  marker, after which the guard is inert for the rest of the run — later
+  failures surface their own assertion errors, untouched. Markers are created
+  with `wx` (never overwritten), so parallel workers cannot clobber the first
+  diagnostic, and they live in the OS temp dir keyed by `E2E_RUN_ID` (planted by
+  `support/global-setup.ts`) because Playwright spawns a **fresh worker process
+  after every failure**, so the per-worker caching `support/skip.ts` uses would
+  be discarded exactly when it matters. Corroboration is not proof: the backend
+  logs inbound events in `StripeWebhookEvent` but exposes it only through the
+  Django admin, so a staff/debug read route is what a directly *observed*
+  forwarder verdict would need. Deliberately not a skip — the payment paths are
+  the last coverage we can afford to lose silently, and the healthy skip
+  baseline stays **3**.
 - **Check-in**: use the QR scanner modal's manual-entry path (no camera in CI).

--- a/tests/e2e/journeys/j06-tickets/seat-selection.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/seat-selection.spec.ts
@@ -224,7 +224,12 @@ test.describe('J6 seat selection @p2', () => {
 		await picker.getByRole('button', { name: 'Done', exact: true }).click();
 		await expect(picker).toBeHidden();
 
+		// Assert the group survived the hand-off BEFORE reaching for Buy: the bar
+		// is gated on `!cart.isEmpty`, so a group deleted by its own seat-hold
+		// host (#918) surfaced here as an unreadable "element not found" on the
+		// Buy button rather than as a cart assertion.
 		const summaryBar = page.getByTestId('cart-summary-bar');
+		await expect(summaryBar).toBeVisible({ timeout: 15_000 });
 		await summaryBar.getByRole('button', { name: 'Buy', exact: true }).click();
 		await expect(page.getByText(/reserved/i)).toBeVisible({ timeout: 10_000 });
 

--- a/tests/e2e/journeys/j06-tickets/self-cancel.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/self-cancel.spec.ts
@@ -7,7 +7,11 @@ import {
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
-import { completeStripeCheckout } from '../../support/stripe';
+import {
+	completeStripeCheckout,
+	expectWebhookEffect,
+	requireStripeWebhooks
+} from '../../support/stripe';
 
 // J6.7 (USER_JOURNEYS.md) — attendee self-cancellation on an online ticket:
 // the cancel dialog quotes the refund from the tier's policy before anything
@@ -24,6 +28,7 @@ test.describe('J6 self-cancel @p2', () => {
 	test('refund preview → confirm → ticket cancelled with refund toast', async ({ browser }) => {
 		// Stripe hosted checkout + webhook + refund round-trips.
 		test.setTimeout(240_000);
+		requireStripeWebhooks();
 
 		const [event, buyer] = await Promise.all([
 			createTicketedEvent({ freeTier: false }),
@@ -54,10 +59,14 @@ test.describe('J6 self-cancel @p2', () => {
 			.filter({ hasText: event.name })
 			.filter({ hasText: /Active/i })
 			.first();
-		await expect(async () => {
-			await gotoHydrated(page, '/dashboard/tickets');
-			await expect(activeCard).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 90_000 });
+		await expectWebhookEffect(
+			'the ticket to flip Active on /dashboard/tickets',
+			async () => {
+				await gotoHydrated(page, '/dashboard/tickets');
+				await expect(activeCard).toBeVisible({ timeout: 5_000 });
+			},
+			{ timeout: 90_000 }
+		);
 		await waitForClientAuth(page);
 
 		// Open the ticket modal → "Cancel ticket" (rendered only for active

--- a/tests/e2e/journeys/j06-tickets/stripe-online.spec.ts
+++ b/tests/e2e/journeys/j06-tickets/stripe-online.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from '../../support/fixtures';
 import { createTicketedEvent, createTicketTier, createVerifiedUser } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
-import { completeStripeCheckout } from '../../support/stripe';
+import {
+	completeStripeCheckout,
+	expectWebhookEffect,
+	requireStripeWebhooks
+} from '../../support/stripe';
 
 // J6.3 (USER_JOURNEYS.md) — online fixed-price ticket via Stripe HOSTED
 // checkout: purchase → redirect to checkout.stripe.com → the reserved ticket
@@ -21,8 +25,9 @@ import { completeStripeCheckout } from '../../support/stripe';
 // Requires the full Stripe test-mode setup from tests/e2e/README.md (backend
 // bootstrapped with CONNECTED_TEST_STRIPE_ID + `stripe listen` forwarder) —
 // without a running `stripe listen` forwarder the webhook never arrives and
-// the final ACTIVE poll times out; this is a known, environment-dependent
-// failure (same category as self-cancel.spec.ts), not a rewrite defect.
+// the final ACTIVE poll cannot pass; this is a known, environment-dependent
+// failure (same category as self-cancel.spec.ts), not a rewrite defect — since
+// #919 it fails naming the forwarder instead of timing out silently.
 //
 // Isolation: API-arranged event on the Stripe-connected Org Alpha with an
 // online tier, and a throwaway buyer (per-user ticket limits).
@@ -31,6 +36,7 @@ test.describe('J6 Stripe online checkout @p1', () => {
 	test('purchase → PENDING pre-payment → pay on Stripe → webhook → ACTIVE', async ({ browser }) => {
 		// Stripe's hosted page + webhook round-trip don't fit the default budget.
 		test.setTimeout(240_000);
+		requireStripeWebhooks();
 
 		const [event, user] = await Promise.all([
 			createTicketedEvent({ freeTier: false }),
@@ -94,10 +100,14 @@ test.describe('J6 Stripe online checkout @p1', () => {
 			.filter({ hasText: event.name })
 			.filter({ hasText: /Active/i })
 			.first();
-		await expect(async () => {
-			await gotoHydrated(page, '/dashboard/tickets');
-			await expect(activeCard).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 90_000 });
+		await expectWebhookEffect(
+			'the ticket to flip Active on /dashboard/tickets',
+			async () => {
+				await gotoHydrated(page, '/dashboard/tickets');
+				await expect(activeCard).toBeVisible({ timeout: 5_000 });
+			},
+			{ timeout: 90_000 }
+		);
 
 		await context.close();
 	});

--- a/tests/e2e/journeys/j07-guest-attendee/guest-seated.spec.ts
+++ b/tests/e2e/journeys/j07-guest-attendee/guest-seated.spec.ts
@@ -169,7 +169,12 @@ test.describe('J7 guest seated checkout @p2', () => {
 			await picker.getByRole('button', { name: 'Done', exact: true }).click();
 			await expect(picker).toBeHidden();
 
+			// Assert the group exists BEFORE reaching for Buy: the summary bar is
+			// gated on `!cart.isEmpty`, so a lost hand-off (#918) used to surface
+			// here as an unreadable "element not found" on the Buy button.
 			const summaryBar = page.getByTestId('cart-summary-bar');
+			await expect(summaryBar).toBeVisible({ timeout: 15_000 });
+			await expect(summaryBar).toContainText('1 ticket');
 			await summaryBar.getByRole('button', { name: 'Buy', exact: true }).click();
 
 			// Checkout sheet: identity + this group's ticket-holder name
@@ -447,21 +452,21 @@ test.describe('J7 guest seated checkout @p2', () => {
 				await expect(seatButton).toHaveAttribute('aria-pressed', 'true', { timeout: 5_000 });
 			}).toPass({ timeout: 60_000 });
 
-			// Done, then let the seated group settle (its OWN `CartSeatGroupHolds`
-			// mounts fresh and seeds from a fresh chart/availability fetch) BEFORE
-			// adding the second tier — the summary bar's "1 ticket" is the signal
-			// that write has landed, so the two groups' cart writes don't race.
-			// Idempotent loop: under heavy parallel-worker load the settle can
-			// outrun a short fixed wait, and a dropped click would otherwise hang.
+			// Done hands the pick to the cart. This used to be a `toPass` loop that
+			// re-clicked Done "if the picker is still visible" — dead code on the
+			// failing path (#918), since Done unmounts the picker, so the guard was
+			// permanently false and the loop just spun to its timeout. The race it
+			// was aimed at was real but cart-side: the group's own
+			// `CartSeatGroupHolds` mounted, seeded from a still-PRE-hold
+			// availability snapshot, and wrote the resulting `[]` back over the
+			// group — deleting it. Fixed at the source (`cart-seat-sync.ts`), so
+			// this is a single click and a plain assertion again.
 			const summaryBar = page.getByTestId('cart-summary-bar');
-			await expect(async () => {
-				if (await summaryBar.getByText('1 ticket').isVisible()) return;
-				if (await picker.isVisible()) {
-					await picker.getByRole('button', { name: 'Done', exact: true }).click();
-				}
-				await expect(summaryBar.getByText('1 ticket')).toBeVisible({ timeout: 10_000 });
-			}).toPass({ timeout: 45_000 });
+			await picker.getByRole('button', { name: 'Done', exact: true }).click();
 			await expect(picker).toBeHidden();
+			// The seated group must SURVIVE its host's seed pass before the GA
+			// tier is added, so the two groups' cart writes don't race.
+			await expect(summaryBar.getByText('1 ticket')).toBeVisible({ timeout: 15_000 });
 
 			// Add the GA tier into the SAME cart.
 			const gaStepper = page.getByRole('group', { name: `Quantity for ${gaTier.name}` });

--- a/tests/e2e/journeys/j10-event-admin/organizer-refunds.spec.ts
+++ b/tests/e2e/journeys/j10-event-admin/organizer-refunds.spec.ts
@@ -7,7 +7,11 @@ import {
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
-import { completeStripeCheckout } from '../../support/stripe';
+import {
+	completeStripeCheckout,
+	expectWebhookEffect,
+	requireStripeWebhooks
+} from '../../support/stripe';
 
 // Organizer refunds (FE #831 / BE #870) — refund and cancel are separate
 // operations: the refund dialog moves money and the ticket stays valid; the
@@ -52,6 +56,7 @@ test.describe('J10 organizer refunds @p2', () => {
 	}) => {
 		// Stripe hosted checkout + webhook round-trips.
 		test.setTimeout(240_000);
+		requireStripeWebhooks();
 
 		const { event, buyer } = await arrangePaidTicket(browser, 'RefundBuyer', '20.00');
 		const buyerName = `${buyer.firstName} ${buyer.lastName}`;
@@ -64,11 +69,15 @@ test.describe('J10 organizer refunds @p2', () => {
 			.filter({ hasText: /Active/ })
 			.filter({ visible: true })
 			.first();
-		await expect(async () => {
-			await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/tickets`);
-			await waitForClientAuth(page);
-			await expect(activeRow).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 120_000 });
+		await expectWebhookEffect(
+			"the paid ticket to appear Active on the event's admin tickets tab",
+			async () => {
+				await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/tickets`);
+				await waitForClientAuth(page);
+				await expect(activeRow).toBeVisible({ timeout: 5_000 });
+			},
+			{ timeout: 120_000 }
+		);
 
 		// Refund €5 of €20 via the row's inline Refund action.
 		await activeRow.getByRole('button', { name: 'Refund payment' }).first().click();
@@ -111,6 +120,7 @@ test.describe('J10 organizer refunds @p2', () => {
 
 	test('cancel event with refund-all sweeps the paid ticket', async ({ asOwner, browser }) => {
 		test.setTimeout(240_000);
+		requireStripeWebhooks();
 
 		const { event, buyer } = await arrangePaidTicket(browser, 'SweepBuyer', '12.00');
 		const buyerName = `${buyer.firstName} ${buyer.lastName}`;
@@ -124,11 +134,15 @@ test.describe('J10 organizer refunds @p2', () => {
 			.filter({ hasText: /Active/ })
 			.filter({ visible: true })
 			.first();
-		await expect(async () => {
-			await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/tickets`);
-			await waitForClientAuth(page);
-			await expect(activeRow).toBeVisible({ timeout: 5_000 });
-		}).toPass({ timeout: 120_000 });
+		await expectWebhookEffect(
+			"the paid ticket to appear Active on the event's admin tickets tab",
+			async () => {
+				await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/tickets`);
+				await waitForClientAuth(page);
+				await expect(activeRow).toBeVisible({ timeout: 5_000 });
+			},
+			{ timeout: 120_000 }
+		);
 
 		// Cancel from the edit page with the refund sweep opted in.
 		await gotoHydrated(page, `/org/${event.orgSlug}/admin/events/${event.id}/edit`);

--- a/tests/e2e/journeys/j22-attendee-invoicing/buyer-invoices.spec.ts
+++ b/tests/e2e/journeys/j22-attendee-invoicing/buyer-invoices.spec.ts
@@ -10,7 +10,11 @@ import {
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
-import { completeStripeCheckout } from '../../support/stripe';
+import {
+	completeStripeCheckout,
+	expectWebhookEffect,
+	requireStripeWebhooks
+} from '../../support/stripe';
 
 // J22 (USER_JOURNEYS.md) — buyer-side attendee invoicing: a paid online
 // purchase with billing info generates an invoice that, once issued, the
@@ -27,6 +31,7 @@ test.describe('J22 buyer invoices @p2', () => {
 	test('invoiced purchase → issued invoice in /account/invoices → PDF', async ({ browser }) => {
 		// Stripe hosted checkout + webhook + invoice generation.
 		test.setTimeout(240_000);
+		requireStripeWebhooks();
 
 		await setOrgInvoicingMode('hybrid');
 		const [event, buyer] = await Promise.all([
@@ -53,7 +58,13 @@ test.describe('J22 buyer invoices @p2', () => {
 
 			// Hybrid mode leaves the generated invoice as a draft — wait for it and
 			// issue it as the org owner (API arrange; the UI journey is hybrid-flow).
-			await issueDraftInvoiceFor(buyer.email);
+			// The draft only exists because the checkout webhook recorded a payment,
+			// so this is the run's webhook checkpoint for this spec.
+			await expectWebhookEffect(
+				'the checkout webhook to generate the draft attendee invoice',
+				() => issueDraftInvoiceFor(buyer.email),
+				{ timeout: 120_000 }
+			);
 
 			// A fresh buyer has exactly one invoice — poll for its Issued table row.
 			const invoiceRow = page.getByRole('row').filter({ hasText: 'Issued' });

--- a/tests/e2e/journeys/j22-attendee-invoicing/hybrid-flow.spec.ts
+++ b/tests/e2e/journeys/j22-attendee-invoicing/hybrid-flow.spec.ts
@@ -8,7 +8,11 @@ import {
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
-import { completeStripeCheckout } from '../../support/stripe';
+import {
+	completeStripeCheckout,
+	expectWebhookEffect,
+	requireStripeWebhooks
+} from '../../support/stripe';
 import { waitForEmail } from '../../support/mailpit';
 
 // J22 (USER_JOURNEYS.md) — HYBRID attendee invoicing, organizer side: in
@@ -31,6 +35,7 @@ test.describe('J22 hybrid invoicing @p3', () => {
 		asOwner
 	}) => {
 		test.setTimeout(300_000);
+		requireStripeWebhooks();
 
 		await setOrgInvoicingMode('hybrid');
 		const [event, buyer] = await Promise.all([
@@ -62,11 +67,15 @@ test.describe('J22 hybrid invoicing @p3', () => {
 				.getByRole('row')
 				.filter({ hasText: buyer.email })
 				.filter({ hasText: 'Draft' });
-			await expect(async () => {
-				await gotoHydrated(asOwner, INVOICES_PATH);
-				await asOwner.getByPlaceholder('Search invoices...').fill(buyer.email);
-				await expect(draftRow).toBeVisible({ timeout: 8_000 });
-			}).toPass({ timeout: 120_000 });
+			await expectWebhookEffect(
+				"the draft invoice to appear on the organizer's Attendee Invoices page",
+				async () => {
+					await gotoHydrated(asOwner, INVOICES_PATH);
+					await asOwner.getByPlaceholder('Search invoices...').fill(buyer.email);
+					await expect(draftRow).toBeVisible({ timeout: 8_000 });
+				},
+				{ timeout: 120_000 }
+			);
 
 			// While it's a draft, the buyer sees NOTHING under /account/invoices —
 			// the dashboard endpoint serves issued invoices only.

--- a/tests/e2e/journeys/j23-subscriptions/manage-subscription.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/manage-subscription.spec.ts
@@ -12,7 +12,11 @@ import {
 import { authenticateContext } from '../../support/session';
 import { membershipCard } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
-import { completeStripeCheckout } from '../../support/stripe';
+import {
+	completeStripeCheckout,
+	expectWebhookEffect,
+	requireStripeWebhooks
+} from '../../support/stripe';
 
 // J23.5 (USER_JOURNEYS.md) — member SELF-SERVICE on a live Stripe subscription:
 // change plan (both directions), cancel (both modes) and the billing portal
@@ -142,16 +146,22 @@ async function subscribeAndPay(
 
 	// Activation arrives via the webhook, never the redirect. Each pass is a
 	// fresh navigation so the account queries refetch rather than serve cache.
-	await reloadUntil(
-		page,
-		async (card) => {
+	// Routed through expectWebhookEffect (#919) — same polling, but the first
+	// expiry in a run names the missing `stripe listen` forwarder instead of
+	// blaming the membership card.
+	await expectWebhookEffect(
+		'the subscription webhook to flip the membership card Active',
+		async () => {
+			await gotoHydrated(page, '/account/memberships');
+			await waitForClientAuth(page);
+			const card = orgCard(page);
 			await expect(card).toBeVisible({ timeout: 15_000 });
 			await expect(
 				card.getByTestId('membership-subscription-status').filter({ hasText: 'Active' })
 			).toBeVisible({ timeout: 10_000 });
 			await expect(card.getByText(plan.name)).toBeVisible({ timeout: 5_000 });
 		},
-		150_000
+		{ timeout: 150_000 }
 	);
 }
 
@@ -188,6 +198,7 @@ test.describe('J23 manage subscription @p2', () => {
 		// One hosted checkout plus three Stripe round trips on top (downgrade,
 		// cancel-at-period-end, and the uncancel that undoes it).
 		test.setTimeout(360_000);
+		requireStripeWebhooks();
 
 		const { user, orgId, standard, lite } = await arrangeTwoPlans('SubDowngrade');
 
@@ -282,6 +293,7 @@ test.describe('J23 manage subscription @p2', () => {
 		browser
 	}) => {
 		test.setTimeout(300_000);
+		requireStripeWebhooks();
 
 		const { user, orgId, standard, lite } = await arrangeTwoPlans('SubUpgrade');
 
@@ -369,6 +381,7 @@ test.describe('J23 manage subscription @p2', () => {
 		browser
 	}) => {
 		test.setTimeout(300_000);
+		requireStripeWebhooks();
 
 		const { user, orgId, standard } = await arrangeTwoPlans('SubPortal');
 

--- a/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
+++ b/tests/e2e/journeys/j23-subscriptions/subscribe-online.spec.ts
@@ -9,7 +9,11 @@ import {
 import { authenticateContext } from '../../support/session';
 import { membershipCard, membershipPath, planCard } from '../../support/membership-locators';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
-import { completeStripeCheckout } from '../../support/stripe';
+import {
+	completeStripeCheckout,
+	expectWebhookEffect,
+	requireStripeWebhooks
+} from '../../support/stripe';
 
 // J23.3 / J23.4 (USER_JOURNEYS.md) — the member-initiated hosted-checkout
 // journey: Subscribe → SubscribeDialog → checkout.stripe.com → pay → back on
@@ -95,6 +99,7 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 	}) => {
 		// Stripe's hosted page + the webhook round trip don't fit the default budget.
 		test.setTimeout(240_000);
+		requireStripeWebhooks();
 
 		const { plan, user } = await arrangeOnlinePlan('SubOnline');
 
@@ -120,7 +125,13 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await expect(confirming.or(welcome)).toBeVisible({ timeout: 30_000 });
 
 		// Activation arrives via the webhook, never the redirect — the card polls.
-		await expect(welcome).toBeVisible({ timeout: 120_000 });
+		await expectWebhookEffect(
+			'the subscription webhook to swap "Confirming…" for the Welcome card',
+			async () => {
+				await expect(welcome).toBeVisible({ timeout: 10_000 });
+			},
+			{ timeout: 120_000 }
+		);
 		await expect(page.getByText('Your subscription is active.')).toBeVisible();
 
 		// MUST-COVER: Stripe returned to the backend-built org-UUID membership
@@ -204,6 +215,7 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 
 	test('abandon checkout → cancelled card → resume payment → active', async ({ browser }) => {
 		test.setTimeout(240_000);
+		requireStripeWebhooks();
 
 		const { plan, user } = await arrangeOnlinePlan('SubAbandon');
 
@@ -261,9 +273,15 @@ test.describe('J23 hosted-checkout subscribe @p2', () => {
 		await page.waitForURL(/checkout\.stripe\.com/, { timeout: 30_000 });
 		await completeStripeCheckout(page);
 
-		await expect(page.getByRole('heading', { name: 'Welcome, member!' })).toBeVisible({
-			timeout: 120_000
-		});
+		await expectWebhookEffect(
+			'the resumed subscription webhook to render the Welcome card',
+			async () => {
+				await expect(page.getByRole('heading', { name: 'Welcome, member!' })).toBeVisible({
+					timeout: 10_000
+				});
+			},
+			{ timeout: 120_000 }
+		);
 		expect(page.url()).not.toContain('membership_success');
 
 		await context.close();

--- a/tests/e2e/journeys/j26-series-passes/pass-online-cancel.spec.ts
+++ b/tests/e2e/journeys/j26-series-passes/pass-online-cancel.spec.ts
@@ -8,7 +8,11 @@ import {
 } from '../../support/factories';
 import { authenticateContext } from '../../support/session';
 import { gotoHydrated, waitForClientAuth } from '../../support/navigation';
-import { completeStripeCheckout } from '../../support/stripe';
+import {
+	completeStripeCheckout,
+	expectWebhookEffect,
+	requireStripeWebhooks
+} from '../../support/stripe';
 
 // J26 (USER_JOURNEYS.md) — season pass, online flavor: hosted-Stripe purchase
 // of a pass (the held pass only materializes when the webhook lands), then
@@ -26,6 +30,7 @@ test.describe('J26 season pass online cancel @p3', () => {
 		asOwner
 	}) => {
 		test.setTimeout(300_000);
+		requireStripeWebhooks();
 
 		const series = await createEventSeries('owner', 'revel-events-collective');
 		const [eventA, eventB] = await Promise.all([
@@ -61,10 +66,14 @@ test.describe('J26 season pass online cancel @p3', () => {
 				.filter({ hasText: pass.name })
 				.filter({ hasText: /Active/ })
 				.first();
-			await expect(async () => {
-				await gotoHydrated(page, '/dashboard/passes');
-				await expect(activeCard).toBeVisible({ timeout: 5_000 });
-			}).toPass({ timeout: 90_000 });
+			await expectWebhookEffect(
+				'the webhook to create the Active pass on /dashboard/passes',
+				async () => {
+					await gotoHydrated(page, '/dashboard/passes');
+					await expect(activeCard).toBeVisible({ timeout: 5_000 });
+				},
+				{ timeout: 90_000 }
+			);
 
 			// Organizer cancels the held pass from the Holders dialog.
 			await gotoHydrated(asOwner, `/org/revel-events-collective/admin/event-series/${series.id}`);

--- a/tests/e2e/support/global-setup.ts
+++ b/tests/e2e/support/global-setup.ts
@@ -1,0 +1,17 @@
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Runs once in the RUNNER process, before any worker is spawned.
+ *
+ * Its only job is to plant a per-run id in the environment. Workers are forked
+ * after this hook and inherit it, which gives `support/stripe.ts` a key for the
+ * cross-worker Stripe webhook verdict (see `expectWebhookEffect`) that no other
+ * run — concurrent or later — can collide with. A module-level cache cannot do
+ * that job: Playwright spawns a fresh worker after every test failure.
+ *
+ * An id supplied from outside wins, so a harness can correlate a run with its
+ * own logs.
+ */
+export default function globalSetup(): void {
+	process.env.E2E_RUN_ID ??= randomUUID();
+}

--- a/tests/e2e/support/stripe.ts
+++ b/tests/e2e/support/stripe.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { expect, test, type Page } from '@playwright/test';
 
 /**
@@ -98,7 +99,9 @@ export async function completeStripeCheckout(
  * -------------------------------------------------------------------------- */
 
 export const STRIPE_FORWARDER_MISSING_MESSAGE =
-	'Stripe webhook forwarder not detected. Run `make run-stripe` in `revel-backend` ' +
+	'No webhook-driven effect appeared anywhere in this run, across two independent ' +
+	'Stripe flows. The leading hypothesis is a missing webhook forwarder: run ' +
+	'`make run-stripe` in `revel-backend` ' +
 	'(`stripe listen --forward-to localhost:8000/api/stripe/webhook`) before this suite.';
 
 /**
@@ -120,19 +123,50 @@ export const STRIPE_FORWARDER_MISSING_MESSAGE =
  *               own assertion error on failure. There is no path from here back
  *               to a forwarder complaint, which is what makes a false "missing"
  *               verdict impossible once a single webhook has been seen.
- *   missing   — a webhook-only wait burned its whole budget and NOTHING had
- *               been delivered in this run yet. Later waits then abort
- *               immediately instead of each spending 90–150s on a webhook that
- *               is not coming.
- *   unknown   — nothing observed yet: wait, with the caller's normal timeout.
+ *   expired   — a webhook-only wait burned its whole budget with nothing
+ *               delivered anywhere in the run yet. ONE of these rules nothing
+ *               out (see below); it is filed as evidence and the caller's own
+ *               assertion error is rethrown untouched.
+ *   ruled out — CORROBORATION_THRESHOLD *distinct* webhook effects have expired
+ *               with no delivery. Later waits then abort immediately instead of
+ *               each spending 90–150s on a webhook that is not coming.
  *
- * A false "delivered" is impossible by construction — it is only written after
- * a real webhook-driven assertion passed. A false "missing" costs a red run its
- * detail, not its verdict: the marker is only written when a test was already
- * failing, and the message hedges (it names the first expired wait and says so)
- * rather than asserting a diagnosis. This is DELIBERATELY not a skip: the
- * Stripe paths stay failures, the documented skip baseline stays at 3.
+ * Why corroboration, and what it does NOT prove.
+ *
+ * `expectWebhookEffect` retries an arbitrary UI callback, so a single expiry is
+ * ambiguous by construction: a plain app regression on that surface looks
+ * exactly like a webhook that never arrived. Ruling out a whole run on one
+ * expiry meant a UI bug could abort 21 later tests under a forwarder diagnosis
+ * its assertion never established. The verdict therefore needs evidence from
+ * two DIFFERENT effects — keyed by `description`, so the same effect awaited by
+ * two specs (or the same test on retry) counts once, and the two records come
+ * from genuinely different surfaces (a ticket list vs a membership card vs an
+ * invoice table). A regression that takes out two unrelated surfaces at once is
+ * far less likely than one that takes out a single flow.
+ *
+ * This is corroboration, not proof, which is why the message offers the
+ * forwarder as the leading hypothesis rather than asserting it. Proof would
+ * need a webhook-SPECIFIC signal, and there is none reachable from here: the
+ * backend logs every verified inbound event in `StripeWebhookEvent`, but that
+ * table is exposed only through the Django admin (session auth, and the E2E
+ * seed creates no superuser) — no REST route reads it. A staff-only or
+ * debug-only "events seen since T" counter on the backend would let this guard
+ * observe the forwarder directly and drop the heuristic entirely.
+ *
+ * A false "delivered" remains impossible by construction — it is only written
+ * after a real webhook-driven assertion passed. A false "ruled out" costs a red
+ * run its detail, not its verdict: records are only filed when a test was
+ * already failing. This is DELIBERATELY not a skip: the Stripe paths stay
+ * failures, the documented skip baseline stays at 3.
  */
+
+/**
+ * How many DISTINCT webhook effects must expire, with nothing delivered, before
+ * the run is ruled out. Two is the cheapest number that stops a single UI
+ * regression from mis-diagnosing a run; the cost of raising it from one is a
+ * second full wait (~90–150s) against the ~24 minutes the guard saves.
+ */
+const CORROBORATION_THRESHOLD = 2;
 
 /**
  * The verdict lives in files, not in a module variable.
@@ -151,7 +185,8 @@ const VERDICT_DIR = join(
 	process.env.E2E_RUN_ID ?? `ppid-${process.ppid}`
 );
 const DELIVERED_MARKER = join(VERDICT_DIR, 'delivered');
-const MISSING_MARKER = join(VERDICT_DIR, 'missing');
+/** One file per distinct expired effect, named by a digest of its description. */
+const EXPIRY_DIR = join(VERDICT_DIR, 'expired');
 
 function readMarker(path: string): string | null {
 	try {
@@ -161,10 +196,20 @@ function readMarker(path: string): string | null {
 	}
 }
 
+/**
+ * Create a marker, never overwrite one.
+ *
+ * `wx` is what keeps the FIRST writer's diagnostic: parallel workers can reach
+ * the same marker, and the loser's `EEXIST` lands in the catch below, which is
+ * already best-effort. Nothing reads a marker expecting it to have been
+ * rewritten — `delivered` is only ever tested for existence, and each expiry
+ * file is keyed by its description so a second writer would only be restating
+ * the same effect.
+ */
 function writeMarker(path: string, body: string): void {
 	try {
-		mkdirSync(VERDICT_DIR, { recursive: true });
-		writeFileSync(path, body);
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, body, { flag: 'wx' });
 	} catch {
 		// Bookkeeping only: a verdict we cannot persist costs the next test
 		// another wait. It must never be the reason a test fails.
@@ -179,15 +224,78 @@ function currentTest(): string {
 	}
 }
 
-/** The first expired webhook wait of this run, or null while none has expired. */
-function ruledOutBy(): string | null {
-	if (existsSync(DELIVERED_MARKER)) return null;
-	return readMarker(MISSING_MARKER);
+/** File the expiry of one webhook effect, once per distinct description. */
+function recordExpiry(description: string): void {
+	const key = createHash('sha256').update(description).digest('hex').slice(0, 16);
+	writeMarker(join(EXPIRY_DIR, key), `${currentTest()} — waiting for ${description}`);
+}
+
+function modifiedAt(path: string): number {
+	try {
+		return statSync(path).mtimeMs;
+	} catch {
+		return 0;
+	}
+}
+
+/** Every distinct expired wait of this run, oldest first. */
+function expiredWaits(): string[] {
+	let entries: string[];
+	try {
+		entries = readdirSync(EXPIRY_DIR);
+	} catch {
+		// No directory yet: nothing has expired.
+		return [];
+	}
+	return entries
+		.map((name) => join(EXPIRY_DIR, name))
+		.sort((a, b) => modifiedAt(a) - modifiedAt(b))
+		.map(readMarker)
+		.filter((body): body is string => body !== null);
 }
 
 /**
- * Abort NOW when an earlier test in this run already burned a full webhook
- * budget without a single delivery.
+ * The corroborating expired waits once the run is ruled out, else null.
+ *
+ * A single delivery anywhere makes this permanently null — there is no path
+ * from a seen webhook back to a forwarder complaint.
+ */
+function ruledOutBy(): string[] | null {
+	if (existsSync(DELIVERED_MARKER)) return null;
+	const expired = expiredWaits();
+	return expired.length >= CORROBORATION_THRESHOLD ? expired : null;
+}
+
+function listWaits(waits: readonly string[]): string {
+	return waits.map((wait) => `  - ${wait}`).join('\n');
+}
+
+/**
+ * Leave the forwarder hypothesis on a test that expired without corroboration.
+ *
+ * The assertion error itself is rethrown untouched — it is the honest report
+ * when one wait has expired — so the hint rides along as a report annotation
+ * instead of rewriting the failure. Matters most when a single spec is run
+ * under `--grep`, where a second effect can never corroborate.
+ */
+function noteForwarderHypothesis(description: string): void {
+	try {
+		test.info().annotations.push({
+			type: 'stripe-webhook',
+			description:
+				`The wait for ${description} expired and no webhook-driven effect has been ` +
+				'seen anywhere in this run. If this is not an app regression, check that the ' +
+				'`stripe listen` forwarder is running (`make run-stripe` in `revel-backend`).'
+		});
+	} catch {
+		// Outside a running test there is no report to annotate. A hint we
+		// cannot attach must never be the reason a test fails.
+	}
+}
+
+/**
+ * Abort NOW when earlier tests in this run already burned full webhook budgets
+ * on two distinct effects without a single delivery.
  *
  * Call it as the first statement of any test whose ARRANGE spends minutes
  * driving hosted checkout before it can even reach a webhook-dependent
@@ -196,14 +304,14 @@ function ruledOutBy(): string | null {
  * wait cheaply do not need this call.
  */
 export function requireStripeWebhooks(): void {
-	const firstFailure = ruledOutBy();
-	if (firstFailure === null) return;
+	const corroboration = ruledOutBy();
+	if (corroboration === null) return;
 	throw new Error(
 		`${STRIPE_FORWARDER_MISSING_MESSAGE}\n\n` +
-			'No Stripe webhook was delivered anywhere in this run; the first wait to ' +
-			`expire was:\n  ${firstFailure}\n` +
-			'Aborting before the arrange rather than repeating that wait. If the ' +
-			'forwarder IS running, that first expiry is a real failure — fix it and re-run.'
+			`The ${corroboration.length} distinct waits that expired, oldest first:\n` +
+			`${listWaits(corroboration)}\n` +
+			'Aborting before the arrange rather than repeating those waits. If the ' +
+			'forwarder IS running, those expiries are real failures — fix them and re-run.'
 	);
 }
 
@@ -214,11 +322,12 @@ export function requireStripeWebhooks(): void {
  * Drop-in for the `await expect(async () => { … }).toPass({ timeout })` polling
  * loops that follow `completeStripeCheckout()`: same retry semantics, same
  * timeout budget, no behaviour change at all while webhooks are flowing. What
- * it adds is the run-wide verdict above — the first expiry names the forwarder,
- * the rest of the run stops paying for it.
+ * it adds is the run-wide verdict above — once two distinct effects have
+ * expired with nothing delivered, the rest of the run stops paying for them.
  *
- * `description` is what the webhook is expected to make happen, phrased for a
- * failure line, e.g. 'the ticket flips ACTIVE on /dashboard/tickets'.
+ * `description` identifies the effect, so pick one per surface and keep it
+ * stable: it is both the failure-line wording AND the corroboration key. Phrase
+ * it for a failure line, e.g. 'the ticket flips ACTIVE on /dashboard/tickets'.
  */
 export async function expectWebhookEffect(
 	description: string,
@@ -229,18 +338,28 @@ export async function expectWebhookEffect(
 	try {
 		await expect(assertion).toPass({ timeout: options.timeout });
 	} catch (error) {
-		if (!existsSync(DELIVERED_MARKER)) {
-			writeMarker(MISSING_MARKER, `${currentTest()} — waiting for ${description}`);
-			throw new Error(
-				`${STRIPE_FORWARDER_MISSING_MESSAGE}\n\n` +
-					`Waited ${options.timeout}ms for ${description}, which nothing but that ` +
-					'webhook can produce, and no webhook has been delivered anywhere in this ' +
-					'run. If the forwarder IS running, this is a real failure — the assertion ' +
-					`error follows.\n\n${error instanceof Error ? error.message : String(error)}`,
-				{ cause: error }
-			);
+		// A webhook was seen earlier: this failure is the caller's own, and the
+		// guard has nothing to add to it.
+		if (existsSync(DELIVERED_MARKER)) throw error;
+		recordExpiry(description);
+		const corroboration = ruledOutBy();
+		if (corroboration === null) {
+			// Uncorroborated. One expired UI wait cannot tell a missing forwarder
+			// apart from a regression on this surface, so the caller's assertion
+			// error is rethrown verbatim (Playwright keeps its locator detail) and
+			// the forwarder rides along as an annotated hypothesis.
+			noteForwarderHypothesis(description);
+			throw error;
 		}
-		throw error;
+		throw new Error(
+			`${STRIPE_FORWARDER_MISSING_MESSAGE}\n\n` +
+				`Waited ${options.timeout}ms for ${description}, which nothing but that ` +
+				`webhook can produce. The ${corroboration.length} distinct waits that have ` +
+				`expired in this run, oldest first:\n${listWaits(corroboration)}\n\n` +
+				'If the forwarder IS running, these are real failures — the assertion ' +
+				`error follows.\n\n${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
 	}
 	if (!existsSync(DELIVERED_MARKER)) {
 		writeMarker(DELIVERED_MARKER, `${currentTest()} — ${description}`);

--- a/tests/e2e/support/stripe.ts
+++ b/tests/e2e/support/stripe.ts
@@ -1,4 +1,7 @@
-import { expect, type Page } from '@playwright/test';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, test, type Page } from '@playwright/test';
 
 /**
  * Drives Stripe's HOSTED checkout page in test mode.
@@ -88,4 +91,158 @@ export async function completeStripeCheckout(
 	// Back on the app after payment (success URL is app-origin).
 	await page.waitForURL(/localhost:5173/, { timeout: 45_000 });
 	await expect(page).not.toHaveURL(/checkout\.stripe\.com/);
+}
+
+/* -------------------------------------------------------------------------- *
+ * Webhook-forwarder guard (#919)
+ * -------------------------------------------------------------------------- */
+
+export const STRIPE_FORWARDER_MISSING_MESSAGE =
+	'Stripe webhook forwarder not detected. Run `make run-stripe` in `revel-backend` ' +
+	'(`stripe listen --forward-to localhost:8000/api/stripe/webhook`) before this suite.';
+
+/**
+ * Why the verdict is OBSERVED and never guessed.
+ *
+ * `stripe listen` opens an OUTBOUND websocket to Stripe and binds no local
+ * port, so nothing about the forwarder is reachable from this process: there is
+ * no socket to connect to, and a process-name probe (`pgrep`) is both
+ * platform-specific and a liar (a wedged or wrong-target forwarder still shows
+ * up). The only honest signal available here is the forwarder's EFFECT — a
+ * backend state change that can arrive by no other route (a ticket flipping
+ * ACTIVE, a subscription's Welcome card, a generated attendee invoice).
+ *
+ * So this module never claims "the forwarder is running". It records what the
+ * run actually saw:
+ *
+ *   delivered — some webhook-only effect landed. Every later wait behaves
+ *               exactly as it did before this guard existed: full timeout, its
+ *               own assertion error on failure. There is no path from here back
+ *               to a forwarder complaint, which is what makes a false "missing"
+ *               verdict impossible once a single webhook has been seen.
+ *   missing   — a webhook-only wait burned its whole budget and NOTHING had
+ *               been delivered in this run yet. Later waits then abort
+ *               immediately instead of each spending 90–150s on a webhook that
+ *               is not coming.
+ *   unknown   — nothing observed yet: wait, with the caller's normal timeout.
+ *
+ * A false "delivered" is impossible by construction — it is only written after
+ * a real webhook-driven assertion passed. A false "missing" costs a red run its
+ * detail, not its verdict: the marker is only written when a test was already
+ * failing, and the message hedges (it names the first expired wait and says so)
+ * rather than asserting a diagnosis. This is DELIBERATELY not a skip: the
+ * Stripe paths stay failures, the documented skip baseline stays at 3.
+ */
+
+/**
+ * The verdict lives in files, not in a module variable.
+ *
+ * `support/skip.ts` caches its backend probe per worker, and copying that here
+ * would achieve nothing: Playwright spawns a FRESH worker process after every
+ * test failure, so the cache would be thrown away at exactly the moment it
+ * matters and all 22 Stripe tests would pay the full wait again. Keying the
+ * directory by the run id that `global-setup.ts` plants in the environment
+ * (inherited by every worker, unique per run) keeps concurrent and later runs
+ * from reading each other's verdict.
+ */
+const VERDICT_DIR = join(
+	tmpdir(),
+	'revel-e2e-stripe-webhooks',
+	process.env.E2E_RUN_ID ?? `ppid-${process.ppid}`
+);
+const DELIVERED_MARKER = join(VERDICT_DIR, 'delivered');
+const MISSING_MARKER = join(VERDICT_DIR, 'missing');
+
+function readMarker(path: string): string | null {
+	try {
+		return readFileSync(path, 'utf8');
+	} catch {
+		return null;
+	}
+}
+
+function writeMarker(path: string, body: string): void {
+	try {
+		mkdirSync(VERDICT_DIR, { recursive: true });
+		writeFileSync(path, body);
+	} catch {
+		// Bookkeeping only: a verdict we cannot persist costs the next test
+		// another wait. It must never be the reason a test fails.
+	}
+}
+
+function currentTest(): string {
+	try {
+		return test.info().titlePath.join(' › ');
+	} catch {
+		return 'unknown test';
+	}
+}
+
+/** The first expired webhook wait of this run, or null while none has expired. */
+function ruledOutBy(): string | null {
+	if (existsSync(DELIVERED_MARKER)) return null;
+	return readMarker(MISSING_MARKER);
+}
+
+/**
+ * Abort NOW when an earlier test in this run already burned a full webhook
+ * budget without a single delivery.
+ *
+ * Call it as the first statement of any test whose ARRANGE spends minutes
+ * driving hosted checkout before it can even reach a webhook-dependent
+ * assertion — that whole arrange is wasted once the run has been ruled out.
+ * `expectWebhookEffect` applies the same guard, so tests that reach a webhook
+ * wait cheaply do not need this call.
+ */
+export function requireStripeWebhooks(): void {
+	const firstFailure = ruledOutBy();
+	if (firstFailure === null) return;
+	throw new Error(
+		`${STRIPE_FORWARDER_MISSING_MESSAGE}\n\n` +
+			'No Stripe webhook was delivered anywhere in this run; the first wait to ' +
+			`expire was:\n  ${firstFailure}\n` +
+			'Aborting before the arrange rather than repeating that wait. If the ' +
+			'forwarder IS running, that first expiry is a real failure — fix it and re-run.'
+	);
+}
+
+/**
+ * Wait for a backend state change that can ONLY be delivered by the
+ * `stripe listen` webhook forwarder, and record what happened.
+ *
+ * Drop-in for the `await expect(async () => { … }).toPass({ timeout })` polling
+ * loops that follow `completeStripeCheckout()`: same retry semantics, same
+ * timeout budget, no behaviour change at all while webhooks are flowing. What
+ * it adds is the run-wide verdict above — the first expiry names the forwarder,
+ * the rest of the run stops paying for it.
+ *
+ * `description` is what the webhook is expected to make happen, phrased for a
+ * failure line, e.g. 'the ticket flips ACTIVE on /dashboard/tickets'.
+ */
+export async function expectWebhookEffect(
+	description: string,
+	assertion: () => Promise<void>,
+	options: { timeout: number }
+): Promise<void> {
+	requireStripeWebhooks();
+	try {
+		await expect(assertion).toPass({ timeout: options.timeout });
+	} catch (error) {
+		if (!existsSync(DELIVERED_MARKER)) {
+			writeMarker(MISSING_MARKER, `${currentTest()} — waiting for ${description}`);
+			throw new Error(
+				`${STRIPE_FORWARDER_MISSING_MESSAGE}\n\n` +
+					`Waited ${options.timeout}ms for ${description}, which nothing but that ` +
+					'webhook can produce, and no webhook has been delivered anywhere in this ' +
+					'run. If the forwarder IS running, this is a real failure — the assertion ' +
+					`error follows.\n\n${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error }
+			);
+		}
+		throw error;
+	}
+	if (!existsSync(DELIVERED_MARKER)) {
+		writeMarker(DELIVERED_MARKER, `${currentTest()} — ${description}`);
+	}
 }


### PR DESCRIPTION
Two fixes that came out of driving a full E2E pass against FE `3bb65ff0` + BE `0150f091` (v2.12.1). One is a real revenue-path bug that had been hiding as test flakiness; the other is why the suite took three times longer than it needed to.

## 1 — Seat-picker → cart sync was lossy (#918)

**This is not a flaky test. A buyer loses their seat selection roughly 1 in 3 times, at the moment they commit.**

`SeatPickerDialog.handleDone` creates the cart group correctly. That makes the cart non-empty, which mounts `CartSeatGroupHolds` in the **same flush**, building a fresh `SeatHoldController` that seeds from the warm TanStack cache. The post-tap availability refetch is fire-and-forget and the availability query has no `staleTime`, so that cache is often still the **pre-hold** snapshot (`my_holds: []`). `seedFromAvailability` hard-assigned, the live-sync `$effect` wrote `[]` through, and `cart.setSeatIds(tier, [])` means *delete the group*. `CartSummaryBar` is gated on `!cart.isEmpty`, so it unmounted — which is why Playwright reported *element not found* rather than a wrong value.

It could not self-heal: deleting the group unmounted the very component whose `adoptServerHolds()` would have repaired it once the refetch landed. `onDestroy` then saw zero holds and skipped the release, **leaking the seats server-side for their full TTL** — which can later surface as a `capacity` 409, a second failure mode wearing the first one's clothes.

The fix is two terms:

- `shouldSyncSeatIds` gains a `holdCount` term so the live-sync effect can never delete a group, and (after review) an `unresolvedClaims` term so it can never shrink one either — `cart.setSeatIds` **replaces** `seatIds`, so a seed that resolves only some of a group's claimed seats would otherwise write the shortened list straight through. Verified the premise by grepping every consumer: the only writers that legitimately empty a `user_choice` group are the picker's `handleDone` / `seatPickerCloseAction` and `CartSeatHolds`' expiry sweep, both of which call `setSeatIds` explicitly and neither of which routes through this effect.
- `seedFromAvailability` **unions** known-held ids instead of overwriting (known ids first, so `max` truncation cannot split controller and group apart). This also closes the leak — the controller now owns the seat, so `onDestroy` releases it.

**Why union rather than deferring `seeded` until `dataUpdatedAt` moves:** the deferred option makes a local invariant depend on a network event that may never arrive. An *erroring* refetch leaves `dataUpdatedAt` unmoved, `seeded` stays false forever, the live-sync effect never runs, and a transient desync becomes a permanent one. It would also couple the gate to TanStack's refetch-on-mount policy, which a future global `staleTime` default could disarm invisibly — the #704 failure shape.

### Evidence, both directions

`CartSeatGroupHolds.test.ts` renders the real component under `QueryClientTestWrapper` with the cache pre-seeded to `my_holds: []` and a group carrying `seatIds: ['seat-1']`.

- **On the unfixed code it fails with the literal reported symptom**: `expected undefined to deeply equal [ 'seat-1' ]`
- **With the fix**: 4 passed, stable across 5 consecutive runs.

Each half was then neutralised separately to prove neither term is redundant — with only the gate, the group survives but `myHolds` is wrong; with only the union, a fourth test (the group's seat absent from the warm chart entry, so the union is filtered by `validSeatIds`) is what catches it.

## 2 — Stripe specs now fail fast instead of timing out (#919)

Without `stripe listen`, 11 specs × 2 viewports failed by **timing out** — 240s per attempt, twice — behind messages that pointed at UI locators and never named the cause. Measured cost: **36.5m without the forwarder vs 12.2m with it**.

The verdict is **observed, never guessed**. `stripe listen` opens an outbound websocket and binds no local port, so nothing about it is reachable from the test process, and a `pgrep` probe would be platform-specific *and* a liar — a wedged or wrong-target forwarder still shows up. The only honest signal is the forwarder's **effect**: a backend state change no other route can produce. A false "delivered" is therefore impossible by construction; it is only ever written after a real webhook-driven assertion has passed.

**Deliberately not a skip.** This repo has already been burned by a silent self-skip reporting `exit 0, 400 passed, 99 skipped` as success. Reintroducing that on the payment paths would trade a loud timeout for silently lost coverage. Every path stays a failure; the documented skip baseline stays at **3**.

The verdict lives in a run-keyed file rather than a module variable because Playwright spawns a **fresh worker process after every test failure** — so the `support/skip.ts` per-worker cache pattern would be discarded at exactly the moment it matters, and all 22 tests would pay full price again.

Polling semantics and timeout budgets are unchanged, so there is no new flakiness risk while webhooks flow.

### Known trade-off, stated rather than buried

If the *first* webhook wait of a run expires from a genuine app regression rather than a missing forwarder, the remaining Stripe tests abort under the forwarder message. The run is red either way, and the message names the discovering test and hedges explicitly rather than asserting a diagnosis — the original assertion error is inlined and attached as `cause`. Worth knowing when reading a red run.

## Review response (second round)

A code review of this branch found a real gap in the first fix, plus two findings from CodeRabbit. All are now addressed in `0807751c` and `1cb10fd5`:

1. **The gate stopped group deletion but not group shrinking** — the same bug class as #918, one level down, and untested because all four original tests used a single-seat group. Fixed with the `unresolvedClaims` term; new regression test uses a two-seat group with a one-seat warm chart and was proven to fail before and pass after (`expected [ 'seat-1' ] to deeply equal [ 'seat-1', 'seat-2' ]`).
2. **The missing-forwarder verdict rested on an arbitrary UI assertion** — a UI regression could rule out a run under a forwarder diagnosis it never established. The first uncorroborated expiry now rethrows the caller's own assertion error verbatim and leaves the forwarder as an annotation; only two *distinct* expired effects rule out a run.
3. **The first expiry's diagnostic could be overwritten** by a parallel worker — markers are now created exclusively.

Two further review findings were investigated and **deliberately not acted on**, because they were factually wrong about the control flow: that `seedFromAvailability` re-runs on every effect pass (it is guarded by `!seeded`, which is set immediately, so it runs exactly once), and that the expiry sweep reads `controller.holdExpiresAt` (it reads `registry.expiresAt`, derived from `availabilityQuery.data.my_holds_expire_at`).

Note on CodeRabbit's suggested remedy for (1): preserving the unresolved ids through the seed would relocate the bug rather than fix it — `#reconcileHolds`, which every seat tap goes through, filters through the same `#validSeatIds`, so the buyer's next tap would drop the seat again. Its alternative suggestion, blocking the partial write, is what landed.

## Verification

- `make check` — 0 errors, type gate armed, i18n clean, all files within line limits.
- `make test` — 307 files, 3589 passed, 1 todo.
- E2E verification against the live stack is running now; I'll post results as a comment.

## Note for review

`seat-hold-controller.svelte.ts` landed at **497/500** lines. The next edit there will need the same care or it will trip the file-length gate.

Closes #918
Closes #919


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented selected seats from disappearing when reopening or synchronizing the seat picker.
  - Preserved cart groups during seat selection, including when availability data is delayed or incomplete.
  - Improved handling of previously held seats and expired groups without adding unintended seats.

- **Tests**
  - Expanded coverage for seat-hold persistence and cart synchronization.
  - Improved checkout verification and diagnostics for Stripe-powered flows.

- **Documentation**
  - Clarified Stripe webhook setup requirements and failure behavior for end-to-end testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
