### PR TITLE
chore(release): v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-09-12
+
+### Changed
+
+- Guest checkout and RSVP refusals now explain what to do next instead of surfacing a bare error: a guest whose email already has an account gets sign-in / create-account buttons with that email prefilled, and a guest cart that is too large to email gets a "Log in" link plus a "Split your purchase" button that returns you to the cart with everything intact. Translated in all six languages.
+
+### Fixed
+
+- Seats picked on the seat map no longer disappear from the cart the moment you confirm the selection — the cart summary bar could vanish entirely, and the seats stayed held server-side until their hold expired, which could later resurface as a spurious "no capacity" error.
+- Apple Wallet and Google Wallet now tell a temporary pass-generation failure apart from a deployment that has no wallet credentials: the first says passes are temporarily unavailable and to try again later, instead of the misleading "not configured for this event".
+- Signing in from a guest checkout or RSVP error now returns you to the page you came from instead of stranding you on the dashboard.
+
 ## [2.11.0] - 2026-09-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revel-frontend",
-	"version": "2.11.0",
+	"version": "2.12.0",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION

### Changed

- Guest checkout and RSVP refusals now explain what to do next instead of surfacing a bare error: a guest whose email already has an account gets sign-in / create-account buttons with that email prefilled, and a guest cart that is too large to email gets a "Log in" link plus a "Split your purchase" button that returns you to the cart with everything intact. Translated in all six languages.

### Fixed

- Seats picked on the seat map no longer disappear from the cart the moment you confirm the selection — the cart summary bar could vanish entirely, and the seats stayed held server-side until their hold expired, which could later resurface as a spurious "no capacity" error.
- Apple Wallet and Google Wallet now tell a temporary pass-generation failure apart from a deployment that has no wallet credentials: the first says passes are temporarily unavailable and to try again later, instead of the misleading "not configured for this event".
- Signing in from a guest checkout or RSVP error now returns you to the page you came from instead of stranding you on the dashboard.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer guidance when guests cannot complete checkout or RSVP, including sign-in and account-creation options with email prefilled.
  - Added “Log in” and “Split your purchase” options for oversized guest carts.
  - Translated this guidance into all six supported languages.

- **Bug Fixes**
  - Fixed seat-map selections disappearing from carts and incorrect “no capacity” errors.
  - Improved wallet pass error messages.
  - Sign-in from checkout or RSVP errors now returns customers to the original page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->