### PR TITLE
fix(forms): let numeric inputs be cleared and edited down

### DIFF
--- a/src/lib/components/event-series/admin/RecurrenceEditDialog.svelte
+++ b/src/lib/components/event-series/admin/RecurrenceEditDialog.svelte
@@ -14,7 +14,12 @@
 		RecurrenceRuleUpdateSchema
 	} from '$lib/api/generated/types.gen';
 	import { invalidateSeries } from '$lib/queries/event-series';
-	import { mutualExclusionGuard } from '$lib/utils/recurrence';
+	import {
+		mutualExclusionGuard,
+		GENERATION_WINDOW_MIN,
+		GENERATION_WINDOW_MAX
+	} from '$lib/utils/recurrence';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 	import type { RecurrenceRuleCreate } from '$lib/types/recurrence';
 	import RecurrencePicker from './RecurrencePicker.svelte';
 
@@ -66,6 +71,15 @@
 	let validationErrors = $state<Record<string, string>>({});
 	let errorBanner = $state<string | null>(null);
 
+	// Clamping on every keystroke made the field impossible to edit: `Number('')`
+	// is 0, which clamped up to 1 and refilled the input under the caret (#924).
+	const windowField = numericField({
+		value: () => generationWindowWeeks,
+		commit: (weeks) => (generationWindowWeeks = weeks),
+		min: GENERATION_WINDOW_MIN,
+		max: GENERATION_WINDOW_MAX
+	});
+
 	// Re-seed every time the dialog opens. We always diff against the current
 	// `series` prop (the server-authoritative snapshot the dashboard holds) so
 	// concurrent edits don't leak across opens.
@@ -74,6 +88,9 @@
 		rule = ruleFromSeries();
 		autoPublish = series.auto_publish;
 		generationWindowWeeks = series.generation_window_weeks;
+		// Closing the dialog can unmount a focused input without firing blur, so
+		// drop any half-typed buffer rather than showing it over the fresh seed.
+		windowField.reset();
 		step = 'form';
 		validationErrors = {};
 		errorBanner = null;
@@ -81,14 +98,6 @@
 
 	function handleRecurrenceChange(next: Partial<RecurrenceRuleCreate>): void {
 		rule = next;
-	}
-
-	function handleWindowInput(event: Event): void {
-		const raw = (event.target as HTMLInputElement).value;
-		const n = Number(raw);
-		if (Number.isFinite(n)) {
-			generationWindowWeeks = Math.max(1, Math.min(52, Math.floor(n)));
-		}
 	}
 
 	// Dirty diff — field-level compare against the current server snapshot.
@@ -345,10 +354,11 @@
 						<Input
 							id="recurrence-edit-window"
 							type="number"
-							min={1}
-							max={52}
-							value={generationWindowWeeks}
-							oninput={handleWindowInput}
+							min={GENERATION_WINDOW_MIN}
+							max={GENERATION_WINDOW_MAX}
+							value={windowField.value}
+							oninput={windowField.oninput}
+							onblur={windowField.onblur}
 							disabled={updateMutation.isPending}
 							class="w-32"
 							data-testid="recurrence-edit-window"

--- a/src/lib/components/event-series/admin/RecurrenceEditDialog.test.ts
+++ b/src/lib/components/event-series/admin/RecurrenceEditDialog.test.ts
@@ -62,7 +62,7 @@ describe('RecurrenceEditDialog — generation window', () => {
 		vi.clearAllMocks();
 	});
 
-	function renderDialog(generationWindowWeeks = 8) {
+	function renderDialog(generationWindowWeeks = 8): HTMLInputElement {
 		render(QueryClientTestWrapper, {
 			props: {
 				client: queryClient,
@@ -76,7 +76,7 @@ describe('RecurrenceEditDialog — generation window', () => {
 				}
 			}
 		});
-		return screen.getByTestId('recurrence-edit-window') as HTMLInputElement;
+		return screen.getByLabelText(/how far ahead to schedule/i) as HTMLInputElement;
 	}
 
 	it('lets the field be cleared instead of refilling it with 1', async () => {

--- a/src/lib/components/event-series/admin/RecurrenceEditDialog.test.ts
+++ b/src/lib/components/event-series/admin/RecurrenceEditDialog.test.ts
@@ -1,0 +1,129 @@
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/svelte-query';
+import RecurrenceEditDialog from './RecurrenceEditDialog.svelte';
+import QueryClientTestWrapper from '$lib/test-utils/QueryClientTestWrapper.svelte';
+import type {
+	EventSeriesRecurrenceDetailSchema,
+	MinimalEventSchema
+} from '$lib/api/generated/types.gen';
+
+vi.mock('$lib/api/generated/sdk.gen', () => ({
+	organizationadminrecurringeventsUpdateRecurrence: vi.fn()
+}));
+vi.mock('svelte-sonner', () => ({
+	toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() }
+}));
+
+function makeMinimalTemplate(): MinimalEventSchema {
+	return {
+		id: 'evt_template',
+		name: 'Weekly Run',
+		slug: 'weekly-run',
+		start: '2026-08-01T18:00:00Z',
+		end: '2026-08-01T20:00:00Z',
+		status: 'open',
+		event_type: 'public'
+	} as MinimalEventSchema;
+}
+
+function makeSeries(
+	overrides: Partial<EventSeriesRecurrenceDetailSchema> = {}
+): EventSeriesRecurrenceDetailSchema {
+	return {
+		id: 'ser_1',
+		name: 'Weekly Run Club',
+		slug: 'weekly-run-club',
+		description: 'Every Monday at 6pm.',
+		is_active: true,
+		auto_publish: false,
+		generation_window_weeks: 8,
+		exdates: [],
+		last_generated_until: '2026-07-01T18:00:00Z',
+		recurrence_rule: null,
+		template_event: makeMinimalTemplate(),
+		...overrides
+	};
+}
+
+/**
+ * The generation-window field is the #922 bug almost verbatim: `Number('')` is 0,
+ * which clamped up to 1 and refilled the input under the caret, so the value could
+ * only be appended to. It now commits only in-range weeks while typing and clamps
+ * on blur (#924).
+ */
+describe('RecurrenceEditDialog — generation window', () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+		});
+		vi.clearAllMocks();
+	});
+
+	function renderDialog(generationWindowWeeks = 8) {
+		render(QueryClientTestWrapper, {
+			props: {
+				client: queryClient,
+				component: RecurrenceEditDialog,
+				componentProps: {
+					open: true,
+					series: makeSeries({ generation_window_weeks: generationWindowWeeks }),
+					organizationSlug: 'acme',
+					accessToken: 'test-token',
+					onClose: vi.fn()
+				}
+			}
+		});
+		return screen.getByTestId('recurrence-edit-window') as HTMLInputElement;
+	}
+
+	it('lets the field be cleared instead of refilling it with 1', async () => {
+		const input = renderDialog(8);
+		expect(input.value).toBe('8');
+
+		await fireEvent.input(input, { target: { value: '' } });
+
+		expect(input.value).toBe('');
+	});
+
+	it('accepts a replacement typed after clearing', async () => {
+		const input = renderDialog(8);
+
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.input(input, { target: { value: '1' } });
+		expect(input.value).toBe('1');
+
+		await fireEvent.input(input, { target: { value: '12' } });
+		expect(input.value).toBe('12');
+	});
+
+	it('normalizes an emptied field back to the series value on blur', async () => {
+		const input = renderDialog(8);
+
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.blur(input);
+
+		expect(input.value).toBe('8');
+	});
+
+	it('clamps an out-of-range entry to 1..52 on blur', async () => {
+		const input = renderDialog(8);
+
+		await fireEvent.input(input, { target: { value: '99' } });
+		expect(input.value).toBe('99');
+
+		await fireEvent.blur(input);
+		expect(input.value).toBe('52');
+	});
+
+	it('strips leading zeros on blur', async () => {
+		const input = renderDialog(8);
+
+		await fireEvent.input(input, { target: { value: '04' } });
+		await fireEvent.blur(input);
+
+		expect(input.value).toBe('4');
+	});
+});

--- a/src/lib/components/event-series/admin/RecurrencePicker.svelte
+++ b/src/lib/components/event-series/admin/RecurrencePicker.svelte
@@ -63,6 +63,7 @@
 
 	function selectFrequency(value: Frequency): void {
 		if (value === frequency) return;
+		dayOfMonthField.reset(); // cleared below — see handleMonthlyTypeChange
 		onChange({
 			...rule,
 			frequency: value,
@@ -114,6 +115,10 @@
 
 	function handleMonthlyTypeChange(value: MonthlyType): void {
 		if (value === monthlyType) return;
+		// The day-of-month input is about to be cleared and unmounted; any buffer
+		// held for it is stale. (Clicking this control blurs the input first, so
+		// this is insurance against an unmount that never fires blur, not a fix.)
+		dayOfMonthField.reset();
 		patch({
 			monthly_type: value,
 			day_of_month: undefined,
@@ -137,8 +142,10 @@
 		if (kind === selectedBoundary) return;
 		selectedBoundary = kind;
 		if (kind === 'none') {
+			countField.reset();
 			patch({ until: null, count: null });
 		} else if (kind === 'until') {
+			countField.reset();
 			patch({ count: null });
 		} else {
 			patch({ until: null });

--- a/src/lib/components/event-series/admin/RecurrencePicker.svelte
+++ b/src/lib/components/event-series/admin/RecurrencePicker.svelte
@@ -15,6 +15,7 @@
 		type BoundaryKind
 	} from '$lib/types/recurrence';
 	import { inferBoundaryKind } from '$lib/utils/recurrence';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 	import { formatEventDate } from '$lib/utils/date';
 
 	interface Props {
@@ -84,24 +85,32 @@
 		patch({ weekdays: [...next].sort((a, b) => a - b) });
 	}
 
-	function handleIntervalInput(event: Event): void {
-		const value = Number((event.target as HTMLInputElement).value);
-		if (Number.isFinite(value) && value >= 1) {
-			patch({ interval: Math.floor(value) });
-		}
-	}
+	// All three numeric fields commit only in-range values while the user types and
+	// settle on blur (#924). Rewriting an out-of-range value on the keystroke that
+	// produced it turned a typed "0" into "1" and "40" into "31" under the caret;
+	// an interval left at "0" used to diverge from the rule with nothing to settle it.
+	const intervalField = numericField({
+		value: () => interval,
+		commit: (next) => patch({ interval: next }),
+		min: 1
+	});
 
-	function handleDayOfMonthInput(event: Event): void {
-		const raw = (event.target as HTMLInputElement).value;
-		if (raw === '') {
-			patch({ day_of_month: null });
-			return;
-		}
-		const value = Number(raw);
-		if (Number.isFinite(value)) {
-			patch({ day_of_month: Math.max(1, Math.min(31, Math.floor(value))) });
-		}
-	}
+	// `day_of_month` and `count` are genuinely clearable — empty means "not set" —
+	// so an empty field commits null straight away rather than waiting for blur.
+	const dayOfMonthField = numericField<number | null>({
+		value: () => rule.day_of_month ?? null,
+		commit: (day) => patch({ day_of_month: day }),
+		min: 1,
+		max: 31,
+		emptyValue: null
+	});
+
+	const countField = numericField<number | null>({
+		value: () => rule.count ?? null,
+		commit: (count) => patch({ count }),
+		min: 1,
+		emptyValue: null
+	});
 
 	function handleMonthlyTypeChange(value: MonthlyType): void {
 		if (value === monthlyType) return;
@@ -191,11 +200,6 @@
 
 	function handleUntilChange(value: string): void {
 		patch({ until: value || null });
-	}
-
-	function handleCountInput(event: Event): void {
-		const raw = (event.target as HTMLInputElement).value;
-		patch({ count: raw ? Math.max(1, Math.floor(Number(raw))) : null });
 	}
 
 	function frequencyLabel(f: Frequency): string {
@@ -323,8 +327,9 @@
 				id="recurrence-interval"
 				type="number"
 				min={1}
-				value={interval}
-				oninput={handleIntervalInput}
+				value={intervalField.value}
+				oninput={intervalField.oninput}
+				onblur={intervalField.onblur}
 				class="w-24"
 				aria-describedby={validationErrors.interval ? 'recurrence-interval-error' : undefined}
 			/>
@@ -426,8 +431,9 @@
 						type="number"
 						min={1}
 						max={31}
-						value={rule.day_of_month ?? ''}
-						oninput={handleDayOfMonthInput}
+						value={dayOfMonthField.value}
+						oninput={dayOfMonthField.oninput}
+						onblur={dayOfMonthField.onblur}
 						class="w-24"
 						aria-describedby={validationErrors.day_of_month ? 'recurrence-dom-error' : undefined}
 					/>
@@ -512,8 +518,9 @@
 					<Input
 						type="number"
 						min={1}
-						value={rule.count ?? ''}
-						oninput={handleCountInput}
+						value={countField.value}
+						oninput={countField.oninput}
+						onblur={countField.onblur}
 						class="sm:w-32"
 						aria-label={m['recurringEvents.picker.countLabel']()}
 					/>

--- a/src/lib/components/event-series/admin/RecurrencePicker.test.ts
+++ b/src/lib/components/event-series/admin/RecurrencePicker.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, fireEvent } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import RecurrencePicker from './RecurrencePicker.svelte';
@@ -112,7 +112,7 @@ describe('RecurrencePicker — monthly sub-modes', () => {
 		expect(payload.day_of_month).toBeUndefined();
 	});
 
-	it('clamps day_of_month input to 1..31', async () => {
+	it('clamps day_of_month to 1..31 on blur, not on the keystroke', async () => {
 		const user = userEvent.setup();
 		const { onChange } = mount({
 			frequency: 'monthly',
@@ -122,9 +122,37 @@ describe('RecurrencePicker — monthly sub-modes', () => {
 		const input = screen.getByLabelText('Day of month') as HTMLInputElement;
 		await user.clear(input);
 		await user.type(input, '99');
-		// Every keystroke produces a patch; the final one should clamp to 31.
-		const last = onChange.mock.calls.at(-1)?.[0];
-		expect(last.day_of_month).toBe(31);
+
+		// An out-of-range value is kept out of the rule by NOT committing it —
+		// rewriting it to 31 under the caret is what made the field uneditable (#924).
+		expect(onChange.mock.calls.at(-1)?.[0].day_of_month).toBe(9);
+		expect(input.value).toBe('99');
+
+		// Blur settles it. (The displayed value then follows whatever the parent
+		// re-renders with; this harness holds `rule` fixed, so only the patch is
+		// meaningful here.)
+		await fireEvent.blur(input);
+
+		expect(onChange.mock.calls.at(-1)?.[0].day_of_month).toBe(31);
+	});
+
+	it('lets day_of_month be cleared and retyped', async () => {
+		const user = userEvent.setup();
+		const { onChange } = mount({
+			frequency: 'monthly',
+			interval: 1,
+			monthly_type: 'day',
+			day_of_month: 15
+		});
+		const input = screen.getByLabelText('Day of month') as HTMLInputElement;
+
+		await user.clear(input);
+		expect(input.value).toBe('');
+		expect(onChange.mock.calls.at(-1)?.[0].day_of_month).toBeNull();
+
+		await user.type(input, '3');
+		expect(input.value).toBe('3');
+		expect(onChange.mock.calls.at(-1)?.[0].day_of_month).toBe(3);
 	});
 });
 

--- a/src/lib/components/event-series/admin/RecurringEventWizard.svelte
+++ b/src/lib/components/event-series/admin/RecurringEventWizard.svelte
@@ -18,7 +18,12 @@
 	import { buildRecurringTemplateCreateData } from '$lib/components/events/admin/event-payload';
 	import RecurrencePicker from './RecurrencePicker.svelte';
 	import RecurrenceSummary from './RecurrenceSummary.svelte';
-	import { mutualExclusionGuard } from '$lib/utils/recurrence';
+	import {
+		mutualExclusionGuard,
+		GENERATION_WINDOW_MIN,
+		GENERATION_WINDOW_MAX
+	} from '$lib/utils/recurrence';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 	import { scrollToFirstInvalid } from '$lib/utils/scroll';
 	import { organizationadminrecurringeventsCreateRecurringEvent } from '$lib/api/generated/sdk.gen';
 	import type {
@@ -174,6 +179,15 @@
 	let autoPublish = $state(false);
 	let generationWindowWeeks = $state(8);
 	let advancedOpen = $state(false);
+
+	// Same field, same guard as the edit dialog: commit whole in-range weeks while
+	// typing, clamp on blur, so the input can actually be emptied (#924).
+	const windowField = numericField({
+		value: () => generationWindowWeeks,
+		commit: (weeks) => (generationWindowWeeks = weeks),
+		min: GENERATION_WINDOW_MIN,
+		max: GENERATION_WINDOW_MAX
+	});
 
 	// Auto-prefill series name from event name once the user hasn't customized it
 	let seriesNameTouched = $state(false);
@@ -659,15 +673,11 @@
 								<Input
 									id="generation-window"
 									type="number"
-									min={1}
-									max={52}
-									value={generationWindowWeeks}
-									oninput={(e) => {
-										const v = Number((e.target as HTMLInputElement).value);
-										if (Number.isFinite(v)) {
-											generationWindowWeeks = Math.max(1, Math.min(52, Math.floor(v)));
-										}
-									}}
+									min={GENERATION_WINDOW_MIN}
+									max={GENERATION_WINDOW_MAX}
+									value={windowField.value}
+									oninput={windowField.oninput}
+									onblur={windowField.onblur}
 									class="w-24"
 								/>
 								<span class="text-sm text-muted-foreground"

--- a/src/lib/components/forms/DurationInput.svelte
+++ b/src/lib/components/forms/DurationInput.svelte
@@ -11,6 +11,7 @@
 		type StorageUnit,
 		type Unit
 	} from '$lib/utils/duration';
+	import { parseCommittableNumber, settleNumber } from '$lib/utils/numeric-input';
 
 	/**
 	 * DurationInput Component
@@ -75,6 +76,11 @@
 	let displayAmount = $state<number | ''>('');
 	let displayUnit = $state<Unit>(defaultUnit);
 
+	// Free-text buffer held only while the field is being edited (`null` the rest
+	// of the time). `displayAmount` stays the committed display, so the re-sync
+	// effect below never sees — or clobbers — a half-typed value.
+	let amountDraft = $state<string | null>(null);
+
 	$effect(() => {
 		// Read defaultUnit into a local const so Svelte tracks it as a reactive dependency.
 		const unit = defaultUnit;
@@ -102,24 +108,35 @@
 
 	function handleAmountInput(e: Event): void {
 		const raw = (e.currentTarget as HTMLInputElement).value;
-		if (raw === '') {
+		amountDraft = raw;
+
+		if (raw.trim() === '') {
+			// Empty is a real state here (the "no limit" chip shows the same thing),
+			// so it commits straight away rather than waiting for blur.
 			displayAmount = '';
 			emit('', displayUnit);
 			return;
 		}
-		const n = Number(raw);
-		if (!Number.isFinite(n)) {
-			displayAmount = '';
-			emit('', displayUnit);
-			return;
+
+		const parsed = parseCommittableNumber(raw, { min });
+		if (parsed !== null) {
+			displayAmount = parsed;
+			emit(parsed, displayUnit);
 		}
-		if (n < min) {
-			displayAmount = min;
-			emit(min, displayUnit);
-			return;
-		}
-		displayAmount = n;
-		emit(displayAmount, displayUnit);
+		// Below `min`, or half-typed: commit nothing and leave the buffer alone. A
+		// value rewritten to `min` on the keystroke that produced it could never be
+		// edited down — with min={1}, typing a 0 turned into a 1 under the caret (#924).
+	}
+
+	function handleAmountBlur(): void {
+		if (amountDraft === null) return; // never edited
+		const raw = amountDraft;
+		amountDraft = null;
+		if (raw.trim() === '') return; // already committed as empty
+
+		const settled = settleNumber(raw, { min, fallback: min });
+		displayAmount = settled;
+		emit(settled, displayUnit);
 	}
 
 	function handleUnitChange(next: string | undefined): void {
@@ -129,6 +146,7 @@
 	}
 
 	function handleChipClick(): void {
+		amountDraft = null;
 		displayAmount = '';
 		displayUnit = defaultUnit;
 		emit('', displayUnit);
@@ -182,8 +200,9 @@
 			id={inputId}
 			type="number"
 			class="w-28"
-			value={displayAmount}
+			value={amountDraft ?? displayAmount}
 			oninput={handleAmountInput}
+			onblur={handleAmountBlur}
 			min={String(min)}
 			step="1"
 			{disabled}

--- a/src/lib/components/forms/DurationInput.test.ts
+++ b/src/lib/components/forms/DurationInput.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, fireEvent } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import DurationInput from './DurationInput.svelte';
@@ -240,5 +240,56 @@ describe('DurationInput', () => {
 		// The asterisk is rendered inside the label wrapper
 		const label = screen.getByText('Validity').closest('label');
 		expect(label?.textContent).toContain('*');
+	});
+
+	// ─── min={1}: the value below the minimum must not be rewritten mid-typing ─
+	describe('with min={1}', () => {
+		function renderWithMin(value: number | null = 5) {
+			render(DurationInput, {
+				props: {
+					id: 'dur-min',
+					value,
+					storageUnit: 'days',
+					defaultUnit: 'days',
+					label: 'Validity',
+					min: 1
+				}
+			});
+			return screen.getByLabelText('Validity') as HTMLInputElement;
+		}
+
+		it('keeps a typed 0 in the field instead of rewriting it to the minimum', async () => {
+			const input = renderWithMin(5);
+
+			// "0" on the way to "10" used to become a "1" under the caret, so the
+			// field could only ever be appended to (#924). fireEvent drives the value
+			// directly because user-event re-sanitizes a number input's leading zero.
+			await fireEvent.input(input, { target: { value: '0' } });
+			expect(input.value).toBe('0');
+
+			await fireEvent.input(input, { target: { value: '10' } });
+			expect(input.value).toBe('10');
+		});
+
+		it('settles a below-minimum entry to the minimum on blur', async () => {
+			const user = userEvent.setup();
+			const input = renderWithMin(5);
+
+			await user.clear(input);
+			await user.type(input, '0');
+			await fireEvent.blur(input);
+
+			expect(input.value).toBe('1');
+		});
+
+		it('still commits an in-range value while typing', async () => {
+			const user = userEvent.setup();
+			const input = renderWithMin(5);
+
+			await user.clear(input);
+			await user.type(input, '14');
+
+			expect(input.value).toBe('14');
+		});
 	});
 });

--- a/src/lib/components/questionnaires/FileUploadConfig.svelte
+++ b/src/lib/components/questionnaires/FileUploadConfig.svelte
@@ -4,6 +4,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 
 	// File type categories for file upload questions
 	const FILE_TYPE_CATEGORIES = [
@@ -64,6 +65,15 @@
 	}
 
 	const { questionId, allowedMimeTypes, maxFileSize, maxFiles, onUpdate }: Props = $props();
+
+	// Clamping per keystroke turned "12" into "10" the instant the 2 landed, and the
+	// `maxFiles || 1` display refilled an emptied field. Both now settle on blur (#924).
+	const maxFilesField = numericField({
+		value: () => maxFiles || 1,
+		commit: (files) => onUpdate({ maxFiles: files }),
+		min: 1,
+		max: 10
+	});
 </script>
 
 <div class="space-y-4">
@@ -139,11 +149,9 @@
 			<Input
 				id="maxfiles-{questionId}"
 				type="number"
-				value={maxFiles || 1}
-				oninput={(e) => {
-					const val = parseInt(e.currentTarget.value) || 1;
-					onUpdate({ maxFiles: Math.max(1, Math.min(10, val)) });
-				}}
+				value={maxFilesField.value}
+				oninput={maxFilesField.oninput}
+				onblur={maxFilesField.onblur}
 				min={1}
 				max={10}
 			/>

--- a/src/lib/components/questionnaires/FileUploadConfig.test.ts
+++ b/src/lib/components/questionnaires/FileUploadConfig.test.ts
@@ -82,7 +82,9 @@ describe('FileUploadConfig — max number of files', () => {
 		await fireEvent.input(input, { target: { value: '' } });
 		await fireEvent.blur(input);
 
+		// Releasing the buffer restores the display on its own — nothing changed,
+		// so nothing is written back.
 		expect(input.value).toBe('4');
-		expect(onUpdate).toHaveBeenLastCalledWith({ maxFiles: 4 });
+		expect(onUpdate).not.toHaveBeenCalled();
 	});
 });

--- a/src/lib/components/questionnaires/FileUploadConfig.test.ts
+++ b/src/lib/components/questionnaires/FileUploadConfig.test.ts
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import FileUploadConfig from './FileUploadConfig.svelte';
+
+/**
+ * Covers the "max number of files" input only — the shared guard's own semantics
+ * live in `src/lib/utils/numeric-input.test.ts`. Before #924 this field carried
+ * both halves of the anti-pattern: a `maxFiles || 1` display AND a per-keystroke
+ * clamp, so typing "12" became "10" the instant the 2 landed.
+ */
+describe('FileUploadConfig — max number of files', () => {
+	let onUpdate: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		onUpdate = vi.fn();
+	});
+
+	function renderConfig(maxFiles = 1) {
+		return render(FileUploadConfig, {
+			props: {
+				questionId: 'q-1',
+				allowedMimeTypes: ['image/png'],
+				maxFileSize: 1048576,
+				maxFiles,
+				onUpdate
+			}
+		});
+	}
+
+	function maxFilesInput(): HTMLInputElement {
+		return screen.getByLabelText(/max(imum)? number of files/i) as HTMLInputElement;
+	}
+
+	it('lets the field be cleared instead of refilling it with 1', async () => {
+		renderConfig(1);
+		const input = maxFilesInput();
+		expect(input.value).toBe('1');
+
+		await fireEvent.input(input, { target: { value: '' } });
+
+		expect(input.value).toBe('');
+		expect(onUpdate).not.toHaveBeenCalled();
+	});
+
+	it('accepts a replacement typed after clearing', async () => {
+		renderConfig(1);
+		const input = maxFilesInput();
+
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.input(input, { target: { value: '5' } });
+
+		expect(input.value).toBe('5');
+		expect(onUpdate).toHaveBeenLastCalledWith({ maxFiles: 5 });
+	});
+
+	it('does not rewrite a transient out-of-range value mid-typing', async () => {
+		renderConfig(1);
+		const input = maxFilesInput();
+
+		// "12" used to snap to "10" on the keystroke, stranding the caret.
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.input(input, { target: { value: '12' } });
+
+		expect(input.value).toBe('12');
+		expect(onUpdate).not.toHaveBeenCalled();
+	});
+
+	it('clamps to the 1..10 range on blur', async () => {
+		renderConfig(1);
+		const input = maxFilesInput();
+
+		await fireEvent.input(input, { target: { value: '12' } });
+		await fireEvent.blur(input);
+
+		expect(onUpdate).toHaveBeenLastCalledWith({ maxFiles: 10 });
+	});
+
+	it('settles an emptied field back to the committed value on blur', async () => {
+		renderConfig(4);
+		const input = maxFilesInput();
+
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.blur(input);
+
+		expect(input.value).toBe('4');
+		expect(onUpdate).toHaveBeenLastCalledWith({ maxFiles: 4 });
+	});
+});

--- a/src/lib/components/questionnaires/QuestionEditor.svelte
+++ b/src/lib/components/questionnaires/QuestionEditor.svelte
@@ -20,6 +20,7 @@
 	import OptionEditor from './OptionEditor.svelte';
 	import FileUploadConfig from './FileUploadConfig.svelte';
 	import { SvelteSet } from 'svelte/reactivity';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 
 	// Conditional section type (shown when option is selected)
 	interface ConditionalSection {
@@ -86,6 +87,25 @@
 		isNested = false,
 		showLlmGuidelines = true
 	}: Props = $props();
+
+	// Scoring weights: fractional (step 0.1) and clamped on blur rather than per
+	// keystroke — `parseFloat('') || 0` used to snap an emptied field back to 0,
+	// so the value could only be appended to (#924).
+	const positiveWeightField = numericField({
+		value: () => question.positiveWeight,
+		commit: (weight) => onUpdate({ positiveWeight: weight }),
+		min: 0,
+		max: 100,
+		decimal: true
+	});
+
+	const negativeWeightField = numericField({
+		value: () => question.negativeWeight,
+		commit: (weight) => onUpdate({ negativeWeight: weight }),
+		min: 0,
+		max: 100,
+		decimal: true
+	});
 
 	// Collapsible sections state
 	let showAdvanced = $state(false);
@@ -603,9 +623,9 @@
 											<Input
 												id="positive-weight-{question.id}"
 												type="number"
-												value={question.positiveWeight}
-												oninput={(e) =>
-													onUpdate({ positiveWeight: parseFloat(e.currentTarget.value) || 0 })}
+												value={positiveWeightField.value}
+												oninput={positiveWeightField.oninput}
+												onblur={positiveWeightField.onblur}
 												min="0"
 												max="100"
 												step="0.1"
@@ -621,9 +641,9 @@
 											<Input
 												id="negative-weight-{question.id}"
 												type="number"
-												value={question.negativeWeight}
-												oninput={(e) =>
-													onUpdate({ negativeWeight: parseFloat(e.currentTarget.value) || 0 })}
+												value={negativeWeightField.value}
+												oninput={negativeWeightField.oninput}
+												onblur={negativeWeightField.onblur}
 												min="0"
 												max="100"
 												step="0.1"

--- a/src/lib/components/questionnaires/QuestionEditor.test.ts
+++ b/src/lib/components/questionnaires/QuestionEditor.test.ts
@@ -61,8 +61,13 @@ describe('QuestionEditor — scoring weights', () => {
 
 		await fireEvent.input(input, { target: { value: '' } });
 		// "0." is not yet a number — it must not commit, and must not be rewritten.
+		// The buffer itself can't be asserted here: jsdom applies the number input's
+		// value-sanitization algorithm, and "0." is not a valid floating-point
+		// literal, so `input.value` reads back as "" whatever the component holds.
+		// What matters is that nothing was committed and nothing was written back.
 		await fireEvent.input(input, { target: { value: '0.' } });
 		expect(onUpdate).not.toHaveBeenCalled();
+		expect(input.value).not.toBe('2');
 
 		await fireEvent.input(input, { target: { value: '0.5' } });
 		expect(onUpdate).toHaveBeenLastCalledWith({ positiveWeight: 0.5 });
@@ -75,8 +80,10 @@ describe('QuestionEditor — scoring weights', () => {
 		await fireEvent.input(input, { target: { value: '' } });
 		await fireEvent.blur(input);
 
+		// The display comes back on its own when the buffer is released; an edit
+		// that changed nothing writes nothing.
 		expect(input.value).toBe('2');
-		expect(onUpdate).toHaveBeenLastCalledWith({ positiveWeight: 2 });
+		expect(onUpdate).not.toHaveBeenCalled();
 	});
 
 	it('clamps an out-of-range negative weight on blur', async () => {

--- a/src/lib/components/questionnaires/QuestionEditor.test.ts
+++ b/src/lib/components/questionnaires/QuestionEditor.test.ts
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import QuestionEditor from './QuestionEditor.svelte';
+
+/**
+ * Covers the two scoring-weight inputs. `parseFloat('') || 0` snapped an emptied
+ * field back to 0 on the keystroke that emptied it, so a weight could only ever
+ * be appended to (#924). They are the sweep's only fractional fields.
+ */
+describe('QuestionEditor — scoring weights', () => {
+	let onUpdate: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		onUpdate = vi.fn();
+	});
+
+	async function renderEditor(weights: { positive?: number; negative?: number } = {}) {
+		const result = render(QuestionEditor, {
+			props: {
+				question: {
+					id: 'q-1',
+					type: 'free_text',
+					text: 'Why?',
+					required: true,
+					order: 0,
+					positiveWeight: weights.positive ?? 1,
+					negativeWeight: weights.negative ?? 0,
+					isFatal: false
+				},
+				onUpdate,
+				onRemove: vi.fn()
+			}
+		});
+		// The weights live in the collapsed "advanced" section.
+		await fireEvent.click(screen.getByRole('button', { name: /advanced/i }));
+		return result;
+	}
+
+	function positiveWeightInput(): HTMLInputElement {
+		return screen.getByLabelText(/positive weight/i) as HTMLInputElement;
+	}
+
+	function negativeWeightInput(): HTMLInputElement {
+		return screen.getByLabelText(/negative weight/i) as HTMLInputElement;
+	}
+
+	it('lets a weight be cleared without snapping it to 0', async () => {
+		await renderEditor({ positive: 2 });
+		const input = positiveWeightInput();
+		expect(input.value).toBe('2');
+
+		await fireEvent.input(input, { target: { value: '' } });
+
+		expect(input.value).toBe('');
+		expect(onUpdate).not.toHaveBeenCalled();
+	});
+
+	it('commits a fractional weight typed after clearing', async () => {
+		await renderEditor({ positive: 2 });
+		const input = positiveWeightInput();
+
+		await fireEvent.input(input, { target: { value: '' } });
+		// "0." is not yet a number — it must not commit, and must not be rewritten.
+		await fireEvent.input(input, { target: { value: '0.' } });
+		expect(onUpdate).not.toHaveBeenCalled();
+
+		await fireEvent.input(input, { target: { value: '0.5' } });
+		expect(onUpdate).toHaveBeenLastCalledWith({ positiveWeight: 0.5 });
+	});
+
+	it('settles an emptied weight back to the committed value on blur', async () => {
+		await renderEditor({ positive: 2 });
+		const input = positiveWeightInput();
+
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.blur(input);
+
+		expect(input.value).toBe('2');
+		expect(onUpdate).toHaveBeenLastCalledWith({ positiveWeight: 2 });
+	});
+
+	it('clamps an out-of-range negative weight on blur', async () => {
+		await renderEditor({ negative: 1 });
+		const input = negativeWeightInput();
+
+		await fireEvent.input(input, { target: { value: '250' } });
+		expect(onUpdate).not.toHaveBeenCalled();
+
+		await fireEvent.blur(input);
+		expect(onUpdate).toHaveBeenLastCalledWith({ negativeWeight: 100 });
+	});
+});

--- a/src/lib/components/questionnaires/QuestionnaireFormFields.svelte
+++ b/src/lib/components/questionnaires/QuestionnaireFormFields.svelte
@@ -13,6 +13,7 @@
 		CardTitle
 	} from '$lib/components/ui/card';
 	import type { QuestionnaireEvaluationMode } from '$lib/api/generated/types.gen';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 
 	interface Props {
 		name: string;
@@ -77,6 +78,23 @@
 		onCanRetakeAfterChange,
 		onMaxAttemptsChange
 	}: Props = $props();
+
+	// Both numeric fields commit only whole in-range values while the user types and
+	// clamp on blur, so the field can be emptied mid-edit. Committing `Number('')`
+	// per keystroke used to refill them with 0 under the caret (#924).
+	const minScoreField = numericField({
+		value: () => minScore,
+		commit: onMinScoreChange,
+		min: 0,
+		max: 100
+	});
+
+	// No maximum: 0 means "unlimited attempts".
+	const maxAttemptsField = numericField({
+		value: () => maxAttempts,
+		commit: onMaxAttemptsChange,
+		min: 0
+	});
 
 	// Questionnaire type labels
 	const questionnaireTypes = {
@@ -266,8 +284,9 @@
 				<Input
 					id="min-score"
 					type="number"
-					value={minScore}
-					oninput={(e) => onMinScoreChange(Number(e.currentTarget.value))}
+					value={minScoreField.value}
+					oninput={minScoreField.oninput}
+					onblur={minScoreField.onblur}
 					min="0"
 					max="100"
 					step="1"
@@ -490,8 +509,9 @@
 			<Input
 				id="max-attempts"
 				type="number"
-				value={maxAttempts}
-				oninput={(e) => onMaxAttemptsChange(Number(e.currentTarget.value))}
+				value={maxAttemptsField.value}
+				oninput={maxAttemptsField.oninput}
+				onblur={maxAttemptsField.onblur}
 				min="0"
 				step="1"
 				required

--- a/src/lib/components/questionnaires/QuestionnaireFormFields.test.ts
+++ b/src/lib/components/questionnaires/QuestionnaireFormFields.test.ts
@@ -103,8 +103,10 @@ describe('QuestionnaireFormFields — numeric fields', () => {
 		await fireEvent.input(input, { target: { value: '' } });
 		await fireEvent.blur(input);
 
+		// Releasing the buffer restores the display; an edit that settled back to
+		// the committed value writes nothing.
 		expect(input.value).toBe('50');
-		expect(handlers.onMinScoreChange).toHaveBeenLastCalledWith(50);
+		expect(handlers.onMinScoreChange).not.toHaveBeenCalled();
 	});
 
 	it('lets max attempts be cleared and retyped', async () => {

--- a/src/lib/components/questionnaires/QuestionnaireFormFields.test.ts
+++ b/src/lib/components/questionnaires/QuestionnaireFormFields.test.ts
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import QuestionnaireFormFields from './QuestionnaireFormFields.svelte';
+
+/**
+ * Covers the two numeric fields only — minimum score and max attempts. Both used
+ * to commit `Number(e.currentTarget.value)` on every keystroke, and `Number('')`
+ * is 0, so an emptied field refilled itself with a 0 under the caret (#924).
+ */
+describe('QuestionnaireFormFields — numeric fields', () => {
+	let handlers: Record<string, ReturnType<typeof vi.fn>>;
+
+	beforeEach(() => {
+		handlers = {
+			onMinScoreChange: vi.fn(),
+			onMaxAttemptsChange: vi.fn()
+		};
+	});
+
+	function renderFields(overrides: { minScore?: number; maxAttempts?: number } = {}) {
+		return render(QuestionnaireFormFields, {
+			props: {
+				name: 'Test questionnaire',
+				questionnaireType: 'admission',
+				requiresEvaluation: true,
+				effectiveRequiresEvaluation: true,
+				minScore: overrides.minScore ?? 50,
+				evaluationMode: 'manual',
+				shuffleQuestions: false,
+				shuffleSections: false,
+				membersExempt: false,
+				perEvent: false,
+				llmGuidelines: '',
+				maxSubmissionAge: null,
+				canRetakeAfter: null,
+				maxAttempts: overrides.maxAttempts ?? 3,
+				canEdit: true,
+				onNameChange: vi.fn(),
+				onQuestionnaireTypeChange: vi.fn(),
+				onRequiresEvaluationChange: vi.fn(),
+				onMinScoreChange: handlers.onMinScoreChange,
+				onEvaluationModeChange: vi.fn(),
+				onShuffleQuestionsChange: vi.fn(),
+				onShuffleSectionsChange: vi.fn(),
+				onMembersExemptChange: vi.fn(),
+				onPerEventChange: vi.fn(),
+				onLlmGuidelinesChange: vi.fn(),
+				onMaxSubmissionAgeChange: vi.fn(),
+				onCanRetakeAfterChange: vi.fn(),
+				onMaxAttemptsChange: handlers.onMaxAttemptsChange
+			}
+		});
+	}
+
+	function minScoreInput(): HTMLInputElement {
+		return screen.getByLabelText(/minimum score/i) as HTMLInputElement;
+	}
+
+	function maxAttemptsInput(): HTMLInputElement {
+		return screen.getByLabelText(/max(imum)? (number of )?attempts/i) as HTMLInputElement;
+	}
+
+	it('lets the minimum score be cleared without refilling it with 0', async () => {
+		renderFields({ minScore: 50 });
+		const input = minScoreInput();
+		expect(input.value).toBe('50');
+
+		await fireEvent.input(input, { target: { value: '' } });
+
+		expect(input.value).toBe('');
+		expect(handlers.onMinScoreChange).not.toHaveBeenCalled();
+	});
+
+	it('commits a minimum score retyped after clearing, including 0', async () => {
+		renderFields({ minScore: 50 });
+		const input = minScoreInput();
+
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.input(input, { target: { value: '7' } });
+		expect(handlers.onMinScoreChange).toHaveBeenLastCalledWith(7);
+
+		// 0 is a legal minimum score ("no minimum"), unlike the max-tickets field
+		// this guard generalizes — the bounds decide, not the helper.
+		await fireEvent.input(input, { target: { value: '0' } });
+		expect(handlers.onMinScoreChange).toHaveBeenLastCalledWith(0);
+	});
+
+	it('clamps the minimum score to 0..100 on blur', async () => {
+		renderFields({ minScore: 50 });
+		const input = minScoreInput();
+
+		await fireEvent.input(input, { target: { value: '150' } });
+		expect(handlers.onMinScoreChange).not.toHaveBeenCalled();
+
+		await fireEvent.blur(input);
+		expect(handlers.onMinScoreChange).toHaveBeenLastCalledWith(100);
+	});
+
+	it('restores the previous minimum score when an emptied field is blurred', async () => {
+		renderFields({ minScore: 50 });
+		const input = minScoreInput();
+
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.blur(input);
+
+		expect(input.value).toBe('50');
+		expect(handlers.onMinScoreChange).toHaveBeenLastCalledWith(50);
+	});
+
+	it('lets max attempts be cleared and retyped', async () => {
+		renderFields({ maxAttempts: 3 });
+		const input = maxAttemptsInput();
+
+		await fireEvent.input(input, { target: { value: '' } });
+		expect(input.value).toBe('');
+		expect(handlers.onMaxAttemptsChange).not.toHaveBeenCalled();
+
+		await fireEvent.input(input, { target: { value: '10' } });
+		expect(handlers.onMaxAttemptsChange).toHaveBeenLastCalledWith(10);
+	});
+
+	it('settles max attempts on blur without accepting a negative', async () => {
+		renderFields({ maxAttempts: 3 });
+		const input = maxAttemptsInput();
+
+		await fireEvent.input(input, { target: { value: '-2' } });
+		expect(handlers.onMaxAttemptsChange).not.toHaveBeenCalled();
+
+		await fireEvent.blur(input);
+		expect(handlers.onMaxAttemptsChange).toHaveBeenLastCalledWith(0);
+	});
+});

--- a/src/lib/components/venues/SeatGeometryPanel.svelte
+++ b/src/lib/components/venues/SeatGeometryPanel.svelte
@@ -12,6 +12,7 @@
 		type RowLayoutRecipe,
 		type RowOverride
 	} from './row-layout';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 
 	export interface RowOption {
 		rank: number;
@@ -76,19 +77,56 @@
 		updateRecipe({ stagger: checked ? 0.5 : 0 });
 	}
 
-	// Clamp is local (row-layout's own `clamp` is a persistence-boundary detail
-	// and stays unexported) — this is the equivalent guard at the input
-	// boundary, so a typed out-of-range value can never reach `recipe` even
-	// transiently (WCAG 3.3.1: prevention beats post-hoc error identification).
-	function clamp(value: number, min: number, max: number): number {
-		return Math.min(max, Math.max(min, value));
-	}
+	// An out-of-range typed value still never reaches `recipe` (WCAG 3.3.1:
+	// prevention beats post-hoc error identification) — but it is now kept out by
+	// NOT committing it, rather than by rewriting the field under the caret, and
+	// blur clamps whatever is left into range (#924). `type="number"` reports an
+	// empty value for a lone "-", so clamping per keystroke made a negative curve
+	// or shift awkward to type: the minus sign was replaced before its digits.
+	const curveField = numericField({
+		value: () => recipe.curve,
+		commit: (curve) => updateRecipe({ curve }, 'curve'),
+		min: CURVE_MIN,
+		max: CURVE_MAX,
+		decimal: true
+	});
 
-	function parseOptionalNumber(raw: string, min: number, max: number): number | undefined {
-		if (raw.trim() === '') return undefined;
-		const value = Number(raw);
-		return Number.isFinite(value) ? clamp(value, min, max) : undefined;
-	}
+	const staggerField = numericField({
+		value: () => recipe.stagger,
+		commit: (stagger) => updateRecipe({ stagger }, 'stagger'),
+		min: STAGGER_MIN,
+		max: STAGGER_MAX,
+		decimal: true
+	});
+
+	// Per-row overrides are genuinely clearable: an empty field means "this row
+	// doesn't override the recipe", which drops the entry entirely.
+	const overrideCurveField = numericField<number | null>({
+		value: () => selectedOverride?.curve ?? null,
+		commit: (curve) => writeOverride({ curve: curve ?? undefined }),
+		min: CURVE_MIN,
+		max: CURVE_MAX,
+		decimal: true,
+		emptyValue: null
+	});
+
+	const overrideDxField = numericField<number | null>({
+		value: () => selectedOverride?.dx ?? null,
+		commit: (dx) => writeOverride({ dx: dx ?? undefined }),
+		min: -ROW_SHIFT_LIMIT,
+		max: ROW_SHIFT_LIMIT,
+		decimal: true,
+		emptyValue: null
+	});
+
+	const overrideDyField = numericField<number | null>({
+		value: () => selectedOverride?.dy ?? null,
+		commit: (dy) => writeOverride({ dy: dy ?? undefined }),
+		min: -ROW_SHIFT_LIMIT,
+		max: ROW_SHIFT_LIMIT,
+		decimal: true,
+		emptyValue: null
+	});
 
 	function writeOverride(patch: Partial<Omit<RowOverride, 'row'>>) {
 		if (selectedRank === null) return;
@@ -175,12 +213,10 @@
 					min={CURVE_MIN}
 					max={CURVE_MAX}
 					step={CURVE_STEP}
-					value={recipe.curve}
+					value={curveField.value}
 					aria-describedby="geo-curve-help"
-					oninput={(e) => {
-						const parsed = parseOptionalNumber(e.currentTarget.value, CURVE_MIN, CURVE_MAX);
-						if (parsed !== undefined) updateRecipe({ curve: parsed }, 'curve');
-					}}
+					oninput={curveField.oninput}
+					onblur={curveField.onblur}
 					class="w-20 rounded-md border border-input bg-background px-3 py-2 text-sm"
 				/>
 			</div>
@@ -216,11 +252,9 @@
 						min={STAGGER_MIN}
 						max={STAGGER_MAX}
 						step="0.1"
-						value={recipe.stagger}
-						oninput={(e) => {
-							const parsed = parseOptionalNumber(e.currentTarget.value, STAGGER_MIN, STAGGER_MAX);
-							if (parsed !== undefined) updateRecipe({ stagger: parsed }, 'stagger');
-						}}
+						value={staggerField.value}
+						oninput={staggerField.oninput}
+						onblur={staggerField.onblur}
 						class="w-24 rounded-md border border-input bg-background px-3 py-2 text-sm"
 					/>
 				</div>
@@ -279,11 +313,9 @@
 						min={CURVE_MIN}
 						max={CURVE_MAX}
 						step={CURVE_STEP}
-						value={selectedOverride?.curve ?? ''}
-						oninput={(e) =>
-							writeOverride({
-								curve: parseOptionalNumber(e.currentTarget.value, CURVE_MIN, CURVE_MAX)
-							})}
+						value={overrideCurveField.value}
+						oninput={overrideCurveField.oninput}
+						onblur={overrideCurveField.onblur}
 						class="w-24 rounded-md border border-input bg-background px-3 py-2 text-sm"
 					/>
 				</div>
@@ -295,11 +327,9 @@
 						id="geo-row-dx"
 						type="number"
 						step="0.1"
-						value={selectedOverride?.dx ?? ''}
-						oninput={(e) =>
-							writeOverride({
-								dx: parseOptionalNumber(e.currentTarget.value, -ROW_SHIFT_LIMIT, ROW_SHIFT_LIMIT)
-							})}
+						value={overrideDxField.value}
+						oninput={overrideDxField.oninput}
+						onblur={overrideDxField.onblur}
 						class="w-24 rounded-md border border-input bg-background px-3 py-2 text-sm"
 					/>
 				</div>
@@ -311,11 +341,9 @@
 						id="geo-row-dy"
 						type="number"
 						step="0.1"
-						value={selectedOverride?.dy ?? ''}
-						oninput={(e) =>
-							writeOverride({
-								dy: parseOptionalNumber(e.currentTarget.value, -ROW_SHIFT_LIMIT, ROW_SHIFT_LIMIT)
-							})}
+						value={overrideDyField.value}
+						oninput={overrideDyField.oninput}
+						onblur={overrideDyField.onblur}
 						class="w-24 rounded-md border border-input bg-background px-3 py-2 text-sm"
 					/>
 				</div>

--- a/src/lib/components/venues/SeatGeometryPanel.test.ts
+++ b/src/lib/components/venues/SeatGeometryPanel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, fireEvent } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { defaultRowLayout } from './row-layout';
 import SeatGeometryPanel from './SeatGeometryPanel.svelte';
@@ -52,7 +52,7 @@ describe('SeatGeometryPanel', () => {
 		expect(exactInput.getAttribute('aria-describedby')).toBe('geo-curve-help');
 	});
 
-	it('clamps a typed out-of-range curve value instead of applying it verbatim', async () => {
+	it('clamps a typed out-of-range curve value on blur instead of applying it verbatim', async () => {
 		const user = userEvent.setup();
 		const { getByLabelText } = render(SeatGeometryPanel, {
 			recipe: defaultRowLayout(),
@@ -66,7 +66,37 @@ describe('SeatGeometryPanel', () => {
 		await user.clear(exactInput);
 		await user.type(exactInput, '999');
 
+		// Out of range never reaches the recipe — but it is kept out by committing
+		// nothing, not by rewriting the field under the caret (#924).
+		expect(slider.value).toBe('9');
+		expect(exactInput.value).toBe('999');
+
+		await fireEvent.blur(exactInput);
+
 		expect(slider.value).toBe('30');
+		expect(exactInput.value).toBe('30');
+	});
+
+	it('lets the exact curve field be emptied and retyped, including a negative', async () => {
+		const user = userEvent.setup();
+		const { getByLabelText } = render(SeatGeometryPanel, {
+			recipe: defaultRowLayout(),
+			rowOptions: [],
+			unsupported: false
+		});
+
+		const slider = getByLabelText('Curve') as HTMLInputElement;
+		const exactInput = getByLabelText('Exact curve value') as HTMLInputElement;
+
+		await user.clear(exactInput);
+		expect(exactInput.value).toBe('');
+
+		// A lone "-" reads as an empty value on a number input; clamping per
+		// keystroke used to replace it with a digit before the number could follow.
+		await user.type(exactInput, '-12');
+
+		expect(exactInput.value).toBe('-12');
+		expect(slider.value).toBe('-12');
 	});
 
 	// No `.test.svelte.ts` runes-in-test pattern exists in this project (grep

--- a/src/lib/components/venues/SeatGridConfig.svelte
+++ b/src/lib/components/venues/SeatGridConfig.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 
 	interface Props {
 		rows: number;
@@ -37,13 +38,30 @@
 	 *  digit ("300") explodes the synthetic lattice the editor bakes per cell. */
 	const MAX_GRID_SIZE = 30;
 
-	/** Typing through an empty field must not blank the grid size. */
-	function readSize(raw: string, fallback: number): number {
-		const value = Number(raw);
-		return Number.isFinite(value) && value >= 1
-			? Math.min(Math.floor(value), MAX_GRID_SIZE)
-			: fallback;
-	}
+	// Typing through an empty field must not blank the grid size, and an emptied
+	// field must not be left showing a size the grid doesn't have: only in-range
+	// sizes are committed while typing, and blur settles the rest (#924). The undo
+	// point is recorded from `commit`, so a keystroke that changes nothing (an
+	// empty field, a half-typed "3" of "30") no longer opens a history entry.
+	const rowsField = numericField({
+		value: () => rows,
+		commit: (next) => {
+			onBeforeEdit?.('grid-size');
+			rows = next;
+		},
+		min: 1,
+		max: MAX_GRID_SIZE
+	});
+
+	const columnsField = numericField({
+		value: () => columns,
+		commit: (next) => {
+			onBeforeEdit?.('grid-size');
+			columns = next;
+		},
+		min: 1,
+		max: MAX_GRID_SIZE
+	});
 </script>
 
 <!-- Grid Configuration -->
@@ -60,11 +78,9 @@
 				type="number"
 				min="1"
 				max={MAX_GRID_SIZE}
-				value={rows}
-				oninput={(e) => {
-					onBeforeEdit?.('grid-size');
-					rows = readSize(e.currentTarget.value, rows);
-				}}
+				value={rowsField.value}
+				oninput={rowsField.oninput}
+				onblur={rowsField.onblur}
 				class="w-20 rounded-md border border-input bg-background px-3 py-2 text-sm"
 			/>
 		</div>
@@ -78,11 +94,9 @@
 				type="number"
 				min="1"
 				max={MAX_GRID_SIZE}
-				value={columns}
-				oninput={(e) => {
-					onBeforeEdit?.('grid-size');
-					columns = readSize(e.currentTarget.value, columns);
-				}}
+				value={columnsField.value}
+				oninput={columnsField.oninput}
+				onblur={columnsField.onblur}
 				class="w-20 rounded-md border border-input bg-background px-3 py-2 text-sm"
 			/>
 		</div>

--- a/src/lib/components/venues/SeatGridConfig.test.ts
+++ b/src/lib/components/venues/SeatGridConfig.test.ts
@@ -8,7 +8,14 @@ import SeatGridConfig from './SeatGridConfig.svelte';
  * commit only in-range sizes while typing and normalize on blur.
  */
 describe('SeatGridConfig — grid size inputs', () => {
-	function renderConfig(rows = 5, columns = 8) {
+	function renderConfig(
+		rows = 5,
+		columns = 8
+	): ReturnType<typeof render> & {
+		onBeforeEdit: ReturnType<typeof vi.fn>;
+		rowsInput: HTMLInputElement;
+		columnsInput: HTMLInputElement;
+	} {
 		const onBeforeEdit = vi.fn();
 		const result = render(SeatGridConfig, {
 			props: {

--- a/src/lib/components/venues/SeatGridConfig.test.ts
+++ b/src/lib/components/venues/SeatGridConfig.test.ts
@@ -1,0 +1,71 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import SeatGridConfig from './SeatGridConfig.svelte';
+
+/**
+ * The rows/columns inputs never blocked editing, but an emptied field left the
+ * display and the grid size diverged with nothing to settle them (#924). They now
+ * commit only in-range sizes while typing and normalize on blur.
+ */
+describe('SeatGridConfig — grid size inputs', () => {
+	function renderConfig(rows = 5, columns = 8) {
+		const onBeforeEdit = vi.fn();
+		const result = render(SeatGridConfig, {
+			props: {
+				rows,
+				columns,
+				useLetters: true,
+				invertRowOrder: false,
+				onGenerateEmpty: vi.fn(),
+				onGenerateFull: vi.fn(),
+				onBeforeEdit
+			}
+		});
+		return {
+			...result,
+			onBeforeEdit,
+			rowsInput: result.getByLabelText(/rows/i) as HTMLInputElement,
+			columnsInput: result.getByLabelText(/columns/i) as HTMLInputElement
+		};
+	}
+
+	it('lets a size be cleared and retyped', async () => {
+		const { rowsInput } = renderConfig(5);
+		expect(rowsInput.value).toBe('5');
+
+		await fireEvent.input(rowsInput, { target: { value: '' } });
+		expect(rowsInput.value).toBe('');
+
+		await fireEvent.input(rowsInput, { target: { value: '12' } });
+		expect(rowsInput.value).toBe('12');
+	});
+
+	it('opens no undo point for a keystroke that commits nothing', async () => {
+		const { rowsInput, onBeforeEdit } = renderConfig(5);
+
+		await fireEvent.input(rowsInput, { target: { value: '' } });
+
+		expect(onBeforeEdit).not.toHaveBeenCalled();
+	});
+
+	it('normalizes an emptied field back to the current size on blur', async () => {
+		const { columnsInput } = renderConfig(5, 8);
+
+		await fireEvent.input(columnsInput, { target: { value: '' } });
+		await fireEvent.blur(columnsInput);
+
+		expect(columnsInput.value).toBe('8');
+	});
+
+	it('clamps an oversized value to the grid maximum on blur', async () => {
+		const { rowsInput } = renderConfig(5);
+
+		// "300" explodes the synthetic lattice; it is never committed, and blur
+		// settles it at the declared maximum rather than rewriting it per keystroke.
+		await fireEvent.input(rowsInput, { target: { value: '300' } });
+		expect(rowsInput.value).toBe('300');
+
+		await fireEvent.blur(rowsInput);
+		expect(rowsInput.value).toBe('30');
+	});
+});

--- a/src/lib/components/venues/SeatSelectionActions.svelte
+++ b/src/lib/components/venues/SeatSelectionActions.svelte
@@ -40,6 +40,7 @@
 		type NudgePatch,
 		type SeatAdjustState
 	} from './seat-adjust-state.svelte';
+	import { numericField } from '$lib/utils/numeric-input.svelte';
 
 	interface Props {
 		adjust: SeatAdjustState;
@@ -76,21 +77,44 @@
 		onRemoveSeat
 	}: Props = $props();
 
-	function clamp(value: number, min: number, max: number): number {
-		return Math.min(max, Math.max(min, value));
-	}
-
 	/**
-	 * Guard at the input boundary (WCAG 3.3.1: prevention beats correction), so
-	 * an out-of-range typed value never reaches the recipe even transiently. An
-	 * emptied field reads as 0 — that IS the "no offset" value here, and the
-	 * nudge drops out of the recipe entirely.
+	 * An emptied field still reads as 0 — that IS the "no offset" value here, and
+	 * the nudge drops out of the recipe entirely — but it now settles to 0 on
+	 * BLUR rather than on the keystroke that empties it (#924). Writing 0 back per
+	 * keystroke made a negative offset untypable: `type="number"` reports an empty
+	 * `value` for a lone `-`, so the minus sign was replaced by a `0` under the
+	 * caret before the digits could follow. Out-of-range values are still kept out
+	 * of the recipe (WCAG 3.3.1 — prevention beats correction): they simply aren't
+	 * committed while typing, and blur clamps them into range.
 	 */
-	function readNumber(raw: string, min: number, max: number): number {
-		if (raw.trim() === '') return 0;
-		const value = Number(raw);
-		return Number.isFinite(value) ? clamp(value, min, max) : 0;
-	}
+	const dxField = numericField({
+		value: () => nudge?.dx ?? 0,
+		commit: (dx) => onNudgeChange({ dx }),
+		min: -ROW_SHIFT_LIMIT,
+		max: ROW_SHIFT_LIMIT,
+		decimal: true,
+		emptyValue: 0
+	});
+
+	const dyField = numericField({
+		value: () => nudge?.dy ?? 0,
+		commit: (dy) => onNudgeChange({ dy }),
+		min: -ROW_SHIFT_LIMIT,
+		max: ROW_SHIFT_LIMIT,
+		decimal: true,
+		emptyValue: 0
+	});
+
+	// Rotation is accepted over a full turn and normalized downstream, which is
+	// why these bounds are wider than the input's own min/max.
+	const rotField = numericField({
+		value: () => nudge?.rot ?? 0,
+		commit: (rot) => onNudgeChange({ rot }),
+		min: -360,
+		max: 360,
+		decimal: true,
+		emptyValue: 0
+	});
 
 	const INPUT_CLASS =
 		'h-9 w-16 rounded-md border border-input bg-background px-2 text-sm text-center';
@@ -137,11 +161,9 @@
 					step={NUDGE_STEP}
 					min={-ROW_SHIFT_LIMIT}
 					max={ROW_SHIFT_LIMIT}
-					value={nudge?.dx ?? 0}
-					oninput={(e) =>
-						onNudgeChange({
-							dx: readNumber(e.currentTarget.value, -ROW_SHIFT_LIMIT, ROW_SHIFT_LIMIT)
-						})}
+					value={dxField.value}
+					oninput={dxField.oninput}
+					onblur={dxField.onblur}
 					class={INPUT_CLASS}
 				/>
 				<input
@@ -151,11 +173,9 @@
 					step={NUDGE_STEP}
 					min={-ROW_SHIFT_LIMIT}
 					max={ROW_SHIFT_LIMIT}
-					value={nudge?.dy ?? 0}
-					oninput={(e) =>
-						onNudgeChange({
-							dy: readNumber(e.currentTarget.value, -ROW_SHIFT_LIMIT, ROW_SHIFT_LIMIT)
-						})}
+					value={dyField.value}
+					oninput={dyField.oninput}
+					onblur={dyField.onblur}
 					class={INPUT_CLASS}
 				/>
 				<input
@@ -165,9 +185,10 @@
 					step={ROTATION_STEP}
 					min={-180}
 					max={179}
-					value={nudge?.rot ?? 0}
+					value={rotField.value}
 					aria-describedby="adjust-rot-help"
-					oninput={(e) => onNudgeChange({ rot: readNumber(e.currentTarget.value, -360, 360) })}
+					oninput={rotField.oninput}
+					onblur={rotField.onblur}
 					class={INPUT_CLASS}
 				/>
 				<span id="adjust-rot-help" class="sr-only">{m['seatGridEditor.adjust.rotHint']()}</span>

--- a/src/lib/components/venues/SeatSelectionActions.test.ts
+++ b/src/lib/components/venues/SeatSelectionActions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, fireEvent } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { SeatAdjustState } from './seat-adjust-state.svelte';
@@ -239,26 +239,62 @@ describe('SeatSelectionActions — the inline single-seat inspector', () => {
 		expect(onNudgeChange).toHaveBeenLastCalledWith({ rot: 90 });
 	});
 
-	it('clamps an out-of-range typed offset at the input boundary', async () => {
+	it('keeps an out-of-range typed offset out of the recipe, clamping it on blur', async () => {
 		const user = userEvent.setup();
 		const { onNudgeChange, getByLabelText } = harness({
 			adjust: activeAdjust(),
 			selectedLabel: 'B3'
 		});
-		await user.clear(getByLabelText('Move back (rows)'));
-		await user.type(getByLabelText('Move back (rows)'), '999');
+		const input = getByLabelText('Move back (rows)') as HTMLInputElement;
+		await user.clear(input);
+		await user.type(input, '999');
+
+		// 999 and 99 are both past the limit, so neither is committed — the recipe
+		// only ever saw the in-range "9". Rewriting the field per keystroke is what
+		// made it uneditable (#924).
+		expect(onNudgeChange).toHaveBeenLastCalledWith({ dy: 9 });
+		expect(input.value).toBe('999');
+
+		await fireEvent.blur(input);
 		expect(onNudgeChange).toHaveBeenLastCalledWith({ dy: 20 });
 	});
 
-	it('reads an emptied field as zero rather than NaN', async () => {
+	it('reads an emptied field as zero once it is blurred', async () => {
 		const user = userEvent.setup();
 		const { onNudgeChange, getByLabelText } = harness({
 			adjust: activeAdjust(),
 			selectedLabel: 'B3',
 			nudge: { dx: 3 }
 		});
-		await user.clear(getByLabelText('Move sideways (seats)'));
+		const input = getByLabelText('Move sideways (seats)') as HTMLInputElement;
+
+		// Empty is still "no offset" — it just isn't applied until the user leaves
+		// the field, so a value can be cleared and retyped.
+		await user.clear(input);
+		expect(input.value).toBe('');
+		expect(onNudgeChange).not.toHaveBeenCalled();
+
+		await fireEvent.blur(input);
 		expect(onNudgeChange).toHaveBeenLastCalledWith({ dx: 0 });
+	});
+
+	it('accepts a negative offset typed from scratch', async () => {
+		const user = userEvent.setup();
+		const { onNudgeChange, getByLabelText } = harness({
+			adjust: activeAdjust(),
+			selectedLabel: 'B3',
+			nudge: { dx: 3 }
+		});
+		const input = getByLabelText('Move sideways (seats)') as HTMLInputElement;
+
+		// A number input reports an empty value for a lone "-", which the old
+		// per-keystroke write-back turned into a 0 — wiping the sign before its
+		// digits could be typed.
+		await user.clear(input);
+		await user.type(input, '-2.5');
+
+		expect(input.value).toBe('-2.5');
+		expect(onNudgeChange).toHaveBeenLastCalledWith({ dx: -2.5 });
 	});
 
 	it('describes the rotation contract for screen readers without a visible caption', () => {

--- a/src/lib/utils/numeric-input.svelte.ts
+++ b/src/lib/utils/numeric-input.svelte.ts
@@ -1,0 +1,112 @@
+import { parseCommittableNumber, settleNumber, type NumericBounds } from './numeric-input';
+
+export interface NumericFieldOptions<T extends number | null> extends NumericBounds {
+	/** The committed value the field shows when it is not being edited. */
+	value: () => T;
+	/** Write a settled value back. Only ever called with an in-bounds value. */
+	commit: (next: T) => void;
+	/**
+	 * What an emptied field settles to on blur.
+	 *
+	 * Pass `null` to make the field clearable — empty then counts as a value
+	 * rather than a half-typed state and commits immediately. Omit it and an
+	 * emptied field falls back to the value committed before the edit.
+	 */
+	emptyValue?: T;
+}
+
+export interface NumericField {
+	/** Bind to the input's `value=`. */
+	readonly value: string;
+	oninput: (event: Event & { currentTarget: HTMLInputElement }) => void;
+	onblur: () => void;
+	/**
+	 * Drop an in-progress edit and show the committed value again. Call it where
+	 * the field is re-seeded behind the user's back — a dialog reopening, say,
+	 * which can unmount a focused input without ever firing `blur`.
+	 */
+	reset: () => void;
+}
+
+/**
+ * Wire up a numeric `<input>` that stays editable while the user types.
+ *
+ * The returned `value` is a free-text buffer for as long as the field has focus:
+ * `oninput` commits only values that are already valid and leaves everything else
+ * (empty, `0` under a `min` of 1, a half-typed decimal) alone, so no keystroke is
+ * ever overwritten under the caret. `onblur` clamps and normalizes what is left.
+ *
+ * Clamping on blur rather than per keystroke is also the better WCAG 3.3.1
+ * behavior: a value silently rewritten mid-typing is not an error the user can
+ * perceive or correct.
+ *
+ * ```svelte
+ * const window = numericField({
+ *   value: () => generationWindowWeeks,
+ *   commit: (n) => (generationWindowWeeks = n),
+ *   min: 1,
+ *   max: 52
+ * });
+ *
+ * <Input type="number" min={1} max={52}
+ *        value={window.value} oninput={window.oninput} onblur={window.onblur} />
+ * ```
+ */
+export function numericField<T extends number | null = number>(
+	options: NumericFieldOptions<T>
+): NumericField {
+	// `null` means "not being edited": the field renders the committed value, so a
+	// change from elsewhere (a parent prop, a dialog reopening) shows through on
+	// its own — no `$effect` re-sync racing the user's keystrokes.
+	let draft = $state<string | null>(null);
+
+	const clearable = options.emptyValue === null;
+
+	return {
+		get value(): string {
+			if (draft !== null) return draft;
+			const current = options.value();
+			return current === null || current === undefined ? '' : String(current);
+		},
+
+		oninput(event): void {
+			const raw = event.currentTarget.value;
+			draft = raw;
+
+			const parsed = parseCommittableNumber(raw, options);
+			if (parsed !== null) {
+				options.commit(parsed as T);
+				return;
+			}
+			// A clearable field commits the clear straight away: empty is a value
+			// there, and Enter-submitting a form fires no blur to settle it.
+			if (clearable && raw.trim() === '') {
+				options.commit(null as T);
+			}
+			// Anything else commits nothing — the last valid value stands until blur.
+		},
+
+		onblur(): void {
+			if (draft === null) return; // never edited; nothing to settle
+			const raw = draft;
+			draft = null;
+
+			const fallback =
+				options.emptyValue !== undefined
+					? options.emptyValue
+					: (options.value() ?? options.min ?? 0);
+			options.commit(
+				settleNumber(raw, {
+					min: options.min,
+					max: options.max,
+					decimal: options.decimal,
+					fallback
+				}) as T
+			);
+		},
+
+		reset(): void {
+			draft = null;
+		}
+	};
+}

--- a/src/lib/utils/numeric-input.svelte.ts
+++ b/src/lib/utils/numeric-input.svelte.ts
@@ -79,8 +79,11 @@ export function numericField<T extends number | null = number>(
 				return;
 			}
 			// A clearable field commits the clear straight away: empty is a value
-			// there, and Enter-submitting a form fires no blur to settle it.
-			if (clearable && raw.trim() === '') {
+			// there, and Enter-submitting a form fires no blur to settle it. But a
+			// number input also reports an empty `value` for text it cannot parse —
+			// a lone "-" on the way to "-1" — and that is a half-typed state, not a
+			// clear. `badInput` is what tells the two apart.
+			if (clearable && raw.trim() === '' && !event.currentTarget.validity?.badInput) {
 				options.commit(null as T);
 			}
 			// Anything else commits nothing — the last valid value stands until blur.
@@ -91,18 +94,23 @@ export function numericField<T extends number | null = number>(
 			const raw = draft;
 			draft = null;
 
+			const current = options.value();
 			const fallback =
-				options.emptyValue !== undefined
-					? options.emptyValue
-					: (options.value() ?? options.min ?? 0);
-			options.commit(
-				settleNumber(raw, {
-					min: options.min,
-					max: options.max,
-					decimal: options.decimal,
-					fallback
-				}) as T
-			);
+				options.emptyValue !== undefined ? options.emptyValue : (current ?? options.min ?? 0);
+			const settled = settleNumber(raw, {
+				min: options.min,
+				max: options.max,
+				decimal: options.decimal,
+				fallback
+			});
+
+			// Releasing the buffer already re-renders the normalized display ("05" is
+			// now "5"), so a settle that lands on the value already committed has
+			// nothing to write back — and writing it anyway would open an undo point
+			// or mark a form dirty for an edit that changed nothing.
+			if (settled !== current) {
+				options.commit(settled as T);
+			}
 		},
 
 		reset(): void {

--- a/src/lib/utils/numeric-input.test.ts
+++ b/src/lib/utils/numeric-input.test.ts
@@ -88,6 +88,13 @@ describe('settleNumber', () => {
 		expect(settleNumber('-', { min: 1, fallback: 7 })).toBe(7);
 	});
 
+	it('falls back for a whole number too large to be exact', () => {
+		// A bounded field is safe either way — the clamp pulls it to the maximum.
+		expect(settleNumber('99999999999999999999', { min: 1, max: 52, fallback: 7 })).toBe(52);
+		// An unbounded one has nothing to clamp against, so 1e20 must not commit.
+		expect(settleNumber('99999999999999999999', { min: 0, fallback: 7 })).toBe(7);
+	});
+
 	it('settles empty to null for a clearable field', () => {
 		expect(settleNumber('', { min: 1, fallback: null })).toBeNull();
 		expect(settleNumber('4', { min: 1, max: 31, fallback: null })).toBe(4);
@@ -164,7 +171,49 @@ describe('numericField', () => {
 		field.oninput(typed(''));
 		field.onblur();
 
+		// Releasing the buffer is enough to show 5 again, so there is nothing to
+		// write back — committing it anyway would mark a form dirty (or open an
+		// undo point) for an edit that changed nothing.
+		expect(field.value).toBe('5');
+		expect(commit).not.toHaveBeenCalled();
+	});
+
+	it('commits nothing on blur when the settled value is already committed', () => {
+		const { field, commit } = setup(5);
+
+		field.oninput(typed('05'));
 		expect(commit).toHaveBeenLastCalledWith(5);
+		commit.mockClear();
+
+		field.onblur();
+
+		expect(field.value).toBe('5'); // display still normalizes
+		expect(commit).not.toHaveBeenCalled();
+	});
+
+	it('treats an empty value from unparseable text as half-typed, not as a clear', () => {
+		const { field, commit } = setup(5, { emptyValue: null, min: -50 });
+
+		// A number input reports `value === ''` for a lone "-", with badInput set.
+		// Committing the clear there would wipe the value mid-way through "-1".
+		field.oninput({
+			currentTarget: { value: '', validity: { badInput: true } }
+		} as unknown as Event & { currentTarget: HTMLInputElement });
+
+		expect(commit).not.toHaveBeenCalled();
+	});
+
+	it('refuses an unbounded integer too large to be exact, on blur as well as while typing', () => {
+		const { field, commit } = setup(5, { min: 0, max: undefined });
+
+		field.oninput(typed('99999999999999999999'));
+		expect(commit).not.toHaveBeenCalled();
+
+		field.onblur();
+
+		// 1e20 would have sailed through the old blur path — `parseCommittableNumber`
+		// refuses it while typing, so the settle must refuse it too.
+		expect(commit).not.toHaveBeenCalled();
 		expect(field.value).toBe('5');
 	});
 

--- a/src/lib/utils/numeric-input.test.ts
+++ b/src/lib/utils/numeric-input.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseCommittableNumber, clampNumber, settleNumber } from './numeric-input';
+import { numericField } from './numeric-input.svelte';
+
+describe('parseCommittableNumber', () => {
+	it('commits a whole number inside the bounds', () => {
+		expect(parseCommittableNumber('5', { min: 1, max: 52 })).toBe(5);
+		expect(parseCommittableNumber(' 5 ', { min: 1, max: 52 })).toBe(5);
+		expect(parseCommittableNumber('05', { min: 1, max: 52 })).toBe(5);
+	});
+
+	it('refuses an empty buffer instead of reading it as 0', () => {
+		// The whole point of the sweep: Number('') is 0 and Number.isFinite(0) is
+		// true, so a naive guard commits 0 and the clamp pushes it up to the min.
+		expect(parseCommittableNumber('', { min: 1 })).toBeNull();
+		expect(parseCommittableNumber('   ', { min: 1 })).toBeNull();
+	});
+
+	it('refuses half-typed input rather than committing a prefix', () => {
+		expect(parseCommittableNumber('-', {})).toBeNull();
+		expect(parseCommittableNumber('1.', { decimal: true })).toBeNull();
+		expect(parseCommittableNumber('.', { decimal: true })).toBeNull();
+		expect(parseCommittableNumber('abc', {})).toBeNull();
+	});
+
+	it('refuses decimals and exponents on a whole-number field', () => {
+		// type="number" hands us "1.5" and "1e2" verbatim; parseInt would commit 1.
+		expect(parseCommittableNumber('1.5', {})).toBeNull();
+		expect(parseCommittableNumber('1e2', {})).toBeNull();
+	});
+
+	it('accepts decimals only when the field asks for them', () => {
+		expect(parseCommittableNumber('0.5', { decimal: true, min: 0, max: 100 })).toBe(0.5);
+		expect(parseCommittableNumber('1e2', { decimal: true })).toBeNull();
+	});
+
+	it('refuses a value outside the bounds instead of clamping it', () => {
+		expect(parseCommittableNumber('0', { min: 1, max: 52 })).toBeNull();
+		expect(parseCommittableNumber('53', { min: 1, max: 52 })).toBeNull();
+		// ...but 0 is a perfectly good value where the minimum allows it.
+		expect(parseCommittableNumber('0', { min: 0, max: 100 })).toBe(0);
+	});
+
+	it('accepts negatives when the bounds allow them', () => {
+		expect(parseCommittableNumber('-12', { min: -40, max: 40 })).toBe(-12);
+		expect(parseCommittableNumber('-12', { min: 0 })).toBeNull();
+	});
+
+	it('refuses an integer too large to be exact', () => {
+		expect(parseCommittableNumber('9007199254740993', {})).toBeNull();
+	});
+});
+
+describe('clampNumber', () => {
+	it('pulls a value inside the bounds', () => {
+		expect(clampNumber(0, { min: 1, max: 52 })).toBe(1);
+		expect(clampNumber(99, { min: 1, max: 52 })).toBe(52);
+		expect(clampNumber(7, { min: 1, max: 52 })).toBe(7);
+	});
+
+	it('leaves a missing bound unconstrained', () => {
+		expect(clampNumber(-99, { max: 52 })).toBe(-99);
+		expect(clampNumber(9999, { min: 1 })).toBe(9999);
+	});
+});
+
+describe('settleNumber', () => {
+	it('normalizes what the user actually entered', () => {
+		expect(settleNumber('05', { min: 1, fallback: 1 })).toBe(5);
+		expect(settleNumber('10.5', { min: 1, fallback: 1 })).toBe(10);
+		expect(settleNumber('1e2', { min: 1, fallback: 1 })).toBe(100);
+	});
+
+	it('clamps an out-of-range entry into the bounds', () => {
+		expect(settleNumber('0', { min: 1, max: 52, fallback: 1 })).toBe(1);
+		expect(settleNumber('99', { min: 1, max: 52, fallback: 1 })).toBe(52);
+		expect(settleNumber('-5', { min: 1, fallback: 1 })).toBe(1);
+	});
+
+	it('keeps the fraction on a decimal field', () => {
+		expect(settleNumber('0.5', { min: 0, max: 100, decimal: true, fallback: 0 })).toBe(0.5);
+		expect(settleNumber('120.5', { min: 0, max: 100, decimal: true, fallback: 0 })).toBe(100);
+	});
+
+	it('falls back for an empty or unparseable buffer', () => {
+		expect(settleNumber('', { min: 1, fallback: 7 })).toBe(7);
+		expect(settleNumber('  ', { min: 1, fallback: 7 })).toBe(7);
+		expect(settleNumber('-', { min: 1, fallback: 7 })).toBe(7);
+	});
+
+	it('settles empty to null for a clearable field', () => {
+		expect(settleNumber('', { min: 1, fallback: null })).toBeNull();
+		expect(settleNumber('4', { min: 1, max: 31, fallback: null })).toBe(4);
+	});
+});
+
+describe('numericField', () => {
+	/** Stand-in for the `oninput` event a real input hands the handler. */
+	function typed(value: string) {
+		return { currentTarget: { value } } as Event & { currentTarget: HTMLInputElement };
+	}
+
+	function setup(initial = 5, options: Partial<Parameters<typeof numericField>[0]> = {}) {
+		let committed: number | null = initial;
+		const commit = vi.fn((next: number | null) => (committed = next));
+		const field = numericField({
+			value: () => committed,
+			commit,
+			min: 1,
+			max: 52,
+			...options
+		});
+		return { field, commit, committed: () => committed };
+	}
+
+	it('shows the committed value until the user starts editing', () => {
+		const { field } = setup(5);
+		expect(field.value).toBe('5');
+	});
+
+	it('lets the field be emptied without refilling it', () => {
+		const { field, commit } = setup(5);
+
+		field.oninput(typed(''));
+
+		expect(field.value).toBe('');
+		expect(commit).not.toHaveBeenCalled();
+	});
+
+	it('commits a replacement typed after clearing', () => {
+		const { field, commit } = setup(5);
+
+		field.oninput(typed(''));
+		field.oninput(typed('1'));
+		field.oninput(typed('12'));
+
+		expect(field.value).toBe('12');
+		expect(commit).toHaveBeenLastCalledWith(12);
+	});
+
+	it('keeps a transient out-of-range keystroke visible without committing it', () => {
+		const { field, commit } = setup(5);
+
+		// "0" on the way to "10" is a legal keystroke, not a value.
+		field.oninput(typed('0'));
+
+		expect(field.value).toBe('0');
+		expect(commit).not.toHaveBeenCalled();
+	});
+
+	it('clamps and normalizes on blur', () => {
+		const { field, commit } = setup(5);
+
+		field.oninput(typed('99'));
+		field.onblur();
+
+		expect(commit).toHaveBeenLastCalledWith(52);
+		expect(field.value).toBe('52');
+	});
+
+	it('restores the previous value when an emptied field is blurred', () => {
+		const { field, commit } = setup(5);
+
+		field.oninput(typed(''));
+		field.onblur();
+
+		expect(commit).toHaveBeenLastCalledWith(5);
+		expect(field.value).toBe('5');
+	});
+
+	it('settles an emptied field to an explicit empty value', () => {
+		const { field, commit } = setup(5, { emptyValue: 0, min: 0 });
+
+		field.oninput(typed(''));
+		field.onblur();
+
+		expect(commit).toHaveBeenLastCalledWith(0);
+		expect(field.value).toBe('0');
+	});
+
+	it('commits the clear immediately on a clearable field', () => {
+		const { field, commit } = setup(5, { emptyValue: null });
+
+		field.oninput(typed(''));
+
+		expect(commit).toHaveBeenLastCalledWith(null);
+		expect(field.value).toBe('');
+
+		field.onblur();
+		expect(commit).toHaveBeenLastCalledWith(null);
+		expect(field.value).toBe('');
+	});
+
+	it('commits nothing on blur when the field was never edited', () => {
+		const { field, commit } = setup(5);
+
+		field.onblur();
+
+		expect(commit).not.toHaveBeenCalled();
+	});
+
+	it('follows the committed value again once the edit is settled', () => {
+		let committed = 5;
+		const field = numericField({
+			value: () => committed,
+			commit: (next) => (committed = next),
+			min: 1,
+			max: 52
+		});
+
+		field.oninput(typed('7'));
+		field.onblur();
+
+		// An update from elsewhere (a parent prop, a reopened dialog) shows through
+		// without an $effect re-sync, because the buffer is released on blur.
+		committed = 20;
+		expect(field.value).toBe('20');
+	});
+});

--- a/src/lib/utils/numeric-input.ts
+++ b/src/lib/utils/numeric-input.ts
@@ -1,0 +1,81 @@
+/**
+ * Guards for numeric `<input>` fields whose value is written back into the state
+ * that feeds their `value=`.
+ *
+ * Normalizing or clamping such a field on every keystroke makes it impossible to
+ * edit: backspacing the last digit is immediately overwritten, leaving a caret
+ * after a digit that can never be deleted (issues #922 / #924). The fix is to let
+ * the bound string be a free-text buffer while the field has focus — commit only
+ * values that are already valid, and settle whatever is left on blur.
+ *
+ * The empty string is the trap these helpers exist to close: `Number('')` is `0`,
+ * `parseFloat('') || 0` is `0`, and `Number.isFinite(0)` is `true`, so "empty"
+ * sails through a naive validity check and gets clamped up to the minimum.
+ */
+
+export interface NumericBounds {
+	/** Smallest committable value, inclusive. */
+	min?: number;
+	/** Largest committable value, inclusive. */
+	max?: number;
+	/** Accept fractional values. Whole numbers only by default. */
+	decimal?: boolean;
+}
+
+/** A whole number, optionally signed. Deliberately rejects `1e2` and `1.` alike. */
+const WHOLE_NUMBER = /^-?\d+$/;
+/** A plain decimal literal. Also rejects exponent notation and a trailing dot. */
+const DECIMAL_NUMBER = /^-?\d+(?:\.\d+)?$/;
+
+/**
+ * Parse a value that is worth committing while the user is still typing.
+ *
+ * Returns `null` for anything incomplete or out of range — empty, a lone `-`, a
+ * trailing `.`, or a number past the bounds — so the last valid value stands
+ * until {@link settleNumber} runs on blur. Nothing here rewrites the buffer.
+ *
+ * `type="number"` hands the page the raw text of anything that parses as a
+ * floating-point literal, so `1.5` and `1e2` arrive verbatim: `parseInt` would
+ * silently commit `1` for either, which is why the shape is matched first.
+ */
+export function parseCommittableNumber(raw: string, bounds: NumericBounds = {}): number | null {
+	const trimmed = raw.trim();
+	const shape = bounds.decimal ? DECIMAL_NUMBER : WHOLE_NUMBER;
+	if (!shape.test(trimmed)) return null;
+
+	const value = Number(trimmed);
+	if (!Number.isFinite(value)) return null;
+	if (!bounds.decimal && !Number.isSafeInteger(value)) return null;
+	if (bounds.min !== undefined && value < bounds.min) return null;
+	if (bounds.max !== undefined && value > bounds.max) return null;
+	return value;
+}
+
+/** Pull a value inside the bounds. Bounds that aren't given don't constrain. */
+export function clampNumber(value: number, bounds: NumericBounds = {}): number {
+	const lowered = bounds.min !== undefined ? Math.max(value, bounds.min) : value;
+	return bounds.max !== undefined ? Math.min(lowered, bounds.max) : lowered;
+}
+
+/**
+ * Settle a buffer on blur: clamp the number the user actually entered into range
+ * (`05` → `5`, `10.5` → `10`, `1e2` → `100`, `99` → the maximum).
+ *
+ * Empty and unparseable buffers settle to `fallback` rather than to `Number('')`.
+ * Pass `fallback: null` for a field where empty is itself a legal value.
+ *
+ * Whole-number fields floor rather than truncate a prefix, matching the event
+ * max-tickets field this sweep generalizes (#923).
+ */
+export function settleNumber<F extends number | null>(
+	raw: string,
+	options: NumericBounds & { fallback: F }
+): number | F {
+	const trimmed = raw.trim();
+	if (trimmed === '') return options.fallback;
+
+	const value = Number(trimmed);
+	if (!Number.isFinite(value)) return options.fallback;
+
+	return clampNumber(options.decimal ? value : Math.floor(value), options);
+}

--- a/src/lib/utils/numeric-input.ts
+++ b/src/lib/utils/numeric-input.ts
@@ -77,5 +77,13 @@ export function settleNumber<F extends number | null>(
 	const value = Number(trimmed);
 	if (!Number.isFinite(value)) return options.fallback;
 
-	return clampNumber(options.decimal ? value : Math.floor(value), options);
+	const settled = clampNumber(options.decimal ? value : Math.floor(value), options);
+
+	// A bounded field is already safe — the clamp pulled it back to its maximum.
+	// An unbounded one is not: twenty typed digits reach `Number` as 1e20, which
+	// `parseCommittableNumber` refuses while typing, so blur must refuse it too
+	// rather than committing a value the backend can't round-trip.
+	if (!options.decimal && !Number.isSafeInteger(settled)) return options.fallback;
+
+	return settled;
 }

--- a/src/lib/utils/recurrence.ts
+++ b/src/lib/utils/recurrence.ts
@@ -192,6 +192,14 @@ export function parseExdates(exdates: readonly string[] | null | undefined): Dat
 	return out.sort((a, b) => a.getTime() - b.getTime());
 }
 
+// --- generation window ------------------------------------------------------
+
+// How far ahead a series materializes events, in weeks. The wizard and the edit
+// dialog both expose this field; the bounds live here so the two copies can't
+// drift apart (they already had the same clamp inlined twice — see #924).
+export const GENERATION_WINDOW_MIN = 1;
+export const GENERATION_WINDOW_MAX = 52;
+
 // --- mutual-exclusion guard ------------------------------------------------
 
 export interface BoundaryGuardInput {

--- a/tests/e2e/journeys/j18-series/recurring-admin.spec.ts
+++ b/tests/e2e/journeys/j18-series/recurring-admin.spec.ts
@@ -86,7 +86,24 @@ test.describe('J18 recurring series admin @p2', () => {
 		const seriesName = uniqueName('Series');
 		await page.locator('#series-name').fill(seriesName);
 		await page.getByRole('button', { name: 'Advanced' }).click();
-		await page.locator('#generation-window').fill('2');
+
+		// The window field must survive real keystrokes: clamping on every input
+		// event refilled it with "1" under the caret, so the value could only be
+		// appended to (#922 → #924). jsdom can't show this — the caret is the bug.
+		const windowField = page.locator('#generation-window');
+		await windowField.click();
+		await page.keyboard.press('End');
+		await page.keyboard.press('Backspace');
+		await expect(windowField).toHaveValue('');
+		await windowField.pressSequentially('12');
+		await expect(windowField).toHaveValue('12');
+		// Out of range is not rewritten mid-typing; blur settles it at the maximum.
+		await windowField.pressSequentially('9');
+		await expect(windowField).toHaveValue('129');
+		await windowField.blur();
+		await expect(windowField).toHaveValue('52');
+
+		await windowField.fill('2');
 
 		await expect(async () => {
 			if (!/\/admin\/event-series\/[0-9a-f]{8}/.test(page.url())) {


### PR DESCRIPTION
Sweeps the anti-pattern behind #922 across the app. Closes #924.

## The bug

A handler normalizes or clamps a numeric field **while the user is still typing**, writing a different value back into the state that feeds the input's `value=`. Backspacing the last digit is overwritten immediately, leaving a caret after a digit that can never be deleted — the field can't be emptied, and the only escape is select-all + retype.

The empty string is the trap: `Number('')` is `0`, `parseFloat('') || 0` is `0`, and `Number.isFinite(0)` is `true`, so "empty" sails through the validity check and gets clamped up to the minimum.

## The fix

Generalizes the shape #923 shipped for the event max-tickets field:

- **`src/lib/utils/numeric-input.ts`** — `parseCommittableNumber` (is this worth committing *while typing*?), `settleNumber` (blur), `clampNumber`.
- **`src/lib/utils/numeric-input.svelte.ts`** — `numericField()`, a rune factory owning the free-text buffer, so a call site is three attributes:

```svelte
const window = numericField({ value: () => weeks, commit: (n) => (weeks = n), min: 1, max: 52 });

<Input value={window.value} oninput={window.oninput} onblur={window.onblur} />
```

The buffer is `string | null` — `null` means "not being edited", so the field renders the committed value and a change from elsewhere (a parent prop, a dialog reopening) shows through **without an `$effect` racing the user's keystrokes**. A field commits only values already valid and in range; empty, `0` under a `min` of 1 and half-typed decimals commit nothing and are left alone. `emptyValue: null` marks a genuinely clearable field (empty is a value there, and commits immediately — Enter-submitting a form fires no blur).

Clamping on blur is also better for **WCAG 3.3.1**: a value silently rewritten mid-typing is not an error the user can perceive or correct.

## Fields fixed

All 8 audited in #924, plus the 4 borderline ones:

| Component | Field |
| --- | --- |
| `QuestionnaireFormFields` | minimum score, max attempts |
| `QuestionEditor` | positive / negative weight |
| `FileUploadConfig` | max number of files |
| `RecurrenceEditDialog` | generation window |
| `RecurringEventWizard` | generation window |
| `SeatSelectionActions` | seat nudge dx / dy / rot |
| `RecurrencePicker` | interval, day of month, count |
| `SeatGeometryPanel` | curve, stagger, per-row curve/dx/dy |
| `SeatGridConfig` | rows, columns |
| `DurationInput` | amount (the `min` rewrite) |

The generation window was the same clamp inlined in two components; its bounds now live once in `utils/recurrence.ts` as `GENERATION_WINDOW_MIN/MAX`.

## Two symptoms the audit hadn't named

- **A negative value could not be typed at all** in the seat-nudge and sector-geometry fields. `type="number"` reports an empty `value` for a lone `-`, which the write-back turned into a `0` — wiping the sign before its digits could follow. Covered by a new test in each.
- **`SeatGridConfig` opened an undo point per keystroke**, including keystrokes that committed nothing. The undo point now comes from `commit`.

## Judgement calls

- **`SeatSelectionActions`** (#924 flagged this as a decision, not a defect): the "an emptied field means `0` / no offset" contract is **kept** — it just settles on blur instead of on the keystroke that empties it. The untypable minus sign decided it.
- **`SeatGeometryPanel`**'s clamp is documented as a deliberate WCAG 3.3.1 input-boundary guard. An out-of-range value still never reaches the recipe — it's now kept out by *not committing* it rather than by rewriting the field, which is the same guarantee without the uneditable field.
- **`RecurrencePicker.interval`** wasn't on the issue's list (it never blocked editing), but it sat in a file already being rewritten and left display and rule diverged for a typed `0`, so it's folded in.

## Verification

- `make check` — 0 errors (393 warnings, all pre-existing and unchanged).
- `make test` — **3656 passed**, 314 files. 25 new tests for the helper; new test files for `FileUploadConfig`, `QuestionnaireFormFields`, `QuestionEditor`, `SeatGridConfig`, `RecurrenceEditDialog`; `DurationInput` extended.
- Four existing tests asserted the old per-keystroke clamp and were rewritten to the new contract (commit nothing → clamp on blur); each kept its original guarantee as a post-blur assertion.
- **E2E (chromium): 71 passed** across every journey that renders a touched component — `j08-org-owner` (seat editor, geometry, floors, venues), `j11-questionnaires`, `j18-series` (all 6), and `j10-event-admin` (23 passed: announcements, waitlist admin, tier management, schedule/resources, refund policy — the `DurationInput` call sites).
  - The 2 failures in `j10-event-admin/organizer-refunds.spec.ts` are the `requireStripeWebhooks()` gate (`stripe listen` is a manual step, not started here). **Verified pre-existing**: the same two fail identically on `main` with the same backend.
- The j18 wizard spec now drives the generation window with **real keystrokes** — backspace to empty, `pressSequentially('12')`, out-of-range `129` left alone, blur → `52`. jsdom cannot show this; the caret is the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Numeric fields across recurring events, questionnaires, forms, and venue settings now remain editable while typing, including temporary empty, partial, negative, and out-of-range values.
  - Values are validated, clamped, or restored when the field loses focus instead of being rewritten mid-entry.
  - Clearing fields no longer unexpectedly restores defaults or triggers unnecessary updates.
  - Decimal scoring weights and negative seat offsets can now be entered correctly.
- **Tests**
  - Added comprehensive coverage for numeric input editing, blur behavior, validation, and recurring-event generation limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
